### PR TITLE
merge in item actions in a new frame, 'page', processed after retrieval from data source

### DIFF
--- a/src/encoded/commands/create_mapping.py
+++ b/src/encoded/commands/create_mapping.py
@@ -169,6 +169,11 @@ def es_mapping(mapping):
                 'include_in_all': False,
                 'index': 'not_analyzed'
             },
+            'principals_allowed_edit': {
+                'type': 'string',
+                'include_in_all': False,
+                'index': 'not_analyzed'
+            },
             'embedded_uuid_closure': {
                 'type': 'string',
                 'include_in_all': False,

--- a/src/encoded/contentbase.py
+++ b/src/encoded/contentbase.py
@@ -478,6 +478,7 @@ class Item(object):
         'uuid': {'$value': '{uuid}', '$templated': True},
     }
     template_type = None
+    actions = []
 
     def __init__(self, collection, model):
         self.__parent__ = collection
@@ -636,6 +637,12 @@ class Item(object):
         paths = [p.split('.') for p in self.embedded]
         for path in paths:
             expand_path(request, properties, path)
+
+    def add_actions(self, request, properties):
+        if request.has_permission('edit', self):
+            properties['actions'] = getattr(self, 'actions', [])
+        else:
+            properties['actions'] = []
 
     @classmethod
     def create(cls, parent, uuid, properties, sheets=None):
@@ -798,6 +805,7 @@ class CustomItemMeta(MergedDictsMeta, ABCMeta):
             'rev',
             'name_key',
             'namespace_from_path',
+            'actions',
         ]
 
         if 'Item' in attrs:
@@ -1021,6 +1029,9 @@ class Collection(Mapping):
     def expand_embedded(self, request, properties):
         pass
 
+    def add_actions(self, request, properties):
+        pass
+
 
 def column_value(obj, column):
     path = column.split('.')
@@ -1135,7 +1146,7 @@ def item_view(context, request):
 
     if frame is None:
         if asbool(request.params.get('embed', True)):
-            frame = 'embedded'
+            frame = 'page'
         else:
             frame = 'object'
 
@@ -1143,6 +1154,10 @@ def item_view(context, request):
         return properties
 
     context.expand_embedded(request, properties)
+    if frame == 'embedded':
+        return properties
+
+    context.add_actions(request, properties)
     return properties
 
 
@@ -1240,9 +1255,12 @@ def item_index_data(context, request):
     for key in context.model.unique_keys:
         keys[key.name].append(key.value)
 
-    principals = principals_allowed_by_permission(context, 'view')
-    if principals is Everyone:
-        principals = [Everyone]
+    principals = {}
+    for permission in ('view', 'edit'):
+        p  = principals_allowed_by_permission(context, permission)
+        if p is Everyone:
+            p = [Everyone]
+        principals[permission] = p
 
     path = resource_path(context)
     paths = {path}
@@ -1262,14 +1280,15 @@ def item_index_data(context, request):
                 resource_path(base, key)
                 for key in keys[key_name])
 
-    embedded = embed(request, path + '/')
+    embedded = embed(request, path + '/?frame=embedded')
     audit = request.audit(embedded, embedded['@type'], path=path)
     document = {
         'embedded': embedded,
         'object': embed(request, path + '/?frame=object'),
         'links': links,
         'keys': keys,
-        'principals_allowed_view': sorted(principals),
+        'principals_allowed_view': sorted(principals['view']),
+        'principals_allowed_edit': sorted(principals['edit']),
         'paths': sorted(paths),
         'audit': audit,
     }

--- a/src/encoded/views/views.py
+++ b/src/encoded/views/views.py
@@ -249,11 +249,9 @@ class Source(Collection):
         'title': 'Sources',
         'description': 'Listing of sources and vendors for ENCODE material',
     }
-    item_template = {
-        'actions': [
-            {'name': 'edit', 'title': 'Edit', 'profile': '/profiles/{item_type}.json', 'method': 'PUT', 'href': '', '$templated': True, '$condition': 'permission:edit'},
-        ],
-    }
+    item_actions = [
+        {'name': 'edit', 'title': 'Edit', 'profile': '/profiles/{item_type}.json', 'method': 'PUT', 'href': ''},
+    ]
     item_name_key = 'name'
     unique_key = 'source:name'
     item_keys = ALIAS_KEYS + ['name']
@@ -875,20 +873,16 @@ class Page(Collection):
             'deleted': ONLY_ADMIN_VIEW,
         }
 
-        template = {
-            'actions': [
-                {
-                    'name': 'edit',
-                    'title': 'Edit',
-                    'profile': '/profiles/page.json',
-                    'method': 'PUT',
-                    'href': '#!edit',
-                    'className': 'btn navbar-btn',
-                    '$templated': True,
-                    '$condition': 'permission:edit'
-                },
-            ],
-        }
+        actions = [
+            {
+                'name': 'edit',
+                'title': 'Edit',
+                'profile': '/profiles/page.json',
+                'method': 'PUT',
+                'href': '#!edit',
+                'className': 'btn navbar-btn',
+            },
+        ]
 
 
 @location('about')


### PR DESCRIPTION
- Include actions in the page frame if the user has 'edit' permission
- Default to rendering the page frame instead of embedded
- Index edit permission so the elasticsearch tween can determine whether to include actions without loading the object from the db
