### PR TITLE
fix preview in object picker

### DIFF
--- a/src/encoded/static/components/blocks/item.js
+++ b/src/encoded/static/components/blocks/item.js
@@ -39,10 +39,14 @@ var FetchedItemBlockView = React.createClass({
 
 var ItemPreview = React.createClass({
     render: function() {
-        var context = this.props.data;
+        var context = this.props.data['@graph'][0];
         var style = {width: '80%'};
-        var title = globals.listing_titles.lookup(context)({context: context});
-        return <h2><a href={context['@id']}>{title}</a></h2>;
+        var Listing = globals.listing_views.lookup(context);
+        return (
+            <ul className="nav result-table">
+                <Listing context={context} columns={this.props.data.columns} key={context['@id']} />
+            </ul>
+        );
     }
 });
 
@@ -62,9 +66,7 @@ var ObjectPicker = module.exports.ObjectPicker = React.createClass({
 
     render: function() {
         var url = this.props.value;
-        if (url && url.indexOf('/') !== 0) {
-            url = '/' + url;
-        }
+        var previewUrl = '/search?mode=picker&@id=' + url;
         var searchUrl = '/search' + this.state.search;
         var actions = [
             <button className="btn btn-primary" onClick={this.handleSelect}>Select</button>
@@ -78,7 +80,7 @@ var ObjectPicker = module.exports.ObjectPicker = React.createClass({
                                showSpinnerOnUpdate={false} />
                 : <div className="clearfix">
                     <button className="btn btn-default pull-right" onClick={this.handleBrowse}>Browse&hellip;</button>
-                    {this.transferPropsTo(<FetchedData url={url} Component={ItemPreview} loadingComplete={true} showSpinnerOnUpdate={false} />)}
+                    {url ? this.transferPropsTo(<FetchedData url={previewUrl} Component={ItemPreview} loadingComplete={true} showSpinnerOnUpdate={false} />) : ''}
                   </div>}
             </div>
         );

--- a/src/encoded/static/scss/encoded/modules/_facet.scss
+++ b/src/encoded/static/scss/encoded/modules/_facet.scss
@@ -171,6 +171,7 @@
     list-style-type: none;
     margin: 0;
     padding: 0;
+    overflow: hidden;
 
     li {
         margin-top: 10px;

--- a/src/encoded/tests/data/inserts/about.json
+++ b/src/encoded/tests/data/inserts/about.json
@@ -38,7 +38,7 @@
                 {
                     "@id": "#block4",
                     "@type": "teaserblock",
-                    "image": "8a91ae78-731a-4a92-ae7c-273214be408a",
+                    "image": "/images/8a91ae78-731a-4a92-ae7c-273214be408a/",
                     "body": "<h2>Chromatin Structure</h2>",
                     "href": "/about/chromatin-structure"
                 }
@@ -86,7 +86,7 @@
                 {
                     "@id": "#block4",
                     "@type": "itemblock",
-                    "item": "b4589f52-521e-45db-8dfa-378d92cbbd86"
+                    "item": "/images/b4589f52-521e-45db-8dfa-378d92cbbd86/"
                 }
             ]
         }


### PR DESCRIPTION
This provides a better preview in the object picker by reusing the listing views. In order to do that it:
- Fetches the object using /search?mode=picker&@id=/id/of/object/ so it has the same sort of context as when searching
- Fixes the search view to return the object frame for types without columns even when querying multiple types
