### PR TITLE
Add "paired set" to dataset dataset_type enum

### DIFF
--- a/src/encoded/schemas/dataset.json
+++ b/src/encoded/schemas/dataset.json
@@ -39,7 +39,8 @@
             "enum": [
                 "project",
                 "composite",
-                "publication"
+                "publication",
+                "paired set"
             ]
         },
         "dbxrefs": {


### PR DESCRIPTION
For UW's "paired sample" datasets - a special term they've negotiated with the NHGRI as a group of paired tissue samples from different donors.
