### PR TITLE
1727 Have Portal Tags Jump, and include header?

### DIFF
--- a/src/encoded/static/scss/encoded/modules/_blocks.scss
+++ b/src/encoded/static/scss/encoded/modules/_blocks.scss
@@ -37,7 +37,6 @@ $block-mobile-font-size-p:  floor($block-font-size-p * 1.2);
             :target {
                 margin-top: -40px !important;
                 padding-top: 40px !important;
-                @include animation(bgfade 1s linear);
             }
         }
     }


### PR DESCRIPTION
Changed Sass to allow jumped-to targets appear below the fixed-position header. When header isn‘t fixed (narrow browser), there’s no change. For Release 16.
