### PR TITLE
Fix target.features test for Uniprot change

### DIFF
--- a/src/encoded/tests/features/targets.feature
+++ b/src/encoded/tests/features/targets.feature
@@ -16,7 +16,7 @@ Feature: Targets
 
         When I click the link to "http://www.uniprot.org/uniprot/Q9H2P0"
         Then the browser's URL should contain "www.uniprot.org"
-        Then I should see "Q9H2P0 (ADNP_HUMAN)"
+        Then I should see "Q9H2P0 - ADNP_HUMAN"
 
         When I go back
         Then the browser's URL should contain "/targets/"


### PR DESCRIPTION
The UniProt website changed, causing the target.features test for the string “Q9H2P0 (ADNP_HUMAN)“ to fail. Changed the string to “Q9H2P0 - ADNP_HUMAN”
