### PR TITLE
Removed duplicated key-value pair in moleculeDict

### DIFF
--- a/src/encoded/audit/library.py
+++ b/src/encoded/audit/library.py
@@ -9,7 +9,6 @@ moleculeDict = {"DNA": "SO:0000352",
                 "polyadenylated mRNA": "SO:0000871",
                 "miRNA": "SO:0000276",
                 "rRNA": "SO:0000252",
-                "polyadenylated mRNA": "SO:0000871",
                 "capped mRNA": "SO:0000862"
                 }
 


### PR DESCRIPTION
This audit (#1626) was already fixed in #1651 size_range branch which was already merged. I just removed a duplicate key-pair from a dictionary used in the audit.
