### PR TITLE
Update target test for changed UniProt site

### DIFF
--- a/src/encoded/tests/features/targets.feature
+++ b/src/encoded/tests/features/targets.feature
@@ -16,7 +16,7 @@ Feature: Targets
 
         When I click the link to "http://www.uniprot.org/uniprot/Q9H2P0"
         Then the browser's URL should contain "www.uniprot.org"
-        Then I should see "Q9H2P0 - ADNP_HUMAN"
+        Then I should see "Q9H2P0"
 
         When I go back
         Then the browser's URL should contain "/targets/"


### PR DESCRIPTION
Made a change before because UniProt’s site changed, but now it’s not matching again. They changed their site again, maybe?

This and current master fail Travis test on test_jsonld_context.
