### PR TITLE
Need to retain to preserve existing objects

### DIFF
--- a/src/encoded/schemas/construct.json
+++ b/src/encoded/schemas/construct.json
@@ -28,7 +28,8 @@
             "type": "string",
             "enum": [
                 "fusion protein",
-                "zinc-finger knockout"
+                "zinc-finger knockout",
+                "TALEN"
             ]
         },
         "description": {


### PR DESCRIPTION
My fault ... there are some existing construct "stub" objects of construct_type TALEN, so removing this from the enum is going to break those.  After we make new talen objects, these constructs will get deleted, and we can then remove TALEN from the construct schema.
