### PR TITLE
Remove primary/secondary

### DIFF
--- a/src/encoded/static/components/__tests__/antibody-test.js
+++ b/src/encoded/static/components/__tests__/antibody-test.js
@@ -115,7 +115,7 @@ describe('Antibody', function() {
             var charData = panel.getElementsByClassName('characterization-meta-data')[0];
             var item = charData.querySelector('[data-test="method"]');
             var itemDescription = item.getElementsByTagName('dd')[0];
-            expect(itemDescription.textContent).toEqual('immunoblot (primary)');
+            expect(itemDescription.textContent).toEqual('immunoblot');
 
             item = charData.querySelector('[data-test="targetspecies"]');
             itemDescription = item.getElementsByTagName('dd')[0];

--- a/src/encoded/static/components/antibody.js
+++ b/src/encoded/static/components/antibody.js
@@ -21,7 +21,7 @@ var Lot = module.exports.Lot = React.createClass({
     render: function() {
         var context = this.props.context;
 
-        // Sort characterization arrays, first by species, then by primary/secondary characterization method
+        // Sort characterization arrays
         var sortedChars = _(context.characterizations).sortBy(function(characterization) {
             return [characterization.target.label, characterization.target.organism.name];
         });
@@ -274,7 +274,7 @@ var Characterization = module.exports.Characterization = React.createClass({
                             {context.characterization_method ?
                                 <div data-test="method">
                                     <dt className="h3">Method</dt>
-                                    <dd className="h3">{context.characterization_method} ({context.primary_characterization_method ? 'primary' : 'secondary'})</dd>
+                                    <dd className="h3">{context.characterization_method}</dd>
                                 </div>
                             : null}
 


### PR DESCRIPTION
Remove “(primary)” and “(secondary)” from the antibody characterization method.
