### PR TITLE
Change target.label check to use unflattened style

### DIFF
--- a/src/encoded/static/components/search.js
+++ b/src/encoded/static/components/search.js
@@ -402,7 +402,7 @@ var AuditMixin = audit.AuditMixin;
                             </a>
                         </div>
                         <div className="data-row">
-                            {result['target.label'] ?
+                            {result.target && result.target.label ?
                                 <div>
                                     <strong>{columns['target.label']['title'] + ': '}</strong>
                                     {result.target.label}


### PR DESCRIPTION
Prevented targets from being displayed on Experiment search results.
