### PR TITLE
1532 model org dependencies

### DIFF
--- a/src/encoded/schemas/biosample.json
+++ b/src/encoded/schemas/biosample.json
@@ -28,8 +28,6 @@
         "depleted_in_term_name": ["depleted_in_term_id"],
         "post_synchronization_time_units": ["post_synchronization_time"],
         "post_synchronization_time": ["post_synchronization_time_units"],
-        "starting_amount_units": ["starting_amount"],
-        "starting_amount": ["starting_amount_units"],
         "depleted_in_term_id": {
             "required": ["depleted_in_term_name"],
             "properties": {


### PR DESCRIPTION
#1532 dependencies to allow organism-specific properties to be used only in appropriate organisms
