### PR TITLE
1794 multi object forms (not enabled)

### DIFF
--- a/src/encoded/calculated.py
+++ b/src/encoded/calculated.py
@@ -88,6 +88,12 @@ class CalculatedProperties(object):
     def __init__(self):
         self.category_cls_props = {}
 
+    def register_prop(self, fn, name, context, condition=None, schema=None,
+                      attr=None, define=False, category='object'):
+        prop = CalculatedProperty(fn, name, attr, condition, schema, define)
+        cls_props = self.category_cls_props.setdefault(category, {})
+        cls_props.setdefault(context, {})[name] = prop
+
     def props_for(self, context, category='object'):
         if isinstance(context, type):
             cls = context
@@ -109,11 +115,17 @@ class CalculatedProperties(object):
                 schema['properties'][name] = prop.schema
         return schema
 
-    def register_prop(self, fn, name, context, condition=None, schema=None,
-                      attr=None, define=False, category='object'):
-        prop = CalculatedProperty(fn, name, attr, condition, schema, define)
-        cls_props = self.category_cls_props.setdefault(category, {})
-        cls_props.setdefault(context, {})[name] = prop
+    def schema_rev_links_for(self, cls):
+        schema = self.schema_for(cls)
+
+        revs = {}
+        for key, prop in schema['properties'].items():
+            linkFrom = prop.get('linkFrom', prop.get('items', {}).get('linkFrom'))
+            if linkFrom is None:
+                continue
+            linkType, linkProp = linkFrom.split('.')
+            revs[key] = linkType, linkProp
+        return revs
 
 
 class CalculatedProperty(object):

--- a/src/encoded/calculated.py
+++ b/src/encoded/calculated.py
@@ -129,8 +129,9 @@ class CalculatedProperty(object):
         if schema is not None:
             if 'default' in schema:
                 raise ValueError('schema may not specify default for calculated property')
-            schema = schema.copy()
-            schema['calculatedProperty'] = True
+            if 'linkFrom' not in schema.get('items', {}):
+                schema = schema.copy()
+                schema['calculatedProperty'] = True
         self.schema = schema
 
     def __call__(self, namespace):

--- a/src/encoded/commands/create_mapping.py
+++ b/src/encoded/commands/create_mapping.py
@@ -274,13 +274,11 @@ def collection_mapping(calculated_properties, collection, embed=True):
 
         for i, p in enumerate(prop.split('.')):
             name = None
-            subschema = None
 
-            if name is None:
-                subschema = new_schema.get('properties', {}).get(p)
-                if subschema is not None:
-                    subschema = subschema.get('items', subschema)
-                    name = subschema.get('linkTo')
+            subschema = new_schema.get('properties', {}).get(p)
+            if subschema is not None:
+                subschema = subschema.get('items', subschema)
+                name = subschema.get('linkTo')
 
             if name is None and p in new_rev:
                 name, rev_path = new_rev[p]

--- a/src/encoded/contentbase.py
+++ b/src/encoded/contentbase.py
@@ -265,6 +265,7 @@ class Root(object):
     __acl__ = [
         (Allow, 'remoteuser.INDEXER', ('view', 'list', 'index')),
         (Allow, 'remoteuser.EMBED', ('view', 'expand', 'audit')),
+        (Allow, 'group.forms', ('forms',)),
     ]
 
     def __init__(self, registry):

--- a/src/encoded/static/components/form.js
+++ b/src/encoded/static/components/form.js
@@ -11,6 +11,21 @@ var _ = require('underscore');
 var FormFor = ReactForms.FormFor;
 
 
+var filterValue = function(value) {
+    if (Array.isArray(value)) {
+        value.map(filterValue);
+    } else if (typeof value == 'object') {
+        _.each(value, function(v, k) {
+            if (v === null || k == 'schema_version') {
+                delete value[k];
+            } else {
+                filterValue(v);
+            }
+        });
+    }
+};
+
+
 var Form = module.exports.Form = React.createClass({
     mixins: [ReactForms.FormMixin],
 
@@ -32,7 +47,7 @@ var Form = module.exports.Form = React.createClass({
             var $ = require('jquery');
             var $error = $('alert-danger:first');
             if (!$error.length) {
-                $error = $('.rf-Message:first').closest('.rf-Field');
+                $error = $('.rf-Message:first').closest('.rf-Field,.rf-RepeatingFieldset');
             }
             if ($error.length) {
                 $('body').animate({scrollTop: $error.offset().top - $('#navbar').height()}, 200);
@@ -43,13 +58,13 @@ var Form = module.exports.Form = React.createClass({
     render: function() {
         return (
           <form>
-            {(this.state.errors || []).map(error => <div className="alert alert-danger">{error}</div>)}
             <FormFor externalValidation={this.state.externalValidation} />
             <div className="pull-right">
                 <a href="" className="btn btn-default">Cancel</a>
                 {' '}
                 <button onClick={this.save} className="btn btn-success" disabled={this.communicating || this.state.editor_error}>Save</button>
             </div>
+            {(this.state.errors || []).map(error => <div className="alert alert-danger">{error}</div>)}
           </form>
         );
     },
@@ -64,11 +79,7 @@ var Form = module.exports.Form = React.createClass({
         e.preventDefault();
         var $ = require('jquery');
         var value = this.value().value;
-        _.each(value, function(v, k) {
-            if (v === null || k == 'schema_version') {
-                delete value[k];
-            }
-        });
+        filterValue(value);
         var method = this.props.method;
         var url = this.props.action;
         var xhr = $.ajax({
@@ -113,19 +124,27 @@ var Form = module.exports.Form = React.createClass({
     },
 
     receive: function (data, status, xhr) {
-        var externalValidation = {children: {}};
+        var externalValidation = {children: {}, validation: {}};
         var schemaErrors = [];
         if (data.errors !== undefined) {
             data.errors.map(function (error) {
                 var name = error.name;
                 var match = /u'(\w+)' is a required property/.exec(error.description);
                 if (match) {
-                    name = [match[1]];
+                    name.push(match[1]);
                 }
                 if (name.length) {
-                    externalValidation.children[name[0]] = {
-                        validation: {failure: error.description,
-                                     validation: {failure: error.description}}};
+                    var v = externalValidation;
+                    for (var i = 0; i < name.length; i++) {
+                        if (v.children[name[i]] === undefined) {
+                            v.children[name[i]] = {children: {}, validation: {}};
+                        }
+                        v = v.children[name[i]];
+                    }
+                    v.validation = {
+                        failure: error.description,
+                        validation: {failure: error.description}
+                    };
                 } else {
                     schemaErrors.push(error.description);
                 }

--- a/src/encoded/static/scss/encoded/modules/_facet.scss
+++ b/src/encoded/static/scss/encoded/modules/_facet.scss
@@ -209,6 +209,11 @@ div.meta-status {
         content: none;
         display: block;
     }
+
+    .pull-right {
+        position: relative;
+        z-index: 2;
+    }
 }
 
  

--- a/src/encoded/static/scss/fontawesome/_icons.scss
+++ b/src/encoded/static/scss/fontawesome/_icons.scss
@@ -19,8 +19,8 @@
 //.#{$fa-css-prefix}-search-minus:before { content: $fa-var-search-minus; }
 //.#{$fa-css-prefix}-power-off:before { content: $fa-var-power-off; }
 //.#{$fa-css-prefix}-signal:before { content: $fa-var-signal; }
-//.#{$fa-css-prefix}-gear:before,
-//.#{$fa-css-prefix}-cog:before { content: $fa-var-cog; }
+.#{$fa-css-prefix}-gear:before,
+.#{$fa-css-prefix}-cog:before { content: $fa-var-cog; }
 .#{$fa-css-prefix}-trash-o:before { content: $fa-var-trash-o; }
 .#{$fa-css-prefix}-home:before { content: $fa-var-home; }
 //.#{$fa-css-prefix}-file-o:before { content: $fa-var-file-o; }

--- a/src/encoded/tests/test_post_put_patch.py
+++ b/src/encoded/tests/test_post_put_patch.py
@@ -41,6 +41,7 @@ item_with_link = [
     },
 ]
 
+
 COLLECTION_URL = '/testing-post-put-patch/'
 
 
@@ -55,6 +56,15 @@ def link_targets(testapp):
 def content(testapp):
     res = testapp.post_json(COLLECTION_URL, item_with_uuid[0], status=201)
     return {'@id': res.location}
+
+
+@pytest.fixture
+def content_with_child(testapp):
+    parent_res = testapp.post_json('/testing-link-targets/', {}, status=201)
+    parent_id = parent_res.json['@graph'][0]['@id']
+    child_res = testapp.post_json('/testing-link-sources/', {'target': parent_id})
+    child_id = child_res.json['@graph'][0]['@id']
+    return {'@id': parent_id, 'child': child_id}
 
 
 def test_admin_post(testapp):
@@ -152,3 +162,89 @@ def test_submitter_put_protected_link(link_targets, testapp, submitter_testapp):
 
     submitter_testapp.put_json(url, item_with_link[0], status=200)
     submitter_testapp.put_json(url, item_with_link[1], status=422)
+
+
+def test_put_object_not_touching_children(content_with_child, testapp):
+    url = content_with_child['@id']
+    res = testapp.put_json(url, {}, status=200)
+    assert content_with_child['child'] in res.json['@graph'][0]['reverse']
+
+
+def test_put_object_editing_child(content_with_child, testapp):
+    edit = {
+        'reverse': [{
+            '@id': content_with_child['child'],
+            'status': 'released',
+        }]
+    }
+    testapp.put_json(content_with_child['@id'], edit, status=200)
+    res = testapp.get(content_with_child['child'] + '?frame=embedded')
+    assert res.json['status'] == 'released'
+
+
+def test_put_object_adding_child(content_with_child, testapp):
+    edit = {
+        'reverse': [
+            content_with_child['child'],
+            {
+                'status': 'released',
+            }
+        ]
+    }
+    testapp.put_json(content_with_child['@id'], edit, status=200)
+    res = testapp.get(content_with_child['@id'])
+    assert len(res.json['reverse']) == 2
+
+
+def test_put_object_removing_child(content_with_child, testapp):
+    edit = {
+        'reverse': [],
+    }
+    testapp.put_json(content_with_child['@id'], edit, status=200)
+    res = testapp.get(content_with_child['@id'] + '?frame=embedded')
+    assert len(res.json['reverse']) == 0
+    res = testapp.get(content_with_child['child'])
+    assert res.json['status'] == 'deleted'
+
+
+def test_put_object_child_validation(content_with_child, testapp):
+    edit = {
+        'reverse': [{
+            '@id': content_with_child['child'],
+            'target': 'BOGUS',
+        }]
+    }
+    res = testapp.put_json(content_with_child['@id'], edit, status=422)
+    assert res.json['errors'][0]['name'] == [u'reverse', 0, u'target']
+
+
+def test_put_object_validates_child_references(content_with_child, testapp):
+    # Try a child that doesn't exist
+    edit = {
+        'reverse': [
+            content_with_child['child'],
+            '/asdf',
+        ]
+    }
+    testapp.put_json(content_with_child['@id'], edit, status=422)
+
+    # Try a child that exists but is the wrong type
+    edit = {
+        'reverse': [
+            content_with_child['child'],
+            content_with_child['@id'],
+        ]
+    }
+    testapp.put_json(content_with_child['@id'], edit, status=422)
+
+
+def test_post_object_with_child(testapp):
+    edit = {
+        'reverse': [{
+            'status': 'released',
+        }]
+    }
+    res = testapp.post_json('/testing-link-targets', edit, status=201)
+    parent_id = res.json['@graph'][0]['@id']
+    source = res.json['@graph'][0]['reverse'][0]
+    assert source['target'] == parent_id

--- a/src/encoded/tests/test_post_put_patch.py
+++ b/src/encoded/tests/test_post_put_patch.py
@@ -248,3 +248,10 @@ def test_post_object_with_child(testapp):
     parent_id = res.json['@graph'][0]['@id']
     source = res.json['@graph'][0]['reverse'][0]
     assert source['target'] == parent_id
+
+
+def test_etag_if_match_tid(testapp, organism):
+    res = testapp.get(organism['@id'] + '?frame=edit', status=200)
+    etag = res.etag
+    testapp.patch_json(organism['@id'], {}, headers={'If-Match': etag}, status=200)
+    testapp.patch_json(organism['@id'], {}, headers={'If-Match': etag}, status=412)

--- a/src/encoded/tests/testing_views.py
+++ b/src/encoded/tests/testing_views.py
@@ -93,6 +93,12 @@ class TestingLinkSource(Item):
     schema = {
         'type': 'object',
         'properties': {
+            'name': {
+                'type': 'string',
+            },
+            'uuid': {
+                'type': 'string',
+            },
             'target': {
                 'type': 'string',
                 'linkTo': 'testing_link_target',
@@ -100,7 +106,9 @@ class TestingLinkSource(Item):
             'status': {
                 'type': 'string',
             },
-        }
+        },
+        'required': ['target'],
+        'additionalProperties': False,
     }
 
 
@@ -110,10 +118,17 @@ class TestingLinkTarget(Item):
     schema = {
         'type': 'object',
         'properties': {
+            'name': {
+                'type': 'string',
+            },
+            'uuid': {
+                'type': 'string',
+            },
             'status': {
                 'type': 'string',
             },
-        }
+        },
+        'additionalProperties': False,
     }
     rev = {
         'reverse': ('testing_link_source', 'target'),
@@ -122,7 +137,14 @@ class TestingLinkTarget(Item):
         'reverse',
     ]
 
-    @calculated_property()
+    @calculated_property(schema={
+        "title": "Sources",
+        "type": "array",
+        "items": {
+            "type": ['string', 'object'],
+            "linkFrom": "testing_link_source.target",
+        },
+    })
     def reverse(self, request, reverse):
         return paths_filtered_by_status(request, reverse)
 

--- a/src/encoded/types/antibody_lot.py
+++ b/src/encoded/types/antibody_lot.py
@@ -71,8 +71,8 @@ class AntibodyLot(Item):
         "title": "Characterizations",
         "type": "array",
         "items": {
-            "type": "string",
-            "linkTo": "antibody_characterization",
+            "type": ['string', 'object'],
+            "linkFrom": "antibody_characterization.characterizes",
         },
     })
     def characterizations(self, request, characterizations):

--- a/src/encoded/types/base.py
+++ b/src/encoded/types/base.py
@@ -5,6 +5,7 @@ from pyramid.security import (
     DENY_ALL,
     Everyone,
 )
+from pyramid.threadlocal import get_current_request
 from .. import contentbase
 
 ALLOW_EVERYONE_VIEW = [
@@ -36,12 +37,6 @@ ONLY_ADMIN_VIEW = [
     (Allow, 'remoteuser.EMBED', ['view', 'expand', 'audit']),
     (Allow, 'remoteuser.INDEXER', ['view', 'index']),
     DENY_ALL,
-]
-
-
-TYPES_WITH_FORMS = [
-    'image',
-    'page',
 ]
 
 
@@ -127,9 +122,14 @@ class Item(contentbase.Item):
                 self.__acl__ = ALLOW_SUBMITTER_ADD
 
 
+def contextless_has_permission(permission):
+    request = get_current_request()
+    return request.has_permission('forms', request.root)
+
+
 @contentbase.calculated_property(context=Item.Collection, category='action')
 def add(item_uri, item_type, has_permission):
-    if item_type in TYPES_WITH_FORMS and has_permission('add'):
+    if has_permission('add') and contextless_has_permission('forms'):
         return {
             'name': 'add',
             'title': 'Add',
@@ -140,10 +140,21 @@ def add(item_uri, item_type, has_permission):
 
 @contentbase.calculated_property(context=Item, category='action')
 def edit(item_uri, item_type, has_permission):
-    if has_permission('edit'):
+    if has_permission('edit') and contextless_has_permission('forms'):
         return {
             'name': 'edit',
             'title': 'Edit',
             'profile': '/profiles/{item_type}.json'.format(item_type=item_type),
-            'href': item_uri + ('#!edit' if item_type in TYPES_WITH_FORMS else '#!edit-json'),
+            'href': item_uri + '#!edit',
+        }
+
+
+@contentbase.calculated_property(context=Item, category='action')
+def edit_json(item_uri, item_type, has_permission):
+    if has_permission('edit'):
+        return {
+            'name': 'edit-json',
+            'title': 'Edit JSON',
+            'profile': '/profiles/{item_type}.json'.format(item_type=item_type),
+            'href': item_uri + '#!edit-json',
         }

--- a/src/encoded/types/base.py
+++ b/src/encoded/types/base.py
@@ -39,12 +39,6 @@ ONLY_ADMIN_VIEW = [
 ]
 
 
-TYPES_WITH_FORMS = [
-    'image',
-    'page',
-]
-
-
 def paths_filtered_by_status(request, paths, exclude=('deleted', 'replaced')):
     return [
         path for path in paths
@@ -129,7 +123,7 @@ class Item(contentbase.Item):
 
 @contentbase.calculated_property(context=Item.Collection, category='action')
 def add(item_uri, item_type, has_permission):
-    if item_type in TYPES_WITH_FORMS and has_permission('add'):
+    if has_permission('add'):
         return {
             'name': 'add',
             'title': 'Add',
@@ -145,5 +139,5 @@ def edit(item_uri, item_type, has_permission):
             'name': 'edit',
             'title': 'Edit',
             'profile': '/profiles/{item_type}.json'.format(item_type=item_type),
-            'href': item_uri + ('#!edit' if item_type in TYPES_WITH_FORMS else '#!edit-json'),
+            'href': item_uri + '#!edit',
         }

--- a/src/encoded/types/base.py
+++ b/src/encoded/types/base.py
@@ -39,6 +39,12 @@ ONLY_ADMIN_VIEW = [
 ]
 
 
+TYPES_WITH_FORMS = [
+    'image',
+    'page',
+]
+
+
 def paths_filtered_by_status(request, paths, exclude=('deleted', 'replaced')):
     return [
         path for path in paths
@@ -123,7 +129,7 @@ class Item(contentbase.Item):
 
 @contentbase.calculated_property(context=Item.Collection, category='action')
 def add(item_uri, item_type, has_permission):
-    if has_permission('add'):
+    if item_type in TYPES_WITH_FORMS and has_permission('add'):
         return {
             'name': 'add',
             'title': 'Add',
@@ -139,5 +145,5 @@ def edit(item_uri, item_type, has_permission):
             'name': 'edit',
             'title': 'Edit',
             'profile': '/profiles/{item_type}.json'.format(item_type=item_type),
-            'href': item_uri + '#!edit',
+            'href': item_uri + ('#!edit' if item_type in TYPES_WITH_FORMS else '#!edit-json'),
         }

--- a/src/encoded/types/biosample.py
+++ b/src/encoded/types/biosample.py
@@ -209,8 +209,8 @@ class Biosample(Item):
         "title": "Characterizations",
         "type": "array",
         "items": {
-            "type": "string",
-            "linkTo": "biosample_characterization",
+            "type": ['string', 'object'],
+            "linkFrom": "biosample_characterization.characterizes",
         },
     })
     def characterizations(self, request, characterizations):

--- a/src/encoded/types/dataset.py
+++ b/src/encoded/types/dataset.py
@@ -65,8 +65,8 @@ class Dataset(Item):
         "title": "Original files",
         "type": "array",
         "items": {
-            "type": "string",
-            "linkTo": "file",
+            "type": ['string', 'object'],
+            "linkFrom": "file.dataset",
         },
     })
     def original_files(self, request, original_files):

--- a/src/encoded/types/donor.py
+++ b/src/encoded/types/donor.py
@@ -24,8 +24,8 @@ class Donor(Item):
         "title": "Characterizations",
         "type": "array",
         "items": {
-            "type": "string",
-            "linkTo": "donor_characterization",
+            "type": ['string', 'object'],
+            "linkFrom": "donor_characterization.characterizes",
         },
     })
     def characterizations(self, request, characterizations):

--- a/src/encoded/types/experiment.py
+++ b/src/encoded/types/experiment.py
@@ -166,8 +166,8 @@ class Experiment(Dataset):
         "title": "Replicates",
         "type": "array",
         "items": {
-            "type": "string",
-            "linkTo": "replicate",
+            "type": ['string', 'object'],
+            "linkFrom": "replicate.experiment",
         },
     })
     def replicates(self, request, replicates):

--- a/src/encoded/views/jsonld_context.py
+++ b/src/encoded/views/jsonld_context.py
@@ -246,21 +246,23 @@ def ontology_from_schema(schema, prefix, item_type, base_types):
         if 'rdfs:subPropertyOf' in subschema:
             prop_ld['rdfs:subPropertyOf'] = aslist(subschema['rdfs:subPropertyOf'])
 
-        subschema.get('items', subschema)
+        subschema = subschema.get('items', subschema)
         if 'title' in subschema:
             prop_ld['rdfs:label'] = subschema['title']
 
         if 'description' in subschema:
             prop_ld['rdfs:comment'] = subschema['description']
 
-        linkTo = aslist(subschema.get('linkTo', []))
-        if len(linkTo) == 1:
-            linkTo, = linkTo
-            prop_ld['rdfs:range'] = term_path + linkTo
-        elif len(linkTo) > 1:
+        links = aslist(subschema.get('linkTo', []))
+        if subschema.get('linkFrom'):
+            links.append(subschema['linkFrom'].split('.')[0])
+        if len(links) == 1:
+            links, = links
+            prop_ld['rdfs:range'] = term_path + links
+        elif len(links) > 1:
             prop_ld['rdfs:range'] = {
                 '@type': 'owl:Class',
-                'owl:unionOf': [term_path + type_name for type_name in aslist(linkTo)],
+                'owl:unionOf': [term_path + type_name for type_name in aslist(links)],
             }
 
         yield prop_ld


### PR DESCRIPTION
This has the same changes as the 1794-multi-object-forms branch to allow for editing child objects in a form, but doesn't actually link to the forms for any types except page and image.