### PR TITLE
make sure user's session has a csrf token as soon as they log in

### DIFF
--- a/src/encoded/persona.py
+++ b/src/encoded/persona.py
@@ -112,6 +112,7 @@ def login(request):
         request.session['user_properties'] = {}
         request.response.headerlist.extend(forget(request))
         raise LoginDenied()
+    request.session.get_csrf_token()
     request.session['user_properties'] = embed(request, '/current-user', as_user=userid)
     request.response.headerlist.extend(remember(request, 'mailto.' + userid))
     return request.session


### PR DESCRIPTION
Make sure the user's session has a CSRF token once they've logged in. I think this fixes http://redmine.encodedcc.org/issues/2527

Although, as a side note, I'm puzzled why the /login view appears to not require a CSRF token in the browser but test_login_no_csrf in test_persona.py shows it failing without a CSRF token.