### PR TITLE
let child object fieldsets be collapsed

### DIFF
--- a/src/encoded/static/components/inputs/index.js
+++ b/src/encoded/static/components/inputs/index.js
@@ -2,4 +2,5 @@
 'use strict';
 
 var FileInput = module.exports.FileInput = require('./file');
-var ObjectPicker = module.exports.ObjectPicker = require('./object');
+var ObjectPicker = module.exports.ObjectPicker = require('./object').ObjectPicker;
+var ItemPreview = module.exports.ItemPreview = require('./object').ItemPreview;

--- a/src/encoded/static/components/inputs/object.js
+++ b/src/encoded/static/components/inputs/object.js
@@ -18,11 +18,10 @@ var SearchBlockEdit = React.createClass({
 });
 
 
-var ItemPreview = React.createClass({
+var ItemPreview = module.exports.ItemPreview = React.createClass({
     render: function() {
         var context = this.props.data['@graph'][0];
         if (context === undefined) return null;
-        var style = {width: '80%'};
         var Listing = globals.listing_views.lookup(context);
         return (
             <ul className="nav result-table">
@@ -33,7 +32,7 @@ var ItemPreview = React.createClass({
 });
 
 
-var ObjectPicker = React.createClass({
+var ObjectPicker = module.exports.ObjectPicker = React.createClass({
 
     getDefaultProps: function() {
         return {
@@ -98,6 +97,3 @@ var ObjectPicker = React.createClass({
         return false;
     }
 });
-
-
-module.exports = ObjectPicker;

--- a/src/encoded/static/components/item.js
+++ b/src/encoded/static/components/item.js
@@ -7,6 +7,7 @@ var Form = require('./form').Form;
 var globals = require('./globals');
 var LayoutType = require('./page').LayoutType;
 var Layout = require('./layout').Layout;
+var ItemPreview = require('./inputs').ItemPreview;
 var ObjectPicker = require('./inputs').ObjectPicker;
 var FileInput = require('./inputs').FileInput;
 var _ = require('underscore');
@@ -115,7 +116,14 @@ var FetchedFieldset = React.createClass({
     mixins: [ReactForms.FieldsetMixin],
 
     getInitialState: function() {
-        return {url: null};
+        var value = this.value().value;
+        var url = typeof value == 'string' ? value : null;
+        var externalValidation = this.externalValidation();
+        var failure = externalValidation.validation.failure;
+        return {
+            url: url,
+            collapsed: url && !failure,
+        };
     },
 
     render: function() {
@@ -123,37 +131,52 @@ var FetchedFieldset = React.createClass({
         var value = this.value().value;
         var externalValidation = this.externalValidation();
         var failure = externalValidation.validation.failure;
-        var url;
+        var url = typeof value == 'string' ? value : null;
+        var preview, fieldset;
+
         if (this.state.url) {
-            url = this.state.url;
-        } else if (typeof value == 'string') {
-            url = value;
-            this.setState({url: url});
-        }
-        if (url) {
-            return (
-                <div>
-                  {failure && <ReactForms.Message>{failure}</ReactForms.Message>}
-                  <fetched.FetchedData>
-                    <fetched.Param name="defaultValue" url={url + '?frame=edit'} />
-                    {this.transferPropsTo(<ReactForms.Form schema={schema} onChange={this.onChange}
-                                                           externalValidation={externalValidation} />)}
-                  </fetched.FetchedData>
-                </div>
+            var previewUrl = '/search?mode=picker&@id=' + this.state.url;
+            preview = (
+                <fetched.FetchedData>
+                    <fetched.Param name="data" url={previewUrl} />
+                    <ItemPreview />
+                </fetched.FetchedData>
+            );
+            fieldset = (
+                <fetched.FetchedData>
+                    <fetched.Param name="defaultValue" url={this.state.url + '?frame=edit'} />
+                    <ReactForms.Form schema={schema} onUpdate={this.onUpdate}
+                                     externalValidation={externalValidation} />
+                </fetched.FetchedData>
             );
         } else {
-            return (
-                <div>
-                  {failure && <ReactForms.Message>{failure}</ReactForms.Message>}
-                  {this.transferPropsTo(<ReactForms.Form
-                      defaultValue={value} schema={schema} onChange={this.onChange}
-                      externalValidation={externalValidation} />)}
-                </div>
+            preview = (
+                <ul className="nav result-table">
+                  <li>
+                    <div className="accession">{'New ' + schema.props.label}</div>
+                  </li>
+                </ul>
             );
+            fieldset = <ReactForms.Form
+                defaultValue={value} schema={schema} onUpdate={this.onUpdate}
+                externalValidation={externalValidation} />;
         }
+
+        return (
+            <div className="collapsible">
+                <span className="collapsible-trigger" onClick={this.toggleCollapsed}>{this.state.collapsed ? '▶ ' : '▼ '}</span>
+                {failure && <ReactForms.Message>{failure}</ReactForms.Message>}
+                <div style={{display: this.state.collapsed ? 'block' : 'none'}}>{preview}</div>
+                <div style={{display: this.state.collapsed ? 'none' : 'block'}}>{fieldset}</div>
+            </div>
+        );
     },
 
-    onChange: function(value) {
+    toggleCollapsed: function() {
+        this.setState({collapsed: !this.state.collapsed});
+    },
+
+    onUpdate: function(value) {
         value['@id'] = this.state.url;
         value = this.value().updateSerialized(value);
         this.onValueUpdate(value);

--- a/src/encoded/static/scss/encoded/modules/_forms.scss
+++ b/src/encoded/static/scss/encoded/modules/_forms.scss
@@ -141,3 +141,14 @@ input[type="text"], input[type="password"], input[type="date"], input[type="date
 		margin-left: 1em;
 	}
 }
+
+.collapsible {
+	padding-left: 20px;
+	position: relative;
+	.collapsible-trigger {
+		position: absolute;
+		top: 12px;
+		left: 0;
+		cursor: pointer;
+	}
+}

--- a/src/encoded/static/scss/react-forms/_index.scss
+++ b/src/encoded/static/scss/react-forms/_index.scss
@@ -91,7 +91,7 @@
   position: relative;
   border: 1px solid #ccc;
   @include border-radius($border-radius-base);
-  padding: 5px 10px;
+  padding: 5px 30px 5px 10px;
   margin-bottom: 10px;
 
   > .rf-Fieldset {


### PR DESCRIPTION
This implements http://redmine.encodedcc.org/issues/2547

Note: we're using a separate request to get the item's embedded representation and rendering it using the item's listing view. This means:
- some objects, such as characterizations, don't have a very useful collapsed view yet
- the collapsed view won't update as the form is edited

This also fixes a bug where changing a field to a value that does not pass client-side validation would not update the main form value, so submitting the form would succeed (without the change) rather than show the server validation error.