### PR TITLE
Fix graph output in IE8

### DIFF
--- a/src/encoded/static/components/graph.js
+++ b/src/encoded/static/components/graph.js
@@ -4,6 +4,7 @@ var React = require('react');
 var _ = require('underscore');
 var globals = require('./globals');
 var $script = require('scriptjs');
+var BrowserFeat = require('./mixins').BrowserFeat;
 
 
 // The JsonGraph object helps build JSON graph objects. Create a new object
@@ -144,33 +145,40 @@ var Graph = module.exports.Graph = React.createClass({
     },
 
     componentDidMount: function () {
-        globals.bindEvent(window, 'resize', this.handleResize);
+        if (BrowserFeat.getBrowserCaps('svg')) {
+            // Delay loading dagre for Jest testing compatibility;
+            // Both D3 and Jest have their own conflicting JSDOM instances
+            $script('dagre', function() {
+                var d3 = require('d3');
+                var dagreD3 = require('dagre-d3');
+                var el = this.refs.graphdisplay.getDOMNode();
+                this.dagreLoaded = true;
 
-        // Delay loading dagre for Jest testing compatibility;
-        // Both D3 and Jest have their own conflicting JSDOM instances
-        $script('dagre', function() {
-            var d3 = require('d3');
-            var dagreD3 = require('dagre-d3');
-            var el = this.refs.graphdisplay.getDOMNode();
-            this.dagreLoaded = true;
+                // Add SVG element to the graph component, and assign it classes, sizes, and a group
+                var svg = d3.select(el).insert('svg', '#graph-node-info')
+                    .attr('id', 'graphsvg')
+                    .attr('preserveAspectRatio', 'xMidYMid');
+                var svgGroup = svg.append("g");
 
-            // Add SVG element to the graph component, and assign it classes, sizes, and a group
-            var svg = d3.select(el).insert('svg', '#graph-node-info')
-                .attr('id', 'graphsvg')
-                .attr('preserveAspectRatio', 'xMidYMid');
-            var svgGroup = svg.append("g");
+                // Draw the graph into the panel
+                this.drawGraph(el);
 
-            // Draw the graph into the panel
-            this.drawGraph(el);
-
-            // Add click event listeners to each node rendering. Node's ID is its ENCODE object ID
-            var reactThis = this;
-            svg.selectAll("g.node").each(function(nodeId) {
-                globals.bindEvent(this, 'click', function(e) {
-                    reactThis.props.nodeClickHandler(e, nodeId);
+                // Add click event listeners to each node rendering. Node's ID is its ENCODE object ID
+                var reactThis = this;
+                svg.selectAll("g.node").each(function(nodeId) {
+                    globals.bindEvent(this, 'click', function(e) {
+                        reactThis.props.nodeClickHandler(e, nodeId);
+                    });
                 });
-            });
-        }.bind(this));
+            }.bind(this));
+        } else {
+            // Output text indicating that graphs aren't supported.
+            var el = this.refs.graphdisplay.getDOMNode();
+            var para = document.createElement('p');
+            para.className = 'browser-error';
+            para.innerHTML = 'Graphs not supported in your browser. You need a more modern browser to view it.';
+            el.appendChild(para);
+        }
     },
 
     // State change; redraw the graph
@@ -371,7 +379,7 @@ var ExperimentGraph = module.exports.ExperimentGraph = React.createClass({
                         });
 
                         var step = selectedStep.analysis_step;
-                        return (
+                        meta = (
                             <div>
                                 <dl className="key-value">
                                     <div data-test="steptype">

--- a/src/encoded/static/components/mixins.js
+++ b/src/encoded/static/components/mixins.js
@@ -646,11 +646,11 @@ module.exports.BrowserFeat = {
     feat: {},
 
     // Return object with browser capabilities; return from cache if available
-    getBrowserCaps: function () {
+    getBrowserCaps: function (feat) {
         if (Object.keys(this.feat).length === 0) {
             this.feat.svg = document.implementation.hasFeature('http://www.w3.org/TR/SVG11/feature#Image', '1.1');
         }
-        return this.feat;
+        return feat ? this.feat[feat] : this.feat;
     },
 
     setHtmlFeatClass: function() {

--- a/src/encoded/static/scss/encoded/_base.scss
+++ b/src/encoded/static/scss/encoded/_base.scss
@@ -52,3 +52,8 @@ figure {
     -moz-box-sizing: border-box;
     box-sizing: border-box;
 }
+
+.browser-error {
+    margin: 10px;
+    text-align: center;
+}


### PR DESCRIPTION
If SVG isn’t available in the current browser, output an error message instead of attempting to render a graph. Mostly applies to IE8. A couple other minor fixes internal fixes as well.