### PR TITLE
issue 2664 - fix object picker links in forms

### DIFF
--- a/src/encoded/static/components/audit.js
+++ b/src/encoded/static/components/audit.js
@@ -23,7 +23,8 @@ var AuditMixin = module.exports.AuditMixin = {
     },
 
     // React to click in audit indicator. Set state to clicked indicator's error level
-    auditStateToggle: function() {
+    auditStateToggle: function(e) {
+        e.preventDefault();
         this.setState({auditDetailOpen: !this.state.auditDetailOpen});
     }
 };

--- a/src/encoded/static/components/inputs/object.js
+++ b/src/encoded/static/components/inputs/object.js
@@ -6,11 +6,26 @@ var fetched = require('../fetched');
 var ResultTable = require('../search').ResultTable;
 
 
+var openLinksInNewWindow = function(e) {
+    if (e.isDefaultPrevented()) return;
+
+    // intercept links and open in new tab
+    var target = event.target;
+    while (target && (target.tagName.toLowerCase() != 'a')) {
+        target = target.parentElement;
+    }
+    if (!target) return;
+
+    e.preventDefault();
+    window.open(target.getAttribute('href'), '_blank');
+};
+
+
 var SearchBlockEdit = React.createClass({
     render: function() {
         var styles = {maxHeight: 300, overflow: 'scroll', clear: 'both' };
         return (
-            <div className="well" style={styles}>
+            <div className="well" style={styles} onClick={openLinksInNewWindow}>
                 {this.transferPropsTo(<ResultTable mode="picker" />)}
             </div>
         );
@@ -24,7 +39,7 @@ var ItemPreview = module.exports.ItemPreview = React.createClass({
         if (context === undefined) return null;
         var Listing = globals.listing_views.lookup(context);
         return (
-            <ul className="nav result-table">
+            <ul className="nav result-table" onClick={openLinksInNewWindow}>
                 <Listing context={context} columns={this.props.data.columns} key={context['@id']} />
             </ul>
         );


### PR DESCRIPTION
- call preventDefault for click on audit toggle button so it doesn't trigger a form submit when it's in a form
- intercept clicks on links in the object picker and open them in a new window