### PR TITLE
check to make sure bdd steps are found during test collection

### DIFF
--- a/src/encoded/tests/bdd.py
+++ b/src/encoded/tests/bdd.py
@@ -431,6 +431,12 @@ class Scenario(FixtureRequestMixin, pytest.Collector):
 
     def collect(self):
         for step in self.scenario:
+            match = self.runner.step_registry.find_match(step)
+            if match is None:
+                raise Exception(
+                    'Failed to match step "{} {}" at {} line {}'.format(
+                        step.keyword, step.name, step.location.filename, step.location.line,
+                        ))
             yield Step(step, self)
 
     def setup(self):


### PR DESCRIPTION
This avoids having to wait for data to load and the browser to start up, then wrinkling your nose in confusion at why some tests were skipped, if you typed "is" instead of "should be"