### PR TITLE
Preparing read_length for migration

### DIFF
--- a/src/encoded/audit/experiment.py
+++ b/src/encoded/audit/experiment.py
@@ -303,37 +303,6 @@ def audit_experiment_ChIP_control(value, system):
             raise AuditFailure('missing input control', detail, level='NOT_COMPLIANT')
 
 
-@audit_checker('experiment', frame=['replicates'], condition=rfa('ENCODE3', 'FlyWormChIP'))
-def audit_experiment_readlength(value, system):
-    '''
-    All ENCODE 3 experiments of sequencing type should specify their read_length
-    Read-lengths should likely match across replicates
-    Other rfas likely should have warning
-    '''
-
-    if value['status'] in ['deleted', 'replaced']:
-        return
-
-    if value.get('assay_term_name') not in seq_assays:
-        return
-
-    read_lengths = []
-
-    for i in range(len(value['replicates'])):
-        rep = value['replicates'][i]
-        read_length = rep.get('read_length')
-        read_lengths.append(read_length)
-
-        if read_length is None:
-            detail = 'Replicate {} requires a value for read_length'.format(rep['uuid'])
-            yield AuditFailure('missing read_length', detail, level='ERROR')
-
-    if len(set(read_lengths)) > 1:
-        list_of_lens = str(read_lengths)
-        detail = '{} has mixed values for read_length between replicates: {}'.format(value['accession'], list_of_lens)
-        yield AuditFailure('mismatched read_length', detail, level='WARNING')
-
-
 @audit_checker('experiment', frame=['files','files.platform'])
 def audit_experiment_platform(value, system):
     '''

--- a/src/encoded/audit/file.py
+++ b/src/encoded/audit/file.py
@@ -58,6 +58,23 @@ def audit_file_platform(value, system):
         raise AuditFailure('missing platform', detail, level='ERROR')
 
 
+@audit_checker('file', frame='object')
+def audit_file_read_length(value, system):
+    '''
+    A fastq file should have a read_length
+    '''
+
+    if value['status'] in ['deleted', 'replaced']:
+        return
+
+    if value['file_format'] not in ['fastq']:
+        return
+
+    if 'read_length' not in value:
+        detail = 'Fastq file {} missing read_length'.format(value['accession'])
+        raise AuditFailure('missing read_length', detail, level='DCC_ACTION')
+
+
 @audit_checker('file',
                frame=['dataset', 'dataset.target', 'controlled_by',
                       'controlled_by.dataset'],

--- a/src/encoded/schemas/file.json
+++ b/src/encoded/schemas/file.json
@@ -162,6 +162,11 @@
             "type": "string",
             "linkTo": "platform"
         },
+        "read_length": {
+            "title": "Read length",
+            "description": "For high-throughput sequencing, the number of contiguous nucleotides determined by sequencing.",
+            "type": "integer"
+        },
         "flowcell_details": {
             "title": "Flowcells",
             "description": "For high-throughput sequencing, the flowcells used for the sequencing of the replicate.",

--- a/src/encoded/schemas/replicate.json
+++ b/src/encoded/schemas/replicate.json
@@ -18,9 +18,7 @@
     ],
     "dependencies": {
         "rbns_protein_concentration": ["rbns_protein_concentration_units"],
-        "rbns_protein_concentration_units": ["rbns_protein_concentration"],
-        "read_length": ["read_length_units"],
-        "read_length_units": ["read_length"]
+        "rbns_protein_concentration_units": ["rbns_protein_concentration"]
     },
     "properties": {
         "schema_version": {

--- a/src/encoded/tests/test_audit_experiment.py
+++ b/src/encoded/tests/test_audit_experiment.py
@@ -209,15 +209,6 @@ def test_audit_experiment_target(testapp, base_experiment):
     assert any(error['category'] == 'missing target' for error in errors_list)
 
 
-def test_audit_experiment_replicate_read_length(testapp, base_experiment, base_replicate):
-    testapp.patch_json(base_experiment['@id'], {'assay_term_id': 'OBI:0000716', 'assay_term_name': 'ChIP-seq'})
-    res = testapp.get(base_experiment['@id'] + '@@index-data')
-    errors = res.json['audit']
-    errors_list = []
-    for error_type in errors:
-        errors_list.extend(errors[error_type])
-    assert any(error['category'] == 'missing read_length' for error in errors_list)
-
 def test_audit_experiment_library_paired_end(testapp, base_experiment, base_replicate, base_library):
     testapp.patch_json(base_replicate['@id'], {'library': base_library['@id']})
     res = testapp.get(base_experiment['@id'] + '@@index-data')

--- a/src/encoded/tests/test_audit_file.py
+++ b/src/encoded/tests/test_audit_file.py
@@ -117,6 +117,15 @@ def test_audit_file_size(testapp, file1):
     assert any(error['category'] == 'missing file_size' for error in errors_list)
 
 
+def test_audit_read_length(testapp, file1):
+    res = testapp.get(file1['@id'] + '@@index-data')
+    errors = res.json['audit']
+    errors_list = []
+    for error_type in errors:
+        errors_list.extend(errors[error_type])
+    assert any(error['category'] == 'missing read_length' for error in errors_list)
+
+
 def test_audit_file_missing_controlled_by(testapp, file3):
     res = testapp.get(file3['@id'] + '@@index-data')
     errors = res.json['audit']

--- a/src/encoded/types/file.py
+++ b/src/encoded/types/file.py
@@ -131,6 +131,17 @@ class File(Item):
         return self.propsheets['external']['upload_credentials']
 
     @calculated_property(schema={
+        "title": "Read length units",
+        "type": "string",
+        "enum": [
+            "nt"
+        ]
+        })
+    def read_length_units(self, read_length=None):
+        if read_length is not None:
+            return "nt"
+
+    @calculated_property(schema={
         "title": "Pipeline",
         "type": "string",
         "linkTo": "pipeline"


### PR DESCRIPTION
This is establishing read_length in the file without taking it out of the replicate.  That part will happen in the large upgrade.