### PR TITLE
2910 Fix IE8 JS crash

### DIFF
--- a/src/encoded/static/components/browserfeat.js
+++ b/src/encoded/static/components/browserfeat.js
@@ -14,7 +14,7 @@ module.exports.BrowserFeat = {
             })();
             this.feat.todataurlpng = (function() {
                 var canvas = document.createElement('canvas');
-                return !!canvas && canvas.toDataURL('image/png').indexOf('data:image/png') === 0;
+                return !!(canvas && canvas.toDataURL && canvas.toDataURL('image/png').indexOf('data:image/png') === 0);
             })();
 
             // UA checks; should be retired as soon as possible


### PR DESCRIPTION
My test for the existence of canvas assumed too much, and caused an IE8 crash. This fix removes that assumption, and IE8 passes without crashing.