### PR TITLE
Split output_type display to different lines

### DIFF
--- a/src/encoded/static/components/pipeline.js
+++ b/src/encoded/static/components/pipeline.js
@@ -272,7 +272,14 @@ var StepDetailView = module.exports.StepDetailView = function(node) {
                     {selectedStep.output_file_types && selectedStep.output_file_types.length ?
                         <div data-test="outputtypes">
                             <dt>Output file types</dt>
-                            <dd>{selectedStep.output_file_types.join(', ')}</dd>
+                            <dd>{selectedStep.output_file_types.map(function(type, i) {
+                                return (
+                                    <span>
+                                        {i > 0 ? <span>{','}<br /></span> : null}
+                                        {type}
+                                    </span>
+                                );
+                            })}</dd>
                         </div>
                     : null}
 


### PR DESCRIPTION
Clicking a step with multiple output types now shows each one on its own line instead of all on one, concatenated by commas. This is a suggestion by Brian Lee on Ticket #2770.