### PR TITLE
handle boolean type in schema-based forms

### DIFF
--- a/src/encoded/static/components/item.js
+++ b/src/encoded/static/components/item.js
@@ -257,6 +257,9 @@ var jsonSchemaToFormSchema = function(attrs) {
     } else if (p.type == 'array') {
         props.component = <ReactForms.RepeatingFieldset className={props.required ? "required" : ""} item={RepeatingItem} />;
         return ReactForms.schema.List(props, jsonSchemaToFormSchema({schemas: schemas, jsonNode: p.items}));
+    } else if (p.type == 'boolean') {
+        props.type = 'bool';
+        return ReactForms.schema.Scalar(props);
     } else {
         if (props.required) props.component = <ReactForms.Field className="required" />;
         if (p.pattern) {


### PR DESCRIPTION
This fixes issue 2950

The travis failure on python 2.7 is the same as the one on master where this was branched from.