### PR TITLE
Categorize missing output_types 

### DIFF
--- a/src/encoded/schemas/file.json
+++ b/src/encoded/schemas/file.json
@@ -539,9 +539,11 @@
     "output_type_output_category": {
         "idat green channel": "raw data",
         "idat red channel": "raw data",
+        "intensity values": "raw data",
         "reads": "raw data",
         "rejected reads": "raw data",
         "raw data": "raw data",
+        "reporter code counts": "raw data",
 
         "alignments": "alignment",
         "transcriptome alignments": "alignment",
@@ -605,6 +607,7 @@
         "predicted whole brain enhancers": "annotation",
         "predicted enhancers": "annotation",
         "predicted transcription start sites": "annotation",
+        "transcription start sites": "annotation",
                 
         "genome index": "reference",
         "genome reference": "reference",


### PR DESCRIPTION
reporter code counts, intensity values and transcription start sites.

I think that I inherited the Travis failure from master so I am just going to make the pull request and see what laurence thinks