### PR TITLE
Added audit for paired-end run_type without paired_with

### DIFF
--- a/src/encoded/audit/file.py
+++ b/src/encoded/audit/file.py
@@ -248,7 +248,8 @@ def audit_file_paired_ended_run_type(value, system):
     '''
     Audit to catch those files that were upgraded to have run_type = paired ended
     resulting from its migration out of replicate but lack the paired_end property
-    to specify which read it is
+    to specify which read it is. This audit will also catch the case where run_type
+    = paired-ended but there is no paired_end = 2 due to registeration error.
     '''
 
     if value['status'] in ['deleted', 'replaced', 'revoked', 'upload failed']:
@@ -262,3 +263,8 @@ def audit_file_paired_ended_run_type(value, system):
             detail = 'File {} has a paired-ended run_type but is missing its paired_end value'.format(
                 value['@id'])
             raise AuditFailure('missing paired_end', detail, level='DCC_ACTION')
+
+        if (value['paired_end'] == 1) and 'paired_with' not in value:
+            detail = 'File {} has a paired-ended run_type but is missing a paired_end=2 mate'.format(
+                value['@id'])
+            raise AuditFailure('missing mate pair', detail, level='DCC_ACTION')    

--- a/src/encoded/tests/test_audit_file.py
+++ b/src/encoded/tests/test_audit_file.py
@@ -169,7 +169,7 @@ def test_audit_file_replicate_match(testapp, file1, file_rep2):
     assert any(error['category'] == 'mismatched replicate' for error in errors_list)
 
 
-def test_audit_file_paired_ended_run_type(testapp, file2, file_rep2):
+def test_audit_file_paired_ended_run_type1(testapp, file2, file_rep2):
     testapp.patch_json(file_rep2['@id'], {'paired_ended': True})
     testapp.patch_json(file2['@id'] + '?validate=false', {'run_type': 'paired-ended', 'output_type': 'reads', 'file_size': 23498234})
     res = testapp.get(file2['@id'] + '@@index-data')
@@ -178,3 +178,14 @@ def test_audit_file_paired_ended_run_type(testapp, file2, file_rep2):
     for error_type in errors:
         errors_list.extend(errors[error_type])
     assert any(error['category'] == 'missing paired_end' for error in errors_list)
+
+
+def test_audit_file_paired_ended_run_type2(testapp, file2, file_rep2):
+    testapp.patch_json(file_rep2['@id'], {'paired_ended': False})
+    testapp.patch_json(file2['@id'] + '?validate=false', {'run_type': 'paired-ended', 'output_type': 'reads', 'file_size': 23498234, 'paired_end': 1})
+    res = testapp.get(file2['@id'] + '@@index-data')
+    errors = res.json['audit']
+    errors_list = []
+    for error_type in errors:
+        errors_list.extend(errors[error_type])
+    assert any(error['category'] == 'missing mate pair' for error in errors_list)


### PR DESCRIPTION
Added an additional file audit as per request in #2948-5