### PR TITLE
2964 Downloaded graphs have black nodes

### DIFF
--- a/src/encoded/static/scss/encoded/modules/_pipeline.scss
+++ b/src/encoded/static/scss/encoded/modules/_pipeline.scss
@@ -5,7 +5,7 @@ $pipeline-node-types:
 
 @each $node-type, $color in $pipeline-node-types {
     // Audit icons
-    .pipeline-node-#{$node-type} {
+    g.pipeline-node-#{$node-type} {
         font-size: 14px;
         font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
         font-weight: bold;


### PR DESCRIPTION
This is a low-risk change involving one character in an SCSS file, so it’d be great to get it into Release 26 if possible.