### PR TITLE
2990 Hard code titles in search result pages

### DIFF
--- a/src/encoded/static/components/publication.js
+++ b/src/encoded/static/components/publication.js
@@ -164,8 +164,6 @@ var SupplementaryDataListing = React.createClass({
 
     render: function() {
         var data = this.props.data;
-        var columns = this.props.columns;
-
         var summary = data.data_summary;
         var excerpt = (summary && (summary.length > 100) ? globals.truncateString(summary, 100) : undefined);
 
@@ -175,20 +173,20 @@ var SupplementaryDataListing = React.createClass({
         return (
             <div className="list-supplementary" key={this.props.key}>
                 {data.supplementary_data_type ?
-                    <span><strong>{columns['supplementary_data.supplementary_data_type']['title']}</strong>: {data.supplementary_data_type}<br /></span>
+                    <div><strong>Available supplemental data: </strong>{data.supplementary_data_type}</div>
                 : null}
 
                 {data.file_format ?
-                    <span><strong>{columns['supplementary_data.file_format']['title']}</strong>: {data.file_format}<br /></span>
+                    <div><strong>File format: </strong>{data.file_format}</div>
                 : null}
 
                 {data.url ?
-                    <span><strong>{columns['supplementary_data.url']['title']}</strong>: <a href={data.url}>{data.url}</a><br /></span>
+                    <div><strong>URL: </strong><a href={data.url}>{data.url}</a></div>
                 : null}
 
                 {summary ?
                     <span id={nodeId} aria-expanded={excerpt ? this.state.excerptExpanded : true}>
-                        <strong>{columns['supplementary_data.data_summary']['title']}</strong>: {excerpt ?
+                        <strong>Data summary: </strong>{excerpt ?
                             <span>
                                 {this.state.excerptExpanded ? summary : excerpt}
                                 <button className="btn btn-link" aria-controls={nodeId} onClick={this.handleClick}>
@@ -208,7 +206,6 @@ var Listing = React.createClass({
     mixins: [search.PickerActionsMixin, AuditMixin],
     render: function() {
         var result = this.props.context;
-        var columns = this.props.columns;
         var authorList = result.authors && result.authors.length ? result.authors.split(', ', 4) : [];
         var authors = authorList.length === 4 ? authorList.splice(0, 3).join(', ') + ', et al' : result.authors;
 
@@ -229,7 +226,7 @@ var Listing = React.createClass({
                         {result.supplementary_data && result.supplementary_data.length ?
                             <div>
                                 {result.supplementary_data.map(function(data, i) {
-                                    return <SupplementaryDataListing data={data} columns={columns} id={result['@id']} key={i} />;
+                                    return <SupplementaryDataListing data={data} id={result['@id']} key={i} />;
                                 })}
                             </div>
                         : null}

--- a/src/encoded/static/components/search.js
+++ b/src/encoded/static/components/search.js
@@ -174,7 +174,6 @@ var AuditMixin = audit.AuditMixin;
         mixins: [PickerActionsMixin, AuditMixin],
         render: function() {
             var result = this.props.context;
-            var columns = this.props.columns;
 
             // Sort the lot reviews by their status according to our predefined order
             // given in the statusOrder array.
@@ -230,8 +229,8 @@ var AuditMixin = audit.AuditMixin;
                             })}
                         </div>
                         <div className="data-row">
-                            <strong>{columns['source.title']['title']}</strong>: {result.source.title}<br />
-                            <strong>{columns.product_id.title}/{columns.lot_id.title}</strong>: {result.product_id} / {result.lot_id}<br />
+                            <div><strong>Source: </strong>{result.source.title}</div>
+                            <div><strong>Product ID / Lot ID: </strong>{result.product_id} / {result.lot_id}</div>
                         </div>
                     </div>
                     <AuditDetail context={result} id={this.props.context['@id']} forcedEditLink />
@@ -245,7 +244,6 @@ var AuditMixin = audit.AuditMixin;
         mixins: [PickerActionsMixin, AuditMixin],
         render: function() {
             var result = this.props.context;
-            var columns = this.props.columns;
             var lifeStage = (result['life_stage'] && result['life_stage'] != 'unknown') ? ' ' + result['life_stage'] : '';
             var age = (result['age'] && result['age'] != 'unknown') ? ' ' + result['age'] : '';
             var ageUnits = (result['age_units'] && result['age_units'] != 'unknown' && age) ? ' ' + result['age_units'] : '';
@@ -287,50 +285,15 @@ var AuditMixin = audit.AuditMixin;
                             </a>
                         </div>
                         <div className="data-row">
-                            <div><strong>{columns['biosample_type']['title']}</strong>: {result['biosample_type']}</div>
-                            {rnais ?
-                                <div>
-                                    <strong>{columns['rnais.target.label']['title'] + ': '}</strong>
-                                    {rnais}
-                                </div>
-                            : null}
-                            {constructs ?
-                                <div>
-                                    <strong>{columns['constructs.target.label']['title'] + ': '}</strong>
-                                    {constructs}
-                                </div>
-                            : null}
-                            {treatment ?
-                                <div>
-                                    <strong>{columns['treatments.treatment_term_name']['title'] + ': '}</strong>
-                                    {treatment}
-                                </div>
-                            : null}
-                            {mutatedGenes ?
-                                <div>
-                                    <strong>{columns['donor.mutated_gene.label']['title'] + ': '}</strong>
-                                    {mutatedGenes}
-                                </div>
-                            : null}
-                            {result.culture_harvest_date ?
-                                <div>
-                                    <strong>{columns['culture_harvest_date']['title'] + ': '}</strong>
-                                    {result.culture_harvest_date}
-                                </div>
-                            : null}
-                            {result.date_obtained ?
-                                <div>
-                                    <strong>{columns['date_obtained']['title'] + ': '}</strong>
-                                    {result.date_obtained}
-                                </div>
-                            : null}
-                            {synchText ?
-                                <div>
-                                    <strong>Synchronization timepoint: </strong>
-                                    {synchText}
-                                </div>
-                            : null}
-                            <div><strong>{columns['source.title']['title']}</strong>: {result.source.title}</div>
+                            <div><strong>Type: </strong>{result['biosample_type']}</div>
+                            {rnais ?<div><strong>RNAi target: </strong>{rnais}</div> : null}
+                            {constructs ? <div><strong>Construct: </strong>{constructs}</div> : null}
+                            {treatment ? <div><strong>Treatment: </strong>{treatment}</div> : null}
+                            {mutatedGenes ? <div><strong>Mutated gene: </strong>{mutatedGenes}</div> : null}
+                            {result.culture_harvest_date ? <div><strong>Culture harvest date: </strong>{result.culture_harvest_date}</div> : null}
+                            {result.date_obtained ? <div><strong>Date obtained: </strong>{result.date_obtained}</div> : null}
+                            {synchText ? <div><strong>Synchronization timepoint: </strong>{synchText}</div> : null}
+                            <div><strong>Source: </strong>{result.source.title}</div>
                         </div>
                     </div>
                     <AuditDetail context={result} id={this.props.context['@id']} forcedEditLink />
@@ -345,7 +308,6 @@ var AuditMixin = audit.AuditMixin;
         mixins: [PickerActionsMixin, AuditMixin],
         render: function() {
             var result = this.props.context;
-            var columns = this.props.columns;
 
             // Make array of scientific names from replicates; remove all duplicates
             var names = _.uniq(result.replicates.map(function(replicate) {
@@ -417,25 +379,19 @@ var AuditMixin = audit.AuditMixin;
                         </div>
                         <div className="data-row">
                             {result.target && result.target.label ?
-                                <div>
-                                    <strong>{columns['target.label']['title'] + ': '}</strong>
-                                    {result.target.label}
-                                </div>
+                                <div><strong>Target: </strong>{result.target.label}</div>
                             : null}
+
                             {treatment ?
-                                <div>
-                                    <strong>{columns['replicates.library.biosample.treatments.treatment_term_name']['title'] + ': '}</strong>
-                                    {treatment}
-                                </div>
+                                <div><strong>Treatment: </strong>{treatment}</div>
                             : null}
+
                             {synchronizations && synchronizations.length ?
-                                <div>
-                                    <strong>Synchronization timepoint: </strong>
-                                    {synchronizations.join(', ')}
-                                </div>
+                                <div><strong>Synchronization timepoint: </strong>{synchronizations.join(', ')}</div>
                             : null}
-                            <div><strong>{columns['lab.title']['title']}</strong>: {result.lab.title}</div>
-                            <div><strong>{columns['award.project']['title']}</strong>: {result.award.project}</div>
+
+                            <div><strong>Lab: </strong>{result.lab.title}</div>
+                            <div><strong>Project: </strong>{result.award.project}</div>
                         </div>
                     </div>
                     <AuditDetail context={result} id={this.props.context['@id']} forcedEditLink />
@@ -449,7 +405,6 @@ var AuditMixin = audit.AuditMixin;
         mixins: [PickerActionsMixin, AuditMixin],
         render: function() {
             var result = this.props.context;
-            var columns = this.props.columns;
             return (
                 <li>
                     <div className="clearfix">
@@ -463,14 +418,9 @@ var AuditMixin = audit.AuditMixin;
                             <a href={result['@id']}>{result['description']}</a>
                         </div>
                         <div className="data-row">
-                            {result['dataset_type'] ?
-                                <div>
-                                    <strong>{columns['dataset_type']['title'] + ': '}</strong>
-                                    {result['dataset_type']}
-                                </div>
-                            : null}
-                            <strong>{columns['lab.title']['title']}</strong>: {result.lab.title}<br />
-                            <strong>{columns['award.project']['title']}</strong>: {result.award.project}
+                            {result['dataset_type'] ? <div><strong>Dataset type: </strong>{result['dataset_type']}</div> : null}
+                            <div><strong>Lab: </strong>{result.lab.title}</div>
+                            <div><strong>Project: </strong>{result.award.project}</div>
                         </div>
                     </div>
                     <AuditDetail context={result} id={this.props.context['@id']} forcedEditLink />
@@ -484,7 +434,6 @@ var AuditMixin = audit.AuditMixin;
         mixins: [PickerActionsMixin, AuditMixin],
         render: function() {
             var result = this.props.context;
-            var columns = this.props.columns;
             return (
                 <li>
                     <div className="clearfix">
@@ -500,10 +449,10 @@ var AuditMixin = audit.AuditMixin;
                             </a>
                         </div>
                         <div className="data-row">
-                            <strong>{columns['dbxref']['title']}</strong>:
+                            <strong>External resources: </strong>
                             {result.dbxref && result.dbxref.length ?
                                 <DbxrefList values={result.dbxref} target_gene={result.gene_name} />
-                                : <em> None submitted</em> }
+                            : <em>None submitted</em> }
                         </div>
                     </div>
                     <AuditDetail context={result} id={this.props.context['@id']} forcedEditLink />


### PR DESCRIPTION
Hard codes item titles on search result pages instead of using the ones in the columns array. Covers antibodies, biosamples, experiments, targets, datasets, publications, and software; and I’ve made the corresponding changes to the 2975-pipeline-search branch which has titles for pipeline search results.

I guess this can go into Release 27? If you think the changes are fine, you can set the target version of 2990.