### PR TITLE
Fix blockquote style

### DIFF
--- a/src/encoded/static/scss/encoded/_base.scss
+++ b/src/encoded/static/scss/encoded/_base.scss
@@ -86,6 +86,9 @@ h4, .h4 { @include font-size(1.3); }
 h5, .h5 { @include font-size(1); }
 h6, .h6 { @include font-size(0.85); }
 
+blockquote {
+    @include font-size(1);
+}
 
 .repl-acc {
     margin: -5px 0 15px;


### PR DESCRIPTION
For Release 27: blockquote Sizing was too large. Now setting explicitly to the same size as paragraphs.