### PR TITLE
Update experiment graph file details

### DIFF
--- a/src/encoded/static/components/experiment.js
+++ b/src/encoded/static/components/experiment.js
@@ -987,7 +987,7 @@ var FileDetailView = function(node) {
                 {selectedFile.file_format ?
                     <div data-test="format">
                         <dt>Format</dt>
-                        <dd>{selectedFile.file_format}</dd>
+                        <dd>{selectedFile.file_type}</dd>
                     </div>
                 : null}
 


### PR DESCRIPTION
Now show file_type on Format line instead of file_format.