### PR TITLE
Update pipeline.status with replaced

### DIFF
--- a/src/encoded/schemas/pipeline.json
+++ b/src/encoded/schemas/pipeline.json
@@ -37,6 +37,7 @@
             "default": "in progress",
             "enum": [
                 "in progress",
+                "replaced",
                 "deleted",
                 "archived",
                 "active"


### PR DESCRIPTION
I know that I have been on the arguing side of removing the accessions.  BUT if we are not removing the accessions, I strongly believe that we need replaced.  We have alternate_accessions but I cannot use them.