### PR TITLE
2747: better UI for object picker input

### DIFF
--- a/src/encoded/search.py
+++ b/src/encoded/search.py
@@ -84,7 +84,7 @@ def get_search_fields(request, doc_types):
     """
     Returns set of columns that are being searched and highlights
     """
-    fields = set()
+    fields = {'uuid'}
     highlights = {}
     for doc_type in (doc_types or request.root.by_item_type.keys()):
         collection = request.root[doc_type]

--- a/src/encoded/static/components/inputs/object.js
+++ b/src/encoded/static/components/inputs/object.js
@@ -28,7 +28,12 @@ var SearchBlockEdit = React.createClass({
                 <ResultTable {...this.props} mode="picker" />
             </div>
         );
-    }
+    },
+
+    componentDidMount: function() {
+        // focus the first "Select" button in the search results
+        this.getDOMNode().querySelector('button.btn-primary').focus();
+    },
 });
 
 
@@ -39,7 +44,7 @@ var ItemPreview = module.exports.ItemPreview = React.createClass({
         var Listing = globals.listing_views.lookup(context);
         return (
             <ul className="nav result-table" onClick={openLinksInNewWindow}>
-                <Listing context={context} columns={this.props.data.columns} key={context['@id']} />
+                <Listing context={context} columns={undefined} key={context['@id']} />
             </ul>
         );
     }
@@ -58,8 +63,16 @@ var ObjectPicker = module.exports.ObjectPicker = React.createClass({
     getInitialState: function() {
         return {
             browsing: false,
-            search: this.props.searchBase
+            search: '',
         };
+    },
+
+    componentDidUpdate: function(prevProps, prevState) {
+        if (!this.props.value && !this.state.searchInput && this.state.searchInput != prevState.searchInput) {
+            this.refs.input.getDOMNode().focus();
+        } else if (this.props.value != prevProps.value) {
+            this.refs.clear.getDOMNode().focus();
+        }
     },
 
     render: function() {
@@ -69,26 +82,52 @@ var ObjectPicker = module.exports.ObjectPicker = React.createClass({
         var actions = [
             <button className="btn btn-primary" onClick={this.handleSelect}>Select</button>
         ];
+        var searchParams = this.state.searchParams || this.props.searchBase;
+        if (this.state.search) {
+            searchParams += '&searchTerm=' + encodeURIComponent(this.state.search);
+        }
         return (
             <div className="item-picker">
-                <button className="btn btn-primary pull-right" onClick={this.handleBrowse}>Browse&hellip;</button>
-                <div className="item-picker-preview">
-                    {url ? <a className="clear" href="#" onClick={this.handleClear}><i className="icon icon-times"></i></a> : ''}
+                <div className="item-picker-preview" style={{display: 'inline-block', width: 'calc(100% - 120px)'}}>
                     {url ?
                         <fetched.FetchedData>
                             <fetched.Param name="data" url={previewUrl} />
                             <ItemPreview {...this.props} />
                         </fetched.FetchedData> : ''}
+                    {!url ? <input value={this.state.searchInput} ref="input" type="text"
+                                   placeholder="Enter a search term (accession, uuid, alias, ...)"
+                                   onChange={this.handleInput} onBlur={this.handleSearch} onKeyDown={this.handleInput} /> : ''}
+                    {this.state.error ? <div className="alert alert-danger">{this.state.error}</div> : ''}
+                </div>
+                <div className="pull-right">
+                    <a className="clear" href="#" ref="clear" onClick={this.handleClear}><i className="icon icon-times"></i></a>
+                    {' '}<button className={"btn btn-primary" + (this.state.browsing ? ' active' : '')} onClick={this.handleBrowse}>Browse&hellip;</button>
                 </div>
                 {this.state.browsing ? 
                     <fetched.FetchedData>
-                        <fetched.Param name="context" url={searchUrl} />
+                        <fetched.Param name="context" url={'/search/' + searchParams} />
                         <SearchBlockEdit
-                            searchBase={this.state.search} restrictions={this.props.restrictions}
+                            searchBase={searchParams} restrictions={this.props.restrictions}
+                            hideTextFilter={!url}
                             actions={actions} onChange={this.handleFilter} />
                     </fetched.FetchedData> : ''}
             </div>
         );
+    },
+
+    handleInput: function(e) {
+        if (e.keyCode == 13) {
+            e.preventDefault();
+            this.handleSearch();
+        }
+        this.setState({searchInput: e.target.value});
+    },
+
+    handleSearch: function(e) {
+        if (this.state.searchInput) {
+            this.setState({search: this.state.searchInput, browsing: true});
+        }
+        this.props.onBlur();
     },
 
     handleBrowse: function(e) {
@@ -97,17 +136,19 @@ var ObjectPicker = module.exports.ObjectPicker = React.createClass({
     },
 
     handleFilter: function(href) {
-        this.setState({search: href});
+        this.setState({searchParams: href});
     },
 
     handleSelect: function(e) {
         var value = e.currentTarget.id;
-        this.setState({browsing: false});
+        this.setState({browsing: false, searchInput: null, search: ''});
         this.props.onChange(value);
     },
 
     handleClear: function(e) {
-        this.props.onChange("");
+        this.props.onBlur();
+        this.props.onChange(null);
+        this.setState({browsing: false, searchInput: '', search: '', searchParams: null});
         e.preventDefault();
     }
 });

--- a/src/encoded/static/components/search.js
+++ b/src/encoded/static/components/search.js
@@ -695,7 +695,7 @@ var AuditMixin = audit.AuditMixin;
             }
             return (
                 <div className="box facets">
-                    {this.props.mode === 'picker' ? <TextFilter {...this.props} filters={filters} /> : ''}
+                    {this.props.mode === 'picker' && !this.props.hideTextFilter ? <TextFilter {...this.props} filters={filters} /> : ''}
                     {facets.map(function (facet) {
                         if (hideTypes && facet.field == 'type') {
                             return <span key={facet.field} />;
@@ -808,10 +808,10 @@ var AuditMixin = audit.AuditMixin;
             return (
                     <div>
                         <div className="row">
-                            <div className="col-sm-5 col-md-4 col-lg-3">
+                            {facets.length ? <div className="col-sm-5 col-md-4 col-lg-3">
                                 <FacetList {...this.props} facets={facets} filters={filters}
                                            searchBase={searchBase ? searchBase + '&' : searchBase + '?'} onFilter={this.onFilter} />
-                            </div>
+                            </div> : ''}
                             <div className="col-sm-7 col-md-8 col-lg-9">
                                 {context['notification'] === 'Success' ?
                                     <h4>


### PR DESCRIPTION
When entering an object for a linkTo property, if no object is currently selected a text input is now shown. On blur it will search for the entered text and open the search panel.

I tried to make the focus work nicely for keyboard input. (You can tab onto the 'x', hit enter to remove the current value, then enter a search term and hit enter to search, then hit enter to accept the first result.)

I also made sure the 'uuid' field is always searched (we made sure it's included in all mappings even if not explicitly listed as a boost value).