### PR TITLE
Make gene visible on target search page

### DIFF
--- a/src/encoded/schemas/target.json
+++ b/src/encoded/schemas/target.json
@@ -105,6 +105,10 @@
         "dbxref": {
             "title": "External resources",
             "type": "array"
+        },
+        "gene_name": {
+            "title": "Gene name",
+            "type": "string"
         }
     },
     "boost_values": {


### PR DESCRIPTION
target.gene wasn’t available on the target search page, causing “undefined” in the constructed dbxref URL.