### PR TITLE
3069 read length audit error

### DIFF
--- a/src/encoded/audit/file.py
+++ b/src/encoded/audit/file.py
@@ -64,7 +64,7 @@ def audit_file_platform(value, system):
         raise AuditFailure('missing platform', detail, level='ERROR')
 
 
-@audit_checker('file', frame='object', condition=rfa('ENCODE3', 'modERN'))
+@audit_checker('file', frame='object', condition=rfa('ENCODE3', 'modERN', 'ENCODE2', 'ENCODE2-Mouse')
 def audit_file_read_length(value, system):
     '''
     Reads files should have a read_length

--- a/src/encoded/audit/file.py
+++ b/src/encoded/audit/file.py
@@ -64,7 +64,7 @@ def audit_file_platform(value, system):
         raise AuditFailure('missing platform', detail, level='ERROR')
 
 
-@audit_checker('file', frame='object', condition=rfa('ENCODE3', 'modERN', 'ENCODE2', 'ENCODE2-Mouse')
+@audit_checker('file', frame='object', condition=rfa('ENCODE3', 'modERN', 'ENCODE2', 'ENCODE2-Mouse'))
 def audit_file_read_length(value, system):
     '''
     Reads files should have a read_length

--- a/src/encoded/audit/file.py
+++ b/src/encoded/audit/file.py
@@ -78,7 +78,7 @@ def audit_file_read_length(value, system):
 
     if 'read_length' not in value:
         detail = 'Reads file {} missing read_length'.format(value['@id'])
-        raise AuditFailure('missing read_length', detail, level='DCC_ACTION')
+        raise AuditFailure('missing read_length', detail, level='ERROR')
 
 
 @audit_checker('file',


### PR DESCRIPTION
Upgrading read_length audit to ERROR and including ENCODE2 and ENCODE2-mouse