### PR TITLE
3038: s3 attachments

### DIFF
--- a/base.ini
+++ b/base.ini
@@ -2,6 +2,7 @@
 use = egg:encoded
 sqlalchemy.url = postgresql:///encoded
 file_upload_bucket = encoded-files-dev
+file_upload_profile_name = encoded-files-upload
 elasticsearch.server = localhost:9200
 ontology_path = %(here)s/ontology.json
 backfill_2683_path = %(here)s/backfill_2683_md5sum_content_md5sum.json

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -84,6 +84,7 @@ input = ${buildout:directory}/production.ini.in
 output = ${buildout:directory}/production.ini
 accession_factory = encoded.server_defaults.test_accession
 file_upload_bucket = encoded-files-dev
+blob_bucket = encoded-blobs-dev
 
 [production]
 recipe = collective.recipe.modwsgi

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -151,6 +151,7 @@ cmds = ${buildout:bin-directory}/grunt
 [test]
 recipe = zc.recipe.egg
 eggs =
+    coverage
     encoded[test]
     psycopg2
     pytest
@@ -159,5 +160,6 @@ eggs =
     pytest-cov
     pytest-bdd
 scripts =
+    coverage
     py.test=test
     pytest-bdd

--- a/candidate.cfg
+++ b/candidate.cfg
@@ -4,3 +4,4 @@ extends = buildout.cfg
 [production-ini]
 accession_factory = encoded.server_defaults.enc_accession
 file_upload_bucket = encode-files
+blob_bucket = encoded-blobs

--- a/production.ini.in
+++ b/production.ini.in
@@ -2,6 +2,7 @@
 use = config:base.ini#app
 session.secret = %(here)s/session-secret.b64
 file_upload_bucket = ${file_upload_bucket}
+blob_bucket = ${blob_bucket}
 accession_factory = ${accession_factory}
 
 [composite:indexer]

--- a/production.ini.in
+++ b/production.ini.in
@@ -3,6 +3,7 @@ use = config:base.ini#app
 session.secret = %(here)s/session-secret.b64
 file_upload_bucket = ${file_upload_bucket}
 blob_bucket = ${blob_bucket}
+blob_store_profile_name = encoded-files-upload
 accession_factory = ${accession_factory}
 
 [composite:indexer]

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ if sys.version_info.major == 2:
 tests_require = [
     'pytest>=2.4.0',
     'pytest-bdd',
+    'pytest-mock',
     'pytest-splinter',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -88,6 +88,7 @@ setup(
         profile = encoded.commands.profile:main
         spreadsheet-to-json = encoded.commands.spreadsheet_to_json:main
         update-file-status = encoded.commands.update_file_status:main
+        migrate-attachments-aws = encoded.commands.migrate_attachments_aws:main
 
         [paste.app_factory]
         main = encoded:main

--- a/src/contentbase/attachment.py
+++ b/src/contentbase/attachment.py
@@ -141,7 +141,7 @@ class ItemWithAttachment(Item):
             raise ValidationFailure(
                 'body', [prop_name, 'md5sum'], 'MD5 checksum does not match uploaded data.')
         else:
-            attachment['md5sum'] = md5sum
+            download_meta['md5sum'] = attachment['md5sum'] = md5sum
 
         registry = find_root(self).registry
         registry[BLOBS].store_blob(data, download_meta)

--- a/src/contentbase/attachment.py
+++ b/src/contentbase/attachment.py
@@ -197,7 +197,8 @@ def download(context, request):
 
 
 def proxy_or_redirect_to_external_file(request, location):
-    proxy = asbool(request.params.get('proxy')) or 'Origin' in request.headers
+    host_port = request.host.split(':')[-1] if ':' in request.host else '80'
+    proxy = asbool(request.params.get('proxy')) or 'Origin' in request.headers or host_port != request.server_port
 
     if asbool(request.params.get('soft')):
         expires = int(parse_qs(urlparse(location).query)['Expires'][0])

--- a/src/contentbase/attachment.py
+++ b/src/contentbase/attachment.py
@@ -191,8 +191,7 @@ def download(context, request):
     blob_storage = request.registry[BLOBS]
     if hasattr(blob_storage, 'get_blob_url'):
         blob_url = blob_storage.get_blob_url(download_meta)
-        if blob_url is not None:
-            return Response(headers={'X-Accel-Redirect': '/_proxy/' + str(blob_url)})
+        return Response(headers={'X-Accel-Redirect': '/_proxy/' + str(blob_url)})
 
     # Otherwise serve the blob data ourselves
     blob = request.registry[BLOBS].get_blob(download_meta)

--- a/src/contentbase/attachment.py
+++ b/src/contentbase/attachment.py
@@ -189,7 +189,7 @@ def download(context, request):
             return proxy_or_redirect_to_external_file(request, blob_url)
 
     # Otherwise serve the blob data ourselves
-    blob = request.registry[BLOBS].getBlob(download_meta)
+    blob = request.registry[BLOBS].get_blob(download_meta)
     headers = {
         'Content-Type': mimetype,
     }

--- a/src/contentbase/storage.py
+++ b/src/contentbase/storage.py
@@ -263,6 +263,10 @@ class RDBBlobStorage(object):
         blob = session.query(Blob).get(blob_id)
         return blob.data
 
+    def delete_blob(self, download_meta):
+        session = self.DBSession()
+        session.query(Blob).filter_by(blob_id=download_meta['blob_id']).delete()
+
 
 class S3BlobStorage(object):
     def __init__(self, bucket, fallback=None, key_class=boto.s3.key.Key):
@@ -272,6 +276,9 @@ class S3BlobStorage(object):
         self.key_class = key_class
 
     def store_blob(self, data, download_meta):
+        if 'bucket' not in download_meta:
+            self.fallback.delete_blob(download_meta)
+
         key = self.key_class(self.bucket)
         key.key = uuid.uuid4()
         if 'type' in download_meta:

--- a/src/contentbase/storage.py
+++ b/src/contentbase/storage.py
@@ -273,7 +273,7 @@ class S3BlobStorage(object):
     def __init__(self, bucket, fallback=None, read_profile_name=None, store_profile_name=None):
         self.store_conn = boto.connect_s3(profile_name=store_profile_name)
         self.read_conn = boto.connect_s3(profile_name=read_profile_name)
-        self.bucket = self.store_conn.get_bucket(bucket)
+        self.bucket = self.store_conn.get_bucket(bucket, validate=False)
         self.fallback = fallback
 
     def store_blob(self, data, download_meta, blob_id=None):

--- a/src/contentbase/storage.py
+++ b/src/contentbase/storage.py
@@ -276,7 +276,7 @@ class S3BlobStorage(object):
         self.key_class = key_class
 
     def store_blob(self, data, download_meta):
-        if 'bucket' not in download_meta:
+        if 'bucket' not in download_meta and self.fallback is not None:
             self.fallback.delete_blob(download_meta)
 
         key = self.key_class(self.bucket)

--- a/src/contentbase/storage.py
+++ b/src/contentbase/storage.py
@@ -265,13 +265,14 @@ class RDBBlobStorage(object):
 
 
 class S3BlobStorage(object):
-    def __init__(self, bucket, fallback=None):
+    def __init__(self, bucket, fallback=None, key_class=boto.s3.key.Key):
         self.conn = boto.connect_s3()
         self.bucket = self.conn.get_bucket(bucket)
         self.fallback = fallback
+        self.key_class = key_class
 
     def store_blob(self, data, download_meta):
-        key = boto.s3.key.Key(self.bucket)
+        key = self.key_class(self.bucket)
         key.key = uuid.uuid4()
         if 'type' in download_meta:
             key.content_type = download_meta['type']
@@ -300,7 +301,7 @@ class S3BlobStorage(object):
                 raise Exception('Missing S3 bucket: %s' % download_meta)
 
         bucket = self.conn.get_bucket(bucket_name)
-        key = boto.s3.key.Key(bucket)
+        key = self.key_class(bucket)
         key.key = download_meta['key']
         return key.get_contents_as_string()
 

--- a/src/encoded/commands/migrate_attachments_aws.py
+++ b/src/encoded/commands/migrate_attachments_aws.py
@@ -1,0 +1,73 @@
+"""\
+Move attachment blobs to S3.
+
+"""
+import copy
+import logging
+import transaction
+from pyramid.paster import get_app
+from pyramid.threadlocal import manager
+from pyramid.testing import DummyRequest
+from contentbase.interfaces import (
+    BLOBS,
+    DBSESSION
+)
+from contentbase.storage import PropertySheet
+
+EPILOG = __doc__
+
+logger = logging.getLogger(__name__)
+
+
+def run(app):
+    root = app.root_factory(app)
+    dummy_request = DummyRequest(root=root, registry=app.registry, _stats={})
+    manager.push({'request': dummy_request, 'registry': app.registry})
+    session = app.registry[DBSESSION]()
+    blob_storage = app.registry[BLOBS]
+
+    for sheet in session.query(PropertySheet).filter(PropertySheet.name == 'downloads'):
+        # Copy the properties so sqlalchemy realizes it changed after it's mutated
+        properties = copy.deepcopy(sheet.properties)
+        download_meta = properties['attachment']
+        if 'bucket' not in download_meta:
+            # Re-writing the blob while the S3BlobStorage is in use
+            # will move it to S3.
+            data = blob_storage.get_blob(download_meta)
+            blob_storage.store_blob(data, download_meta)
+            sheet.properties = properties
+            logger.info('Updated %s' % sheet.sid)
+
+
+def main():
+    import argparse
+    parser = argparse.ArgumentParser(
+        description="Move attachment blobs to S3", epilog=EPILOG,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument('--app-name', help="Pyramid app name in configfile")
+    parser.add_argument('--abort', action='store_true', help="Rollback transaction")
+    parser.add_argument('config_uri', help="path to configfile")
+    args = parser.parse_args()
+
+    logging.basicConfig()
+    app = get_app(args.config_uri, args.app_name)
+    # Loading app will have configured from config file. Reconfigure here:
+    logging.getLogger('encoded').setLevel(logging.DEBUG)
+
+    raised = False
+    try:
+        run(app)
+    except:
+        raised = True
+        raise
+    finally:
+        if raised or args.abort:
+            transaction.abort()
+            logger.info('Rolled back.')
+        else:
+            transaction.commit()
+
+
+if __name__ == '__main__':
+    main()

--- a/src/encoded/commands/migrate_attachments_aws.py
+++ b/src/encoded/commands/migrate_attachments_aws.py
@@ -5,7 +5,6 @@ Move attachment blobs to S3.
 import copy
 import logging
 import transaction
-import uuid
 from hashlib import md5
 from pyramid.paster import get_app
 from pyramid.threadlocal import manager
@@ -14,10 +13,7 @@ from contentbase.interfaces import (
     BLOBS,
     DBSESSION
 )
-from contentbase.storage import (
-    Blob,
-    PropertySheet,
-)
+from contentbase.storage import PropertySheet
 
 EPILOG = __doc__
 
@@ -43,7 +39,6 @@ def run(app):
             download_meta['md5sum'] = md5(data).hexdigest()
             blob_storage.store_blob(data, download_meta, blob_id=blob_id)
             sheet.properties = properties
-            session.query(Blob).filter_by(blob_id=uuid.UUID(blob_id)).delete()
             logger.info('Updated %s' % sheet.sid)
 
 

--- a/src/encoded/tests/test_download.py
+++ b/src/encoded/tests/test_download.py
@@ -30,6 +30,7 @@ def test_download_create(testapp, testing_download):
     assert res.json['attachment']['type'] == 'image/png'
     assert res.json['attachment']['width'] == 5
     assert res.json['attachment']['height'] == 5
+    assert res.json['attachment']['md5sum'] == 'b60ab2708daec7685f3d412a5e05191a'
     url = testing_download + '/' + res.json['attachment']['href']
     res = testapp.get(url)
     assert res.content_type == 'image/png'
@@ -96,5 +97,15 @@ def test_download_create_wrong_extension(testapp):
     item = {'attachment': {
         'download': 'red-dot.jpg',
         'href': RED_DOT,
+    }}
+    testapp.post_json(url, item, status=422)
+
+
+def test_download_create_w_wrong_md5sum(testapp):
+    url = '/testing-downloads/'
+    item = {'attachment': {
+        'download': 'red-dot.jpg',
+        'href': RED_DOT,
+        'md5sum': 'deadbeef',
     }}
     testapp.post_json(url, item, status=422)

--- a/src/encoded/tests/test_storage.py
+++ b/src/encoded/tests/test_storage.py
@@ -173,29 +173,14 @@ def test_S3BlobStorage(mocker):
     url = storage.get_blob_url(download_meta)
     assert url == 'http://testurl'
     storage.read_conn.generate_url.assert_called_once_with(
-        129600, method='GET', bucket='test', key=download_meta['key'],
-        response_headers={
-            'response-content-disposition': 'inline; filename=test.txt'
-        }
+        129600, method='GET', bucket='test', key=download_meta['key']
     )
 
 
 def test_S3BlobStorage_get_blob_url_for_non_s3_file(mocker):
     from contentbase.storage import S3BlobStorage
-    mocker.patch('boto.connect_s3')
     storage = S3BlobStorage(bucket='test')
-    download_meta = {}
+    download_meta = {'blob_id': 'blob_id'}
     url = storage.get_blob_url(download_meta)
-    assert url is None
-
-
-def test_S3BlobStorage_get_blob_fallback_for_non_s3_file(mocker):
-    from contentbase.storage import S3BlobStorage
-    mocker.patch('boto.connect_s3')
-    fallback_storage = mocker.Mock()
-    fallback_storage.get_blob.return_value = 'data'
-    storage = S3BlobStorage(bucket='test', fallback=fallback_storage)
-    download_meta = {}
-    data = storage.get_blob(download_meta)
-    assert data == 'data'
-    fallback_storage.get_blob.assert_called_once_with(download_meta)
+    assert 'test' in url
+    assert 'blob_id' in url

--- a/src/encoded/tests/test_storage.py
+++ b/src/encoded/tests/test_storage.py
@@ -179,8 +179,14 @@ def test_S3BlobStorage(mocker):
 
 def test_S3BlobStorage_get_blob_url_for_non_s3_file(mocker):
     from contentbase.storage import S3BlobStorage
-    storage = S3BlobStorage(bucket='test')
+    mocker.patch('boto.connect_s3')
+    bucket = 'test'
+    storage = S3BlobStorage(bucket)
+    storage.bucket.name = bucket
     download_meta = {'blob_id': 'blob_id'}
+    storage.read_conn.generate_url.return_value = 'http://testurl'
     url = storage.get_blob_url(download_meta)
-    assert 'test' in url
-    assert 'blob_id' in url
+    assert url == 'http://testurl'
+    storage.read_conn.generate_url.assert_called_once_with(
+        129600, method='GET', bucket='test', key=download_meta['blob_id']
+    )

--- a/src/encoded/tests/test_storage.py
+++ b/src/encoded/tests/test_storage.py
@@ -146,3 +146,55 @@ def test_keys(session):
     session.add(key3)
     with pytest.raises(FlushError):
         session.flush()
+
+
+def test_S3BlobStorage(mocker):
+    from contentbase.storage import S3BlobStorage
+    mocker.patch('boto.connect_s3')
+    bucket = 'test'
+    fake_key = mocker.Mock()
+    def FakeKey(bucket):
+        return fake_key
+    storage = S3BlobStorage(bucket, key_class=FakeKey)
+    storage.bucket.name = bucket
+
+    download_meta = {'download': 'test.txt'}
+    storage.store_blob('data', download_meta)
+    assert download_meta['bucket'] == 'test'
+    assert 'key' in download_meta
+    fake_key.set_contents_from_string.assert_called_once_with('data')
+
+    fake_key.get_contents_as_string.return_value = 'data'
+    data = storage.get_blob(download_meta)
+    assert data == 'data'
+
+    storage.conn.generate_url.return_value = 'http://testurl'
+    url = storage.get_blob_url(download_meta)
+    assert url == 'http://testurl'
+    storage.conn.generate_url.assert_called_once_with(
+        129600, method='GET', bucket='test', key=download_meta['key'],
+        response_headers={
+            'response-content-disposition': 'inline; filename=test.txt'
+        }
+    )
+
+
+def test_S3BlobStorage_get_blob_url_for_non_s3_file(mocker):
+    from contentbase.storage import S3BlobStorage
+    mocker.patch('boto.connect_s3')
+    storage = S3BlobStorage(bucket='test')
+    download_meta = {}
+    url = storage.get_blob_url(download_meta)
+    assert url is None
+
+
+def test_S3BlobStorage_get_blob_fallback_for_non_s3_file(mocker):
+    from contentbase.storage import S3BlobStorage
+    mocker.patch('boto.connect_s3')
+    fallback_storage = mocker.Mock()
+    fallback_storage.get_blob.return_value = 'data'
+    storage = S3BlobStorage(bucket='test', fallback=fallback_storage)
+    download_meta = {}
+    data = storage.get_blob(download_meta)
+    assert data == 'data'
+    fallback_storage.get_blob.assert_called_once_with(download_meta)

--- a/src/encoded/tests/test_storage.py
+++ b/src/encoded/tests/test_storage.py
@@ -168,10 +168,10 @@ def test_S3BlobStorage(mocker):
     data = storage.get_blob(download_meta)
     assert data == 'data'
 
-    storage.conn.generate_url.return_value = 'http://testurl'
+    storage.read_conn.generate_url.return_value = 'http://testurl'
     url = storage.get_blob_url(download_meta)
     assert url == 'http://testurl'
-    storage.conn.generate_url.assert_called_once_with(
+    storage.read_conn.generate_url.assert_called_once_with(
         129600, method='GET', bucket='test', key=download_meta['key'],
         response_headers={
             'response-content-disposition': 'inline; filename=test.txt'

--- a/src/encoded/types/file.py
+++ b/src/encoded/types/file.py
@@ -5,6 +5,7 @@ from contentbase import (
     collection,
     load_schema,
 )
+from contentbase.attachment import proxy_or_redirect_to_external_file
 from contentbase.schema_utils import schema_validator
 from .base import (
     Item,
@@ -12,21 +13,13 @@ from .base import (
 )
 from pyramid.httpexceptions import (
     HTTPForbidden,
-    HTTPTemporaryRedirect,
     HTTPNotFound,
 )
-from pyramid.response import Response
 from pyramid.settings import asbool
 from pyramid.traversal import traverse
 from pyramid.view import view_config
-from urllib.parse import (
-    parse_qs,
-    urlparse,
-)
 import boto
-import datetime
 import json
-import pytz
 import time
 
 
@@ -307,16 +300,4 @@ def download(context, request):
     else:
         raise ValueError(external.get('service'))
 
-    if asbool(request.params.get('soft')):
-        expires = int(parse_qs(urlparse(location).query)['Expires'][0])
-        return {
-            '@type': ['SoftRedirect'],
-            'location': location,
-            'expires': datetime.datetime.fromtimestamp(expires, pytz.utc).isoformat(),
-        }
-
-    if proxy:
-        return Response(headers={'X-Accel-Redirect': '/_proxy/' + str(location)})
-
-    # 307 redirect specifies to keep original method
-    raise HTTPTemporaryRedirect(location=location)
+    return proxy_or_redirect_to_external_file(request, location)

--- a/src/encoded/upgrade/document.py
+++ b/src/encoded/upgrade/document.py
@@ -2,7 +2,6 @@ from past.builtins import basestring
 from contentbase import upgrade_step
 from .shared import ENCODE2_AWARDS, REFERENCES_UUID
 from pyramid.traversal import find_root
-from uuid import UUID
 import re
 
 

--- a/versions.cfg
+++ b/versions.cfg
@@ -197,3 +197,6 @@ Mako = 1.0.1
 # Required by:
 # pytest-bdd==2.12.2
 glob2 = 0.4.1
+
+# Added by buildout at 2015-08-14 10:09:23.695584
+pytest-mock = 0.7.0

--- a/versions.cfg
+++ b/versions.cfg
@@ -200,3 +200,4 @@ glob2 = 0.4.1
 
 # Added by buildout at 2015-08-14 10:09:23.695584
 pytest-mock = 0.7.0
+mock = 1.0.1


### PR DESCRIPTION
This is not quite ready to merge but I've made good progress and wanted to give @lrowe a chance to look it over.

If the blob_bucket setting is set, we use an s3-backed BlobStorage implementation; otherwise the old rdb-backed one. The s3-backed storage falls back to the rdb-backed one for stored files with no bucket name stored.

Outstanding questions:

- Is there a reliable way to tell when we're behind a proxy and should use X-Accel-Redirect? The existing code in types/file.py checked for an Origin header, which wasn't there when I was testing access via the dev nginx. The X-Forwarded-For header set by nginx is swallowed by the PasteDeploy prefix middleware. For now I am comparing the port from the Host header to the SERVER_PORT to see if they differ, but that feels hacky.
- What buckets should we use in production and for demo servers? I've been using 'davisagli-test' for testing.

Remaining tasks:

- [x] calculate md5 checksum (ticket 478)
- [x] upgrade script to move existing files