### PR TITLE
3228 related items

### DIFF
--- a/src/contentbase/jsonld_context.py
+++ b/src/contentbase/jsonld_context.py
@@ -177,6 +177,9 @@ def context_from_schema(schema, prefix, item_type, base_types):
         jsonld_context[type_name] = '%s:%s' % (prefix, type_name)
 
     for name, subschema in schema.get('properties', {}).items():
+        if name.startswith('@'):
+            continue
+
         if '@id' in subschema and subschema['@id'] is None:
             jsonld_context[name] = None
             continue
@@ -186,7 +189,7 @@ def context_from_schema(schema, prefix, item_type, base_types):
         if '@reverse' in prop_ld:
             continue
         if '@id' not in prop_ld:
-            prop_ld['@id'] = '%s:%s' % (prefix, type_name)
+            prop_ld['@id'] = '%s:%s' % (prefix, name)
 
         subschema.get('items', subschema)
         if '@type' in prop_ld:
@@ -234,6 +237,9 @@ def ontology_from_schema(schema, prefix, term_path, item_type, base_types):
     }
 
     for name, subschema in schema.get('properties', {}).items():
+        if name.startswith('@'):
+            continue
+
         if '@id' in subschema and subschema['@id'] is None:
             continue
         if '@reverse' in subschema:

--- a/src/contentbase/jsonld_context.py
+++ b/src/contentbase/jsonld_context.py
@@ -4,7 +4,10 @@ from pyramid.events import (
 )
 from pyramid.httpexceptions import HTTPNotFound
 from pyramid.view import view_config
-from urllib.parse import urlparse
+from urllib.parse import (
+    quote,
+    urlparse,
+)
 from .util import ensurelist
 
 
@@ -190,7 +193,7 @@ def context_from_schema(schema, prefix, item_type, base_types):
         if '@reverse' in prop_ld:
             continue
         if '@id' not in prop_ld:
-            prop_ld['@id'] = '%s:%s' % (prefix, name)
+            prop_ld['@id'] = '%s:%s' % (prefix, quote(name, safe=''))
 
         subschema.get('items', subschema)
         if '@type' in prop_ld:
@@ -247,7 +250,7 @@ def ontology_from_schema(schema, prefix, term_path, item_type, base_types):
             continue
 
         prop_ld = {
-            '@id': subschema.get('@id', term_path + name),
+            '@id': subschema.get('@id', term_path + quote(name, safe='')),
             '@type': 'rdf:Property',
             'rdfs:domain': term_path + item_type,
         }

--- a/src/contentbase/jsonld_context.py
+++ b/src/contentbase/jsonld_context.py
@@ -92,14 +92,14 @@ def make_jsonld_context(event):
         }
 
     # These are broken definitions
-    defines['BrokenPropertyOrClass'] = {
+    BROKEN = {
         '@id': prefix + ':BrokenPropertyOrClass',
         'owl:unionOf': [
             'rdf:Property',
             'rdfs:Class',
         ],
         '@type': 'owl:Class',
-    },
+    }
 
     MERGED_PROPS = [
         'rdfs:subClassOf',
@@ -144,6 +144,7 @@ def make_jsonld_context(event):
 
             if existing['@type'] != definition['@type']:
                 existing['@type'] = prefix + ':BrokenPropertyOrClass'
+                defines['BrokenPropertyOrClass'] = BROKEN
 
             for prop in MERGED_TYPES:
                 if prop not in definition:

--- a/src/encoded/commands/check_files.py
+++ b/src/encoded/commands/check_files.py
@@ -197,10 +197,11 @@ def check_file(item):
 
     result = None
     errors = {}
-    r = requests.head(
-        urljoin(CONFIG['url'], item['@id'] + '@@download'),
+    r = requests.get(
+        urljoin(CONFIG['url'], item['@id'] + '@@upload'),
         auth=(CONFIG['username'], CONFIG['password']), headers=HEADERS)
-    path = urlparse(r.headers['Location']).path[1:]
+    upload_url = r.json()['@graph'][0]['upload_credentials']['upload_url']
+    path = urlparse(upload_url).path[1:]
     local_path = CONFIG['mirror'] + path
 
     key = BUCKET.get_key(path)

--- a/src/encoded/commands/jsonld_rdf.py
+++ b/src/encoded/commands/jsonld_rdf.py
@@ -19,6 +19,10 @@ def run(sources, output, parser='json-ld', serializer='xml', base=None):
 def main():
     import argparse
     import sys
+    stdout = sys.stdout
+    if sys.version_info.major > 2:
+        stdout = stdout.buffer
+
     rdflib_parsers = sorted(
         p.name for p in rdflib.plugin.plugins(kind=rdflib.parser.Parser)
         if '/' not in p.name)
@@ -37,7 +41,7 @@ def main():
     parser.add_argument(
         '-b', '--base', default=None, help='Base URL')
     parser.add_argument(
-        '-o', '--output', type=argparse.FileType('w'), default=sys.stdout,
+        '-o', '--output', type=argparse.FileType('w'), default=stdout,
         help="Output file.")
     args = parser.parse_args()
     run(args.sources, args.output, args.parser, args.serializer, args.base)

--- a/src/encoded/static/components/antibody.js
+++ b/src/encoded/static/components/antibody.js
@@ -5,9 +5,9 @@ var url = require('url');
 var _ = require('underscore');
 var globals = require('./globals');
 var dataset = require('./dataset');
-var fetched = require('./fetched');
 var dbxref = require('./dbxref');
 var image = require('./image');
+var item = require('./item');
 var audit = require('./audit');
 var statuslabel = require('./statuslabel');
 
@@ -16,10 +16,10 @@ var AuditIndicators = audit.AuditIndicators;
 var AuditDetail = audit.AuditDetail;
 var AuditMixin = audit.AuditMixin;
 var DbxrefList = dbxref.DbxrefList;
-var FetchedItems = fetched.FetchedItems;
 var ExperimentTable = dataset.ExperimentTable;
 var StatusLabel = statuslabel.StatusLabel;
 var statusOrder = globals.statusOrder;
+var RelatedItems = item.RelatedItems;
 
 
 var Lot = module.exports.Lot = React.createClass({
@@ -55,9 +55,6 @@ var Lot = module.exports.Lot = React.createClass({
 
         // Make string of alternate accessions
         var altacc = context.alternate_accessions ? context.alternate_accessions.join(', ') : undefined;
-
-        // To search list of linked experiments
-        var experiments_url = '/search/?type=experiment&replicates.antibody.accession=' + context.accession;
 
         return (
             <div className={globals.itemClass(context, 'view-item')}>
@@ -189,31 +186,15 @@ var Lot = module.exports.Lot = React.createClass({
                     {characterizations}
                 </div>
 
-                <FetchedItems {...this.props} url={experiments_url} Component={ExperimentsUsingAntibody} />
+                <RelatedItems title={'Experiments using antibody ' + context.accession}
+                              url={'/search/?type=experiment&replicates.antibody.accession=' + context.accession}
+                              Component={ExperimentTable} />
             </div>
         );
     }
 });
 
 globals.content_views.register(Lot, 'antibody_lot');
-
-
-var ExperimentsUsingAntibody = React.createClass({
-    render: function () {
-        var context = this.props.context;
-
-        return (
-            <div>
-                <span className="pull-right">
-                    <a className="btn btn-info btn-sm" href={this.props.url}>View all</a>
-                </span>
-
-                <ExperimentTable {...this.props} limit={5}
-                    title={'Experiments using antibody ' + context.accession} />
-            </div>
-        );
-    }
-});
 
 
 var Documents = React.createClass({

--- a/src/encoded/static/components/biosample.js
+++ b/src/encoded/static/components/biosample.js
@@ -503,12 +503,6 @@ var HumanDonor = module.exports.HumanDonor = React.createClass({
                         </div>
                     : null}
                 </dl>
-
-                {!biosample ?
-                    <RelatedItems title="Biosamples from this donor"
-                                  url={'/search/?type=biosample&donor.uuid=' + context.uuid}
-                                  columns={biosample_columns} />
-                : ''}
             </div>
         );
     }
@@ -610,12 +604,6 @@ var MouseDonor = module.exports.MouseDonor = React.createClass({
                         </section>
                     : null}
                 </dl>
-
-                {!biosample ?
-                    <RelatedItems title="Biosamples from this strain"
-                                  url={'/search/?type=biosample&donor.uuid=' + context.uuid}
-                                  columns={biosample_columns} />
-                : ''}
             </div>
         );
     }
@@ -732,12 +720,6 @@ var FlyWormDonor = module.exports.FlyDonor = React.createClass({
                     </section>
                 : null}
 
-                {!biosample ?
-                    <RelatedItems title="Biosamples from this strain"
-                                  url={'/search/?type=biosample&donor.uuid=' + context.uuid}
-                                  columns={biosample_columns} />
-                : ''}
-
             </div>
         );
     }
@@ -745,6 +727,47 @@ var FlyWormDonor = module.exports.FlyDonor = React.createClass({
 
 globals.panel_views.register(FlyWormDonor, 'fly_donor');
 globals.panel_views.register(FlyWormDonor, 'worm_donor');
+
+
+var Donor = module.exports.Donor = React.createClass({
+    render: function() {
+        var context = this.props.context;
+        var itemClass = globals.itemClass(context, 'view-item');
+        var altacc = context.alternate_accessions ? context.alternate_accessions.join(', ') : undefined;
+
+        return (
+            <div className={itemClass}>
+                <header className="row">
+                    <div className="col-sm-12">
+                        <ul className="breadcrumb">
+                            <li>Donors</li>
+                            <li className="active"><em>{context.organism.scientific_name}</em></li>
+                        </ul>
+                        <h2>{context.accession}</h2>
+                        {altacc ? <h4 className="repl-acc">Replaces {altacc}</h4> : null}
+                        <div className="status-line">
+                            <div className="characterization-status-labels">
+                                <StatusLabel title="Status" status={context.status} />
+                            </div>
+                        </div>
+                    </div>
+                </header>
+
+                <div className="panel data-display">
+                    {Panel(context)}
+                </div>
+
+                <RelatedItems title={"Biosamples from this " + (context.organism.name == 'human' ? 'donor': 'strain')}
+                              url={'/search/?type=biosample&donor.uuid=' + context.uuid}
+                              columns={biosample_columns} />
+
+            </div>
+        );
+    }
+});
+
+globals.content_views.register(Donor, 'donor');
+
 
 
 var SingleTreatment = module.exports.SingleTreatment = function(treatment) {

--- a/src/encoded/static/components/biosample.js
+++ b/src/encoded/static/components/biosample.js
@@ -43,14 +43,13 @@ var RelatedItems = React.createClass({
     },
 
     render: function() {
-        var Component = this.props.Component;
-        var context = this.props.context;
+        var {Component, context, title, url, ...props} = this.props;
         if (context === undefined) return null;
         if (!context['@graph'].length) return null;
         return (
             <section>
-                <h3>{this.props.title}</h3>
-                <Component {...this.props} location_href={this.props.url} context={context} items={context['@graph']} />
+                <h3>{title}</h3>
+                <Component {...props} location_href={url} context={context} items={context['@graph']} />
             </section>
         );
     }

--- a/src/encoded/static/components/biosample.js
+++ b/src/encoded/static/components/biosample.js
@@ -479,8 +479,8 @@ var HumanDonor = module.exports.HumanDonor = React.createClass({
             <div>
                 <dl className="key-value">
                     <div data-test="accession">
-                        <dt>AccessionASDF</dt>
-                        <dd>{context.accession}</dd>
+                        <dt>Accession</dt>
+                        <dd><a href={context['@id']}>{context.accession}</a></dd>
                     </div>
 
                     {context.aliases.length ?
@@ -564,7 +564,7 @@ var MouseDonor = module.exports.MouseDonor = React.createClass({
                 <dl className="key-value">
                     <div data-test="accession">
                         <dt>Accession</dt>
-                        <dd>{context.accession}</dd>
+                        <dd><a href={context['@id']}>{context.accession}</a></dd>
                     </div>
 
                     {context.aliases.length ?
@@ -678,7 +678,7 @@ var FlyWormDonor = module.exports.FlyDonor = React.createClass({
                 <dl className="key-value">
                     <div data-test="accession">
                         <dt>Accession</dt>
-                        <dd>{context.accession}</dd>
+                        <dd><a href={context['@id']}>{context.accession}</a></dd>
                     </div>
 
                     {context.aliases.length ?

--- a/src/encoded/static/components/biosample.js
+++ b/src/encoded/static/components/biosample.js
@@ -3,14 +3,13 @@ var React = require('react');
 var cx = require('react/lib/cx');
 var _ = require('underscore');
 var url = require('url');
-var collection = require('./collection');
 var globals = require('./globals');
 var dataset = require('./dataset');
-var fetched = require('./fetched');
 var dbxref = require('./dbxref');
 var statuslabel = require('./statuslabel');
 var audit = require('./audit');
 var image = require('./image');
+var item = require('./item');
 var reference = require('./reference');
 
 var DbxrefList = dbxref.DbxrefList;
@@ -21,7 +20,7 @@ var AuditMixin = audit.AuditMixin;
 var ExperimentTable = dataset.ExperimentTable;
 var Attachment = image.Attachment;
 var PubReferenceList = reference.PubReferenceList;
-var Table = collection.Table;
+var RelatedItems = item.RelatedItems;
 
 
 var Panel = function (props) {
@@ -34,26 +33,6 @@ var Panel = function (props) {
     var PanelView = globals.panel_views.lookup(props.context);
     return <PanelView {...props} />;
 };
-
-
-var RelatedItems = React.createClass({
-
-    getDefaultProps: function() {
-        return {Component: Table};
-    },
-
-    render: function() {
-        var {Component, context, title, url, ...props} = this.props;
-        if (context === undefined) return null;
-        if (!context['@graph'].length) return null;
-        return (
-            <section>
-                <h3>{title}</h3>
-                <Component {...props} location_href={url} context={context} items={context['@graph']} />
-            </section>
-        );
-    }
-});
 
 
 var biosample_columns = {
@@ -425,30 +404,22 @@ var Biosample = module.exports.Biosample = React.createClass({
                     </div>
                 : null}
 
-                <fetched.FetchedData>
-                    <fetched.Param name="context" url={'/search/?type=experiment&replicates.library.biosample.uuid=' + context.uuid} />
-                    <RelatedItems
-                        title={'Experiments using biosample ' + context.accession}
-                        Component={ExperimentTable} />
-                </fetched.FetchedData>
+                <RelatedItems
+                    title={'Experiments using biosample ' + context.accession}
+                    url={'/search/?type=experiment&replicates.library.biosample.uuid=' + context.uuid}
+                    Component={ExperimentTable} />
 
-                <fetched.FetchedData>
-                    <fetched.Param name="context" url={'/search?type=biosample&part_of.uuid=' + context.uuid} />
-                    <RelatedItems title="Biosamples that are part of this biosample"
-                                  columns={biosample_columns} />
-                </fetched.FetchedData>
+                <RelatedItems title="Biosamples that are part of this biosample"
+                              url={'/search/?type=biosample&part_of.uuid=' + context.uuid}
+                              columns={biosample_columns} />
 
-                <fetched.FetchedData>
-                    <fetched.Param name="context" url={'/search?type=biosample&derived_from.uuid=' + context.uuid} />
-                    <RelatedItems title="Biosamples that are derived from this biosample"
-                                  columns={biosample_columns} />
-                </fetched.FetchedData>
+                <RelatedItems title="Biosamples that are derived from this biosample"
+                              url={'/search/?type=biosample&derived_from.uuid=' + context.uuid}
+                              columns={biosample_columns} />
 
-                <fetched.FetchedData>
-                    <fetched.Param name="context" url={'/search?type=biosample&pooled_from.uuid=' + context.uuid} />
-                    <RelatedItems title="Biosamples that are pooled from this biosample"
-                                  columns={biosample_columns} />
-                </fetched.FetchedData>
+                <RelatedItems title="Biosamples that are pooled from this biosample"
+                              url={'/search/?type=biosample&pooled_from.uuid=' + context.uuid}
+                              columns={biosample_columns} />
 
             </div>
         );
@@ -480,7 +451,7 @@ var HumanDonor = module.exports.HumanDonor = React.createClass({
                 <dl className="key-value">
                     <div data-test="accession">
                         <dt>Accession</dt>
-                        <dd><a href={context['@id']}>{context.accession}</a></dd>
+                        <dd>{biosample ? <a href={context['@id']}>{context.accession}</a> : context.accession}</dd>
                     </div>
 
                     {context.aliases.length ?
@@ -534,10 +505,9 @@ var HumanDonor = module.exports.HumanDonor = React.createClass({
                 </dl>
 
                 {!biosample ?
-                    <fetched.FetchedData>
-                        <fetched.Param name="context" url={'/search/?type=biosample&donor.uuid=' + context.uuid} />
-                        <RelatedItems title="Biosamples from this donor" columns={biosample_columns} />
-                    </fetched.FetchedData>
+                    <RelatedItems title="Biosamples from this donor"
+                                  url={'/search/?type=biosample&donor.uuid=' + context.uuid}
+                                  columns={biosample_columns} />
                 : ''}
             </div>
         );
@@ -564,7 +534,7 @@ var MouseDonor = module.exports.MouseDonor = React.createClass({
                 <dl className="key-value">
                     <div data-test="accession">
                         <dt>Accession</dt>
-                        <dd><a href={context['@id']}>{context.accession}</a></dd>
+                        <dd>{biosample ? <a href={context['@id']}>{context.accession}</a> : context.accession}</dd>
                     </div>
 
                     {context.aliases.length ?
@@ -642,10 +612,9 @@ var MouseDonor = module.exports.MouseDonor = React.createClass({
                 </dl>
 
                 {!biosample ?
-                    <fetched.FetchedData>
-                        <fetched.Param name="context" url={'/search/?type=biosample&donor.uuid=' + context.uuid} />
-                        <RelatedItems title="Biosamples from this strain" columns={biosample_columns} />
-                    </fetched.FetchedData>
+                    <RelatedItems title="Biosamples from this strain"
+                                  url={'/search/?type=biosample&donor.uuid=' + context.uuid}
+                                  columns={biosample_columns} />
                 : ''}
             </div>
         );
@@ -678,7 +647,7 @@ var FlyWormDonor = module.exports.FlyDonor = React.createClass({
                 <dl className="key-value">
                     <div data-test="accession">
                         <dt>Accession</dt>
-                        <dd><a href={context['@id']}>{context.accession}</a></dd>
+                        <dd>{biosample ? <a href={context['@id']}>{context.accession}</a> : context.accession}</dd>
                     </div>
 
                     {context.aliases.length ?
@@ -764,10 +733,9 @@ var FlyWormDonor = module.exports.FlyDonor = React.createClass({
                 : null}
 
                 {!biosample ?
-                    <fetched.FetchedData>
-                        <fetched.Param name="context" url={'/search/?type=biosample&donor.uuid=' + context.uuid} />
-                        <RelatedItems title="Biosamples from this strain" columns={biosample_columns} />
-                    </fetched.FetchedData>
+                    <RelatedItems title="Biosamples from this strain"
+                                  url={'/search/?type=biosample&donor.uuid=' + context.uuid}
+                                  columns={biosample_columns} />
                 : ''}
 
             </div>

--- a/src/encoded/static/components/collection.js
+++ b/src/encoded/static/components/collection.js
@@ -102,7 +102,8 @@ var lookup_column = function (result, column) {
 
         getDefaultProps: function () {
             return {
-                defaultSortOn: 0
+                defaultSortOn: 0,
+                showControls: true,
             };
         },
 
@@ -305,7 +306,7 @@ var lookup_column = function (result, column) {
                 <div className="table-responsive">            
                     <table className={table_class + " table table-striped table-hover table-panel"}>
                         <thead className="sticky-header">
-                            <tr className="nosort table-controls">
+                            {this.props.showControls ? <tr className="nosort table-controls">
                                 <th colSpan={columns.length}>
                                     {loading_or_total}
                                     {actions}
@@ -320,7 +321,7 @@ var lookup_column = function (result, column) {
                                         <input ref="reversed" type="hidden" name="reversed" defaultValue={!!reversed || ''} />
                                     </form>
                                 </th>
-                            </tr>
+                            </tr> : ''}
                             <tr className="col-headers">
                                 {headers}
                             </tr>

--- a/src/encoded/static/components/dataset.js
+++ b/src/encoded/static/components/dataset.js
@@ -162,9 +162,6 @@ var UnreleasedFiles = module.exports.UnreleasedFiles = React.createClass({
 });
 
 var ExperimentTable = module.exports.ExperimentTable = React.createClass({
-    getDefaultProps: function() {
-        return {title: 'Experiments'};
-    },
 
     render: function() {
         var experiments;
@@ -181,7 +178,7 @@ var ExperimentTable = module.exports.ExperimentTable = React.createClass({
 
         return (
             <div>
-                <h3>{this.props.title}</h3>
+                {this.props.title ? <h3>{this.props.title}</h3> : ''}
                 <div className="table-responsive">
                     <table className="table table-panel table-striped table-hover">
                         <thead>

--- a/src/encoded/static/components/form.js
+++ b/src/encoded/static/components/form.js
@@ -5,8 +5,16 @@ var ReactForms = require('react-forms');
 var parseAndLogError = require('./mixins').parseAndLogError;
 var closest = require('../libs/closest');
 var offset = require('../libs/offset');
+var fetched = require('./fetched');
+var inputs = require('./inputs');
+var layout = require('./layout');
 var ga = require('google-analytics');
 var _ = require('underscore');
+
+var Layout = layout.Layout;
+var ItemPreview = inputs.ItemPreview;
+var ObjectPicker = inputs.ObjectPicker;
+var FileInput = inputs.FileInput;
 
 
 var filterValue = function(value) {
@@ -45,6 +53,207 @@ var makeValidationResult = function(validation) {
 };
 
 
+var RepeatingItem = React.createClass({
+
+  render: function() {
+    return (
+      <div {...this.props} className="rf-RepeatingFieldset__item">
+        {this.props.children}
+        <button
+          onClick={this.onRemove}
+          type="button"
+          className="rf-RepeatingFieldset__remove">&times;</button>
+      </div>
+    );
+  },
+
+  onRemove: function(e) {
+    if (!confirm('Are you sure you want to remove this item?')) {
+        e.preventDefault();
+        return;
+    }
+    if (this.props.onRemove) {
+      this.props.onRemove(this.props.name);
+    }
+  }
+
+});
+
+
+var FetchedFieldset = React.createClass({
+
+    getInitialState: function() {
+        var value = this.props.value;
+        var url = typeof value.value == 'string' ? value.value : null;
+        var externalValidation = value.externalValidation;
+        return {
+            url: url,
+            collapsed: url && !externalValidation.isFailure,
+        };
+    },
+
+    render: function() {
+        var ReactForms = require('react-forms');
+        var schema = this.props.schema;
+        var value = this.props.value;
+        var externalValidation = value.externalValidation;
+        var isFailure = externalValidation.isFailure;
+        externalValidation = isFailure ? externalValidation : null;
+        value = value.value;
+        var url = typeof value == 'string' ? value : null;
+        var preview, fieldset;
+
+        if (this.state.url) {
+            var previewUrl = this.state.url;
+            preview = (
+                <fetched.FetchedData>
+                    <fetched.Param name="data" url={previewUrl} />
+                    <ItemPreview />
+                </fetched.FetchedData>
+            );
+            fieldset = (
+                <fetched.FetchedData>
+                    <fetched.Param name="defaultValue" url={this.state.url + '?frame=edit'} />
+                    <ReactForms.Form schema={schema} onUpdate={this.onUpdate}
+                                     externalValidation={externalValidation} />
+                </fetched.FetchedData>
+            );
+        } else {
+            preview = (
+                <ul className="nav result-table">
+                  <li>
+                    <div className="accession">{'New ' + schema.props.get('label')}</div>
+                  </li>
+                </ul>
+            );
+            fieldset = <ReactForms.Form
+                defaultValue={value} schema={schema} onUpdate={this.onUpdate}
+                externalValidation={externalValidation} />;
+        }
+
+        return (
+            <div className="collapsible">
+                <span className="collapsible-trigger" onClick={this.toggleCollapsed}>{this.state.collapsed ? '▶ ' : '▼ '}</span>
+                {isFailure && <ReactForms.Message>{externalValidation.error}</ReactForms.Message>}
+                <div style={{display: this.state.collapsed ? 'block' : 'none'}}>{preview}</div>
+                <div style={{display: this.state.collapsed ? 'none' : 'block'}}>{fieldset}</div>
+            </div>
+        );
+    },
+
+    toggleCollapsed: function() {
+        this.setState({collapsed: !this.state.collapsed});
+    },
+
+    onUpdate: function(value) {
+        value = value.set('@id', this.state.url);
+        this.props.value.setSerialized(value);
+    }
+
+});
+
+
+var jsonSchemaToFormSchema = function(attrs) {
+    var ReactForms = require('react-forms');
+    var schemas = attrs.schemas,
+        p = attrs.jsonNode,
+        props = attrs.props,
+        id = attrs.id,
+        skip = attrs.skip || [];
+    if (props === undefined) {
+        props = {};
+    }
+    if (p.title) props.label = p.title;
+    if (p.description) props.hint = p.description;
+    if (p.type == 'object') {
+        if (p.formInput == 'file') {
+            props.input = <FileInput />;
+            return ReactForms.schema.Scalar(props);
+        } else if (p.formInput == 'layout') {
+            props.input = <Layout editable={true} />;
+            return ReactForms.schema.Scalar(props);
+        } else {
+            props.component = <ReactForms.Fieldset className={props.required ? "required" : ''} />;
+        }
+        var properties = {}, name;
+        for (name in p.properties) {
+            if (name == 'uuid' || name == 'schema_version') continue;
+            if (p.properties[name].calculatedProperty) continue;
+            if (_.contains(skip, name)) continue;
+            var required = _.contains(p.required || [], name);
+            var subprops = {required: required};
+            properties[name] = jsonSchemaToFormSchema({
+                schemas: schemas,
+                jsonNode: p.properties[name],
+                props: subprops,
+            });
+        }
+        return ReactForms.schema.Mapping(props, properties);
+    } else if (p.type == 'array') {
+        props.component = <ReactForms.RepeatingFieldset className={props.required ? "required" : ""} item={RepeatingItem} />;
+        return ReactForms.schema.List(props, jsonSchemaToFormSchema({schemas: schemas, jsonNode: p.items}));
+    } else if (p.type == 'boolean') {
+        props.type = 'bool';
+        return ReactForms.schema.Scalar(props);
+    } else {
+        if (props.required) props.component = <ReactForms.Field className="required" />;
+        if (p.pattern) {
+            props.validate = function(schema, value) { return (typeof value == 'string') ? value.match(p.pattern) : true; };
+        }
+        if (p['enum']) {
+            var options = p['enum'].map(v => <option value={v}>{v}</option>);
+            if (!p.default) {
+                options = [<option value={null} />].concat(options);
+            }
+            props.input = <select className="form-control">{options}</select>;
+        }
+        if (p.linkTo) {
+            var restrictions = {type: [p.linkTo]};
+            props.input = (
+                <ObjectPicker searchBase={"?mode=picker&type=" + p.linkTo} restrictions={restrictions} />
+            );
+        } else if (p.linkFrom) {
+            // Backrefs have a linkFrom property in the form
+            // (object type).(property name)
+            var a = p.linkFrom.split('.'), linkType = a[0], linkProp = a[1];
+            // Get the schema for the child object, omitting the attribute that
+            // refers to the parent.
+            var linkFormSchema = jsonSchemaToFormSchema({
+                schemas: schemas,
+                jsonNode: schemas[linkType],
+                skip: [linkProp]
+            });
+            // Use a special FetchedFieldset component which can take either an IRI
+            // or a full object as its value, and render a sub-form using the child
+            // object schema.
+            var component = <FetchedFieldset schema={linkFormSchema} />;
+            // Default value for new children needs to refer to the parent.
+            var defaultValue = jsonSchemaToDefaultValue(schemas[linkType]);
+            defaultValue[linkProp] = id;
+            return ReactForms.schema.Scalar({component: component, defaultValue: defaultValue});
+        }
+        if (p.type == 'integer' || p.type == 'number') {
+            props.type = 'number';
+        }
+        if (p.formInput == 'textarea') {
+            props.input = <textarea rows="4" />;
+        }
+        return ReactForms.schema.Scalar(props);
+    }
+};
+
+
+var jsonSchemaToDefaultValue = function(schema) {
+    var defaultValue = {};
+    _.each(schema.properties, function(property, name) {
+        if (property['default'] !== undefined) {
+            defaultValue[name] = property['default'];
+        }
+    });
+    return defaultValue;
+};
+
+
 var Form = module.exports.Form = React.createClass({
     contextTypes: {
         adviseUnsavedChanges: React.PropTypes.func,
@@ -67,7 +276,7 @@ var Form = module.exports.Form = React.createClass({
     getDefaultProps: function() {
         return {
             submitLabel: 'Save',
-        }
+        };
     },
 
     getInitialState: function() {
@@ -230,4 +439,26 @@ var Form = module.exports.Form = React.createClass({
             errors: schemaErrors
         });
     }
+});
+
+
+var JSONSchemaForm = module.exports.JSONSchemaForm = React.createClass({
+
+    getInitialState: function() {
+        var type = this.props.type;
+        var schemas = this.props.schemas;
+        return {
+            schema: jsonSchemaToFormSchema({
+                schemas: schemas,
+                jsonNode: schemas[type],
+                id: this.props.id
+            }),
+            value: this.props.context || jsonSchemaToDefaultValue(schemas[type]),
+        };
+    },
+
+    render: function() {
+        return <Form {...this.props} defaultValue={this.state.value} schema={this.state.schema} />;
+    }
+
 });

--- a/src/encoded/static/components/form.js
+++ b/src/encoded/static/components/form.js
@@ -6,15 +6,8 @@ var parseAndLogError = require('./mixins').parseAndLogError;
 var closest = require('../libs/closest');
 var offset = require('../libs/offset');
 var fetched = require('./fetched');
-var inputs = require('./inputs');
-var layout = require('./layout');
 var ga = require('google-analytics');
 var _ = require('underscore');
-
-var Layout = layout.Layout;
-var ItemPreview = inputs.ItemPreview;
-var ObjectPicker = inputs.ObjectPicker;
-var FileInput = inputs.FileInput;
 
 
 var filterValue = function(value) {
@@ -94,6 +87,7 @@ var FetchedFieldset = React.createClass({
 
     render: function() {
         var ReactForms = require('react-forms');
+        var inputs = require('./inputs');
         var schema = this.props.schema;
         var value = this.props.value;
         var externalValidation = value.externalValidation;
@@ -108,7 +102,7 @@ var FetchedFieldset = React.createClass({
             preview = (
                 <fetched.FetchedData>
                     <fetched.Param name="data" url={previewUrl} />
-                    <ItemPreview />
+                    <inputs.ItemPreview />
                 </fetched.FetchedData>
             );
             fieldset = (
@@ -155,6 +149,7 @@ var FetchedFieldset = React.createClass({
 
 var jsonSchemaToFormSchema = function(attrs) {
     var ReactForms = require('react-forms');
+    var inputs = require('./inputs');
     var schemas = attrs.schemas,
         p = attrs.jsonNode,
         props = attrs.props,
@@ -167,10 +162,11 @@ var jsonSchemaToFormSchema = function(attrs) {
     if (p.description) props.hint = p.description;
     if (p.type == 'object') {
         if (p.formInput == 'file') {
-            props.input = <FileInput />;
+            props.input = <inputs.FileInput />;
             return ReactForms.schema.Scalar(props);
         } else if (p.formInput == 'layout') {
-            props.input = <Layout editable={true} />;
+            var layout = require('./layout');
+            props.input = <layout.Layout editable={true} />;
             return ReactForms.schema.Scalar(props);
         } else {
             props.component = <ReactForms.Fieldset className={props.required ? "required" : ''} />;
@@ -209,8 +205,9 @@ var jsonSchemaToFormSchema = function(attrs) {
         }
         if (p.linkTo) {
             var restrictions = {type: [p.linkTo]};
+            var inputs = require('./inputs');
             props.input = (
-                <ObjectPicker searchBase={"?mode=picker&type=" + p.linkTo} restrictions={restrictions} />
+                <inputs.ObjectPicker searchBase={"?mode=picker&type=" + p.linkTo} restrictions={restrictions} />
             );
         } else if (p.linkFrom) {
             // Backrefs have a linkFrom property in the form

--- a/src/encoded/static/components/item.js
+++ b/src/encoded/static/components/item.js
@@ -2,17 +2,15 @@
 var React = require('react');
 var fetched = require('./fetched');
 var globals = require('./globals');
-var Layout = require('./layout').Layout;
-var ItemPreview = require('./inputs').ItemPreview;
-var ObjectPicker = require('./inputs').ObjectPicker;
-var FileInput = require('./inputs').FileInput;
 var audit = require('./audit');
+var form = require('./form');
 var _ = require('underscore');
 
 var cx = require('react/lib/cx');
 var AuditIndicators = audit.AuditIndicators;
 var AuditDetail = audit.AuditDetail;
 var AuditMixin = audit.AuditMixin;
+var JSONSchemaForm = form.JSONSchemaForm;
 
 
 var Fallback = module.exports.Fallback = React.createClass({
@@ -123,230 +121,6 @@ globals.listing_titles.fallback = function () {
 };
 
 
-var RepeatingItem = React.createClass({
-
-  render: function() {
-    return (
-      <div {...this.props} className="rf-RepeatingFieldset__item">
-        {this.props.children}
-        <button
-          onClick={this.onRemove}
-          type="button"
-          className="rf-RepeatingFieldset__remove">&times;</button>
-      </div>
-    );
-  },
-
-  onRemove: function(e) {
-    if (!confirm('Are you sure you want to remove this item?')) {
-        e.preventDefault();
-        return;
-    }
-    if (this.props.onRemove) {
-      this.props.onRemove(this.props.name);
-    }
-  }
-
-});
-
-
-var FetchedFieldset = React.createClass({
-
-    getInitialState: function() {
-        var value = this.props.value;
-        var url = typeof value.value == 'string' ? value.value : null;
-        var externalValidation = value.externalValidation;
-        return {
-            url: url,
-            collapsed: url && !externalValidation.isFailure,
-        };
-    },
-
-    render: function() {
-        var ReactForms = require('react-forms');
-        var schema = this.props.schema;
-        var value = this.props.value;
-        var externalValidation = value.externalValidation;
-        var isFailure = externalValidation.isFailure;
-        externalValidation = isFailure ? externalValidation : null;
-        value = value.value;
-        var url = typeof value == 'string' ? value : null;
-        var preview, fieldset;
-
-        if (this.state.url) {
-            var previewUrl = this.state.url;
-            preview = (
-                <fetched.FetchedData>
-                    <fetched.Param name="data" url={previewUrl} />
-                    <ItemPreview />
-                </fetched.FetchedData>
-            );
-            fieldset = (
-                <fetched.FetchedData>
-                    <fetched.Param name="defaultValue" url={this.state.url + '?frame=edit'} />
-                    <ReactForms.Form schema={schema} onUpdate={this.onUpdate}
-                                     externalValidation={externalValidation} />
-                </fetched.FetchedData>
-            );
-        } else {
-            preview = (
-                <ul className="nav result-table">
-                  <li>
-                    <div className="accession">{'New ' + schema.props.get('label')}</div>
-                  </li>
-                </ul>
-            );
-            fieldset = <ReactForms.Form
-                defaultValue={value} schema={schema} onUpdate={this.onUpdate}
-                externalValidation={externalValidation} />;
-        }
-
-        return (
-            <div className="collapsible">
-                <span className="collapsible-trigger" onClick={this.toggleCollapsed}>{this.state.collapsed ? '▶ ' : '▼ '}</span>
-                {isFailure && <ReactForms.Message>{externalValidation.error}</ReactForms.Message>}
-                <div style={{display: this.state.collapsed ? 'block' : 'none'}}>{preview}</div>
-                <div style={{display: this.state.collapsed ? 'none' : 'block'}}>{fieldset}</div>
-            </div>
-        );
-    },
-
-    toggleCollapsed: function() {
-        this.setState({collapsed: !this.state.collapsed});
-    },
-
-    onUpdate: function(value) {
-        value = value.set('@id', this.state.url);
-        this.props.value.setSerialized(value);
-    }
-
-});
-
-
-var jsonSchemaToFormSchema = function(attrs) {
-    var ReactForms = require('react-forms');
-    var schemas = attrs.schemas,
-        p = attrs.jsonNode,
-        props = attrs.props,
-        id = attrs.id,
-        skip = attrs.skip || [];
-    if (props === undefined) {
-        props = {};
-    }
-    if (p.title) props.label = p.title;
-    if (p.description) props.hint = p.description;
-    if (p.type == 'object') {
-        if (p.formInput == 'file') {
-            props.input = <FileInput />;
-            return ReactForms.schema.Scalar(props);
-        } else if (p.formInput == 'layout') {
-            props.input = <Layout editable={true} />;
-            return ReactForms.schema.Scalar(props);
-        } else {
-            props.component = <ReactForms.Fieldset className={props.required ? "required" : ''} />;
-        }
-        var properties = {}, name;
-        for (name in p.properties) {
-            if (name == 'uuid' || name == 'schema_version') continue;
-            if (p.properties[name].calculatedProperty) continue;
-            if (_.contains(skip, name)) continue;
-            var required = _.contains(p.required || [], name);
-            var subprops = {required: required};
-            properties[name] = jsonSchemaToFormSchema({
-                schemas: schemas,
-                jsonNode: p.properties[name],
-                props: subprops,
-            });
-        }
-        return ReactForms.schema.Mapping(props, properties);
-    } else if (p.type == 'array') {
-        props.component = <ReactForms.RepeatingFieldset className={props.required ? "required" : ""} item={RepeatingItem} />;
-        return ReactForms.schema.List(props, jsonSchemaToFormSchema({schemas: schemas, jsonNode: p.items}));
-    } else if (p.type == 'boolean') {
-        props.type = 'bool';
-        return ReactForms.schema.Scalar(props);
-    } else {
-        if (props.required) props.component = <ReactForms.Field className="required" />;
-        if (p.pattern) {
-            props.validate = function(schema, value) { return (typeof value == 'string') ? value.match(p.pattern) : true; };
-        }
-        if (p['enum']) {
-            var options = p['enum'].map(v => <option value={v}>{v}</option>);
-            if (!p.default) {
-                options = [<option value={null} />].concat(options);
-            }
-            props.input = <select className="form-control">{options}</select>;
-        }
-        if (p.linkTo) {
-            var restrictions = {type: [p.linkTo]};
-            props.input = (
-                <ObjectPicker searchBase={"?mode=picker&type=" + p.linkTo} restrictions={restrictions} />
-            );
-        } else if (p.linkFrom) {
-            // Backrefs have a linkFrom property in the form
-            // (object type).(property name)
-            var a = p.linkFrom.split('.'), linkType = a[0], linkProp = a[1];
-            // Get the schema for the child object, omitting the attribute that
-            // refers to the parent.
-            var linkFormSchema = jsonSchemaToFormSchema({
-                schemas: schemas,
-                jsonNode: schemas[linkType],
-                skip: [linkProp]
-            });
-            // Use a special FetchedFieldset component which can take either an IRI
-            // or a full object as its value, and render a sub-form using the child
-            // object schema.
-            var component = <FetchedFieldset schema={linkFormSchema} />;
-            // Default value for new children needs to refer to the parent.
-            var defaultValue = jsonSchemaToDefaultValue(schemas[linkType]);
-            defaultValue[linkProp] = id;
-            return ReactForms.schema.Scalar({component: component, defaultValue: defaultValue});
-        }
-        if (p.type == 'integer' || p.type == 'number') {
-            props.type = 'number';
-        }
-        if (p.formInput == 'textarea') {
-            props.input = <textarea rows="4" />;
-        }
-        return ReactForms.schema.Scalar(props);
-    }
-};
-
-
-var jsonSchemaToDefaultValue = function(schema) {
-    var defaultValue = {};
-    _.each(schema.properties, function(property, name) {
-        if (property['default'] !== undefined) {
-            defaultValue[name] = property['default'];
-        }
-    });
-    return defaultValue;
-};
-
-
-var FetchedForm = React.createClass({
-
-    getInitialState: function() {
-        var type = this.props.type;
-        var schemas = this.props.schemas;
-        return {
-            schema: jsonSchemaToFormSchema({
-                schemas: schemas,
-                jsonNode: schemas[type],
-                id: this.props.id
-            }),
-            value: this.props.context || jsonSchemaToDefaultValue(schemas[type]),
-        };
-    },
-
-    render: function() {
-        var Form = require('./form').Form;
-        return <Form {...this.props} defaultValue={this.state.value} schema={this.state.schema} />;
-    }
-
-});
-
-
 var ItemEdit = module.exports.ItemEdit = React.createClass({
     contextTypes: {
         navigate: React.PropTypes.func
@@ -364,7 +138,7 @@ var ItemEdit = module.exports.ItemEdit = React.createClass({
             form = (
                 <fetched.FetchedData>
                     <fetched.Param name="schemas" url="/profiles/" />
-                    <FetchedForm {...this.props} context={null} type={type} action={action} method="POST" onFinish={this.finished} />
+                    <JSONSchemaForm {...this.props} context={null} type={type} action={action} method="POST" onFinish={this.finished} />
                 </fetched.FetchedData>
             );
         } else {  // edit form
@@ -376,7 +150,7 @@ var ItemEdit = module.exports.ItemEdit = React.createClass({
                 <fetched.FetchedData>
                     <fetched.Param name="context" url={url} etagName="etag" />
                     <fetched.Param name="schemas" url="/profiles/" />
-                    <FetchedForm id={id} type={type} action={id} method="PUT" onFinish={this.finished} />
+                    <JSONSchemaForm id={id} type={type} action={id} method="PUT" onFinish={this.finished} />
                 </fetched.FetchedData>
             );
         }

--- a/src/encoded/static/components/item.js
+++ b/src/encoded/static/components/item.js
@@ -210,8 +210,9 @@ var RelatedItems = module.exports.RelatedItems = React.createClass({
     },
 
     render: function() {
-        var limited_url = this.props.url + '&limit=' + this.props.limit;
-        var unlimited_url = this.props.url + '&limit=all';
+        var url = this.props.url + '&status!=deleted&status!=revoked&status!=replaced';
+        var limited_url = url + '&limit=' + this.props.limit;
+        var unlimited_url = url + '&limit=all';
         return (
             <fetched.FetchedData>
                 <fetched.Param name="context" url={limited_url} />

--- a/src/encoded/static/components/item.js
+++ b/src/encoded/static/components/item.js
@@ -1,5 +1,6 @@
 'use strict';
 var React = require('react');
+var collection = require('./collection');
 var fetched = require('./fetched');
 var globals = require('./globals');
 var audit = require('./audit');
@@ -11,6 +12,7 @@ var AuditIndicators = audit.AuditIndicators;
 var AuditDetail = audit.AuditDetail;
 var AuditMixin = audit.AuditMixin;
 var JSONSchemaForm = form.JSONSchemaForm;
+var Table = collection.Table;
 
 
 var Fallback = module.exports.Fallback = React.createClass({
@@ -173,3 +175,48 @@ var ItemEdit = module.exports.ItemEdit = React.createClass({
 
 globals.content_views.register(ItemEdit, 'item', 'edit');
 globals.content_views.register(ItemEdit, 'collection', 'add');
+
+
+var FetchedRelatedItems = React.createClass({
+    getDefaultProps: function() {
+        return {Component: Table};
+    },
+
+    render: function() {
+        var {Component, context, title, url, ...props} = this.props;
+        if (context === undefined) return null;
+        var items = context['@graph'];
+        if (!items.length) return null;
+        var total = context['total'];
+
+        return (
+            <section>
+                <span className="pull-right">
+                    Displaying {items.length} of {total}{' '}
+                    {items.length < total ? <a className="btn btn-info btn-sm" href={url}>View all</a> : ''}
+                </span>
+                <h3>{title}</h3>
+                <Component {...props} context={context} items={items} showControls={false} />
+            </section>
+        );
+    },
+
+});
+
+
+var RelatedItems = module.exports.RelatedItems = React.createClass({
+    getDefaultProps: function() {
+        return {limit: 5};
+    },
+
+    render: function() {
+        var limited_url = this.props.url + '&limit=' + this.props.limit;
+        var unlimited_url = this.props.url + '&limit=all';
+        return (
+            <fetched.FetchedData>
+                <fetched.Param name="context" url={limited_url} />
+                <FetchedRelatedItems {...this.props} url={unlimited_url} />
+            </fetched.FetchedData>
+        );
+    },
+});

--- a/src/encoded/static/components/target.js
+++ b/src/encoded/static/components/target.js
@@ -4,12 +4,12 @@ var _ = require('underscore');
 var globals = require('./globals');
 var dataset = require('./dataset');
 var dbxref = require('./dbxref');
-var fetched = require('./fetched');
+var item = require('./item');
 
 var DbxrefList = dbxref.DbxrefList;
 var Dbxref = dbxref.Dbxref;
 var ExperimentTable = dataset.ExperimentTable;
-var FetchedItems = fetched.FetchedItems;
+var RelatedItems = item.RelatedItems;
 
 var Target = module.exports.Target = React.createClass({
     render: function() {
@@ -36,7 +36,6 @@ var Target = module.exports.Target = React.createClass({
                 geneLink = baseUrl + baseName;
             }
         }
-        var experiments_url = '/search/?type=experiment&target.uuid=' + context.uuid;
         return (
             <div className={globals.itemClass(context, 'view-item')}>
                 <header className="row">
@@ -60,8 +59,9 @@ var Target = module.exports.Target = React.createClass({
                     </dd>
                 </dl>
 
-                <FetchedItems url={experiments_url} Component={ExperimentTable}
-                              title={'Experiments using target ' + context.label} />
+                <RelatedItems title={'Experiments using target ' + context.label}
+                              url={'/search/?type=experiment&target.uuid=' + context.uuid}
+                              Component={ExperimentTable} />
             </div>
         );
     }


### PR DESCRIPTION
Various changes to show more related items on views of biosample, donor, and target:
- refactored a bunch of form-related code into form.js instead of item.js
- add a description column for biosamples
- tweaked the collection table component so it can be rendered without a header and with customized columns
- add a RelatedItems component which does a search and renders a limited collection table of results with a link to the full resultset (or renders nothing if there are no results)
- refactored existing uses of ExperimentTable to use RelatedItems
- added a full page view of donors