### PR TITLE
3259 UI display for antibody exemption status

### DIFF
--- a/src/encoded/static/components/antibody.js
+++ b/src/encoded/static/components/antibody.js
@@ -303,6 +303,20 @@ var Characterization = module.exports.Characterization = React.createClass({
                             </div>
                         : null}
 
+                        {context.comment ?
+                            <div data-test="comment">
+                                <dt>Submitter comment</dt>
+                                <dd className="para-text">{context.comment}</dd>
+                            </div>
+                        : null}
+
+                        {context.notes ?
+                            <div data-test="comment">
+                                <dt>Reviewer comment</dt>
+                                <dd className="para-text">{context.notes}</dd>
+                            </div>
+                        : null}
+
                         {context.submitted_by && context.submitted_by.title ?
                             <div data-test="submitted">
                                 <dt>Submitted by</dt>

--- a/src/encoded/static/components/globals.js
+++ b/src/encoded/static/components/globals.js
@@ -31,7 +31,7 @@ var itemClass = module.exports.itemClass = function (context, htmlClass) {
 var statusClass = module.exports.statusClass = function (status, htmlClass) {
     htmlClass = htmlClass || '';
     if (typeof status == 'string') {
-        htmlClass += ' status-' + status.toLowerCase().replace(/ /g, '-');
+        htmlClass += ' status-' + status.toLowerCase().replace(/ /g, '-').replace(/\(|\)/g,'');
     }
     return htmlClass;
 };

--- a/src/encoded/static/scss/encoded/modules/_characterizations.scss
+++ b/src/encoded/static/scss/encoded/modules/_characterizations.scss
@@ -1,9 +1,10 @@
-$indicator-eligible:    #00e500;
-$indicator-pending:     #33aaff;
-$indicator-noteligible: #cc0700;
-$indicator-awaiting:    #ebe310;
-$indicator-notreviewed: #1475c9;
-$indicator-notpursued:  #d0d0d0;
+$indicator-eligible:        #00e500;
+$indicator-eligible-exempt: #e38000;
+$indicator-pending:         #33aaff;
+$indicator-noteligible:     #cc0700;
+$indicator-awaiting:        #ebe310;
+$indicator-notreviewed:     #1475c9;
+$indicator-notpursued:      #d0d0d0;
 
 $document-figure-width: 130px;
 $document-figure-height: 130px;
@@ -345,6 +346,9 @@ $characterization-figure-height: 200px;
     // NOT REVIEWED (red)
     .#{$item}.status-not-reviewed         { background-color: #a0a0a0; }
     .#{$item}.status-not-reviewed[href]    { background-color: darken(#a0a0a0, 10%); }
+    // NOT REVIEWED (orange)
+    .#{$item}.status-exempt-from-standards         { background-color: $indicator-eligible-exempt; }
+    .#{$item}.status-exempt-from-standards[href]    { background-color: darken($indicator-eligible-exempt, 10%); }
 
     // Experiment (Dataset) and Biosample states
     // IN PROGRESS (blue)
@@ -391,6 +395,7 @@ $characterization-figure-height: 200px;
 
 // Status indicator glyph colors
 .indicator.status-eligible-for-new-data { color: $indicator-eligible; }
+.indicator.status-eligible-for-new-data-via-exemption { color: $indicator-eligible-exempt; }
 .indicator.status-pending-dcc-review { color: $indicator-pending; }
 .indicator.status-not-eligible-for-new-data { color: $indicator-noteligible; }
 .indicator.status-awaiting-lab-characterization { color: $indicator-awaiting; }


### PR DESCRIPTION
For [Redmine 3259](http://redmine.encodedcc.org/issues/3259), [Release 33](http://redmine.encodedcc.org/versions/90)

* On the antibody pages in the characterization panels, now displays “Submitter comment” that displays ```antibody_characterization.comment```, and “Reviewer comment” that displays ```antibody_characterization.notes```.
* Added CSS classes for exempt-from-standards statuses, both for the new exempt status circle as well as the exempt status badge for antibody characterization documents.