### PR TITLE
Tweak so that we do not trigger new xids unnecessarily.

### DIFF
--- a/src/encoded/commands/es_index_listener.py
+++ b/src/encoded/commands/es_index_listener.py
@@ -58,6 +58,7 @@ def run(testapp, timeout=DEFAULT_TIMEOUT, dry_run=False, control=None, update_st
         connection.detach()
         conn = connection.connection
         conn.autocommit = True
+        conn.set_session(readonly=True)
         sockets = [conn]
         if control is not None:
             sockets.append(control)


### PR DESCRIPTION
Does not fix the same problem caused by ``wal_level hot_standby``: http://www.postgresql.org/message-id/CAOycyLTc0+jtJhsTOs5i7gJLEuKW_Y8yxBQms0yXY12HxemfBA@mail.gmail.com