### PR TITLE
3307 Add Ontologies menu

### DIFF
--- a/src/encoded/static/components/app.js
+++ b/src/encoded/static/components/app.js
@@ -35,6 +35,7 @@ var portal = {
             {id: 'gettingstarted', title: 'Getting started', url: '/help/getting-started'},
             {id: 'restapi', title: 'REST API', url: '/help/rest-api'},
             {id: 'fileformats', title: 'File formats', url: '/help/file-formats'},
+            {id: 'ontologies', title: 'Ontologies', url: '/help/getting-started/#Ontologies'},
             {id: 'tutorials', title: 'Tutorials', url: '/tutorials'},
             {id: 'contact', title: 'Contact', url: '/help/contacts'}
         ]}


### PR DESCRIPTION
Added an “Ontologies” menu item to the “Help” menu that points to an anchor on the existing /help/getting-started page. This also required adding this anchor to that page, which @aditin14 did.

![screen shot 2015-10-26 at 10 14 19](https://cloud.githubusercontent.com/assets/1181324/10736545/d8b027c2-7bca-11e5-8297-56cf830787a2.png)
