### PR TITLE
3284 Dataset audit and status display

### DIFF
--- a/src/encoded/schemas/dataset.json
+++ b/src/encoded/schemas/dataset.json
@@ -146,6 +146,10 @@
         "award.project": {
             "title": "Project",
             "type": "string"
+        },
+        "status": {
+            "title": "Status",
+            "type": "string"
         }
     },
     "boost_values": {

--- a/src/encoded/static/components/audit.js
+++ b/src/encoded/static/components/audit.js
@@ -143,7 +143,7 @@ var DetailEmbeddedLink = React.createClass({
         var detail = this.props.detail;
 
         // Get an array of all paths in the detail string, if any.
-        var matches = detail.match(/\/[^\/]+?\/[^\/]+?\//g);
+        var matches = detail.match(/(?!^|\s+)(\/.+?\/)(?=$|\s+)/g);
         if (matches) {
             // Build React object of text followed by path for all paths in detail string
             var lastStart = 0;

--- a/src/encoded/static/components/dataset.js
+++ b/src/encoded/static/components/dataset.js
@@ -61,11 +61,11 @@ var Dataset = module.exports.Dataset = React.createClass({
                         <h2>Dataset {context.accession}</h2>
                         {altacc ? <h4 className="repl-acc">Replaces {altacc}</h4> : null}
                         <div className="status-line">
-                            <AuditIndicators context={context} key="experiment-audit" />
+                            <AuditIndicators audits={context.audit} id="dataset-audit" />
                         </div>
                     </div>
                 </header>
-                <AuditDetail context={context} key="experiment-audit" />
+                <AuditDetail context={context} id="dataset-audit" />
                 <div className="panel data-display">
                     <dl className="key-value">
                         <dt>Accession</dt>

--- a/src/encoded/static/components/dataset.js
+++ b/src/encoded/static/components/dataset.js
@@ -37,7 +37,8 @@ var Dataset = module.exports.Dataset = React.createClass({
         var context = this.props.context;
         var itemClass = globals.itemClass(context, 'view-item');
         var experiments = {};
-        context.files.forEach(function (file) {
+        var statuses = [{status: context.status, title: "Status"}];
+        context.files.forEach(function(file) {
             var experiment = file.replicate && file.replicate.experiment;
             if (experiment) {
                 experiments[experiment['@id']] = experiment;
@@ -61,6 +62,9 @@ var Dataset = module.exports.Dataset = React.createClass({
                         <h2>Dataset {context.accession}</h2>
                         {altacc ? <h4 className="repl-acc">Replaces {altacc}</h4> : null}
                         <div className="status-line">
+                            <div className="characterization-status-labels">
+                                <StatusLabel status={statuses} />
+                            </div>
                             <AuditIndicators audits={context.audit} id="dataset-audit" />
                         </div>
                     </div>

--- a/src/encoded/static/components/search.js
+++ b/src/encoded/static/components/search.js
@@ -415,6 +415,7 @@ var AuditMixin = audit.AuditMixin;
                         <div className="pull-right search-meta">
                             <p className="type meta-title">Dataset</p>
                             <p className="type">{' ' + result['accession']}</p>
+                            <p className="type meta-status">{' ' + result['status']}</p>
                             <AuditIndicators audits={result.audit} id={this.props.context['@id']} search />
                         </div>
                         <div className="accession">


### PR DESCRIPTION
Now displays the usual status badge and audit indicators below the title on dataset pages.

![dataset-page](https://cloud.githubusercontent.com/assets/1181324/10736995/057f2ada-7bcd-11e5-83b0-16e8c2571b98.png)

Now displays the status and audit indicators on dataset search results, below the accession.

![dataset-search](https://cloud.githubusercontent.com/assets/1181324/10737014/1a5fb78a-7bcd-11e5-9ed5-5c09ad9a97f2.png)