### PR TITLE
1415 Links to references

### DIFF
--- a/src/encoded/static/components/biosample.js
+++ b/src/encoded/static/components/biosample.js
@@ -235,19 +235,17 @@ var Biosample = module.exports.Biosample = React.createClass({
                             </div>
                         : null}
 
-                        {context.references && context.references.length ?
-                            <div data-test="references">
-                                <dt>Publications</dt>
-                                <dd>
-                                    <PubReferenceList values={context.references} />
-                                </dd>
-                            </div>
-                        : null}
-
                         {context.dbxrefs.length ?
                             <div data-test="externalresources">
                                 <dt>External resources</dt>
                                 <dd><DbxrefList values={context.dbxrefs} /></dd>
+                            </div>
+                        : null}
+
+                        {context.references && context.references.length ?
+                            <div data-test="references">
+                                <dt>References</dt>
+                                <dd><PubReferenceList values={context.references} /></dd>
                             </div>
                         : null}
 
@@ -502,6 +500,13 @@ var HumanDonor = module.exports.HumanDonor = React.createClass({
                             <dd className="sentence-case">{context.ethnicity}</dd>
                         </div>
                     : null}
+
+                    {context.references && context.references.length ?
+                        <div data-test="references">
+                            <dt>References</dt>
+                            <dd><PubReferenceList values={context.references} /></dd>
+                        </div>
+                    : null}
                 </dl>
             </div>
         );
@@ -602,6 +607,13 @@ var MouseDonor = module.exports.MouseDonor = React.createClass({
                                 {biosample.donor.characterizations.map(Panel)}
                             </div>
                         </section>
+                    : null}
+
+                    {context.references && context.references.length ?
+                        <div data-test="references">
+                            <dt>References</dt>
+                            <dd><PubReferenceList values={context.references} /></dd>
+                        </div>
                     : null}
                 </dl>
             </div>

--- a/src/encoded/static/components/dataset.js
+++ b/src/encoded/static/components/dataset.js
@@ -94,10 +94,8 @@ var Dataset = module.exports.Dataset = React.createClass({
 
                         {context.references && context.references.length ?
                             <div data-test="references">
-                                <dt>Publications</dt>
-                                <dd>
-                                    <PubReferenceList values={context.references} />
-                                </dd>
+                                <dt>References</dt>
+                                <dd><PubReferenceList values={context.references} /></dd>
                             </div>
                         : null}
                     </dl>

--- a/src/encoded/static/components/experiment.js
+++ b/src/encoded/static/components/experiment.js
@@ -261,19 +261,17 @@ var Experiment = module.exports.Experiment = React.createClass({
                             </div>
                         : null}
 
+                        {context.references && context.references.length ?
+                            <div data-test="references">
+                                <dt>References</dt>
+                                <dd><PubReferenceList values={context.references} /></dd>
+                            </div>
+                        : null}
+
                         {context.aliases.length ?
                             <div data-test="aliases">
                                 <dt>Aliases</dt>
                                 <dd>{aliasList}</dd>
-                            </div>
-                        : null}
-
-                        {context.references && context.references.length ?
-                            <div data-test="references">
-                                <dt>Publications</dt>
-                                <dd>
-                                    <PubReferenceList values={context.references} />
-                                </dd>
                             </div>
                         : null}
 

--- a/src/encoded/types/biosample.py
+++ b/src/encoded/types/biosample.py
@@ -31,6 +31,7 @@ class Biosample(Item):
         'donor.characterizations.award',
         'donor.characterizations.lab',
         'donor.characterizations.submitted_by',
+        'donor.references',
         'model_organism_donor_constructs',
         'model_organism_donor_constructs.submitted_by',
         'model_organism_donor_constructs.target',

--- a/src/encoded/types/donor.py
+++ b/src/encoded/types/donor.py
@@ -12,7 +12,7 @@ from .base import (
 
 class Donor(Item):
     base_types = ['Donor'] + Item.base_types
-    embedded = ['organism']
+    embedded = ['organism', 'references']
     name_key = 'accession'
     rev = {
         'characterizations': ('DonorCharacterization', 'characterizes'),

--- a/src/encoded/types/donor.py
+++ b/src/encoded/types/donor.py
@@ -12,7 +12,7 @@ from .base import (
 
 class Donor(Item):
     base_types = ['Donor'] + Item.base_types
-    embedded = ['organism', 'references']
+    embedded = ['organism']
     name_key = 'accession'
     rev = {
         'characterizations': ('DonorCharacterization', 'characterizes'),
@@ -40,6 +40,7 @@ class Donor(Item):
 class MouseDonor(Donor):
     item_type = 'mouse_donor'
     schema = load_schema('encoded:schemas/mouse_donor.json')
+    embedded = Donor.embedded + ['references']
 
     def __ac_local_roles__(self):
         # Disallow lab submitter edits
@@ -79,3 +80,4 @@ class WormDonor(Donor):
 class HumanDonor(Donor):
     item_type = 'human_donor'
     schema = load_schema('encoded:schemas/human_donor.json')
+    embedded = Donor.embedded + ['references']


### PR DESCRIPTION
The biosample, experiment, dataset, human donor, and mouse donor pages can now display links to their PMID: and doi: references. When they appear, they link to the appropriate ENCODE publication page which itself has links to PubMed or source page as appropriate.

The references get displayed as their own line item in the summary panel of these pages.