### PR TITLE
#2978 Fix IE graph filtering bug

### DIFF
--- a/src/encoded/static/components/experiment.js
+++ b/src/encoded/static/components/experiment.js
@@ -1159,7 +1159,7 @@ var ExperimentGraph = module.exports.ExperimentGraph = React.createClass({
     },
 
     handleFilterChange: function(e) {
-        var value = e.target.selectedOptions[0].value;
+        var value = e.target.value;
         if (value !== 'default') {
             var filters = value.split('-');
             this.setState({selectedAssembly: filters[0], selectedAnnotation: filters[1]});


### PR DESCRIPTION
@aditin14 noticed that experiment file graph filtering didn’t work on any version of Internet Explorer, in that you could choose a filtering option, but the graph display wouldn’t change.

I had been using an older method of getting the currently selected option from the React synthetic event which works on every browser but Internet Explorer. I’ve now changed this to use the proper method.