### PR TITLE
3421 Fix IE graph filtering bug

### DIFF
--- a/src/encoded/static/components/experiment.js
+++ b/src/encoded/static/components/experiment.js
@@ -1159,7 +1159,7 @@ var ExperimentGraph = module.exports.ExperimentGraph = React.createClass({
     },
 
     handleFilterChange: function(e) {
-        var value = e.target.selectedOptions[0].value;
+        var value = e.target.value;
         if (value !== 'default') {
             var filters = value.split('-');
             this.setState({selectedAssembly: filters[0], selectedAnnotation: filters[1]});


### PR DESCRIPTION
I had been using an older property of the React synthetic events to get the currently selected item, which worked everywhere except IE — in IE, the currently selected filtering item came up with “undefined.” Now using the proper property that works across all browsers.