### PR TITLE
Add RNaseIII to fragmentation enums

### DIFF
--- a/src/encoded/schemas/library.json
+++ b/src/encoded/schemas/library.json
@@ -166,7 +166,8 @@
             "type": "string",
             "enum": [
                 "chemical (generic)",
-                "chemical (DnaseI)",
+                "chemical (DNaseI)",
+                "chemical (RNase III)",
                 "chemical (HindIII/DpnII restriction)",
                 "chemical (Tn5 transposase)",
                 "chemical (micrococcal nuclease)",


### PR DESCRIPTION
Also capitalized DnaseI to DNaseI. No libraries currently use that enum in the data.