### PR TITLE
TALEN search result crash fix

### DIFF
--- a/src/encoded/schemas/talen.json
+++ b/src/encoded/schemas/talen.json
@@ -188,5 +188,23 @@
             "title": "Project",
             "type": "string"
         }
+    },
+    "columns": {
+        "name": {
+            "title": "Construct name",
+            "description": "The name of the TALEN construct."
+        },
+        "description": {
+            "title": "Description",
+            "description": "A plain text description of the TALEN construct."
+        },
+        "talen_platform": {
+            "title": "TALEN platform",
+            "description": "The TALEN platform used to make the construct. E.g. Golden Gate"
+        },
+        "target_genomic_coordinates": {
+            "title": "Genome assembly",
+            "description": "The GRC genome assembly to which the target coordinates relate.  E.g. GRCh38"
+        }
     }
 }

--- a/src/encoded/static/components/talen.js
+++ b/src/encoded/static/components/talen.js
@@ -148,7 +148,7 @@ var Listing = React.createClass({
                         <a href={result['@id']}>{result.name}</a>
                     </div>
                     <div className="data-row">
-                        <div>{result.description}</div>
+                        {result.description ? <div>{result.description}</div> : null}
                         <div><strong>Platform: </strong>{result.talen_platform}</div>
                         <div>
                             <strong>Genomic coordinates: </strong>
@@ -160,4 +160,5 @@ var Listing = React.createClass({
         );
     }
 });
+
 globals.listing_views.register(Listing, 'TALEN');


### PR DESCRIPTION
Supply columns to TALEN schema so that listing has data to display. I hope adding columns to the schema doesn’t cause reindexing. Doesn’t seem like it should, but I’m not sure.