### PR TITLE
Set X-Request-Url header in a tween instead of in a BeforeRender subs…

### DIFF
--- a/src/encoded/renderers.py
+++ b/src/encoded/renderers.py
@@ -38,11 +38,21 @@ def includeme(config):
         '.renderers.normalize_cookie_tween_factory',
         under='.renderers.fix_request_method_tween_factory')
 
-    config.add_tween(
+    renderer_tween = (
         '.renderers.debug_page_or_json'
         if config.registry.settings['pyramid.reload_templates']
-        else '.renderers.page_or_json',
+        else '.renderers.page_or_json'
+    )
+
+    config.add_tween(
+        renderer_tween,
         under='.renderers.normalize_cookie_tween_factory')
+
+    config.add_tween(
+        '.renderers.set_x_request_url_tween_factory',
+        under=renderer_tween,
+    )
+
     config.add_tween('.renderers.security_tween_factory', under='pyramid_tm.tm_tween_factory')
     config.scan(__name__)
 
@@ -144,11 +154,14 @@ def normalize_cookie_tween_factory(handler, registry):
     return normalize_cookie_tween
 
 
-@subscriber(BeforeRender)
-def set_x_request_url(event):
-    # Used by fetch polyfill and server rendering
-    request = event['request']
-    request.response.headers['X-Request-URL'] = request.url
+def set_x_request_url_tween_factory(handler, registry):
+
+    def set_x_request_url_tween(request):
+        response = handler(request)
+        response.headers['X-Request-URL'] = request.url
+        return response
+
+    return set_x_request_url_tween
 
 
 @subscriber(BeforeRender)


### PR DESCRIPTION
…criber so limit=all search pages have the header.