### PR TITLE
3512 Add Lab, Award PI, and project to Series pages

### DIFF
--- a/src/encoded/static/components/dataset.js
+++ b/src/encoded/static/components/dataset.js
@@ -1217,6 +1217,23 @@ var Series = module.exports.Series = React.createClass({
                             </div>
                         : null}
 
+                        <div data-test="lab">
+                            <dt>Lab</dt>
+                            <dd>{context.lab.title}</dd>
+                        </div>
+
+                        {context.award.pi && context.award.pi.lab ?
+                            <div data-test="awardpi">
+                                <dt>Award PI</dt>
+                                <dd>{context.award.pi.lab.title}</dd>
+                            </div>
+                        : null}
+
+                        <div data-test="project">
+                            <dt>Project</dt>
+                            <dd>{context.award.project}</dd>
+                        </div>
+
                         <div data-type="externalresources">
                             <dt>External resources</dt>
                             <dd>


### PR DESCRIPTION
Ticket [3512](http://redmine.encodedcc.org/issues/3512)

For all Series-type Dataset pages, now displays Lab, Award PI (when available), and Project in the top-most summary panel.