### PR TITLE
3520 Series search result target display

### DIFF
--- a/src/encoded/schemas/reference_epigenome.json
+++ b/src/encoded/schemas/reference_epigenome.json
@@ -144,7 +144,11 @@
             "title": "Status",
             "type": "string"
         },
-         "related_datasets.replicates.antibody.accession": {
+        "target.label": {
+            "title": "Target",
+            "type": "string"
+        },
+        "related_datasets.replicates.antibody.accession": {
             "title": "Linked Antibody",
             "type": "string"
         },

--- a/src/encoded/static/components/search.js
+++ b/src/encoded/static/components/search.js
@@ -435,7 +435,7 @@ var AuditMixin = audit.AuditMixin;
         mixins: [PickerActionsMixin, AuditMixin],
         render: function() {
             var result = this.props.context;
-            var biosampleTerm, organism, lifeSpec, lifeStages = [], ages = [];
+            var biosampleTerm, organism, lifeSpec, targets, lifeStages = [], ages = [];
 
             // Determine whether the dataset is a series or not
             var seriesDataset = result['@type'].indexOf('Series') >= 0;
@@ -470,6 +470,13 @@ var AuditMixin = audit.AuditMixin;
                     ages = _.uniq(ages);
                 }
                 lifeSpec = _.compact([lifeStages.length === 1 ? lifeStages[0] : null, ages.length === 1 ? ages[0] : null]);
+
+                // Get list of target labels
+                if (result.target) {
+                    targets = _.uniq(result.target.map(function(target) {
+                        return target.label;
+                    }));
+                }
             }
 
             var haveSeries = result['@type'].indexOf('Series') >= 0;
@@ -507,6 +514,7 @@ var AuditMixin = audit.AuditMixin;
                         </div>
                         <div className="data-row">
                             {result['dataset_type'] ? <div><strong>Dataset type: </strong>{result['dataset_type']}</div> : null}
+                            {targets && targets.length ? <div><strong>Targets: </strong>{targets.join(', ')}</div> : null}
                             <div><strong>Lab: </strong>{result.lab.title}</div>
                             <div><strong>Project: </strong>{result.award.project}</div>
                         </div>


### PR DESCRIPTION
For [Redmine 3520](http://redmine.encodedcc.org/issues/3520): Search result pages show all targets associated with any of the Series types of datasets: reference epigenome, organism development, matched set, replication timing, treatment concentration, and treatment timing