### PR TITLE
3556 ReferenceEpigenome search result biosample_term_name

### DIFF
--- a/src/encoded/schemas/reference_epigenome.json
+++ b/src/encoded/schemas/reference_epigenome.json
@@ -112,6 +112,10 @@
             "title": "Accession",
             "type": "string"
         },
+        "biosample_term_name" : {
+            "title": "Biosample term",
+            "type": "string"
+        },
         "related_datasets.assay_term_name": {
             "title": "Assay Type",
             "type": "string"


### PR DESCRIPTION
Search results with ReferenceEpigenome objects now display:

Reference epigenome series in _biosample_term_name_

…for the linked title. This makes it the same as the other Series dataset search results.