### PR TITLE
#3456 Fix missing View All button for biosample tables

### DIFF
--- a/src/encoded/static/components/biosample.js
+++ b/src/encoded/static/components/biosample.js
@@ -57,10 +57,36 @@ var BiosampleTable = React.createClass({
     },
 
     render: function() {
+        var biosamples;
+
+        // If there's a limit on entries to display and the array is greater than that
+        // limit, then clone the array with just that specified number of elements
+        if (this.props.limit && (this.props.limit < this.props.items.length)) {
+            // Limit the experiment list by cloning first {limit} elements
+            biosamples = this.props.items.slice(0, this.props.limit);
+        } else {
+            // No limiting; just reference the original array
+            biosamples = this.props.items;
+        }
+
         return (
             <SortTablePanel>
-                <SortTable list={this.props.items} columns={this.columns} />
+                <SortTable list={this.props.items} columns={this.columns} footer={<BiosampleTableFooter items={biosamples} total={this.props.total} url={this.props.url} />} />
             </SortTablePanel>
+        );
+    }
+});
+
+// Display a count of biosamples in the footer, with a link to the corresponding search if needed
+var BiosampleTableFooter = React.createClass({
+    render: function() {
+        var {items, total, url} = this.props;
+
+        return (
+            <div>
+                <span>Displaying {items.length} of {total} </span>
+                {items.length < total ? <a className="btn btn-info btn-xs pull-right" href={url}>View all</a> : null}
+            </div>
         );
     }
 });

--- a/src/encoded/static/components/dataset.js
+++ b/src/encoded/static/components/dataset.js
@@ -1609,7 +1609,7 @@ var ExperimentTableFooter = React.createClass({
         return (
             <div>
                 <span>Displaying {items.length} of {total} </span>
-                {items.length < total ? <a className="btn btn-info btn-sm pull-right" href={url}>View all</a> : null}
+                {items.length < total ? <a className="btn btn-info btn-xs pull-right" href={url}>View all</a> : null}
             </div>
         );
     }

--- a/src/encoded/static/components/sorttable.js
+++ b/src/encoded/static/components/sorttable.js
@@ -208,7 +208,7 @@ var SortTable = module.exports.SortTable = React.createClass({
                     <tbody>
                         {list.sort(this.sortColumn).map(item => {
                             return (
-                                <tr key={item.uuid}>
+                                <tr key={item['@id']}>
                                     {columnIds.map(columnId => {
                                         if (!hiddenColumns[columnId]) {
                                             if (columns[columnId].display) {


### PR DESCRIPTION
Donors used by more than five biosamples now show the biosample table with a footer showing the number displayed and the total number, and a *View all* button if the total is more than five. Also makes the *View all* button smaller than before to fit the footer better.