### PR TITLE
Fix bad frame name

### DIFF
--- a/src/contentbase/resource_views.py
+++ b/src/contentbase/resource_views.py
@@ -105,12 +105,16 @@ def item_view(context, request):
     if getattr(request, '__parent__', None) is None:
         # We need the response headers from non subrequests
         try:
-            return render_view_to_response(context, request, name=frame)
+            response = render_view_to_response(context, request, name=frame)
         except PredicateMismatch:
             # Avoid this view emitting PredicateMismatch
             exc_class, exc, tb = sys.exc_info()
             exc.__class__ = HTTPNotFound
             raise_with_traceback(exc, tb)
+        else:
+            if response is None:
+                raise HTTPNotFound('?frame=' + frame)
+            return response
     path = request.resource_path(context, '@@' + frame)
     if request.query_string:
         path += '?' + request.query_string

--- a/src/encoded/renderers.py
+++ b/src/encoded/renderers.py
@@ -181,6 +181,9 @@ def canonical_redirect(event):
     if request.path_info == '/':
         return
 
+    if not isinstance(event.rendering_val, dict):
+        return
+
     canonical = event.rendering_val.get('@id', None)
     if canonical is None:
         return

--- a/src/encoded/tests/test_views.py
+++ b/src/encoded/tests/test_views.py
@@ -349,3 +349,8 @@ def test_profiles(testapp, item_type):
     res = testapp.get('/profiles/%s.json' % item_type).maybe_follow(status=200)
     errors = Draft4Validator.check_schema(res.json)
     assert not errors
+
+
+def test_bad_frame(testapp, human):
+    res = testapp.get(human['@id'] + '?frame=bad', status=404)
+    assert res.json['detail'] == '?frame=bad'


### PR DESCRIPTION
Return a 404 Not Found instead returning None causing a later error to be thrown.