### PR TITLE
3587 antibody characterization captions

### DIFF
--- a/src/encoded/static/components/__tests__/antibody-test.js
+++ b/src/encoded/static/components/__tests__/antibody-test.js
@@ -121,8 +121,7 @@ describe('Antibody', function() {
 
             var charData = panel.getElementsByClassName('characterization-intro')[0];
             var item = charData.querySelector('[data-test="method"]');
-            var itemDescription = item.getElementsByTagName('dd')[0];
-            expect(itemDescription.textContent).toEqual('immunoblot');
+            expect(item.textContent).toContain('immunoblot');
 
             charData = panel.getElementsByClassName('characterization-slider')[0];
             item = charData.querySelector('[data-test="documents"]');
@@ -131,7 +130,7 @@ describe('Antibody', function() {
             expect(anchor.getAttribute('href')).toEqual('/documents/bcb5f3c8-d5e9-40d2-805f-4274f940c36d/@@download/attachment/Antibody_Characterization_ENCODE3_February2014.pdf');
 
             item = charData.querySelector('[data-test="submitted"]');
-            itemDescription = item.getElementsByTagName('dd')[0];
+            var itemDescription = item.getElementsByTagName('dd')[0];
             expect(itemDescription.textContent).toEqual('Ad Est');
 
             item = charData.querySelector('[data-test="grant"]');

--- a/src/encoded/static/components/antibody.js
+++ b/src/encoded/static/components/antibody.js
@@ -316,7 +316,7 @@ var Characterization = module.exports.Characterization = React.createClass({
 
                         <dl className="characterization-intro characterization-meta-data">
                             {context.characterization_method ?
-                                <div>
+                                <div data-test="method">
                                     <strong>Method: </strong>
                                     {context.characterization_method}
                                 </div>

--- a/src/encoded/static/components/antibody.js
+++ b/src/encoded/static/components/antibody.js
@@ -331,7 +331,7 @@ var Characterization = module.exports.Characterization = React.createClass({
                         </dl>
                     </div>
                     <dl ref="collapse" className={keyClass}>
-                        {excerpt ?
+                        {context.caption && context.caption.length ?
                             <div data-test="caption">
                                 <dt>Caption</dt>
                                 <dd className="sentence-case para-text">{context.caption}</dd>

--- a/src/encoded/static/components/antibody.js
+++ b/src/encoded/static/components/antibody.js
@@ -314,18 +314,18 @@ var Characterization = module.exports.Characterization = React.createClass({
                             <div className="characterization-badge"><StatusLabel status={context.status} /></div>
                         </figure>
 
-                        <dl className="characterization-intro characterization-meta-data key-value-left">
+                        <dl className="characterization-intro characterization-meta-data">
                             {context.characterization_method ?
-                                <div data-test="method">
-                                    <dt>Method</dt>
-                                    <dd>{context.characterization_method}</dd>
+                                <div>
+                                    <strong>Method: </strong>
+                                    {context.characterization_method}
                                 </div>
                             : null}
 
                             {excerpt || (context.caption && context.caption.length) ?
                                 <div data-test="caption">
-                                    <dt>{excerpt ? 'Caption excerpt' : 'Caption'}</dt>
-                                    <dd>{excerpt ? excerpt : context.caption}</dd>
+                                    <strong>{excerpt ? 'Caption excerpt' : 'Caption'}: </strong>
+                                    {excerpt ? excerpt : context.caption}
                                 </div>
                             : null}
                         </dl>

--- a/src/encoded/static/scss/encoded/modules/_characterizations.scss
+++ b/src/encoded/static/scss/encoded/modules/_characterizations.scss
@@ -213,10 +213,6 @@ $characterization-figure-height: 200px;
     }
 }
 
-.characterization-meta-data {
-    padding: 0;
-}
-
 .characterization-status {
     margin-bottom: 8px;
     font-weight: bold;


### PR DESCRIPTION
Primarily a bug fix to show the caption which I oddly gated on whether I had calculated an excerpt from a long caption or not. It now gates on whether the caption exists or not.

Also fixed ticket 3504 where the caption would sometimes get pushed off the panel, disappearing.

Also fixed an unreported styling problem where the drop-down data had no padding with the edge of the panel.