### PR TITLE
3360 remove raw indexing from large fields

### DIFF
--- a/src/contentbase/elasticsearch/create_mapping.py
+++ b/src/contentbase/elasticsearch/create_mapping.py
@@ -18,7 +18,6 @@ from .interfaces import ELASTIC_SEARCH
 import collections
 import json
 import logging
-import pdb
 
 EPILOG = __doc__
 
@@ -49,7 +48,6 @@ def sorted_dict(d):
 
 
 def schema_mapping(name, schema):
-    # pdb.set_trace()
     if 'linkFrom' in schema:
         type_ = 'string'
     else:

--- a/src/contentbase/elasticsearch/create_mapping.py
+++ b/src/contentbase/elasticsearch/create_mapping.py
@@ -209,7 +209,7 @@ def audit_mapping():
         },
         'detail': {
             'type': 'string',
-            'index': 'not_analyzed',
+            'index': 'analyzed',
         },
         'level_name': {
             'type': 'string',

--- a/src/contentbase/elasticsearch/create_mapping.py
+++ b/src/contentbase/elasticsearch/create_mapping.py
@@ -18,6 +18,7 @@ from .interfaces import ELASTIC_SEARCH
 import collections
 import json
 import logging
+import pdb
 
 EPILOG = __doc__
 
@@ -48,6 +49,7 @@ def sorted_dict(d):
 
 
 def schema_mapping(name, schema):
+    # pdb.set_trace()
     if 'linkFrom' in schema:
         type_ = 'string'
     else:
@@ -88,7 +90,7 @@ def schema_mapping(name, schema):
             }
         }
 
-    if type_ in ['string', 'boolean']:
+    if type_ ==  'boolean':
         return {
             'type': 'string',
             'store': True,
@@ -99,6 +101,26 @@ def schema_mapping(name, schema):
                 }
             }
         }
+
+    if type_ == 'string':
+
+        if schema.get('elasticsearch_mapping_index_type'):
+             if schema.get('elasticsearch_mapping_index_type')['default'] == 'analyzed':
+                return {
+                    'type': 'string',
+                    'store': True,
+                }
+        else:
+            return {
+                'type': 'string',
+                'store': True,
+                'fields': {
+                    'raw': {
+                        'type': 'string',
+                        'index': 'not_analyzed'
+                    }
+                }
+            }
 
     if type_ == 'number':
         return {

--- a/src/contentbase/elasticsearch/create_mapping.py
+++ b/src/contentbase/elasticsearch/create_mapping.py
@@ -209,7 +209,7 @@ def audit_mapping():
         },
         'detail': {
             'type': 'string',
-            'index': 'analyzed',
+            'index': 'analyzed', 
         },
         'level_name': {
             'type': 'string',

--- a/src/encoded/schemas/biosample.json
+++ b/src/encoded/schemas/biosample.json
@@ -128,7 +128,18 @@
             "title": "Description",
             "description": "A plain text description of the biosample. Do not include experiment details, constructs or treatments.",
             "type": "string",
-            "default": ""
+            "default": "",
+            "elasticsearch_mapping_index_type": {
+                "title": "Field mapping index type",
+                "description": "Defines one of three types of indexing available",
+                "type": "string",
+                "default": "analyzed",
+                "enum": [
+                    "analyzed",
+                    "not_analyzed",
+                    "no"
+                ]
+            }
         },
        "constructs": {
             "title": "DNA constructs",

--- a/src/encoded/schemas/construct.json
+++ b/src/encoded/schemas/construct.json
@@ -37,7 +37,18 @@
             "title": "Description",
             "description": "A plain text description of the construct. May include backbone name, description of the insert or purpose of the construct.",
             "type": "string",
-            "default": ""
+            "default": "",
+            "elasticsearch_mapping_index_type": {
+                "title": "Field mapping index type",
+                "description": "Defines one of three types of indexing available",
+                "type": "string",
+                "default": "analyzed",
+                "enum": [
+                    "analyzed",
+                    "not_analyzed",
+                    "no"
+                ]
+            }
         },
         "url": {
             "title": "URL",

--- a/src/encoded/schemas/dataset.json
+++ b/src/encoded/schemas/dataset.json
@@ -30,7 +30,18 @@
             "title": "Description",
             "description": "A plain text description of the dataset.",
             "type": "string",
-            "default": ""
+            "default": "",
+            "elasticsearch_mapping_index_type": {
+                "title": "Field mapping index type",
+                "description": "Defines one of three types of indexing available",
+                "type": "string",
+                "default": "analyzed",
+                "enum": [
+                    "analyzed",
+                    "not_analyzed",
+                    "no"
+                ]
+            }
         },
         "dbxrefs": {
             "@type": "@id",

--- a/src/encoded/schemas/document.json
+++ b/src/encoded/schemas/document.json
@@ -65,7 +65,18 @@
             "title": "Description",
             "description": "A plain text description of the document.",
             "type": "string",
-            "default": ""
+            "default": "",
+            "elasticsearch_mapping_index_type": {
+                "title": "Field mapping index type",
+                "description": "Defines one of three types of indexing available",
+                "type": "string",
+                "default": "analyzed",
+                "enum": [
+                    "analyzed",
+                    "not_analyzed",
+                    "no"
+                ]
+            }
         },
         "urls": {
             "rdfs:subPropertyOf": "rdfs:seeAlso",

--- a/src/encoded/schemas/mixins.json
+++ b/src/encoded/schemas/mixins.json
@@ -264,7 +264,18 @@
             "title": "Notes",
             "description": "Additional information.",
             "type": "string",
-            "permission": "import_items"
+            "permission": "import_items",
+            "elasticsearch_mapping_index_type": {
+                "title": "Field mapping index type",
+                "description": "Defines one of three types of indexing available",
+                "type": "string",
+                "default": "analyzed",
+                "enum": [
+                    "analyzed",
+                    "not_analyzed",
+                    "no"
+                ]
+            }
         }
     },
     "strains": {

--- a/src/encoded/schemas/page.json
+++ b/src/encoded/schemas/page.json
@@ -50,7 +50,18 @@
                         "type": "object",
                         "properties": {
                             "body": {
-                                "type": "string"
+                                "type": "string",
+                                "elasticsearch_mapping_index_type": {
+                                    "title": "Field mapping index type",
+                                    "description": "Defines one of three types of indexing available",
+                                    "type": "string",
+                                    "default": "analyzed",
+                                    "enum": [
+                                        "analyzed",
+                                        "not_analyzed",
+                                        "no"
+                                    ]
+                                }
                             },
                             "image": {
                                 "type": "string",

--- a/src/encoded/schemas/pipeline.json
+++ b/src/encoded/schemas/pipeline.json
@@ -48,7 +48,18 @@
             "description": "A place to provide a curated discription of the pipeline.  Only wranglers can post",
             "type": "string",
             "permission": "import_items",
-            "default": ""
+            "default": "",
+            "elasticsearch_mapping_index_type": {
+                "title": "Field mapping index type",
+                "description": "Defines one of three types of indexing available",
+                "type": "string",
+                "default": "analyzed",
+                "enum": [
+                    "analyzed",
+                    "not_analyzed",
+                    "no"
+                ]
+            }
         },
         "analysis_steps": {
             "title": "Analysis steps",

--- a/src/encoded/schemas/talen.json
+++ b/src/encoded/schemas/talen.json
@@ -44,7 +44,18 @@
             "title": "Description",
             "description": "A plain text description of the TALEN construct.",
             "type": "string",
-            "default": ""
+            "default": "",
+            "elasticsearch_mapping_index_type": {
+                "title": "Field mapping index type",
+                "description": "Defines one of three types of indexing available",
+                "type": "string",
+                "default": "analyzed",
+                "enum": [
+                    "analyzed",
+                    "not_analyzed",
+                    "no"
+                ]
+            }
         },
         "url": {
             "title": "URL",


### PR DESCRIPTION
removed raw indexing from every 'description' and 'notes' field of every schema object. Also, page object's layout.blocks.body is not being raw indexed.