### PR TITLE
3626 Make biosample characterization captions appear again

### DIFF
--- a/src/encoded/static/components/biosample.js
+++ b/src/encoded/static/components/biosample.js
@@ -1065,7 +1065,7 @@ var Document = module.exports.Document = React.createClass({
             );
         }
 
-        var characterization = context['@type'].indexOf('characterization') >= 0;
+        var characterization = context['@type'].indexOf('Characterization') >= 0;
         var caption = characterization ? context.caption : context.description;
         var excerpt;
         if (caption && caption.length > 100) {


### PR DESCRIPTION
This display used to key off an @type of “characterization,” but with the @type casing change, this test failed. It now instead keys off “Characterization.”