### PR TITLE
3360 boosting notes in biosample and experiment objects

### DIFF
--- a/src/encoded/schemas/biosample.json
+++ b/src/encoded/schemas/biosample.json
@@ -780,6 +780,7 @@
         "constructs.target.label": 1.0,
         "constructs.target.aliases": 1.0,
         "constructs.target.gene_name": 1.0,
-        "award.pi.title": 1.0
+        "award.pi.title": 1.0,
+        "notes": 1.0
     }
 }

--- a/src/encoded/schemas/experiment.json
+++ b/src/encoded/schemas/experiment.json
@@ -301,6 +301,7 @@
         "target.organism.name": 1.0,
         "target.organism.scientific_name": 1.0,
         "references.title": 1.0,
-        "replicates.library.biosample.rnais.product_id": 1.0
+        "replicates.library.biosample.rnais.product_id": 1.0,
+        "notes": 1.0
     }
 }


### PR DESCRIPTION
This is part of removing raw indexing from certain fields. There was a use case for searching the notes, and notes needed to be boosted.