### PR TITLE
3663 Chrome 48 doesn’t draw graphs properly

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2267,22 +2267,22 @@
     },
     "color": {
       "version": "0.10.1",
-      "from": "color@*",
+      "from": "https://registry.npmjs.org/color/-/color-0.10.1.tgz",
       "resolved": "https://registry.npmjs.org/color/-/color-0.10.1.tgz",
       "dependencies": {
         "color-convert": {
           "version": "0.5.3",
-          "from": "color-convert@>=0.5.3 <0.6.0",
+          "from": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz"
         },
         "color-string": {
           "version": "0.3.0",
-          "from": "color-string@>=0.3.0 <0.4.0",
+          "from": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
           "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
           "dependencies": {
             "color-name": {
               "version": "1.0.1",
-              "from": "color-name@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/color-name/-/color-name-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.0.1.tgz"
             }
           }
@@ -2301,36 +2301,36 @@
     },
     "dagre-d3": {
       "version": "0.4.3-pre",
-      "from": "git+https://github.com/ENCODE-DCC/dagre-d3.git#3d89b2a2a2d531fc2806b27bb15246912eb0ea40",
-      "resolved": "git+https://github.com/ENCODE-DCC/dagre-d3.git#3d89b2a2a2d531fc2806b27bb15246912eb0ea40",
+      "from": "git+https://github.com/ENCODE-DCC/dagre-d3.git#compound-nodes",
+      "resolved": "git+https://github.com/ENCODE-DCC/dagre-d3.git#6dc456e09a43a20ad08905479077b27897740293",
       "dependencies": {
         "dagre": {
           "version": "0.7.4",
-          "from": "https://registry.npmjs.org/dagre/-/dagre-0.7.4.tgz",
+          "from": "dagre@>=0.7.1 <0.8.0",
           "resolved": "https://registry.npmjs.org/dagre/-/dagre-0.7.4.tgz",
           "dependencies": {
             "lodash": {
               "version": "3.10.1",
-              "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+              "from": "lodash@>=3.10.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
             }
           }
         },
         "graphlib": {
           "version": "1.0.7",
-          "from": "https://registry.npmjs.org/graphlib/-/graphlib-1.0.7.tgz",
+          "from": "graphlib@>=1.0.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/graphlib/-/graphlib-1.0.7.tgz",
           "dependencies": {
             "lodash": {
               "version": "3.10.1",
-              "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+              "from": "lodash@>=3.10.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
             }
           }
         },
         "lodash": {
           "version": "2.4.2",
-          "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "from": "lodash@>=2.4.1 <3.0.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
         }
       }

--- a/src/encoded/static/components/graph.js
+++ b/src/encoded/static/components/graph.js
@@ -195,12 +195,13 @@ var Graph = module.exports.Graph = React.createClass({
         var g = new dagreD3.graphlib.Graph({multigraph: true, compound: true})
             .setGraph({rankdir: this.state.verticalGraph ? 'TB' : 'LR'})
             .setDefaultEdgeLabel(function() { return {}; });
+        var render = new dagreD3.render();
+        render(svg.select('g'), g);
 
         // Convert from given node architecture to the dagre nodes and edges
         this.convertGraph(this.props.graph, g);
 
         // Run the renderer. This is what draws the final graph.
-        var render = new dagreD3.render();
         render(svg.select('g'), g);
 
         // Dagre-D3 has a width and height for the graph.


### PR DESCRIPTION
First fix involved integrating a change from dagre-d3 author Chris Pettit for handing the issue. The second fix involved changing our code to clear the graph before redrawing it on changes, like from changing the filter.