### PR TITLE
3611 Fix contributing file oversight

### DIFF
--- a/src/encoded/static/components/experiment.js
+++ b/src/encoded/static/components/experiment.js
@@ -1242,6 +1242,7 @@ var assembleGraph = module.exports.assembleGraph = function(context, session, in
                 shape: 'rect',
                 cornerRadius: 16,
                 parentNode: replicateNode,
+                contributing: fileContributed,
                 ref: fileRef
             }, metricsInfo);
 

--- a/src/encoded/types/file.py
+++ b/src/encoded/types/file.py
@@ -105,6 +105,8 @@ class File(Item):
         'replicate.experiment.target',
         'lab',
         'derived_from',
+        'derived_from.analysis_step_version.software_versions',
+        'derived_from.analysis_step_version.software_versions.software',
         'submitted_by',
         'analysis_step_version.analysis_step',
         'analysis_step_version.analysis_step.pipelines',


### PR DESCRIPTION
I focused so much on getting the placeholder display right, I forgot to get the display of the normal case right. master now doesn’t show an information panel when you click a contributing file. This fixes that, as well as removes contributing_files from the experiment.py embed because the Javascript doesn’t use it anymore.