### PR TITLE
3635 wgbs rep corr qc metric

### DIFF
--- a/src/encoded/loadxl.py
+++ b/src/encoded/loadxl.py
@@ -59,6 +59,7 @@ ORDER = [
     'file',
     'star_quality_metric',
     'bismark_quality_metric',
+    'cpg_correlation_quality_metric',
     'chipseq_filter_quality_metric',
     'encode2_chipseq_quality_metric',
     'fastqc_quality_metric',

--- a/src/encoded/schemas/cpg_correlation_quality_metric.json
+++ b/src/encoded/schemas/cpg_correlation_quality_metric.json
@@ -25,10 +25,12 @@
         },
         "CpG pairs with atleast 10 reads each": {
             "type": "number",
-            "description": "CpG pairs with at least 10 reads each"
+            "description": "CpG pairs with atleast 10 reads each"
         },
-        "Pearson's correlation": {
+        "Pearson Correlation Coefficient": {
             "type": "number",
+            "minimum": -1,
+            "maximum": 1,
             "description": "Pearson's correlation of CpG pairs with at least 10 reads each"
         }
     }

--- a/src/encoded/schemas/cpg_correlation_quality_metric.json
+++ b/src/encoded/schemas/cpg_correlation_quality_metric.json
@@ -1,0 +1,35 @@
+{
+    "description": "Schema for reporting the 'CpG Correlation' output as a quality metric",
+    "id": "/profiles/cpg_correlation_quality_metric.json",
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "required": ["step_run","quality_metric_of"],
+    "additionalProperties": false,
+    "identifyingProperties": ["uuid"],
+    "mixinProperties": [
+        { "$ref": "mixins.json#/schema_version" },
+        { "$ref": "quality_metric.json#/properties" },
+        { "$ref": "mixins.json#/uuid" },
+        { "$ref": "mixins.json#/submitted"},
+        { "$ref": "mixins.json#/aliases" },
+        { "$ref": "mixins.json#/standard_status"},
+        { "$ref": "mixins.json#/assay" }
+   ],
+    "properties": {
+        "schema_version": {
+            "default": "1"
+        },
+        "CpG pairs": {
+            "type": "number",
+            "description": "CpG pairs"
+        },
+        "CpG pairs with atleast 10 reads each": {
+            "type": "number",
+            "description": "CpG pairs with at least 10 reads each"
+        },
+        "Pearson's correlation": {
+            "type": "number",
+            "description": "Pearson's correlation of CpG pairs with at least 10 reads each"
+        }
+    }
+}

--- a/src/encoded/tests/data/inserts/cpg_correlation_quality_metric.json
+++ b/src/encoded/tests/data/inserts/cpg_correlation_quality_metric.json
@@ -1,0 +1,14 @@
+[
+    {
+        "status": "released",
+        "step_run": "7c81414f-a9c0-44ed-87fb-2e2207733d3b",
+        "uuid": "23d36ff2-8219-4bf2-b163-2a922b1d8054",
+        "assay_term_name": "whole-genome shotgun bisulfite sequencing",
+        "assay_term_id": "OBI:0001863",
+        "quality_metric_of": [ "46e82a90-49e5-4c33-afab-9ec90d65faf3", "582d6675-0b2e-4886-b43d-f6efa9033b37" ],
+        "attachment": "generic_from_star_final_out.txt",
+        "CpG pairs": 43730532,
+        "CpG pairs with atleast 10 reads each": 31107909,
+        "Pearson Correlation Coefficient": 0.8993
+    }
+]

--- a/src/encoded/types/quality_metric.py
+++ b/src/encoded/types/quality_metric.py
@@ -54,6 +54,17 @@ class BismarkQualityMetric(QualityMetric):
 
 
 @collection(
+    name='cpg-correlation-quality-metrics',
+    properties={
+        'title': "WGBS replicate correlation CpG quality metrics",
+        'description': 'A set of QC metrics from WGBS replicate CpG correlations',
+    })
+class CpgCorrelationQualityMetric(QualityMetric):
+    item_type = 'cpg_correlation_quality_metric'
+    schema = load_schema('encoded:schemas/cpg_correlation_quality_metric.json')
+
+
+@collection(
     name='encode2-chipseq-quality-metrics',
     properties={
         'title': "Quality metrics for ChIP-seq (ENCODE2)",


### PR DESCRIPTION
Please pull this simple change, which adds a single schema: cpg_correlation_quality_metric.  This object type is needed for posting WGBS experiments. 