### PR TITLE
Make etag record tid of all propsheets.

### DIFF
--- a/src/contentbase/storage.py
+++ b/src/contentbase/storage.py
@@ -483,7 +483,8 @@ class Resource(Base):
 
     @property
     def tid(self):
-        return self.data[''].propsheet.tid
+        tids = (str(self.data[k].propsheet.tid) for k in self.data.keys())
+        return ','.join(sorted(set(tids)))
 
     def invalidated(self):
         return False


### PR DESCRIPTION
This is enabling infrastructure to make check_files more robust in the face of user changes to the file it is checking.