### PR TITLE
3769 read depth fix

### DIFF
--- a/src/encoded/audit/file.py
+++ b/src/encoded/audit/file.py
@@ -562,21 +562,13 @@ def audit_file_read_depth(value, system):
     for derived_from_file in derived_from_files:
         if 'file_type' in derived_from_file and derived_from_file['file_type'] == 'fastq' and \
            'run_type' in derived_from_file:
-            if derived_from_file['run_type'] == 'single-ended':
-                paired_ended_status = False
                 paring_status_detected = True
                 break
-            else:
-                if derived_from_file['run_type'] == 'paired-ended':
-                    paired_ended_status = True
-                    paring_status_detected = True
-                    break
 
     if paring_status_detected is False:
         detail = 'ENCODE Processed alignment file {} has no run_type in derived_from files'.format(
             value['@id'])
         yield AuditFailure('missing run_type in derived_from files', detail, level='DCC_ACTION')
-        return
 
     for metric in quality_metrics:
         if 'Uniquely mapped reads number' in metric:  # start_quality_metric.json
@@ -584,10 +576,10 @@ def audit_file_read_depth(value, system):
             break  # continue
         else:
             if "total" in metric:
-                if paired_ended_status is False:
-                    read_depth = metric['total']
-                else:
+                if "read1" in metric and "read2" in metric:
                     read_depth = int(metric['total']/2)
+                else:
+                    read_depth = metric['total']
                 break
 
     if read_depth == 0:

--- a/src/encoded/tests/test_audit_file.py
+++ b/src/encoded/tests/test_audit_file.py
@@ -447,7 +447,7 @@ def test_audit_file_read_depth_chip_seq_paired_end_no_target(testapp, file_exp, 
                                                              analysis_step_bam,
                                                              pipeline_bam):
     testapp.patch_json(file6['@id'], {'dataset': file_exp['@id']})
-    testapp.patch_json(file4['@id'], {'run_type': 'paired-ended'})
+    testapp.patch_json(chipseq_bam_quality_metric['@id'], {'read1': 100, 'read2': 100})
     testapp.patch_json(file6['@id'], {'derived_from': [file4['@id']]})
     res = testapp.get(file6['@id'] + '@@index-data')
     errors = res.json['audit']
@@ -520,7 +520,7 @@ def test_audit_file_read_depth_chip_seq_paired_end(testapp, file_exp, file6, fil
                                                    pipeline_bam):
     testapp.patch_json(file_exp['@id'], {'target': target_H3K27ac['@id']})
     testapp.patch_json(file6['@id'], {'dataset': file_exp['@id']})
-    testapp.patch_json(file4['@id'], {'run_type': 'paired-ended'})
+    testapp.patch_json(chipseq_bam_quality_metric['@id'], {'read1': 100, 'read2': 100})
     testapp.patch_json(file6['@id'], {'derived_from': [file4['@id']]})
     res = testapp.get(file6['@id'] + '@@index-data')
     errors = res.json['audit']
@@ -537,9 +537,9 @@ def test_audit_file_insufficient_read_depth_chip_seq_paired_end(testapp, file_ex
                                                                 analysis_step_bam, target_H3K27ac,
                                                                 pipeline_bam):
     testapp.patch_json(file_exp['@id'], {'target': target_H3K27ac['@id']})
-    testapp.patch_json(chipseq_bam_quality_metric['@id'], {'total': 10000000})
+    testapp.patch_json(chipseq_bam_quality_metric['@id'], {'total': 10000000,
+                                                           'read1': 100, 'read2': 100})
     testapp.patch_json(file6['@id'], {'dataset': file_exp['@id']})
-    testapp.patch_json(file4['@id'], {'run_type': 'paired-ended'})
     testapp.patch_json(file6['@id'], {'derived_from': [file4['@id']]})
     res = testapp.get(file6['@id'] + '@@index-data')
     errors = res.json['audit']


### PR DESCRIPTION
fixing the audit of read depth to rely on the QC metric rather than on derived from FASTQ run)type property