### PR TITLE
don't include readonly fields in form default

### DIFF
--- a/src/encoded/static/components/form.js
+++ b/src/encoded/static/components/form.js
@@ -345,7 +345,7 @@ var jsonSchemaToFormSchema = function(attrs) {
 var jsonSchemaToDefaultValue = function(schema) {
     var defaultValue = {};
     _.each(schema.properties, function(property, name) {
-        if (property['default'] !== undefined) {
+        if (property.default !== undefined && !property.readonly) {
             defaultValue[name] = property['default'];
         }
     });


### PR DESCRIPTION
This fixes http://redmine.encodedcc.org/issues/3822 where submitters could not add items because the form was including default values for readonly fields.