### PR TITLE
forms: don't load child objects until they are expanded

### DIFF
--- a/src/encoded/static/components/form.js
+++ b/src/encoded/static/components/form.js
@@ -203,8 +203,7 @@ var FetchedFieldset = React.createClass({
             <div className="collapsible">
                 <span className="collapsible-trigger" onClick={this.toggleCollapsed}>{this.state.collapsed ? '▶ ' : '▼ '}</span>
                 {isFailure && <ReactForms.Message>{externalValidation.error}</ReactForms.Message>}
-                <div style={{display: this.state.collapsed ? 'block' : 'none'}}>{preview}</div>
-                <div style={{display: this.state.collapsed ? 'none' : 'block'}}>{fieldset}</div>
+                {this.state.collapsed ? preview : fieldset}
             </div>
         );
     },


### PR DESCRIPTION
This fixes http://redmine.encodedcc.org/issues/3834 and also avoids unnecessary data transfer.