### PR TITLE
3807 Use first MGI: in list for mouse targets for gene link

### DIFF
--- a/src/encoded/static/components/dataset.js
+++ b/src/encoded/static/components/dataset.js
@@ -20,7 +20,6 @@ var doc = require('./doc');
 
 var Breadcrumbs = navbar.Breadcrumbs;
 var DbxrefList = dbxref.DbxrefList;
-var Dbxref = dbxref.Dbxref;
 var FetchedItems = fetched.FetchedItems;
 var StatusLabel = statuslabel.StatusLabel;
 var PubReferenceList = reference.PubReferenceList;

--- a/src/encoded/static/components/publication.js
+++ b/src/encoded/static/components/publication.js
@@ -8,7 +8,6 @@ var audit = require('./audit');
 
 var Breadcrumbs = navbar.Breadcrumbs;
 var DbxrefList = dbxref.DbxrefList;
-var Dbxref = dbxref.Dbxref;
 var AuditIndicators = audit.AuditIndicators;
 var AuditDetail = audit.AuditDetail;
 var AuditMixin = audit.AuditMixin;

--- a/src/encoded/static/components/search.js
+++ b/src/encoded/static/components/search.js
@@ -16,7 +16,6 @@ var audit = require('./audit');
 var objectutils = require('./objectutils');
 
 var DbxrefList = dbxref.DbxrefList;
-var Dbxref = dbxref.Dbxref;
 var statusOrder = globals.statusOrder;
 var SingleTreatment = objectutils.SingleTreatment;
 var AuditIndicators = audit.AuditIndicators;

--- a/src/encoded/static/components/target.js
+++ b/src/encoded/static/components/target.js
@@ -22,10 +22,11 @@ var Target = module.exports.Target = React.createClass({
         if (context.organism.name == "human") {
             geneLink = globals.dbxref_prefix_map.HGNC + context.gene_name;
         } else if (context.organism.name == "mouse") {
-            var uniProtValue = JSON.stringify(context.dbxref);
-            sep = uniProtValue.indexOf(":") + 1;
-            var uniProtID = uniProtValue.substring(sep, uniProtValue.length - 2);
-            geneLink = globals.dbxref_prefix_map.UniProtKB + uniProtID;
+            var mgiRef = _(context.dbxref).find(ref => ref.substr(0,4) === 'MGI:');
+            if (mgiRef) {
+                var base = globals.dbxref_prefix_map['MGI'];
+                geneLink = base + mgiRef;
+            }
         } else if (context.organism.name == 'dmelanogaster' || context.organism.name == 'celegans') {
             var organismPrefix = context.organism.name == 'dmelanogaster' ? 'FBgn': 'WBGene';
             var baseUrl = context.organism.name == 'dmelanogaster' ? globals.dbxref_prefix_map.FlyBase : globals.dbxref_prefix_map.WormBase;


### PR DESCRIPTION
Target gene links did not expect to find an array of dbxrefs, and made a malformed URL from it. It now searches for the first MGI: dbxref and makes a link from that.