### PR TITLE
3989 Hide audits while logged out

### DIFF
--- a/src/encoded/static/components/app.js
+++ b/src/encoded/static/components/app.js
@@ -85,7 +85,8 @@ var App = React.createClass({
         currentResource: React.PropTypes.func,
         location_href: React.PropTypes.string,
         onDropdownChange: React.PropTypes.func,
-        portal: React.PropTypes.object
+        portal: React.PropTypes.object,
+        hidePublicAudits: React.PropTypes.bool
     },
 
     // Retrieve current React context
@@ -96,7 +97,8 @@ var App = React.createClass({
             currentResource: this.currentResource,
             location_href: this.props.href,
             onDropdownChange: this.handleDropdownChange, // Function to process dropdown state change
-            portal: portal
+            portal: portal,
+            hidePublicAudits: true // True if audits should be hidden on the UI while logged out
         };
     },
 

--- a/src/encoded/static/components/audit.js
+++ b/src/encoded/static/components/audit.js
@@ -52,7 +52,8 @@ var AuditIndicators = module.exports.AuditIndicators = React.createClass({
     contextTypes: {
         auditDetailOpen: React.PropTypes.bool,
         auditStateToggle: React.PropTypes.func,
-        session: React.PropTypes.object
+        session: React.PropTypes.object,
+        hidePublicAudits: React.PropTypes.bool
     },
 
     render: function() {
@@ -60,7 +61,7 @@ var AuditIndicators = module.exports.AuditIndicators = React.createClass({
         var audits = this.props.audits;
         var loggedIn = this.context.session && this.context.session['auth.userid'];
 
-        if (audits && Object.keys(audits).length) {
+        if ((!this.context.hidePublicAudits || loggedIn) && audits && Object.keys(audits).length) {
             // Sort the audit levels by their level number, using the first element of each warning category
             var sortedAuditLevels = _(Object.keys(audits)).sortBy(function(level) {
                 return -audits[level][0].level;

--- a/src/encoded/static/components/search.js
+++ b/src/encoded/static/components/search.js
@@ -790,12 +790,18 @@ var TextFilter = search.TextFilter = React.createClass({
 });
 
 var FacetList = search.FacetList = React.createClass({
+    contextTypes: {
+        session: React.PropTypes.object,
+        hidePublicAudits: React.PropTypes.bool
+    },
+
     getDefaultProps: function() {
         return {orientation: 'vertical'};
     },
 
     render: function() {
         var {context, term} = this.props;
+        var loggedIn = this.context.session && this.context.session['auth.userid'];
 
         // Get all facets, and "normal" facets, meaning non-audit facets
         var facets = this.props.facets;
@@ -841,14 +847,14 @@ var FacetList = search.FacetList = React.createClass({
                     </div>
                 : null}
                 {this.props.mode === 'picker' && !this.props.hideTextFilter ? <TextFilter {...this.props} filters={filters} /> : ''}
-                {facets.map(function (facet, i) {
-                    if (hideTypes && facet.field == 'type') {
+                {facets.map(facet => {
+                    if ((hideTypes && facet.field == 'type') || (!loggedIn && this.context.hidePublicAudits && facet.field.substring(0, 6) === 'audit.')) {
                         return <span key={facet.field} />;
                     } else {
                         return <Facet {...this.props} key={facet.field} facet={facet} filters={filters}
                                         width={width} />;
                     }
-                }.bind(this))}
+                })}
             </div>
         );
     }


### PR DESCRIPTION
Implement a single switch that enables/disables the display of audits while logged out. It’s disabled in this build, so merge if needed.