### PR TITLE
4006 Display document and characterization disclosure triangles properly

### DIFF
--- a/src/encoded/static/components/antibody.js
+++ b/src/encoded/static/components/antibody.js
@@ -391,7 +391,7 @@ var CharacterizationFile = React.createClass({
                 <div className="characterization-badge"><StatusLabel status={doc.status} /></div>
                 {detailSwitch ?
                     <div className={'detail-switch' + (detailOpen ? ' open' : '')}>
-                        <i className={'icon detail-trigger' + (detailOpen ? ' open' : '')} onClick={detailSwitch}>
+                        <i className={'icon detail-trigger' + (detailOpen ? '' : ' collapsed')} onClick={detailSwitch}>
                             <span className="sr-only">More</span>
                         </i>
                     </div>


### PR DESCRIPTION
They were stuck in the pointing-down direction. They now respond to clicks property, pointing left until clicked, whereupon they point down.