### PR TITLE
4073 Some green QC circles in the graph aren’t clickable

### DIFF
--- a/src/encoded/static/components/experiment.js
+++ b/src/encoded/static/components/experiment.js
@@ -1814,13 +1814,17 @@ var QcDetailsView = function(metrics) {
         // property as a key to retrieve the list of properties appropriate for that QC type.
         var qcAttachmentPropertyList = qcAttachmentProperties[metrics.ref['@type'][0]];
         if (qcAttachmentPropertyList) {
-            qcPanels = qcAttachmentPropertyList.map(attachmentPropertyInfo => {
+            qcPanels = _(qcAttachmentPropertyList.map(attachmentPropertyInfo => {
                 // Each object in the list has only one key (the metric attachment property name), so get it here.
                 var attachmentPropertyName = Object.keys(attachmentPropertyInfo)[0];
+                var attachment = metrics.ref[attachmentPropertyName];
 
                 // Generate the JSX for the panel. Use the property name as the key to get the corresponding human-readable description for the title
-                return <AttachmentPanel context={metrics.ref} attachment={metrics.ref[attachmentPropertyName]} title={attachmentPropertyInfo[attachmentPropertyName]} />;
-            });
+                if (attachment) {
+                    return <AttachmentPanel context={metrics.ref} attachment={metrics.ref[attachmentPropertyName]} title={attachmentPropertyInfo[attachmentPropertyName]} />;
+                }
+                return null;
+            })).compact();
         }
 
         // Convert the QC metric object @id to a displayable string
@@ -1856,17 +1860,19 @@ var QcDetailsView = function(metrics) {
                         </dl>
                     </div>
 
-                    <div className="col-md-8 col-sm-12 quality-metrics-attachments">
-                        <h5>Quality metric attachments</h5>
-                        <div className="row">
-                            {/* If the metrics object has an `attachment` property, display that first, then display the properties
-                                not named `attachment` but which have their own schema attribute, `attachment`, set to true */}
-                            {metrics.ref.attachment ?
-                                <AttachmentPanel context={metrics.ref} attachment={metrics.ref.attachment} />
-                            : null}
-                            {qcPanels}
+                    {qcPanels && qcPanels.length ?
+                        <div className="col-md-8 col-sm-12 quality-metrics-attachments">
+                            <h5>Quality metric attachments</h5>
+                            <div className="row">
+                                {/* If the metrics object has an `attachment` property, display that first, then display the properties
+                                    not named `attachment` but which have their own schema attribute, `attachment`, set to true */}
+                                {metrics.ref.attachment ?
+                                    <AttachmentPanel context={metrics.ref} attachment={metrics.ref.attachment} />
+                                : null}
+                                {qcPanels}
+                            </div>
                         </div>
-                    </div>
+                    : null}
                 </div>
             </div>
         );


### PR DESCRIPTION
Stop assuming chip-seq QC attachments exist. This caused the Javascript to crash on click when they didn’t.