### PR TITLE
4130 Eliminate unnecessary arrows with no filtering menu

### DIFF
--- a/src/encoded/static/components/filegallery.js
+++ b/src/encoded/static/components/filegallery.js
@@ -479,11 +479,11 @@ var FileGalleryRenderer = React.createClass({
                                 </DropdownButton>
                             </div>
                         : null}
-                        <div className="file-gallery-control file-gallery-control-select">
-                            {filterOptions.length ?
+                        {filterOptions.length ?
+                            <div className="file-gallery-control file-gallery-control-select">
                                 <FilterMenu selectedFilterValue={this.state.selectedFilterValue} filterOptions={filterOptions} handleFilterChange={this.handleFilterChange} />
-                            : null}
-                        </div>
+                            </div>
+                        : null}
                     </div>
                 </PanelHeading>
 


### PR DESCRIPTION
When an experiment/annotation has a file table and/or graph but has no filtering menu, the up/down arrows for it still appeared. This change removes that by a small rearranging of JSX so that the entire <div> for the menu doesn’t get rendered when the menu’s not needed, not just the menu itself.