### PR TITLE
4086 Replicate table with two biological replicates and no library

### DIFF
--- a/src/encoded/static/components/experiment.js
+++ b/src/encoded/static/components/experiment.js
@@ -74,7 +74,7 @@ var Experiment = module.exports.Experiment = React.createClass({
         var itemClass = globals.itemClass(context, 'view-item');
         var replicates = context.replicates;
         if (replicates) {
-            var condensedReplicatesKeyed = _(replicates).groupBy(replicate => replicate.library && replicate.library['@id']);
+            var condensedReplicatesKeyed = _(replicates).groupBy(replicate => replicate.library ? replicate.library['@id'] : replicate.uuid);
             if (Object.keys(condensedReplicatesKeyed).length) {
                 condensedReplicates = _.toArray(condensedReplicatesKeyed);
             }


### PR DESCRIPTION
Had been grouping them by library, but obviously this doesn’t work with no library. Now we don’t group at all if there’s no library.