### PR TITLE
4249 audit links handle surrounding punctuation

### DIFF
--- a/src/encoded/static/components/audit.js
+++ b/src/encoded/static/components/audit.js
@@ -227,7 +227,7 @@ var DetailEmbeddedLink = React.createClass({
         var detail = this.props.detail;
 
         // Get an array of all paths in the detail string, if any.
-        var matches = detail.match(/(\/.+?\/)(?=$|\s+)/g);
+        var matches = detail.match(/(\/.*?\/.*?\/)/g);
         if (matches) {
             // Build React object of text followed by path for all paths in detail string
             var lastStart = 0;


### PR DESCRIPTION
Simply made the regex more flexible. Handles surrounding non-space characters, as well as links at the beginning and end of audit text.