### PR TITLE
Add linkout for BDSC dbxrefs

### DIFF
--- a/src/encoded/static/components/globals.js
+++ b/src/encoded/static/components/globals.js
@@ -161,6 +161,7 @@ module.exports.dbxref_prefix_map = {
     "FlyBase": "http://flybase.org/cgi-bin/quicksearch_solr.cgi?caller=quicksearch&tab=basic_tab&data_class=FBgn&species=Dmel&search_type=all&context=",
     // This WormBase link is strictly for Fly strains
     "FlyBaseStock": "http://flybase.org/reports/",
+    "BDSC": "http://flystocks.bio.indiana.edu/Reports/",
     "WormBaseTargets": "http://www.wormbase.org/species/c_elegans/gene/",
     // This WormBase link is strictly for C. elegans strains
     "WormBase": "http://www.wormbase.org/species/c_elegans/strain/",

--- a/src/encoded/tests/data/inserts/fly_donor.json
+++ b/src/encoded/tests/data/inserts/fly_donor.json
@@ -30,6 +30,6 @@
             "ENCODE:sample_strain_generation_protocol"
         ],
         "uuid": "094a484e-817c-4cb3-a8dd-9ea2c3c1067b",
-        "dbxrefs": ["FlyBase:FBst0038626"]
+        "dbxrefs": ["FlyBase:FBst0038626", "BDSC:38626"]
     }
 ]


### PR DESCRIPTION
#4263 - added missing linkout to BDSC stock number dbxrefs in fly donors