### PR TITLE
4352 biosample part_of causing Javascript crashes

### DIFF
--- a/src/encoded/types/biosample.py
+++ b/src/encoded/types/biosample.py
@@ -82,6 +82,7 @@ class Biosample(Item, CalculatedBiosampleSlims, CalculatedBiosampleSynonyms):
         'part_of.rnais.documents.award',
         'part_of.rnais.documents.lab',
         'part_of.rnais.documents.submitted_by',
+        'part_of.treatments.protocols',
         'parent_of',
         'pooled_from',
         'characterizations.submitted_by',

--- a/src/encoded/types/biosample.py
+++ b/src/encoded/types/biosample.py
@@ -83,6 +83,7 @@ class Biosample(Item, CalculatedBiosampleSlims, CalculatedBiosampleSynonyms):
         'part_of.rnais.documents.lab',
         'part_of.rnais.documents.submitted_by',
         'part_of.treatments.protocols',
+        'part_of.talens.documents',
         'parent_of',
         'pooled_from',
         'characterizations.submitted_by',


### PR DESCRIPTION
biosamples with part_of set display their parent’s documents. Not all document types for part_of were embedded, leading to a Javascript crash. This branch embeds the needed documents for part_of.