### PR TITLE
4404 Stop assuming audit URL form

### DIFF
--- a/src/encoded/static/components/search.js
+++ b/src/encoded/static/components/search.js
@@ -699,8 +699,12 @@ var Facet = search.Facet = React.createClass({
         if (field.substr(0, 6) === 'audit.') {
             var titleParts = title.split(': ');
             var fieldParts = field.match(/^audit.(.+).category$/i);
-            var iconClass = 'icon audit-activeicon-' + fieldParts[1].toLowerCase();
-            title = <span>{titleParts[0]}: <i className={iconClass}></i></span>;
+            if (fieldParts && fieldParts.length === 2 && titleParts) {
+                var iconClass = 'icon audit-activeicon-' + fieldParts[1].toLowerCase();
+                title = <span>{titleParts[0]}: <i className={iconClass}></i></span>;
+            } else {
+                title = <span>{title}</span>;
+            }
         }
 
         return (


### PR DESCRIPTION
Was assuming that query string for audits would always be something like “audit.ERROR.category=something” but wasn’t taking things like != into account. Redmine #4404.