### PR TITLE
4330 Stop expecting optional properties in genetic modification objects

### DIFF
--- a/src/encoded/static/components/genetic_modification.js
+++ b/src/encoded/static/components/genetic_modification.js
@@ -196,7 +196,7 @@ const GeneticModification = module.exports.GeneticModification = React.createCla
                                         </div>
                                     : null}
 
-                                    {context.source.title ?
+                                    {context.source && context.source.title ?
                                         <div data-test="sourcetitle">
                                             <dt>Source</dt>
                                             <dd>
@@ -221,7 +221,7 @@ const GeneticModification = module.exports.GeneticModification = React.createCla
                                         </div>
                                     : null}
 
-                                    {context.aliases.length ?
+                                    {context.aliases && context.aliases.length ?
                                         <div data-test="aliases">
                                             <dt>Aliases</dt>
                                             <dd>{context.aliases.join(", ")}</dd>

--- a/src/encoded/tests/data/inserts/genetic_modification.json
+++ b/src/encoded/tests/data/inserts/genetic_modification.json
@@ -101,7 +101,6 @@
             "end": 48560547
         },
         "award": "/awards/U41HG007355/",
-        "source":"gregory-crawford",
         "lab": "/labs/robert-waterston/",
         "uuid": "b9264c83-2222-4678-a82f-4915af941fa4",
         "submitted_by": "amet.fusce@est.fermentum",


### PR DESCRIPTION
Treat genetic_modification.source and genetic_modification.source.alias as optional.