### PR TITLE
4554 Allow 0-count facet terms to be clickable again

### DIFF
--- a/src/encoded/static/components/search.js
+++ b/src/encoded/static/components/search.js
@@ -647,21 +647,12 @@ var Term = search.Term = React.createClass({
             <li id={selected ? "selected" : null} key={term}>
                 {selected ? '' : <span className="bar" style={barStyle}></span>}
                 {field === 'lot_reviews.status' ? <span className={globals.statusClass(term, 'indicator pull-left facet-term-key icon icon-circle')}></span> : null}
-                {count ?
-                    <a id={selected ? "selected" : null} href={href} onClick={href ? this.props.onFilter : null}>
-                        <span className="pull-right">{count} {selected && this.props.canDeselect ? <i className="icon icon-times-circle-o"></i> : ''}</span>
-                        <span className="facet-item">
-                            {em ? <em>{title}</em> : <span>{title}</span>}
-                        </span>
-                    </a>
-                :
-                    <span>
-                        <span className="pull-right">{count}</span>
-                        <span className="facet-item">
-                            {em ? <em>{title}</em> : <span>{title}</span>}
-                        </span>
+                <a id={selected ? "selected" : null} href={href} onClick={href ? this.props.onFilter : null}>
+                    <span className="pull-right">{count} {selected && this.props.canDeselect ? <i className="icon icon-times-circle-o"></i> : ''}</span>
+                    <span className="facet-item">
+                        {em ? <em>{title}</em> : <span>{title}</span>}
                     </span>
-                }
+                </a>
             </li>
         );
     }
@@ -685,10 +676,7 @@ var TypeTerm = search.TypeTerm = React.createClass({
 
 var Facet = search.Facet = React.createClass({
     getDefaultProps: function() {
-        return {
-            width: 'inherit',
-            hideZeros: true
-        };
+        return {width: 'inherit'};
     },
 
     getInitialState: function () {
@@ -708,21 +696,18 @@ var Facet = search.Facet = React.createClass({
         var field = facet['field'];
         var total = facet['total'];
         var termID = title.replace(/\s+/g, '');
-        var terms = facet.terms;
-        if (this.props.hideZeros) {
-            terms = terms.filter(function (term) {
-                if (term.key) {
-                    for(var filter in filters) {
-                        if(filters[filter].term === term.key) {
-                            return true;
-                        }
+        var terms = facet['terms'].filter(function (term) {
+            if (term.key) {
+                for(var filter in filters) {
+                    if(filters[filter].term === term.key) {
+                        return true;
                     }
-                    return term.doc_count > 0;
-                } else {
-                    return false;
                 }
-            });
-        }
+                return term.doc_count > 0;
+            } else {
+                return false;
+            }
+        });
         var moreTerms = terms.slice(5);
         var TermComponent = field === 'type' ? TypeTerm : Term;
         var selectedTermCount = countSelectedTerms(moreTerms, field, filters);


### PR DESCRIPTION
This was an odd leftover from David’s original homepage_summary branch I had inadvertently left in. This change reverts his experimental changes.

For Release 49