### PR TITLE
4519 Stop multiple redraws on the home page charts

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -86,7 +86,7 @@ accession_factory = encoded.server_defaults.test_accession
 file_upload_bucket = encoded-files-dev
 blob_bucket = encoded-blobs-dev
 region_search_instance = region-search-test-v5.instance.encodedcc.org:9200
-indexer_processes = 16
+indexer_processes = 
 
 [production]
 recipe = collective.recipe.modwsgi

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -86,7 +86,7 @@ accession_factory = encoded.server_defaults.test_accession
 file_upload_bucket = encoded-files-dev
 blob_bucket = encoded-blobs-dev
 region_search_instance = region-search-test-v5.instance.encodedcc.org:9200
-indexer_processes = 
+indexer_processes = 16
 
 [production]
 recipe = collective.recipe.modwsgi

--- a/src/encoded/static/components/app.js
+++ b/src/encoded/static/components/app.js
@@ -52,7 +52,8 @@ var portal = {
 
 
 // Keep lists of currently known project and biosample_type. As new project and biosample_type
-// enter the system, these lists must be updated.
+// enter the system, these lists must be updated. Used mostly to keep chart and matrix colors
+// consistent.
 const projectList = [
     'ENCODE',
     'Roadmap',

--- a/src/encoded/static/components/home.js
+++ b/src/encoded/static/components/home.js
@@ -384,7 +384,7 @@ let HomepageChart = React.createClass({
             // Have chartjs draw the legend into the DOM.
             document.getElementById('chart-legend').innerHTML = this.myPieChart.generateLegend();
 
-            // Save the chart <div> height so we can set it to that value when no data's available.'
+            // Save the chart <div> height so we can set it to that value when no data's available.
             let chartWrapperDiv = document.getElementById('chart-wrapper-1');
             this.wrapperHeight = chartWrapperDiv.clientHeight;
         }.bind(this));
@@ -482,16 +482,11 @@ var HomepageChart2 = React.createClass({
         // require.
         require.ensure(['chart.js'], function(require) {
             var Chart = require('chart.js');
+            var colors = this.context.biosampleTypeColors.colorList(facetData.map(term => term.key), {shade: 10});
             var data = [];
             var labels = [];
-            var assayFacet;
 
-            var totalDocCount = 0;
-
-            // for each item, set doc count, add to total doc count, add proper label, and assign color
-            var colors = this.context.biosampleTypeColors.colorList(facetData.map(term => term.key), {shade: 10});
             facetData.forEach((term, i) => {
-                totalDocCount += term.doc_count;
                 data[i] = term.doc_count;
                 labels[i] = term.key;
             });
@@ -555,7 +550,10 @@ var HomepageChart2 = React.createClass({
                 }
             });
 
+            // Have chartjs draw the legend into the DOM.
             document.getElementById('chart-legend-2').innerHTML = this.myPieChart.generateLegend();
+
+            // Save the chart <div> height so we can set it to that value when no data's available.
             let chartWrapperDiv = document.getElementById('chart-wrapper-2');
             this.wrapperHeight = chartWrapperDiv.clientHeight;
         }.bind(this));
@@ -578,6 +576,8 @@ var HomepageChart2 = React.createClass({
         Chart.data.datasets[0].backgroundColor = colors;
         Chart.data.labels = labels;
         Chart.update();
+
+        // Redraw the updated legend
         document.getElementById('chart-legend-2').innerHTML = Chart.generateLegend(); // generates legend
     },
 
@@ -654,16 +654,13 @@ let HomepageChart3 = React.createClass({
         // require.
         require.ensure(['chart.js'], function(require) {
             let Chart = require('chart.js');
+            let colors = [];
             let data = [];
             let labels = [];
-            let colors = [];
             let selectedAssay = (this.props.assayCategory && this.props.assayCategory !== 'COMPPRED') ? this.props.assayCategory.replace(/\+/g,' ') : '';
-
-            let totalDocCount = 0;
 
             // for each item, set doc count, add to total doc count, add proper label, and assign color
             facetData.forEach((term, i) => {
-                totalDocCount += term.doc_count;
                 data[i] = term.doc_count;
                 labels[i] = term.key;
                 colors[i] = selectedAssay ? (term.key === selectedAssay ? 'rgb(255,217,98)' : 'rgba(255,217,98,.4)') : '#FFD962';

--- a/src/encoded/static/components/home.js
+++ b/src/encoded/static/components/home.js
@@ -15,7 +15,7 @@ const newsUri = '/search/?type=Page&news=true&status=released';
 // Main page component to render the home page
 var Home = module.exports.Home = React.createClass({
 
-    getInitialState: function() { // sets initial state for current and newtabs
+    getInitialState: function () { // sets initial state for current and newtabs
         return {
             current: "?type=Experiment&status=released", // show all released experiments
             organisms: [], // create empty array of selected tabs
@@ -24,40 +24,40 @@ var Home = module.exports.Home = React.createClass({
         };
     },
 
-    handleAssayCategoryClick: function(assayCategory) {
+    handleAssayCategoryClick: function (assayCategory) {
         if (this.state.assayCategory === assayCategory) {
-            this.setState({assayCategory: ''});
-        } else{
-            this.setState({assayCategory: assayCategory});
+            this.setState({ assayCategory: '' });
+        } else {
+            this.setState({ assayCategory: assayCategory });
         }
     },
 
     // pass in string with organism query and either adds or removes tab from list of selected tabs
-    handleTabClick: function(selectedTab) {
+    handleTabClick: function (selectedTab) {
 
         var tempArray = _.clone(this.state.organisms); // creates a copy of this.state.newtabs
 
         if (tempArray.indexOf(selectedTab) == -1) {
             // if tab isn't already in array, then add it
             tempArray.push(selectedTab);
-        } else{
+        } else {
             // otherwise if it is in array, remove it from array and from link
             let indexToRemoveArray = tempArray.indexOf(selectedTab);
             tempArray.splice(indexToRemoveArray, 1);
         }
 
         // update newtabs
-        this.setState({organisms: tempArray});
+        this.setState({ organisms: tempArray });
     },
 
-    newsLoaded: function() {
+    newsLoaded: function () {
         // Called once the news content gets loaded
         let newsEl = this.refs.newslisting.getDOMNode();
-        this.setState({socialHeight: newsEl.clientHeight});
+        this.setState({ socialHeight: newsEl.clientHeight });
     },
 
     // Convert the selected organisms and assays into an encoded query.
-    generateQuery: function(selectedOrganisms, selectedAssayCategory) {
+    generateQuery: function (selectedOrganisms, selectedAssayCategory) {
         // Make the base query
         let query = selectedAssayCategory === 'COMPPRED' ? '?type=Annotation&encyclopedia_version=3' : "?type=Experiment&status=released";
 
@@ -69,25 +69,26 @@ var Home = module.exports.Home = React.createClass({
         // Add all the selected organisms, if any
         if (selectedOrganisms.length) {
             let organismSpec = selectedAssayCategory === 'COMPPRED' ? 'organism.scientific_name=' : 'replicates.library.biosample.donor.organism.scientific_name=';
-            let queryStrings = {'HUMAN': organismSpec + 'Homo+sapiens', // human
-                                'MOUSE': organismSpec + 'Mus+musculus', // mouse
-                                'WORM':  organismSpec + 'Caenorhabditis+elegans', // worm
-                                'FLY':   organismSpec + 'Drosophila+melanogaster&' + // fly
-                                         organismSpec + 'Drosophila+pseudoobscura&' +
-                                         organismSpec + 'Drosophila+simulans&' +
-                                         organismSpec + 'Drosophila+mojavensis&' +
-                                         organismSpec + 'Drosophila+ananassae&' +
-                                         organismSpec + 'Drosophila+virilis&' +
-                                         organismSpec + 'Drosophila+yakuba'
+            let queryStrings = {
+                'HUMAN': organismSpec + 'Homo+sapiens', // human
+                'MOUSE': organismSpec + 'Mus+musculus', // mouse
+                'WORM': organismSpec + 'Caenorhabditis+elegans', // worm
+                'FLY': organismSpec + 'Drosophila+melanogaster&' + // fly
+                organismSpec + 'Drosophila+pseudoobscura&' +
+                organismSpec + 'Drosophila+simulans&' +
+                organismSpec + 'Drosophila+mojavensis&' +
+                organismSpec + 'Drosophila+ananassae&' +
+                organismSpec + 'Drosophila+virilis&' +
+                organismSpec + 'Drosophila+yakuba'
             };
             let organismQueries = selectedOrganisms.map(organism => queryStrings[organism]);
             query += '&' + organismQueries.join('&');
         }
-    
+
         return query;
     },
 
-    render: function() {
+    render: function () {
         // Based on the currently selected organisms and assay category, generate a query string
         // for the GET request to retrieve chart data.
         let currentQuery = this.generateQuery(this.state.organisms, this.state.assayCategory);
@@ -134,7 +135,7 @@ var Home = module.exports.Home = React.createClass({
 
 // Given retrieved data, draw all home-page charts.
 var ChartGallery = React.createClass({
-    render: function() {
+    render: function () {
         return (
             <PanelBody>
                 <div className="view-all">
@@ -164,7 +165,7 @@ var AssayClicking = React.createClass({
     },
 
     // Properly adds or removes assay category from link
-    sortByAssay: function(category, e) {
+    sortByAssay: function (category, e) {
 
         function handleClick(category, ctx) {
             // Call the Home component's function to record the new assay cateogry
@@ -182,14 +183,14 @@ var AssayClicking = React.createClass({
     },
 
     // Renders classic image and svg rectangles
-    render: function() {
+    render: function () {
         const assayList = ["3D+chromatin+structure",
-                        "DNA+accessibility",
-                        "DNA+binding",
-                        "DNA+methylation",
-                        "COMPPRED",
-                        "Transcription",
-                        "RNA+binding"];
+            "DNA+accessibility",
+            "DNA+binding",
+            "DNA+methylation",
+            "COMPPRED",
+            "Transcription",
+            "RNA+binding"];
         let assayCategory = this.props.assayCategory;
         return (
             <div ref="graphdisplay">
@@ -202,13 +203,13 @@ var AssayClicking = React.createClass({
                             <img src="static/img/classic-image.jpg" />
 
                             <svg id="site-banner-overlay" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2260 1450" className="classic-svg">
-                                <rect id={assayList[0]} x="101.03" y="645.8" width="257.47" height="230.95"  className={"rectangle-box" + (assayCategory == assayList[0] ? " selected": "")} onClick={this.sortByAssay.bind(null, assayList[0])} onTouchEnd={this.sortByAssay.bind(null, assayList[0])} />
-                                <rect id={assayList[1]} x="386.6" y="645.8" width="276.06" height="230.95"   className={"rectangle-box" + (assayCategory == assayList[1] ? " selected": "")} onClick={this.sortByAssay.bind(null, assayList[1])} onTouchEnd={this.sortByAssay.bind(null, assayList[1])} />
-                                <rect id={assayList[2]} x="688.7" y="645.8" width="237.33" height="230.95"   className={"rectangle-box" + (assayCategory == assayList[2] ? " selected": "")} onClick={this.sortByAssay.bind(null, assayList[2])} onTouchEnd={this.sortByAssay.bind(null, assayList[2])} />
-                                <rect id={assayList[3]} x="950.83" y="645.8" width="294.65" height="230.95"  className={"rectangle-box" + (assayCategory == assayList[3] ? " selected": "")} onClick={this.sortByAssay.bind(null, assayList[3])} onTouchEnd={this.sortByAssay.bind(null, assayList[3])} />
-                                <rect id={assayList[4]} x="1273.07" y="645.8" width="373.37" height="230.95" className={"rectangle-box" + (assayCategory == assayList[4] ? " selected": "")} onClick={this.sortByAssay.bind(null, assayList[4])} onTouchEnd={this.sortByAssay.bind(null, assayList[4])} />
-                                <rect id={assayList[5]} x="1674.06" y="645.8" width="236.05" height="230.95" className={"rectangle-box" + (assayCategory == assayList[5] ? " selected": "")} onClick={this.sortByAssay.bind(null, assayList[5])} onTouchEnd={this.sortByAssay.bind(null, assayList[5])} />
-                                <rect id={assayList[6]} x="1937.74" y="645.8" width="227.38" height="230.95" className={"rectangle-box" + (assayCategory == assayList[6] ? " selected": "")} onClick={this.sortByAssay.bind(null, assayList[6])} onTouchEnd={this.sortByAssay.bind(null, assayList[6])} />
+                                <rect id={assayList[0]} x="101.03" y="645.8" width="257.47" height="230.95" className={"rectangle-box" + (assayCategory == assayList[0] ? " selected" : "")} onClick={this.sortByAssay.bind(null, assayList[0])} onTouchEnd={this.sortByAssay.bind(null, assayList[0])} />
+                                <rect id={assayList[1]} x="386.6" y="645.8" width="276.06" height="230.95" className={"rectangle-box" + (assayCategory == assayList[1] ? " selected" : "")} onClick={this.sortByAssay.bind(null, assayList[1])} onTouchEnd={this.sortByAssay.bind(null, assayList[1])} />
+                                <rect id={assayList[2]} x="688.7" y="645.8" width="237.33" height="230.95" className={"rectangle-box" + (assayCategory == assayList[2] ? " selected" : "")} onClick={this.sortByAssay.bind(null, assayList[2])} onTouchEnd={this.sortByAssay.bind(null, assayList[2])} />
+                                <rect id={assayList[3]} x="950.83" y="645.8" width="294.65" height="230.95" className={"rectangle-box" + (assayCategory == assayList[3] ? " selected" : "")} onClick={this.sortByAssay.bind(null, assayList[3])} onTouchEnd={this.sortByAssay.bind(null, assayList[3])} />
+                                <rect id={assayList[4]} x="1273.07" y="645.8" width="373.37" height="230.95" className={"rectangle-box" + (assayCategory == assayList[4] ? " selected" : "")} onClick={this.sortByAssay.bind(null, assayList[4])} onTouchEnd={this.sortByAssay.bind(null, assayList[4])} />
+                                <rect id={assayList[5]} x="1674.06" y="645.8" width="236.05" height="230.95" className={"rectangle-box" + (assayCategory == assayList[5] ? " selected" : "")} onClick={this.sortByAssay.bind(null, assayList[5])} onTouchEnd={this.sortByAssay.bind(null, assayList[5])} />
+                                <rect id={assayList[6]} x="1937.74" y="645.8" width="227.38" height="230.95" className={"rectangle-box" + (assayCategory == assayList[6] ? " selected" : "")} onClick={this.sortByAssay.bind(null, assayList[6])} onTouchEnd={this.sortByAssay.bind(null, assayList[6])} />
                             </svg>
                         </div>
 
@@ -235,15 +236,15 @@ var TabClicking = React.createClass({
         handleTabClick: React.PropTypes.func
     },
 
-    render: function() {
+    render: function () {
         let organisms = this.props.organisms;
         return (
             <div ref="tabdisplay">
                 <div className="organism-selector">
-                    <a className={"single-tab" + (organisms.indexOf('HUMAN') != -1 ? " selected": "")} href="#" data-trigger onClick={this.props.handleTabClick.bind(null, 'HUMAN')}>Human</a>
-                    <a className={"single-tab" + (organisms.indexOf('MOUSE') != -1 ? " selected": "")} href="#" data-trigger onClick={this.props.handleTabClick.bind(null, 'MOUSE')}>Mouse</a>
-                    <a className={"single-tab" + (organisms.indexOf('WORM') != -1 ? " selected": "")} href="#" data-trigger onClick={this.props.handleTabClick.bind(null, 'WORM')}>Worm</a>
-                    <a className={"single-tab" + (organisms.indexOf('FLY') != -1 ? " selected": "")} href="#" data-trigger onClick={this.props.handleTabClick.bind(null, 'FLY')}>Fly</a>
+                    <a className={"single-tab" + (organisms.indexOf('HUMAN') != -1 ? " selected" : "")} href="#" data-trigger onClick={this.props.handleTabClick.bind(null, 'HUMAN')}>Human</a>
+                    <a className={"single-tab" + (organisms.indexOf('MOUSE') != -1 ? " selected" : "")} href="#" data-trigger onClick={this.props.handleTabClick.bind(null, 'MOUSE')}>Mouse</a>
+                    <a className={"single-tab" + (organisms.indexOf('WORM') != -1 ? " selected" : "")} href="#" data-trigger onClick={this.props.handleTabClick.bind(null, 'WORM')}>Worm</a>
+                    <a className={"single-tab" + (organisms.indexOf('FLY') != -1 ? " selected" : "")} href="#" data-trigger onClick={this.props.handleTabClick.bind(null, 'FLY')}>Fly</a>
                 </div>
             </div>
         );
@@ -259,7 +260,7 @@ var HomepageChartLoader = React.createClass({
         query: React.PropTypes.string // Current search URI based on selected assayCategory
     },
 
-    render: function() {
+    render: function () {
         return (
             <FetchedData ignoreErrors>
                 <Param name="data" url={'/search/' + this.props.query} />
@@ -305,14 +306,16 @@ let HomepageChart = React.createClass({
         projectColors: React.PropTypes.object // DataColor instance for experiment project
     },
 
+    wrapperHeight: 200,
+
     // Draw the Project chart, for initial load, or when the previous load had no data for this
     // chart.
-    createChart: function(facetData) {
-        require.ensure(['chart.js'], function(require) {
+    createChart: function (facetData) {
+        require.ensure(['chart.js'], function (require) {
             let Chart = require('chart.js');
 
             // for each item, set doc count, add to total doc count, add proper label, and assign color.
-            let colors = this.context.projectColors.colorList(facetData.map(term => term.key), {shade: 10});
+            let colors = this.context.projectColors.colorList(facetData.map(term => term.key), { shade: 10 });
             let data = [];
             let labels = [];
 
@@ -350,14 +353,14 @@ let HomepageChart = React.createClass({
                     animation: {
                         duration: 200
                     },
-                    legendCallback: function(chart) { // allows for legend clicking
+                    legendCallback: function (chart) { // allows for legend clicking
                         let data = chart.data.datasets[0].data;
                         let text = [];
                         text.push('<ul>');
                         for (let i = 0; i < data.length; i++) {
                             if (data[i]) {
                                 text.push('<li>');
-                                text.push('<a href="' + '/matrix/' + this.props.query + '&award.project=' + chart.data.labels[i]  + '">'); // go to matrix view when clicked
+                                text.push('<a href="' + '/matrix/' + this.props.query + '&award.project=' + chart.data.labels[i] + '">'); // go to matrix view when clicked
                                 text.push('<span class="chart-legend-chip" style="background-color:' + chart.data.datasets[0].backgroundColor[i] + '"></span>');
                                 if (chart.data.labels[i]) {
                                     text.push('<span class="chart-legend-label">' + chart.data.labels[i] + '</span>');
@@ -368,7 +371,7 @@ let HomepageChart = React.createClass({
                         text.push('</ul>');
                         return text.join('');
                     }.bind(this),
-                    onClick: function(e) {
+                    onClick: function (e) {
                         // React to clicks on pie sections
                         var activePoints = this.myPieChart.getElementAtEvent(e);
 
@@ -391,9 +394,9 @@ let HomepageChart = React.createClass({
     },
 
     // Update existing chart with new data.
-    updateChart: function(Chart, facetData) {
+    updateChart: function (Chart, facetData) {
         // for each item, set doc count, add to total doc count, add proper label, and assign color.
-        let colors = this.context.projectColors.colorList(facetData.map(term => term.key), {shade: 10});
+        let colors = this.context.projectColors.colorList(facetData.map(term => term.key), { shade: 10 });
         let data = [];
         let labels = [];
 
@@ -413,12 +416,14 @@ let HomepageChart = React.createClass({
         document.getElementById('chart-legend').innerHTML = Chart.generateLegend();
     },
 
-    componentDidMount: function() {
+    componentDidMount: function () {
         // Create the chart, and assign the chart to this.myPieChart when the process finishes.
-        this.createChart(this.facetData);
+        if (document.getElementById("myChart")) {
+            this.createChart(this.facetData);
+        }
     },
 
-    componentDidUpdate: function() {
+    componentDidUpdate: function () {
         if (this.myPieChart) {
             // Existing data updated
             this.updateChart(this.myPieChart, this.facetData);
@@ -428,19 +433,29 @@ let HomepageChart = React.createClass({
         }
     },
 
-    render: function() {
-        let facets = this.props.data.facets;
+    render: function () {
+        let facets = this.props.data && this.props.data.facets;
+        let total;
 
         // Get all project facets, or an empty array if none.
-        let projectFacet = facets.find(facet => facet.field === 'award.project');
-        this.facetData = projectFacet ? projectFacet.terms : [];
-        let total = this.facetData.length ? this.facetData.reduce((prev, curr) => prev.doc_count + curr.doc_count) : 0;
+        if (facets) {
+            let projectFacet = facets.find(facet => facet.field === 'award.project');
+            this.facetData = projectFacet ? projectFacet.terms : [];
+            let docCounts = this.facetData.length ? this.facetData.map(data => data.doc_count) : [];
+            total = docCounts.length ? docCounts.reduce((prev, curr) => prev + curr) : 0;
 
-        // No data with the current selection, but we used to? Destroy the existing chart so we can
-        // display a no-data message instead.
-        if ((this.facetData.length === 0 || total === 0) && this.myPieChart) {
-            this.myPieChart.destroy();
-            this.myPieChart = null;
+            // No data with the current selection, but we used to? Destroy the existing chart so we can
+            // display a no-data message instead.
+            if ((this.facetData.length === 0 || total === 0) && this.myPieChart) {
+                this.myPieChart.destroy();
+                this.myPieChart = null;
+            }
+        } else {
+            this.facets = null;
+            if (this.myPieChart) {
+                this.myPieChart.destroy();
+                this.myPiechart = null;
+            }
         }
 
         return (
@@ -449,15 +464,15 @@ let HomepageChart = React.createClass({
                     Project
                     <center> <hr width="80%" position="static" color="blue"></hr> </center>
                 </div>
-                {this.facetData.length ?
+                {this.facetData.length && total ?
                     <div id="chart-wrapper-1" className="chart-wrapper">
                         <div className="chart-container">
                             <canvas id="myChart"></canvas>
                         </div>
                         <div id="chart-legend" className="chart-legend"></div>
                     </div>
-                :
-                    <div className="chart-no-data" style={{height: this.wrapperHeight}}><p>No data to display</p></div>
+                    :
+                    <div className="chart-no-data" style={{ height: this.wrapperHeight }}><p>No data to display</p></div>
                 }
             </div>
         );
@@ -474,15 +489,17 @@ var HomepageChart2 = React.createClass({
         biosampleTypeColors: React.PropTypes.object // DataColor instance for experiment project
     },
 
-    createChart: function(facetData) {
+    wrapperHeight: 200,
+
+    createChart: function (facetData) {
 
         // Draw the chart of search results given in this.props.data.facets. Since D3 doesn't work
         // with the React virtual DOM, we have to load it separately using the webpack .ensure
         // mechanism. Once the callback is called, it's loaded and can be referenced through
         // require.
-        require.ensure(['chart.js'], function(require) {
+        require.ensure(['chart.js'], function (require) {
             var Chart = require('chart.js');
-            var colors = this.context.biosampleTypeColors.colorList(facetData.map(term => term.key), {shade: 10});
+            var colors = this.context.biosampleTypeColors.colorList(facetData.map(term => term.key), { shade: 10 });
             var data = [];
             var labels = [];
 
@@ -518,7 +535,7 @@ var HomepageChart2 = React.createClass({
                     animation: {
                         duration: 200
                     },
-                    legendCallback: function(chart) { // allows for legend clicking
+                    legendCallback: function (chart) { // allows for legend clicking
                         let data = chart.data.datasets[0].data;
                         let text = [];
                         let query = this.computationalPredictions ? 'biosample_type=' : 'replicates.library.biosample.biosample_type=';
@@ -526,7 +543,7 @@ var HomepageChart2 = React.createClass({
                         for (let i = 0; i < data.length; i++) {
                             if (data[i]) {
                                 text.push('<li>');
-                                text.push('<a href="/matrix/' + this.props.query + '&' + query + chart.data.labels[i]  + '">'); // go to matrix view when clicked
+                                text.push('<a href="/matrix/' + this.props.query + '&' + query + chart.data.labels[i] + '">'); // go to matrix view when clicked
                                 text.push('<span class="chart-legend-chip" style="background-color:' + chart.data.datasets[0].backgroundColor[i] + '"></span>');
                                 if (chart.data.labels[i]) {
                                     text.push('<span class="chart-legend-label">' + chart.data.labels[i] + '</span>');
@@ -537,7 +554,7 @@ var HomepageChart2 = React.createClass({
                         text.push('</ul>');
                         return text.join('');
                     }.bind(this),
-                    onClick: function(e) {
+                    onClick: function (e) {
                         // React to clicks on pie sections
                         let query = this.computationalPredictions ? 'biosample_type=' : 'replicates.library.biosample.biosample_type=';
                         let activePoints = this.myPieChart.getElementAtEvent(e);
@@ -559,9 +576,9 @@ var HomepageChart2 = React.createClass({
         }.bind(this));
     },
 
-    updateChart: function(Chart, facetData) {
+    updateChart: function (Chart, facetData) {
         // for each item, set doc count, add to total doc count, add proper label, and assign color.
-        let colors = this.context.biosampleTypeColors.colorList(facetData.map(term => term.key), {shade: 10});
+        let colors = this.context.biosampleTypeColors.colorList(facetData.map(term => term.key), { shade: 10 });
         let data = [];
         let labels = [];
 
@@ -581,11 +598,13 @@ var HomepageChart2 = React.createClass({
         document.getElementById('chart-legend-2').innerHTML = Chart.generateLegend(); // generates legend
     },
 
-    componentDidMount: function() {
-        this.createChart(this.facetData);
+    componentDidMount: function () {
+        if (document.getElementById("myChart2")) {
+            this.createChart(this.facetData);
+        }
     },
 
-    componentDidUpdate: function() {
+    componentDidUpdate: function () {
         if (this.myPieChart) {
             // Existing data updated
             this.updateChart(this.myPieChart, this.facetData);
@@ -595,26 +614,35 @@ var HomepageChart2 = React.createClass({
         }
     },
 
-    render: function() {
+    render: function () {
         let assayFacet = {};
-        let facets = this.props.data.facets;
+        let facets = this.props.data && this.props.data.facets;
+        let total;
 
         // Our data source will be different for computational predictions
-        this.computationalPredictions = this.props.assayCategory === 'COMPPRED';
-        if (this.computationalPredictions) {
-            assayFacet = facets.find(facet => facet.field === 'biosample_type');
-        } else {
-            assayFacet = facets.find(facet => facet.field === 'replicates.library.biosample.biosample_type');
-        }
-        this.facetData = assayFacet ? assayFacet.terms : [];
-        let docCounts = this.facetData.length ? this.facetData.map(data => data.doc_count) : [];
-        let total = docCounts.length ? docCounts.reduce((prev, curr) => prev + curr) : 0;
+        if (facets) {
+            this.computationalPredictions = this.props.assayCategory === 'COMPPRED';
+            if (this.computationalPredictions) {
+                assayFacet = facets.find(facet => facet.field === 'biosample_type');
+            } else {
+                assayFacet = facets.find(facet => facet.field === 'replicates.library.biosample.biosample_type');
+            }
+            this.facetData = assayFacet ? assayFacet.terms : [];
+            let docCounts = this.facetData.length ? this.facetData.map(data => data.doc_count) : [];
+            total = docCounts.length ? docCounts.reduce((prev, curr) => prev + curr) : 0;
 
-        // No data with the current selection, but we used to destroy the existing chart so we can
-        // display a no-data message instead.
-        if ((this.facetData.length === 0 || total === 0) && this.myPieChart) {
-            this.myPieChart.destroy();
-            this.myPieChart = null;
+            // No data with the current selection, but we used to destroy the existing chart so we can
+            // display a no-data message instead.
+            if ((this.facetData.length === 0 || total === 0) && this.myPieChart) {
+                this.myPieChart.destroy();
+                this.myPieChart = null;
+            }
+        } else {
+            this.facets = null;
+            if (this.myPieChart) {
+                this.myPieChart.destroy();
+                this.myPiechart = null;
+            }
         }
 
         return (
@@ -623,15 +651,15 @@ var HomepageChart2 = React.createClass({
                     Biosample Type
                     <center> <hr width="80%" position="static" color="blue"></hr> </center>
                 </div>
-                {this.facetData.length && total > 0 ?
+                {this.facetData.length && total ?
                     <div id="chart-wrapper-2" className="chart-wrapper">
                         <div className="chart-container">
                             <canvas id="myChart2"></canvas>
                         </div>
                         <div id="chart-legend-2" className="chart-legend"></div>
                     </div>
-                :
-                    <div className="chart-no-data" style={{height: this.wrapperHeight}}>No data to display</div>
+                    :
+                    <div className="chart-no-data" style={{ height: this.wrapperHeight }}>No data to display</div>
                 }
             </div>
         );
@@ -646,18 +674,20 @@ let HomepageChart3 = React.createClass({
         navigate: React.PropTypes.func
     },
 
-    createChart: function(facetData) {
+    wrapperHeight: 200,
+
+    createChart: function (facetData) {
 
         // Draw the chart of search results given in this.props.data.facets. Since D3 doesn't work
         // with the React virtual DOM, we have to load it separately using the webpack .ensure
         // mechanism. Once the callback is called, it's loaded and can be referenced through
         // require.
-        require.ensure(['chart.js'], function(require) {
+        require.ensure(['chart.js'], function (require) {
             let Chart = require('chart.js');
             let colors = [];
             let data = [];
             let labels = [];
-            let selectedAssay = (this.props.assayCategory && this.props.assayCategory !== 'COMPPRED') ? this.props.assayCategory.replace(/\+/g,' ') : '';
+            let selectedAssay = (this.props.assayCategory && this.props.assayCategory !== 'COMPPRED') ? this.props.assayCategory.replace(/\+/g, ' ') : '';
 
             // for each item, set doc count, add to total doc count, add proper label, and assign color
             facetData.forEach((term, i) => {
@@ -697,7 +727,7 @@ let HomepageChart3 = React.createClass({
                             }
                         }]
                     },
-                    onClick: function(e) {
+                    onClick: function (e) {
                         // React to clicks on pie sections
                         var query = 'assay_slims=';
                         var activePoints = this.myPieChart.getElementAtEvent(e);
@@ -717,14 +747,14 @@ let HomepageChart3 = React.createClass({
 
     },
 
-    updateChart: function(Chart, facetData) {
+    updateChart: function (Chart, facetData) {
         // for each item, set doc count, add to total doc count, add proper label, and assign color.
         let data = [];
         let labels = [];
         let colors = [];
 
         // Convert facet data to chart data.
-        let selectedAssay = (this.props.assayCategory && this.props.assayCategory !== 'COMPPRED') ? this.props.assayCategory.replace(/\+/g,' ') : '';
+        let selectedAssay = (this.props.assayCategory && this.props.assayCategory !== 'COMPPRED') ? this.props.assayCategory.replace(/\+/g, ' ') : '';
         facetData.forEach((term, i) => {
             data[i] = term.doc_count;
             labels[i] = term.key;
@@ -738,11 +768,13 @@ let HomepageChart3 = React.createClass({
         Chart.update();
     },
 
-    componentDidMount: function() {
-        this.createChart(this.facetData);
+    componentDidMount: function () {
+        if (document.getElementById("myChart3")) {
+            this.createChart(this.facetData);
+        }
     },
 
-    componentDidUpdate: function() {
+    componentDidUpdate: function () {
         if (this.myPieChart) {
             // Existing data updated
             this.updateChart(this.myPieChart, this.facetData);
@@ -752,19 +784,29 @@ let HomepageChart3 = React.createClass({
         }
     },
 
-    render: function() {
-        let facets = this.props.data.facets;
+    render: function () {
+        let facets = this.props.data && this.props.data.facets;
+        let total;
 
         // Get all assay category facets, or an empty array if none
-        let projectFacet = facets.find(facet => facet.field === 'assay_slims');
-        this.facetData = projectFacet ? projectFacet.terms : [];
-        let total = this.facetData.length ? this.facetData.reduce((prev, curr) => prev.doc_count + curr.doc_count) : 0;
+        if (facets) {
+            let projectFacet = facets.find(facet => facet.field === 'assay_slims');
+            this.facetData = projectFacet ? projectFacet.terms : [];
+            let docCounts = this.facetData.length ? this.facetData.map(data => data.doc_count) : [];
+            total = docCounts.length ? docCounts.reduce((prev, curr) => prev + curr) : 0;
 
-        // No data with the current selection, but we used to? Destroy the existing chart so we can
-        // display a no-data message instead.
-        if ((this.facetData.length === 0 || total === 0) && this.myPieChart) {
-            this.myPieChart.destroy();
-            this.myPieChart = null;
+            // No data with the current selection, but we used to? Destroy the existing chart so we can
+            // display a no-data message instead.
+            if ((this.facetData.length === 0 || total === 0) && this.myPieChart) {
+                this.myPieChart.destroy();
+                this.myPieChart = null;
+            }
+        } else {
+            this.facets = null;
+            if (this.myPieChart) {
+                this.myPieChart.destroy();
+                this.myPiechart = null;
+            }
         }
 
         return (
@@ -773,14 +815,14 @@ let HomepageChart3 = React.createClass({
                     Assay Categories
                     <center> <hr width="80%" position="static" color="blue"></hr> </center>
                 </div>
-                {this.facetData.length ?
+                {this.facetData.length && total ?
                     <div id="chart-wrapper-3" className="chart-wrapper">
                         <div className="chart-container-assaycat">
                             <canvas id="myChart3"></canvas>
                         </div>
                     </div>
-                :
-                    <div className="chart-no-data" style={{height: this.wrapperHeight}}>No data to display</div>
+                    :
+                    <div className="chart-no-data" style={{ height: this.wrapperHeight }}>No data to display</div>
                 }
             </div>
         );
@@ -795,7 +837,7 @@ var NewsLoader = React.createClass({
         newsLoaded: React.PropTypes.func.isRequired // Called parent once the news is loaded
     },
 
-    render: function() {
+    render: function () {
         return <FetchedItems {...this.props} url={newsUri + '&limit=5'} Component={News} ignoreErrors newsLoaded={this.props.newsLoaded} />;
     }
 });
@@ -807,11 +849,11 @@ var News = React.createClass({
         newsLoaded: React.PropTypes.func.isRequired // Called parent once the news is loaded
     },
 
-    componentDidMount: function() {
+    componentDidMount: function () {
         this.props.newsLoaded();
     },
 
-    render: function() {
+    render: function () {
         var items = this.props.items;
         if (items && items.length) {
             return (
@@ -842,7 +884,7 @@ var TwitterWidget = React.createClass({
         height: React.PropTypes.number.isRequired // Number of pixels tall to make widget
     },
 
-    injectTwitter: function() {
+    injectTwitter: function () {
         var js, link;
         if (!this.initialized) {
             link = this.refs.link.getDOMNode();
@@ -854,19 +896,19 @@ var TwitterWidget = React.createClass({
         }
     },
 
-    componentDidMount: function() { // twitter script from API
+    componentDidMount: function () { // twitter script from API
         if (!this.initialized && this.props.height) {
             this.injectTwitter();
         }
     },
 
-    componentDidUpdate: function() {
+    componentDidUpdate: function () {
         if (!this.initialized && this.props.height) {
             this.injectTwitter();
         }
     },
 
-    render: function() {
+    render: function () {
         var content, ref2, title, widget;
         return (
             <div ref="twitterwidget">
@@ -875,17 +917,17 @@ var TwitterWidget = React.createClass({
                 </div>
                 {this.props.height ?
                     <a
-                    ref="link"
-                    className="twitter-timeline"
-                    href="https://twitter.com/encodedcc" // from encodedcc twitter
-                    widget-id= "encodedcc"
-                    data-chrome="noheader"
-                    data-screen-name="EncodeDCC"
-                    //data-tweet-limit = "4"
-                    //data-width = "300"
-                    data-height={this.props.height + ''} // height so it matches with rest of site
-                    ></a>
-                : null}
+                        ref="link"
+                        className="twitter-timeline"
+                        href="https://twitter.com/encodedcc" // from encodedcc twitter
+                        widget-id="encodedcc"
+                        data-chrome="noheader"
+                        data-screen-name="EncodeDCC"
+                        //data-tweet-limit = "4"
+                        //data-width = "300"
+                        data-height={this.props.height + ''} // height so it matches with rest of site
+                        ></a>
+                    : null}
             </div>
         );
     }

--- a/src/encoded/static/components/home.js
+++ b/src/encoded/static/components/home.js
@@ -380,6 +380,8 @@ let HomepageChart = React.createClass({
                 }
             });
             document.getElementById('chart-legend').innerHTML = this.myPieChart.generateLegend(); // generates legend
+            let chartWrapperDiv = document.getElementById('chart-wrapper-1');
+            this.wrapperHeight = chartWrapperDiv.clientHeight;
         }.bind(this));
     },
 
@@ -441,14 +443,14 @@ let HomepageChart = React.createClass({
                     <center> <hr width="80%" position="static" color="blue"></hr> </center>
                 </div>
                 {this.facetData.length ?
-                    <div className="chart-wrapper">
+                    <div id="chart-wrapper-1" className="chart-wrapper">
                         <div className="chart-container">
                             <canvas id="myChart"></canvas>
                         </div>
                         <div id="chart-legend" className="chart-legend"></div>
                     </div>
                 :
-                    <div className="chart-no-data">No data to display</div>
+                    <div className="chart-no-data" style={{height: this.wrapperHeight}}><p>No data to display</p></div>
                 }
             </div>
         );
@@ -546,7 +548,9 @@ var HomepageChart2 = React.createClass({
                 }
             });
 
-            document.getElementById('chart-legend-2').innerHTML = this.myPieChart.generateLegend(); // generates legend
+            document.getElementById('chart-legend-2').innerHTML = this.myPieChart.generateLegend();
+            let chartWrapperDiv = document.getElementById('chart-wrapper-2');
+            this.wrapperHeight = chartWrapperDiv.clientHeight;
         }.bind(this));
     },
 
@@ -613,14 +617,14 @@ var HomepageChart2 = React.createClass({
                     <center> <hr width="80%" position="static" color="blue"></hr> </center>
                 </div>
                 {this.facetData.length ?
-                    <div className="chart-wrapper">
+                    <div id="chart-wrapper-2" className="chart-wrapper">
                         <div className="chart-container">
                             <canvas id="myChart2"></canvas>
                         </div>
                         <div id="chart-legend-2" className="chart-legend"></div>
                     </div>
                 :
-                    <div className="chart-no-data">No data to display</div>
+                    <div className="chart-no-data" style={{height: this.wrapperHeight}}>No data to display</div>
                 }
             </div>
         );
@@ -701,6 +705,10 @@ let HomepageChart3 = React.createClass({
                     }.bind(this)
                 }
             });
+
+            // Save height of wrapper div.
+            let chartWrapperDiv = document.getElementById('chart-wrapper-3');
+            this.wrapperHeight = chartWrapperDiv.clientHeight;
         }.bind(this));
 
     },
@@ -710,17 +718,21 @@ let HomepageChart3 = React.createClass({
         let totalDocCount = 0;
         let data = [];
         let labels = [];
+        let colors = [];
 
         // Convert facet data to chart data.
+        let selectedAssay = (this.props.assayCategory && this.props.assayCategory !== 'COMPPRED') ? this.props.assayCategory.replace(/\+/g,' ') : '';
         facetData.forEach((term, i) => {
             totalDocCount += term.doc_count;
             data[i] = term.doc_count;
             labels[i] = term.key;
+            colors[i] = selectedAssay ? (term.key === selectedAssay ? 'rgb(255,217,98)' : 'rgba(255,217,98,.4)') : '#FFD962';
         });
 
         // Update chart data and redraw with the new data
         Chart.data.datasets[0].data = data;
         Chart.data.labels = labels;
+        Chart.data.datasets[0].backgroundColor = colors;
         Chart.update();
     },
 
@@ -759,13 +771,13 @@ let HomepageChart3 = React.createClass({
                     <center> <hr width="80%" position="static" color="blue"></hr> </center>
                 </div>
                 {this.facetData.length ?
-                    <div className="chart-wrapper">
+                    <div id="chart-wrapper-3" className="chart-wrapper">
                         <div className="chart-container-assaycat">
                             <canvas id="myChart3"></canvas>
                         </div>
                     </div>
                 :
-                    <div className="chart-no-data">No data to display</div>
+                    <div className="chart-no-data" style={{height: this.wrapperHeight}}>No data to display</div>
                 }
             </div>
         );

--- a/src/encoded/static/components/home.js
+++ b/src/encoded/static/components/home.js
@@ -42,7 +42,7 @@ var Home = module.exports.Home = React.createClass({
             tempArray.push(selectedTab);
         } else{
             // otherwise if it is in array, remove it from array and from link
-            var indexToRemoveArray = tempArray.indexOf(selectedTab);
+            let indexToRemoveArray = tempArray.indexOf(selectedTab);
             tempArray.splice(indexToRemoveArray, 1);
         }
 
@@ -52,10 +52,11 @@ var Home = module.exports.Home = React.createClass({
 
     newsLoaded: function() {
         // Called once the news content gets loaded
-        var newsEl = this.refs.newslisting.getDOMNode();
+        let newsEl = this.refs.newslisting.getDOMNode();
         this.setState({socialHeight: newsEl.clientHeight});
     },
 
+    // Convert the selected organisms and assays into an encoded query.
     generateQuery: function(selectedOrganisms, selectedAssayCategory) {
         // Make the base query
         let query = selectedAssayCategory === 'COMPPRED' ? '?type=Annotation&encyclopedia_version=3' : "?type=Experiment&status=released";
@@ -262,7 +263,7 @@ var HomepageChartLoader = React.createClass({
         return (
             <FetchedData ignoreErrors>
                 <Param name="data" url={'/search/' + this.props.query} />
-                <ChartGallery organisms={this.props.organisms} assayCategory={this.props.assayCategory}query={this.props.query} />
+                <ChartGallery organisms={this.props.organisms} assayCategory={this.props.assayCategory} query={this.props.query} />
             </FetchedData>
         );
     }
@@ -304,6 +305,8 @@ let HomepageChart = React.createClass({
         projectColors: React.PropTypes.object // DataColor instance for experiment project
     },
 
+    // Draw the Project chart, for initial load, or when the previous load had no data for this
+    // chart.
     createChart: function(facetData) {
         require.ensure(['chart.js'], function(require) {
             let Chart = require('chart.js');
@@ -342,7 +345,7 @@ let HomepageChart = React.createClass({
                     responsive: true,
                     maintainAspectRatio: false,
                     legend: {
-                        display: false // hiding automatically generated legend
+                        display: false // Hide automatically generated legend; we draw it ourselves
                     },
                     animation: {
                         duration: 200
@@ -377,12 +380,17 @@ let HomepageChart = React.createClass({
                     }.bind(this)
                 }
             });
-            document.getElementById('chart-legend').innerHTML = this.myPieChart.generateLegend(); // generates legend
+
+            // Have chartjs draw the legend into the DOM.
+            document.getElementById('chart-legend').innerHTML = this.myPieChart.generateLegend();
+
+            // Save the chart <div> height so we can set it to that value when no data's available.'
             let chartWrapperDiv = document.getElementById('chart-wrapper-1');
             this.wrapperHeight = chartWrapperDiv.clientHeight;
         }.bind(this));
     },
 
+    // Update existing chart with new data.
     updateChart: function(Chart, facetData) {
         // for each item, set doc count, add to total doc count, add proper label, and assign color.
         let colors = this.context.projectColors.colorList(facetData.map(term => term.key), {shade: 10});
@@ -400,7 +408,9 @@ let HomepageChart = React.createClass({
         Chart.data.datasets[0].backgroundColor = colors;
         Chart.data.labels = labels;
         Chart.update();
-        document.getElementById('chart-legend').innerHTML = Chart.generateLegend(); // generates legend
+
+        // Redraw the updated legend
+        document.getElementById('chart-legend').innerHTML = Chart.generateLegend();
     },
 
     componentDidMount: function() {

--- a/src/encoded/static/components/home.js
+++ b/src/encoded/static/components/home.js
@@ -310,13 +310,11 @@ let HomepageChart = React.createClass({
 
             // for each item, set doc count, add to total doc count, add proper label, and assign color.
             let colors = this.context.projectColors.colorList(facetData.map(term => term.key), {shade: 10});
-            let totalDocCount = 0;
             let data = [];
             let labels = [];
 
             // Convert facet data to chart data.
             facetData.forEach((term, i) => {
-                totalDocCount += term.doc_count;
                 data[i] = term.doc_count;
                 labels[i] = term.key;
             });
@@ -388,13 +386,11 @@ let HomepageChart = React.createClass({
     updateChart: function(Chart, facetData) {
         // for each item, set doc count, add to total doc count, add proper label, and assign color.
         let colors = this.context.projectColors.colorList(facetData.map(term => term.key), {shade: 10});
-        let totalDocCount = 0;
         let data = [];
         let labels = [];
 
         // Convert facet data to chart data.
         facetData.forEach((term, i) => {
-            totalDocCount += term.doc_count;
             data[i] = term.doc_count;
             labels[i] = term.key;
         });
@@ -428,10 +424,11 @@ let HomepageChart = React.createClass({
         // Get all project facets, or an empty array if none.
         let projectFacet = facets.find(facet => facet.field === 'award.project');
         this.facetData = projectFacet ? projectFacet.terms : [];
+        let total = this.facetData.length ? this.facetData.reduce((prev, curr) => prev.doc_count + curr.doc_count) : 0;
 
         // No data with the current selection, but we used to? Destroy the existing chart so we can
         // display a no-data message instead.
-        if (this.facetData.length === 0 && this.myPieChart) {
+        if ((this.facetData.length === 0 || total === 0) && this.myPieChart) {
             this.myPieChart.destroy();
             this.myPieChart = null;
         }
@@ -557,13 +554,11 @@ var HomepageChart2 = React.createClass({
     updateChart: function(Chart, facetData) {
         // for each item, set doc count, add to total doc count, add proper label, and assign color.
         let colors = this.context.biosampleTypeColors.colorList(facetData.map(term => term.key), {shade: 10});
-        let totalDocCount = 0;
         let data = [];
         let labels = [];
 
         // Convert facet data to chart data.
         facetData.forEach((term, i) => {
-            totalDocCount += term.doc_count;
             data[i] = term.doc_count;
             labels[i] = term.key;
         });
@@ -602,10 +597,12 @@ var HomepageChart2 = React.createClass({
             assayFacet = facets.find(facet => facet.field === 'replicates.library.biosample.biosample_type');
         }
         this.facetData = assayFacet ? assayFacet.terms : [];
+        let docCounts = this.facetData.length ? this.facetData.map(data => data.doc_count) : [];
+        let total = docCounts.length ? docCounts.reduce((prev, curr) => prev + curr) : 0;
 
-        // No data with the current selection, but we used to? Destroy the existing chart so we can
+        // No data with the current selection, but we used to destroy the existing chart so we can
         // display a no-data message instead.
-        if (this.facetData.length === 0 && this.myPieChart) {
+        if ((this.facetData.length === 0 || total === 0) && this.myPieChart) {
             this.myPieChart.destroy();
             this.myPieChart = null;
         }
@@ -616,7 +613,7 @@ var HomepageChart2 = React.createClass({
                     Biosample Type
                     <center> <hr width="80%" position="static" color="blue"></hr> </center>
                 </div>
-                {this.facetData.length ?
+                {this.facetData.length && total > 0 ?
                     <div id="chart-wrapper-2" className="chart-wrapper">
                         <div className="chart-container">
                             <canvas id="myChart2"></canvas>
@@ -715,7 +712,6 @@ let HomepageChart3 = React.createClass({
 
     updateChart: function(Chart, facetData) {
         // for each item, set doc count, add to total doc count, add proper label, and assign color.
-        let totalDocCount = 0;
         let data = [];
         let labels = [];
         let colors = [];
@@ -723,7 +719,6 @@ let HomepageChart3 = React.createClass({
         // Convert facet data to chart data.
         let selectedAssay = (this.props.assayCategory && this.props.assayCategory !== 'COMPPRED') ? this.props.assayCategory.replace(/\+/g,' ') : '';
         facetData.forEach((term, i) => {
-            totalDocCount += term.doc_count;
             data[i] = term.doc_count;
             labels[i] = term.key;
             colors[i] = selectedAssay ? (term.key === selectedAssay ? 'rgb(255,217,98)' : 'rgba(255,217,98,.4)') : '#FFD962';
@@ -756,10 +751,11 @@ let HomepageChart3 = React.createClass({
         // Get all assay category facets, or an empty array if none
         let projectFacet = facets.find(facet => facet.field === 'assay_slims');
         this.facetData = projectFacet ? projectFacet.terms : [];
+        let total = this.facetData.length ? this.facetData.reduce((prev, curr) => prev.doc_count + curr.doc_count) : 0;
 
         // No data with the current selection, but we used to? Destroy the existing chart so we can
         // display a no-data message instead.
-        if (this.facetData.length === 0 && this.myPieChart) {
+        if ((this.facetData.length === 0 || total === 0) && this.myPieChart) {
             this.myPieChart.destroy();
             this.myPieChart = null;
         }

--- a/src/encoded/static/scss/encoded/modules/_home.scss
+++ b/src/encoded/static/scss/encoded/modules/_home.scss
@@ -240,6 +240,10 @@
     height: 180px;
 }
 
+.chart-container-assaycat {
+    height: 280px;
+}
+
 .chart-no-data {
     margin: 20px 0;
     font-size: 1.2rem;

--- a/src/encoded/static/scss/encoded/modules/_home.scss
+++ b/src/encoded/static/scss/encoded/modules/_home.scss
@@ -217,11 +217,11 @@
 // Gives graphs white background color
 .graphs {
     background-color: white;
-    padding-bottom: 25px;
 }
 
 .chart-gallery{
     display: block;
+    padding: 20px;
 
     @media screen and (min-width: $screen-md-min) {
         display: flex;
@@ -232,6 +232,7 @@
 
 .chart-single {
     @media screen and (min-width: $screen-md-min) {
+        width: 33.33333%;
         flex: 1 1 auto;
     }
 }
@@ -245,17 +246,18 @@
 }
 
 .chart-no-data {
-    margin: 20px 0;
     font-size: 1.2rem;
     text-align: center;
+    color: #808080;
+    font-style: italic;
 }
 
 // Positions legends
 .chart-legend {
-    float: center;
     margin-top: 20px;
 
     ul {
+        margin: 0;
         list-style: none;
 
         li {

--- a/src/encoded/static/scss/encoded/modules/_home.scss
+++ b/src/encoded/static/scss/encoded/modules/_home.scss
@@ -220,6 +220,32 @@
     padding-bottom: 25px;
 }
 
+.chart-gallery{
+    display: block;
+
+    @media screen and (min-width: $screen-md-min) {
+        display: flex;
+        flex-wrap: nowrap;
+        align-items: stretch;
+    }
+}
+
+.chart-single {
+    @media screen and (min-width: $screen-md-min) {
+        flex: 1 1 auto;
+    }
+}
+
+.chart-container {
+    height: 180px;
+}
+
+.chart-no-data {
+    margin: 20px 0;
+    font-size: 1.2rem;
+    text-align: center;
+}
+
 // Positions legends
 .chart-legend {
     float: center;


### PR DESCRIPTION
This branch only affects the home page. The original algorithm for the charts involved destroying the chart each time new data came in, and creating the charts fresh. This caused the charts to vanish and redraw as the user chose new selections of assay and organism (each causing a GET request).

In addition, the FetchedData component — that has existed in encoded probably since the beginning of the ReactJS implementation — redraws whatever data it retrieved the last time before doing the GET request. That caused the charts to redraw an extra time. I looked into avoiding this initial redraw, but I could only see having FetchedData clear its past data and rendering nothing before doing the GET request (React components have to render immediately). That reduced one chart redraw, but caused the entire chart to disappear between the time the GET request went out and the response came back — worse than the original problem in my opinion. This change would have also caused the region-search dropdown to flash on each keystroke beyond its throttling mechanism.

So I kept FetchedData the same, and instead keep the chart instances around between user selections. It still calls FetchedData which causes an immediate render, but it simply renders the same data on top of itself, which the user can’t see (note: that’s why we don’t see the redraw problem on the region-search page, which does something similar). As new data comes in, the existing chart instances get the new data and simply update themselves without clearing and redrawing.

The charts do get destroyed if no data comes in, in which case the message “No data to display” gets displayed instead. When the next selection brings in actual data, the charts get recreated.