### PR TITLE
Adding PUT/PATCH/POST forbid to encode-apache.

### DIFF
--- a/etc/encoded-apache.conf
+++ b/etc/encoded-apache.conf
@@ -132,6 +132,11 @@ RewriteCond %{HTTP:X-Forwarded-Proto} =http
 RewriteCond %{HTTP_HOST} ^(www\.encodeproject\.org|test\.encodedcc\.org)$
 RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [redirect=permanent,last,qsappend]
 
+# Forbid PUT/PATCH/POST
+#RewriteEngine On
+#RewriteCond %{REQUEST_METHOD} ^(PUT|POST|PATCH)
+#RewriteRule .* - [F]
+
 ###################
 # Portal redirects
 


### PR DESCRIPTION
i have added the block for POST PATCH and PUT to the encode-apace.conf. By default, it has been commented out. this was tested on a server Idan brought up and was successful. 