### PR TITLE
4590 prevent logo 404

### DIFF
--- a/src/encoded/static/components/mixins.js
+++ b/src/encoded/static/components/mixins.js
@@ -111,9 +111,11 @@ module.exports.Auth0 = {
 
         // Make a URL for the logo.
         const hrefInfo = url.parse(this.props.href);
-        hrefInfo.hash = hrefInfo.query = hrefInfo.search = hrefInfo.path = '';
-        hrefInfo.pathname = '/static/img/encode-logo-small-2x.png';
-        const logoUrl = url.format(hrefInfo);
+        const logoHrefInfo = {
+            protocol: hrefInfo.protocol,
+            pathname: '/static/img/encode-logo-small-2x.png'
+        };
+        const logoUrl = url.format(logoHrefInfo);
 
         var lock_ = require('auth0-lock');
         this.lock = new lock_.default('WIOr638GdDdEGPJmABPhVzMn6SYUIdIH', 'encode.auth0.com', {

--- a/src/encoded/static/components/mixins.js
+++ b/src/encoded/static/components/mixins.js
@@ -108,13 +108,20 @@ module.exports.Auth0 = {
             href: window.location.href,
             session_cookie: session_cookie
         });
+
+        // Make a URL for the logo.
+        const hrefInfo = url.parse(this.props.href);
+        hrefInfo.hash = hrefInfo.query = hrefInfo.search = hrefInfo.path = '';
+        hrefInfo.pathname = '/static/img/encode-logo-small-2x.png';
+        const logoUrl = url.format(hrefInfo);
+
         var lock_ = require('auth0-lock');
         this.lock = new lock_.default('WIOr638GdDdEGPJmABPhVzMn6SYUIdIH', 'encode.auth0.com', {
             auth: {
                 redirect: false
             },
             theme: {
-                logo: 'static/img/encode-logo-small-2x.png'
+                logo: logoUrl
             },
             socialButtonStyle: 'big',
             languageDictionary: {

--- a/src/encoded/static/components/mixins.js
+++ b/src/encoded/static/components/mixins.js
@@ -112,6 +112,8 @@ module.exports.Auth0 = {
         // Make a URL for the logo.
         const hrefInfo = url.parse(this.props.href);
         const logoHrefInfo = {
+            hostname: hrefInfo.hostname,
+            port: hrefInfo.port,
             protocol: hrefInfo.protocol,
             pathname: '/static/img/encode-logo-small-2x.png'
         };


### PR DESCRIPTION
For some reason Auth0 requests the site logo twice; the first time with the proper URL and the second with the incorrect one. This branch changes the mixin.Auth0 code to return the complete URL of the icon instead of just the local path. It does this by parsing the current URL to extract the hostname, port, and protocol, and combining that with the logo file’s path.

Apparently, the Auth0 code caches the URL, because with this change, the logo gets requested only once on instances, and twice on local ones. Local instances no longer give a 404 error on the second request.