### PR TITLE
4959 Use files w/o archived files when assembling grpah

### DIFF
--- a/src/encoded/static/components/filegallery.js
+++ b/src/encoded/static/components/filegallery.js
@@ -1631,7 +1631,7 @@ const FileGalleryRenderer = React.createClass({
         // Build node graph of the files and analysis steps with this experiment
         if (graphFiles && graphFiles.length) {
             try {
-                const { graph, graphedFiles } = assembleGraph(context, this.context.session, this.state.infoNodeId, files, selectedAssembly, selectedAnnotation);
+                const { graph, graphedFiles } = assembleGraph(context, this.context.session, this.state.infoNodeId, graphFiles, selectedAssembly, selectedAnnotation);
                 jsonGraph = graph;
                 allGraphedFiles = (selectedAssembly || selectedAnnotation) ? graphedFiles : {};
             } catch (e) {


### PR DESCRIPTION
New modal code was calculating files to graph like before based on archived status, but then not using that calculation. It was _checking_ the unused variable, so it passed eslint.