### PR TITLE
4671 Remove stray persona reference

### DIFF
--- a/src/encoded/static/components/graph.js
+++ b/src/encoded/static/components/graph.js
@@ -304,7 +304,6 @@ var Graph = module.exports.Graph = React.createClass({
     },
 
     componentDidMount: function () {
-        var $script = require('scriptjs');
         if (BrowserFeat.getBrowserCaps('svg')) {
             // Delay loading dagre for Jest testing compatibility;
             // Both D3 and Jest have their own conflicting JSDOM instances

--- a/src/encoded/static/components/mixins.js
+++ b/src/encoded/static/components/mixins.js
@@ -283,7 +283,6 @@ module.exports.Auth0 = {
     },
 
     triggerLogin: function (event) {
-        var $script = require('scriptjs');
         if (this.state.session && !this.state.session._csrft_) {
             this.fetch('/session');
         }

--- a/src/encoded/static/inline.js
+++ b/src/encoded/static/inline.js
@@ -19,7 +19,6 @@ window.onload = function () {
 
 var $script = require('scriptjs');
 $script.path('/static/build/');
-$script('https://login.persona.org/include.js', 'persona');
 
 // Load the rest of the app as a separate chunk.
 require.ensure(['./libs/compat', './browser'], function(require) {


### PR DESCRIPTION
Looks like I’m behind a long Travis CI queue, so I’ll issue the PR before this branch’s Travis CI has started. I removed the $script reference to the persona script, and removed a couple other unused references to the scriptjs module that were likely optimized out during build.

I kept the $script.path link as it does have a function, and I’m not sure if removing it breaks anything, because we still use scriptjs in richtext.js. Most uses of scriptjs went away with webpack, and I’m guessing richtext.js can stop using it. Maybe with David Glick’s forthcoming update to react-forms, that’ll go away unless there’s some needed functionality in scriptjs we lose with webpack’s require.ensure.