### PR TITLE
4680 matrix gap between horizontal facets

### DIFF
--- a/src/encoded/static/components/search.js
+++ b/src/encoded/static/components/search.js
@@ -727,32 +727,35 @@ var Facet = search.Facet = React.createClass({
             }
         }
 
-        return (
-            <div className="facet" hidden={terms.length === 0} style={{width: this.props.width}}>
-                <h5>{title}</h5>
-                <ul className="facet-list nav">
-                    <div>
-                        {terms.slice(0, 5).map(function (term) {
-                            return <TermComponent {...this.props} key={term.key} term={term} filters={filters} total={total} canDeselect={canDeselect} />;
-                        }.bind(this))}
-                    </div>
-                    {terms.length > 5 ?
-                        <div id={termID} className={moreSecClass}>
-                            {moreTerms.map(function (term) {
+        if (terms.length && terms.some(term => term.doc_count)) {
+            return (
+                <div className="facet">
+                    <h5>{title}</h5>
+                    <ul className="facet-list nav">
+                        <div>
+                            {terms.slice(0, 5).map(function (term) {
                                 return <TermComponent {...this.props} key={term.key} term={term} filters={filters} total={total} canDeselect={canDeselect} />;
                             }.bind(this))}
                         </div>
-                    : null}
-                    {(terms.length > 5 && !moreTermSelected) ?
-                        <label className="pull-right">
-                                <small>
-                                    <button type="button" className={seeMoreClass} data-toggle="collapse" data-target={'#'+termID} onClick={this.handleClick} />
-                                </small>
-                        </label>
-                    : null}
-                </ul>
-            </div>
-        );
+                        {terms.length > 5 ?
+                            <div id={termID} className={moreSecClass}>
+                                {moreTerms.map(function (term) {
+                                    return <TermComponent {...this.props} key={term.key} term={term} filters={filters} total={total} canDeselect={canDeselect} />;
+                                }.bind(this))}
+                            </div>
+                        : null}
+                        {(terms.length > 5 && !moreTermSelected) ?
+                            <label className="pull-right">
+                                    <small>
+                                        <button type="button" className={seeMoreClass} data-toggle="collapse" data-target={'#'+termID} onClick={this.handleClick} />
+                                    </small>
+                            </label>
+                        : null}
+                    </ul>
+                </div>
+            );
+        }
+        return null;
     }
 });
 
@@ -831,9 +834,6 @@ var FacetList = search.FacetList = React.createClass({
         } else {
             hideTypes = filters.filter(filter => filter.field === 'type').length === 1 && normalFacets.length > 1;
         }
-        if (this.props.orientation == 'horizontal') {
-            width = (100 / facets.length) + '%';
-        }
 
         // See if we need the Clear Filters link or not. context.clear_filters 
         var clearButton; // JSX for the clear button
@@ -855,21 +855,23 @@ var FacetList = search.FacetList = React.createClass({
         }
 
         return (
-            <div className={"box facets " + this.props.orientation}>
-                {clearButton ?
-                    <div className="clear-filters-control">
-                        <a href={context.clear_filters}>Clear Filters <i className="icon icon-times-circle"></i></a>
-                    </div>
-                : null}
-                {this.props.mode === 'picker' && !this.props.hideTextFilter ? <TextFilter {...this.props} filters={filters} /> : ''}
-                {facets.map(facet => {
-                    if ((hideTypes && facet.field == 'type') || (!loggedIn && this.context.hidePublicAudits && facet.field.substring(0, 6) === 'audit.')) {
-                        return <span key={facet.field} />;
-                    } else {
-                        return <Facet {...this.props} key={facet.field} facet={facet} filters={filters}
-                                        width={width} />;
-                    }
-                })}
+            <div className="box facets">
+                <div className={this.props.orientation === 'horizontal' ? 'horizontal' : ''}>
+                    {clearButton ?
+                        <div className="clear-filters-control">
+                            <a href={context.clear_filters}>Clear Filters <i className="icon icon-times-circle"></i></a>
+                        </div>
+                    : null}
+                    {this.props.mode === 'picker' && !this.props.hideTextFilter ? <TextFilter {...this.props} filters={filters} /> : ''}
+                    {facets.map(facet => {
+                        if ((hideTypes && facet.field == 'type') || (!loggedIn && this.context.hidePublicAudits && facet.field.substring(0, 6) === 'audit.')) {
+                            return <span key={facet.field} />;
+                        } else {
+                            return <Facet {...this.props} key={facet.field} facet={facet} filters={filters}
+                                            width={width} />;
+                        }
+                    })}
+                </div>
             </div>
         );
     }

--- a/src/encoded/static/components/search.js
+++ b/src/encoded/static/components/search.js
@@ -856,7 +856,7 @@ var FacetList = search.FacetList = React.createClass({
 
         return (
             <div className="box facets">
-                <div className={this.props.orientation === 'horizontal' ? 'horizontal' : ''}>
+                <div className={`orientation${this.props.orientation === 'horizontal' ? ' horizontal' : ''}`}>
                     {clearButton ?
                         <div className="clear-filters-control">
                             <a href={context.clear_filters}>Clear Filters <i className="icon icon-times-circle"></i></a>

--- a/src/encoded/static/scss/encoded/modules/_facet.scss
+++ b/src/encoded/static/scss/encoded/modules/_facet.scss
@@ -1,42 +1,43 @@
-.box {
+.box.facets {
     padding: 10px;
     border: 1px #ccc solid;
     border-radius: 3px;
     overflow: hidden;
+
+    .horizontal {
+        display: block;
+
+        @media screen and (min-width: $screen-sm-min) {
+            display: flex;
+            flex-wrap: wrap;
+        }
+
+        @media screen and (min-width: $screen-md-min) {
+            flex-wrap: nowrap;
+            margin-left: -5px;
+            margin-right: -5px;
+        }
+
+        .facet {
+            display: block;
+
+            @media screen and (min-width: $screen-sm-min) {
+                min-width: 150px;
+                flex: 1 1 auto;
+                margin-left: 5px;
+                margin-right: 5px;
+            }
+
+            @media screen and (min-width: $screen-md-min) {
+                min-width: auto;
+            }
+        }
+    }
 }
 
-@media screen and (max-width: $screen-sm-min) {
-    .sm-no-padding {
-        padding-left: 0 !important;
-        padding-right: 0 !important;
-    }
-    .facets.horizontal .facet {
-        width: auto !important;
-    }
-}
-@media screen and (min-width: $screen-sm-min) {
-    .facets.horizontal {
-        .facet {
-            width: 50% !important;
-            padding: 0 10px;
-            float: left;
-        }
-    }
-}
-@media screen and (min-width: $screen-lg-min) {
-    .facets.horizontal {
-        display: table;
-        width: 100%;
-        .facet {
-            width: initial !important;
-            display: table-cell;
-            float: none;
-        }
-        .facet[hidden] {
-            display: table-cell !important;
-            visibility: hidden;
-        }
-    }
+.sm-no-padding {
+    padding-left: 0;
+    padding-right: 0;
 }
 
 .clear-filters-control {

--- a/src/encoded/tests/features/search.feature
+++ b/src/encoded/tests/features/search.feature
@@ -14,7 +14,7 @@ Feature: Search
         And I click the link to "/search/?type=AntibodyLot"
         And I wait for the content to load
         Then I should see at least 15 elements with the css selector "ul.nav.result-table > li"
-        And I should see at least 5 elements with the css selector "div.box.facets > div.facet"
+        And I should see at least 5 elements with the css selector "div.box.facets > div.orientation > div.facet"
 
         When I click the link to "?type=AntibodyLot&targets.organism.scientific_name=Homo+sapiens"
         And I wait for the content to load
@@ -34,7 +34,7 @@ Feature: Search
         And I click the link to "/search/?type=Biosample"
         And I wait for the content to load
         Then I should see at least 22 elements with the css selector "ul.nav.result-table > li"
-        And I should see at least 7 elements with the css selector "div.box.facets > div.facet"
+        And I should see at least 7 elements with the css selector "div.box.facets > div.orientation > div.facet"
 
         When I click the link to "?type=Biosample&sex=unknown"
         And I wait for the content to load
@@ -50,7 +50,7 @@ Feature: Search
         And I click the link to "/search/?type=Experiment"
         And I wait for the content to load
         Then I should see at least 13 elements with the css selector "ul.nav.result-table > li"
-        And I should see at least 3 elements with the css selector "div.box.facets > div.facet"
+        And I should see at least 3 elements with the css selector "div.box.facets > div.orientation > div.facet"
 
         When I click the link to "?type=Experiment&assay_title=ChIP-seq"
         And I wait for the content to load


### PR DESCRIPTION
* The <Facet> component now checks for the existence of non-zero data in the facet before attempting to display it.
* Converted the CSS table code for horizontal facets to use flexbox instead, as I’ve been doing for several other parts of the code for better consistency and easier maintenance. This does cause a rendering difference at some browser widths, where columns that would have taken half the horizontal space now stretch to the full width of the enclosing space. Here’s an example with the Experiment matrix.

![4680](https://cloud.githubusercontent.com/assets/1181324/20490233/1988f112-afc2-11e6-86a1-a775e6a99848.png)

* To work with flexbox, I found it convenient to add an extra div with the class “orientation” between the “box facets” div and the “facet” div. This caused one of the BDD tests that looks for box.facets > facet to break. I updated that test to account for the extra div: box.facets > orientation > facet.