### PR TITLE
4682 Fix Javascript crash when displaying series objects with files

### DIFF
--- a/src/encoded/static/components/dataset.js
+++ b/src/encoded/static/components/dataset.js
@@ -1368,7 +1368,15 @@ var Series = module.exports.Series = React.createClass({
                 : null }
 
                 {/* Display list of released and unreleased files */}
-                <FetchedItems {...this.props} url={globals.unreleased_files_url(context)} Component={DatasetFiles} filePanelHeader={<FilePanelHeader context={context} />} encodevers={globals.encodeVersion(context)} session={this.context.session} ignoreErrors />
+                <FetchedItems
+                    {...this.props}
+                    url={globals.unreleased_files_url(context)}
+                    Component={DatasetFiles}
+                    filePanelHeader={<FilePanelHeader context={context} />}
+                    encodevers={globals.encodeVersion(context)}
+                    session={this.context.session}
+                    ignoreErrors
+                />
 
                 <DocumentsPanel documentSpecs={[{documents: datasetDocuments}]} />
             </div>

--- a/src/encoded/static/components/filegallery.js
+++ b/src/encoded/static/components/filegallery.js
@@ -273,8 +273,8 @@ export const FileTable = React.createClass({
             title: 'Accession',
             display: (item, meta) => {
                 const { loggedIn, adminUser } = meta;
-                const buttonEnabled = !!meta.graphedFiles[item['@id']];
-                return <DownloadableAccession file={item} buttonEnabled={buttonEnabled} clickHandler={meta.fileClick} loggedIn={loggedIn} adminUser={adminUser} />;
+                const buttonEnabled = !!(meta.graphedFiles && meta.graphedFiles[item['@id']]);
+                return <DownloadableAccession file={item} buttonEnabled={buttonEnabled} clickHandler={meta.fileClick ? meta.fileClick : null} loggedIn={loggedIn} adminUser={adminUser} />;
             },
         },
         file_type: { title: 'File type' },
@@ -327,8 +327,8 @@ export const FileTable = React.createClass({
             title: 'Accession',
             display: (item, meta) => {
                 const { loggedIn, adminUser } = meta;
-                const buttonEnabled = !!meta.graphedFiles[item['@id']];
-                return <DownloadableAccession file={item} buttonEnabled={buttonEnabled} clickHandler={meta.fileClick} loggedIn={loggedIn} adminUser={adminUser} />;
+                const buttonEnabled = !!(meta.graphedFiles && meta.graphedFiles[item['@id']]);
+                return <DownloadableAccession file={item} buttonEnabled={buttonEnabled} clickHandler={meta.fileClick ? meta.fileClick : null} loggedIn={loggedIn} adminUser={adminUser} />;
             },
         },
         file_type: { title: 'File type' },
@@ -718,7 +718,7 @@ const RawSequencingTable = React.createClass({
                                         <tr key={i} className={file.restricted ? 'file-restricted' : ''}>
                                             {i === 0 ? { spanned } : null}
                                             <td className={pairClass}>
-                                                <DownloadableAccession file={file} buttonEnabled={buttonEnabled} clickHandler={meta.fileClick} loggedIn={loggedIn} adminUser={adminUser} />
+                                                <DownloadableAccession file={file} buttonEnabled={buttonEnabled} clickHandler={meta.fileClick ? meta.fileClick : null} loggedIn={loggedIn} adminUser={adminUser} />
                                             </td>
                                             <td className={pairClass}>{file.file_type}</td>
                                             <td className={pairClass}>{runType}{file.read_length ? <span>{runType ? <span /> : null}{file.read_length + file.read_length_units}</span> : null}</td>
@@ -753,7 +753,7 @@ const RawSequencingTable = React.createClass({
                                         <td className="table-raw-biorep">{file.biological_replicates ? file.biological_replicates.sort((a, b) => a - b).join(', ') : ''}</td>
                                         <td>{(file.replicate && file.replicate.library) ? file.replicate.library.accession : ''}</td>
                                         <td>
-                                            <DownloadableAccession file={file} buttonEnabled={buttonEnabled} clickHandler={meta.fileClick} loggedIn={loggedIn} adminUser={adminUser} />
+                                            <DownloadableAccession file={file} buttonEnabled={buttonEnabled} clickHandler={meta.fileClick ? meta.fileClick : null} loggedIn={loggedIn} adminUser={adminUser} />
                                         </td>
                                         <td>{file.file_type}</td>
                                         <td>{runType}{file.read_length ? <span>{runType ? <span /> : null}{file.read_length + file.read_length_units}</span> : null}</td>
@@ -891,7 +891,7 @@ const RawFileTable = React.createClass({
                                         <tr key={i} className={file.restricted ? 'file-restricted' : ''}>
                                             {i === 0 ? { spanned } : null}
                                             <td className={pairClass}>
-                                                <DownloadableAccession file={file} buttonEnabled={buttonEnabled} clickHandler={meta.fileClick} loggedIn={loggedIn} adminUser={adminUser} />
+                                                <DownloadableAccession file={file} buttonEnabled={buttonEnabled} clickHandler={meta.fileClick ? meta.fileClick : null} loggedIn={loggedIn} adminUser={adminUser} />
                                             </td>
                                             <td className={pairClass}>{file.file_type}</td>
                                             <td className={pairClass}>{file.output_type}</td>
@@ -920,7 +920,7 @@ const RawFileTable = React.createClass({
                                         <td className="table-raw-biorep">{file.biological_replicates ? file.biological_replicates.sort((a, b) => a - b).join(', ') : ''}</td>
                                         <td>{(file.replicate && file.replicate.library) ? file.replicate.library.accession : ''}</td>
                                         <td>
-                                            <DownloadableAccession file={file} buttonEnabled={buttonEnabled} clickHandler={meta.fileClick} loggedIn={loggedIn} adminUser={adminUser} />
+                                            <DownloadableAccession file={file} buttonEnabled={buttonEnabled} clickHandler={meta.fileClick ? meta.fileClick : null} loggedIn={loggedIn} adminUser={adminUser} />
                                         </td>
                                         <td>{file.file_type}</td>
                                         <td>{file.output_type}</td>


### PR DESCRIPTION
All Dataset-derived pages use the same graph/file code that I refactored for modals and restricted files — except for Series dataset objects that call that code at a lower level because they show different sets of column headers for their file tables. I didn’t change this code to keep up with the new data the file table code expected, so it tried to reference properties of properties that didn’t exist, and so we got a Javascript crash.

The standard graph/file code now checks to be sure that data’s there before dereferencing it, so that the new features simply won’t be used if the caller doesn’t pass the information for them, such as the Series objects don’t.