### PR TITLE
4697 Flip file size units and value

### DIFF
--- a/src/encoded/static/components/filegallery.js
+++ b/src/encoded/static/components/filegallery.js
@@ -184,7 +184,7 @@ function humanFileSize(size) {
         const i = Math.floor(Math.log(size) / Math.log(1024));
         const adjustedSize = (size / Math.pow(1024, i)).toPrecision(3) * 1;
         const units = ['B', 'kB', 'MB', 'GB', 'TB'][i];
-        return `${units} ${adjustedSize}`;
+        return `${adjustedSize} ${units}`;
     }
     return undefined;
 }


### PR DESCRIPTION
That was embarassingly stupid. Part of converting string arithmetic to string templates for AirBnB compliance, I got the variables mixed up.