### PR TITLE
4745 Pipeline facet removal

### DIFF
--- a/src/encoded/schemas/experiment.json
+++ b/src/encoded/schemas/experiment.json
@@ -186,9 +186,6 @@
         "replicates.library.biosample.treatments.treatment_term_name": {
             "title": "Biosample treatment"
         },
-        "files.analysis_step_version.analysis_step.pipelines.title": {
-            "title": "Pipeline"
-        },
         "files.file_type": {
             "title": "Available data"
         },

--- a/src/encoded/schemas/matched_set.json
+++ b/src/encoded/schemas/matched_set.json
@@ -83,9 +83,6 @@
         "related_datasets.replicates.library.biosample.treatments.treatment_term_name": {
             "title": "Biosample treatment"
         },
-        "related_datasets.files.analysis_step_version.analysis_step.pipelines.title": {
-            "title": "Pipeline"
-        },
         "related_datasets.files.file_type": {
             "title": "Available data"
         },

--- a/src/encoded/schemas/organism_development_series.json
+++ b/src/encoded/schemas/organism_development_series.json
@@ -74,9 +74,6 @@
         "related_datasets.replicates.library.biosample.treatments.treatment_term_name": {
             "title": "Biosample treatment"
         },
-        "related_datasets.files.analysis_step_version.analysis_step.pipelines.title": {
-            "title": "Pipeline"
-        },
         "related_datasets.files.file_type": {
             "title": "Available data"
         },

--- a/src/encoded/schemas/project.json
+++ b/src/encoded/schemas/project.json
@@ -82,9 +82,6 @@
         "organ_slims": {
             "title": "Organ"
         },
-        "files.analysis_step_version.analysis_step.pipelines.title": {
-            "title": "Pipeline"
-        },
         "files.file_type": {
             "title": "Available data"
         },

--- a/src/encoded/schemas/reference_epigenome.json
+++ b/src/encoded/schemas/reference_epigenome.json
@@ -77,9 +77,6 @@
         "related_datasets.replicates.library.biosample.treatments.treatment_term_name": {
             "title": "Biosample treatment"
         },
-        "related_datasets.files.analysis_step_version.analysis_step.pipelines.title": {
-            "title": "Pipeline"
-        },
         "related_datasets.files.file_type": {
             "title": "Available data"
         },

--- a/src/encoded/schemas/replication_timing_series.json
+++ b/src/encoded/schemas/replication_timing_series.json
@@ -101,9 +101,6 @@
         "related_datasets.replicates.library.biosample.treatments.treatment_term_name": {
             "title": "Biosample treatment"
         },
-        "related_datasets.files.analysis_step_version.analysis_step.pipelines.title": {
-            "title": "Pipeline"
-        },
         "related_datasets.files.file_type": {
             "title": "Available data"
         },

--- a/src/encoded/schemas/treatment_concentration_series.json
+++ b/src/encoded/schemas/treatment_concentration_series.json
@@ -77,9 +77,6 @@
         "treatment_term_name": {
             "title": "Biosample treatment"
         },
-        "related_datasets.files.analysis_step_version.analysis_step.pipelines.title": {
-            "title": "Pipeline"
-        },
         "related_datasets.files.file_type": {
             "title": "Available data"
         },

--- a/src/encoded/schemas/treatment_time_series.json
+++ b/src/encoded/schemas/treatment_time_series.json
@@ -77,9 +77,6 @@
         "treatment_term_name": {
             "title": "Biosample treatment"
         },
-        "related_datasets.files.analysis_step_version.analysis_step.pipelines.title": {
-            "title": "Pipeline"
-        },
         "related_datasets.files.file_type": {
             "title": "Available data"
         },


### PR DESCRIPTION
This purely involves removing the `files.analysis_step_version.analysis_step.pipelines.title` facet from all dataset-derived schemas: experiment, matched_set, organism_development_series, project, reference_epigenome, replication_timing_series, treatment_concentration_series, and treatment_time_series.