### PR TITLE
4780 file pages now show panel with a table of files deriving from the displayed one

### DIFF
--- a/src/encoded/static/components/file.js
+++ b/src/encoded/static/components/file.js
@@ -303,7 +303,7 @@ const File = React.createClass({
 
                 <FetchedItems
                     {...this.props}
-                    url={`/search/?type=File&limit=all&derived_from.accession=${context.accession}`}
+                    url={`/search/?type=File&limit=all&derived_from=${context['@id']}`}
                     Component={DerivedFiles}
                     encodevers={globals.encodeVersion(context)}
                     session={this.context.session}


### PR DESCRIPTION
Originally, the file page did a search including the term `derived_from.accession` that equaled the accession of the file being viewed. Because derived_from isn’t embedded anymore, this always gave zero results. I now search for the term `derived_from` instead, as that’s now a list of @ids.