### PR TITLE
4650 content error

### DIFF
--- a/src/encoded/static/components/file.js
+++ b/src/encoded/static/components/file.js
@@ -276,6 +276,13 @@ const File = React.createClass({
                                         </div>
                                     : null}
 
+                                    {context.content_error_detail ?
+                                        <div data-test="contenterrordetail">
+                                            <dt>Content error detail</dt>
+                                            <dd>{context.content_error_detail}</dd>
+                                        </div>
+                                    : null}
+
                                     {aliasList ?
                                         <div data-test="aliases">
                                             <dt>Aliases</dt>


### PR DESCRIPTION
Now displaying content_error under the label “Content error detail” on file pages.