### PR TITLE
4652 news sorting

### DIFF
--- a/src/encoded/search.py
+++ b/src/encoded/search.py
@@ -63,11 +63,14 @@ DEFAULT_DOC_TYPES = [
 ]
 
 
-def get_pagination(request):
+def get_pagination(request, news_search):
     from_ = request.params.get('from') or 0
     size = request.params.get('limit', 25)
     if size in ('all', ''):
-        size = None
+        if news_search:
+            size = 1000
+        else:
+            size = None
     else:
         try:
             size = int(size)
@@ -626,8 +629,6 @@ def search(context, request, search_type=None, return_generator=False):
     es_index = request.registry.settings['snovault.elasticsearch.index']
     search_audit = request.has_permission('search_audit')
 
-    from_, size = get_pagination(request)
-
     search_term = prepare_search_term(request)
 
     if search_type is None:
@@ -637,6 +638,12 @@ def search(context, request, search_type=None, return_generator=False):
 
     else:
         doc_types = [search_type]
+
+    # Determine if we're displaying a news search page
+    news_search = len(doc_types) == 1 and doc_types[0] == 'Page' and request.params.get('news')
+
+    # Always display most recent 1000 news items. Otherwise it depends on type of request.
+    from_, size = get_pagination(request, news_search)
 
     # Normalize to item_type
     try:
@@ -736,7 +743,7 @@ def search(context, request, search_type=None, return_generator=False):
     query['aggs'] = set_facets(facets, used_filters, principals, doc_types)
 
     # Decide whether to use scan for results.
-    do_scan = size is None or size > 1000
+    do_scan = (size is None or size > 1000) and not news_search
     # Execute the query
     if do_scan:
         es_results = es.search(body=query, index=es_index, search_type='count')

--- a/src/encoded/search.py
+++ b/src/encoded/search.py
@@ -849,7 +849,7 @@ def report(context, request):
 
     # Ignore large limits, which make `search` return a Response
     # -- UNLESS we're being embedded by the download_report view
-    from_, size = get_pagination(request)
+    from_, size = get_pagination(request, False)
     if ('limit' in request.GET and request.__parent__ is None
             and (size is None or size > 1000)):
         del request.GET['limit']

--- a/src/encoded/search.py
+++ b/src/encoded/search.py
@@ -63,7 +63,7 @@ DEFAULT_DOC_TYPES = [
 ]
 
 
-def get_pagination(request, news_search):
+def get_pagination(request, news_search=False):
     from_ = request.params.get('from') or 0
     size = request.params.get('limit', 25)
     if size in ('all', ''):
@@ -849,7 +849,7 @@ def report(context, request):
 
     # Ignore large limits, which make `search` return a Response
     # -- UNLESS we're being embedded by the download_report view
-    from_, size = get_pagination(request, False)
+    from_, size = get_pagination(request)
     if ('limit' in request.GET and request.__parent__ is None
             and (size is None or size > 1000)):
         del request.GET['limit']


### PR DESCRIPTION
This is purely a back-end change. Because news items need to get sorted differently from all other searches, I’ve added a news_search boolean that’s true if “Page” is the only `type` in the query string, and the `news` query string boolean is true.

If news_search is true then I want searches not to use do_scan because the do_scan searching stops sorting by date from working. So now do_scan only doesn’t get set to true if news_search is true.