### PR TITLE
4833 Add content error files to list of files searched

### DIFF
--- a/src/encoded/static/components/globals.js
+++ b/src/encoded/static/components/globals.js
@@ -110,7 +110,8 @@ module.exports.unreleased_files_url = function (context) {
         "format check failed",
         "in progress",
         "released",
-        "archived"
+        "archived",
+        "content error",
     ].map(encodeURIComponent).join('&status=');
     return '/search/?limit=all&type=file&dataset=' + context['@id'] + file_states;
 };


### PR DESCRIPTION
When experiment and some other dataset pages display, they do a search of files to display on the graph and file tables. The list of files needed had to increase to include “content error” files so they would display in the file tables too.