### PR TITLE
4871 Datasets with hidden graphs showing info buttons

### DIFF
--- a/src/encoded/static/components/filegallery.js
+++ b/src/encoded/static/components/filegallery.js
@@ -554,7 +554,7 @@ const RawSequencingTable = React.createClass({
                                     }
 
                                     // Determine if accession should be a button or not
-                                    const buttonEnabled = !!meta.graphedFiles[file['@id']];
+                                    const buttonEnabled = !!(meta.graphedFiles && meta.graphedFiles[file['@id']]);
 
                                     return (
                                         <tr key={i} className={file.restricted ? 'file-restricted' : ''}>
@@ -588,7 +588,7 @@ const RawSequencingTable = React.createClass({
                                 ];
 
                                 // Determine if accession should be a button or not.
-                                const buttonEnabled = !!meta.graphedFiles[file['@id']];
+                                const buttonEnabled = !!(meta.graphedFiles && meta.graphedFiles[file['@id']]);
 
                                 return (
                                     <tr key={i} className={rowClasses.join(' ')}>
@@ -730,7 +730,7 @@ const RawFileTable = React.createClass({
                                     }
 
                                     // Determine if the accession should be a button or not.
-                                    const buttonEnabled = !!meta.graphedFiles[file['@id']];
+                                    const buttonEnabled = !!(meta.graphedFiles && meta.graphedFiles[file['@id']]);
 
                                     // Prepare for run_type display
                                     return (
@@ -759,7 +759,7 @@ const RawFileTable = React.createClass({
                                 ];
 
                                 // Determine if accession should be a button or not.
-                                const buttonEnabled = !!meta.graphedFiles[file['@id']];
+                                const buttonEnabled = !!(meta.graphedFiles && meta.graphedFiles[file['@id']]);
 
                                 return (
                                     <tr key={i} className={rowClasses.join(' ')}>

--- a/src/encoded/static/components/filegallery.js
+++ b/src/encoded/static/components/filegallery.js
@@ -1431,7 +1431,7 @@ const FileGalleryRenderer = React.createClass({
     },
 
     render: function () {
-        const { context, data, schemas } = this.props;
+        const { context, data, schemas, hideGraph } = this.props;
         let selectedAssembly = '';
         let selectedAnnotation = '';
         let jsonGraph;
@@ -1452,7 +1452,7 @@ const FileGalleryRenderer = React.createClass({
         const graphFiles = _(files).filter(file => file.status !== 'archived');
 
         // Build node graph of the files and analysis steps with this experiment
-        if (graphFiles && graphFiles.length) {
+        if (graphFiles && graphFiles.length && !hideGraph) {
             try {
                 const { graph, graphedFiles } = assembleGraph(context, this.context.session, this.state.infoNodeId, graphFiles, selectedAssembly, selectedAnnotation);
                 jsonGraph = graph;
@@ -1490,7 +1490,7 @@ const FileGalleryRenderer = React.createClass({
                     </div>
                 </PanelHeading>
 
-                {!this.props.hideGraph ?
+                {!hideGraph ?
                     <FileGraph
                         context={context}
                         items={graphFiles}


### PR DESCRIPTION
Datasets that should never show graphs were still showing the information buttons on the file tables, and clicking them brought up no modal. That’s because datasets without graphs were still generating graphs — just not showing them.

This change makes datasets that don’t show graphs not generate them either, so their information buttons don’t appear because they’re based on files that actually appear in a generate graph.

If there’s a v53rc2, this should go in. If not, it should be OK to wait for v54 because it just shows buttons that don’t actually work, but has no other consequences.