### PR TITLE
Visualization blob cache priming was slow because the request object …

### DIFF
--- a/src/encoded/visualization.py
+++ b/src/encoded/visualization.py
@@ -1996,6 +1996,9 @@ def prime_vis_es_cache(event):
     else:
         log.debug("Starting prime_vis_es_cache: %d uuids" % (raw_count))
 
+    # NOTE: the request object coming from the peak indexer was not using elasticsearch!
+    request.datastore = 'elasticsearch'
+
     visualizabe_types = set(VISIBLE_DATASET_TYPES)
     count = 0
     for uuid in uuids:


### PR DESCRIPTION
One line change to make the peak_indexer process use elasticsearch when building vis blob (trackHub) cache.