### PR TITLE
4906 document subpanel wrapping in Safari

### DIFF
--- a/src/encoded/static/components/doc.js
+++ b/src/encoded/static/components/doc.js
@@ -65,8 +65,8 @@ var DocumentsPanel = module.exports.DocumentsPanel = React.createClass({
                         <PanelHeading>
                             <h4>{this.props.title ? <span>{this.props.title}</span> : <span>Documents</span>}</h4>
                         </PanelHeading>
-                        <PanelBody addClasses="panel-body-doc doc-panel-outer">
-                            <section className="flexrow doc-panel-inner">
+                        <PanelBody addClasses="panel-body-doc doc-panel__outer">
+                            <section className="doc-panel__inner">
                                 {allDocs.map((doc, i) => {
                                     var PanelView = globals.panel_views.lookup(doc);
                                     return <PanelView key={doc['@id']} label={docLabelMap[doc.uuid]} context={doc} />;

--- a/src/encoded/static/scss/encoded/modules/_panels.scss
+++ b/src/encoded/static/scss/encoded/modules/_panels.scss
@@ -225,7 +225,7 @@ a[href^="http://encodedcc.sdsc.edu/warehouse/"]:after {
     }
 
     @at-root #{&}__inner {
-        padding: 0 5px;
+        padding: 0;
 
         @media screen and (min-width: $screen-sm-min) {
             display: flex;

--- a/src/encoded/static/scss/encoded/modules/_panels.scss
+++ b/src/encoded/static/scss/encoded/modules/_panels.scss
@@ -218,12 +218,20 @@ a[href^="http://encodedcc.sdsc.edu/warehouse/"]:after {
     padding: 10px;
 }
 
-.doc-panel-outer {
-    padding: 3px 6px;
-}
+// Panel containing columns of document sub-panels.
+.doc-panel {
+    @at-root #{&}__outer {
+        padding: 3px;
+    }
 
-.doc-panel-inner {
-    padding: 0 5px;
+    @at-root #{&}__inner {
+        padding: 0 5px;
+
+        @media screen and (min-width: $screen-sm-min) {
+            display: flex;
+            flex-wrap: wrap;
+        }
+    }
 }
 
 .panel-attachment {


### PR DESCRIPTION
Small change to the flexbox CSS styles, and a little renaming to [BEM](http://getbem.com/introduction/) standards, as I’ve been very slowly transitioning to.