### PR TITLE
4985 Javascript crash when clicking form Browse button

### DIFF
--- a/src/encoded/static/components/search.js
+++ b/src/encoded/static/components/search.js
@@ -706,7 +706,7 @@ const Term = search.Term = React.createClass({
 const TypeTerm = search.TypeTerm = React.createClass({
     propTypes: {
         term: React.PropTypes.object,
-        filters: React.PropTypes.object,
+        filters: React.PropTypes.array,
         total: React.PropTypes.number,
     },
 
@@ -814,7 +814,7 @@ const Facet = search.Facet = React.createClass({
 
 const TextFilter = search.TextFilter = React.createClass({
     propTypes: {
-        filters: React.PropTypes.object,
+        filters: React.PropTypes.array,
         searchBase: React.PropTypes.string,
         onChange: React.PropTypes.func,
     },
@@ -980,7 +980,7 @@ const BatchDownload = search.BatchDownload = React.createClass({
 const ResultTable = search.ResultTable = React.createClass({
     propTypes: {
         context: React.PropTypes.object,
-        actions: React.PropTypes.string,
+        actions: React.PropTypes.array,
         restrictions: React.PropTypes.object,
         assemblies: React.PropTypes.array, // List of assemblies of all 'File' objects in search results
         searchBase: React.PropTypes.string,
@@ -999,7 +999,7 @@ const ResultTable = search.ResultTable = React.createClass({
 
     getInitialState: function () {
         return {
-            browserAssembly: this.props.assemblies[0], // Currently selected assembly for the browser
+            browserAssembly: this.props.assemblies && this.props.assemblies[0], // Currently selected assembly for the browser
             selectedTab: '',
         };
     },


### PR DESCRIPTION
Some new biodalliance-related code used a new `assemblies` prop to the `ResultTable` component. While regular /search/ results add this prop, form code doesn’t, and really shouldn’t have to. This change makes it so we check for their existence before using it.

Also fixed some incorrect prop types that caused React warnings.