### PR TITLE
4533 Disable Quick View for fly/worm assemblies and dataset-derived types

### DIFF
--- a/src/encoded/static/components/dataset.js
+++ b/src/encoded/static/components/dataset.js
@@ -252,7 +252,7 @@ const Annotation = React.createClass({
                 </Panel>
 
                 {/* Display the file widget with the facet, graph, and tables */}
-                <FileGallery context={context} encodevers={encodevers} />
+                <FileGallery context={context} encodevers={encodevers} annotationSource />
 
                 <DocumentsPanel documentSpecs={[{ documents: datasetDocuments }]} />
             </div>
@@ -414,7 +414,7 @@ const PublicationData = React.createClass({
                 </Panel>
 
                 {/* Display the file widget with the facet, graph, and tables */}
-                <FileGallery context={context} encodevers={globals.encodeVersion(context)} hideGraph />
+                <FileGallery context={context} encodevers={globals.encodeVersion(context)} hideGraph annotationSource />
 
                 <DocumentsPanel documentSpecs={[{ documents: datasetDocuments }]} />
             </div>
@@ -576,7 +576,7 @@ const Reference = React.createClass({
                 </Panel>
 
                 {/* Display the file widget with the facet, graph, and tables */}
-                <FileGallery context={context} encodevers={globals.encodeVersion(context)} hideGraph altFilterDefault />
+                <FileGallery context={context} encodevers={globals.encodeVersion(context)} hideGraph altFilterDefault annotationSource />
 
                 <DocumentsPanel documentSpecs={[{ documents: datasetDocuments }]} />
             </div>
@@ -762,7 +762,7 @@ const Project = React.createClass({
                 </Panel>
 
                 {/* Display the file widget with the facet, graph, and tables */}
-                <FileGallery context={context} encodevers={globals.encodeVersion(context)} hideGraph />
+                <FileGallery context={context} encodevers={globals.encodeVersion(context)} hideGraph annotationSource />
 
                 <DocumentsPanel documentSpecs={[{ documents: datasetDocuments }]} />
             </div>
@@ -934,7 +934,7 @@ const UcscBrowserComposite = React.createClass({
                 </Panel>
 
                 {/* Display the file widget with the facet, graph, and tables */}
-                <FileGallery context={context} encodevers={globals.encodeVersion(context)} hideGraph />
+                <FileGallery context={context} encodevers={globals.encodeVersion(context)} hideGraph annotationSource />
 
                 <DocumentsPanel documentSpecs={[{ documents: datasetDocuments }]} />
             </div>

--- a/src/encoded/static/components/filegallery.js
+++ b/src/encoded/static/components/filegallery.js
@@ -815,6 +815,7 @@ export const FileGallery = React.createClass({
         anisogenic: React.PropTypes.bool, // True if anisogenic experiment
         hideGraph: React.PropTypes.bool, // T to hide graph display
         altFilterDefault: React.PropTypes.bool, // T to default to All Assemblies and Annotations
+        annotationSource: React.PropTypes.bool, // v55rc3 only
     },
 
     contextTypes: {
@@ -829,7 +830,7 @@ export const FileGallery = React.createClass({
             <FetchedData ignoreErrors>
                 <Param name="data" url={globals.unreleased_files_url(context)} />
                 <Param name="schemas" url="/profiles/" />
-                <FileGalleryRenderer context={context} session={this.context.session} encodevers={encodevers} anisogenic={anisogenic} hideGraph={hideGraph} altFilterDefault={altFilterDefault} />
+                <FileGalleryRenderer context={context} session={this.context.session} encodevers={encodevers} anisogenic={anisogenic} hideGraph={hideGraph} altFilterDefault={altFilterDefault} annotationSource={this.props.annotationSource} />
             </FetchedData>
         );
     },
@@ -1350,6 +1351,7 @@ const FileGalleryRenderer = React.createClass({
         schemas: React.PropTypes.object, // Schemas for the entire system; used for QC property titles
         hideGraph: React.PropTypes.bool, // T to hide graph display
         altFilterDefault: React.PropTypes.bool, // T to default to All Assemblies and Annotations
+        annotationSource: React.PropTypes.bool, // v55rc3 only
     },
 
     contextTypes: {
@@ -1459,7 +1461,7 @@ const FileGalleryRenderer = React.createClass({
                     <div className="file-gallery-controls">
                         {context.visualize ?
                             <div className="file-gallery-control">
-                                <BrowserSelector visualizeCfg={context.visualize} />
+                                <BrowserSelector visualizeCfg={context.visualize} annotationSource={this.props.annotationSource} />
                             </div>
                         : null}
                         {filterOptions.length ?

--- a/src/encoded/static/components/objectutils.js
+++ b/src/encoded/static/components/objectutils.js
@@ -472,19 +472,14 @@ export const BrowserSelector = React.createClass({
                                                     {assembly}:
                                                 </div>
                                                 <div className="browser-selector__browsers">
-                                                    {browserList.map((browser) => {
-                                                        if (!flyWormException || browser !== 'Quick View') {
-                                                            return (
-                                                                <div key={browser} className="browser-selector__browser">
-                                                                    <a href={assemblyBrowsers[browser]} onClick={this.handleClick} rel="noopener noreferrer" target="_blank">
-                                                                        {browser}
-                                                                        {browser === 'Quick View' ? <span className="beta-badge">BETA</span> : null}
-                                                                    </a>
-                                                                </div>
-                                                            );
-                                                        }
-                                                        return null;
-                                                    })}
+                                                    {browserList.map(browser =>
+                                                        <div key={browser} className="browser-selector__browser">
+                                                            <a href={assemblyBrowsers[browser]} onClick={this.handleClick} disabled={flyWormException && browser === 'Quick View'} rel="noopener noreferrer" target="_blank">
+                                                                {browser}
+                                                                {browser === 'Quick View' ? <span className="beta-badge">BETA</span> : null}
+                                                            </a>
+                                                        </div>
+                                                    )}
                                                 </div>
                                             </div>
                                         );

--- a/src/encoded/static/components/objectutils.js
+++ b/src/encoded/static/components/objectutils.js
@@ -462,20 +462,29 @@ export const BrowserSelector = React.createClass({
                                     {assemblyList.map((assembly) => {
                                         const assemblyBrowsers = visualizeCfg[assembly];
                                         const browserList = _(Object.keys(assemblyBrowsers)).sortBy(browser => _(globals.browserPriority).indexOf(browser));
+
+                                        // Only for v55; see http://redmine.encodedcc.org/issues/4533#note-48
+                                        const flyWormException = ['ce10', 'ce11', 'dm3', 'dm6'].indexOf(assembly) !== -1;
+
                                         return (
                                             <div key={assembly} className="browser-selector__assembly-option">
                                                 <div className="browser-selector__assembly">
                                                     {assembly}:
                                                 </div>
                                                 <div className="browser-selector__browsers">
-                                                    {browserList.map(browser => (
-                                                        <div key={browser} className="browser-selector__browser">
-                                                            <a href={assemblyBrowsers[browser]} onClick={this.handleClick} rel="noopener noreferrer" target="_blank">
-                                                                {browser}
-                                                                {browser === 'Quick View' ? <span className="beta-badge">BETA</span> : null}
-                                                            </a>
-                                                        </div>
-                                                    ))}
+                                                    {browserList.map((browser) => {
+                                                        if (!flyWormException || browser !== 'Quick View') {
+                                                            return (
+                                                                <div key={browser} className="browser-selector__browser">
+                                                                    <a href={assemblyBrowsers[browser]} onClick={this.handleClick} rel="noopener noreferrer" target="_blank">
+                                                                        {browser}
+                                                                        {browser === 'Quick View' ? <span className="beta-badge">BETA</span> : null}
+                                                                    </a>
+                                                                </div>
+                                                            );
+                                                        }
+                                                        return null;
+                                                    })}
                                                 </div>
                                             </div>
                                         );

--- a/src/encoded/static/components/objectutils.js
+++ b/src/encoded/static/components/objectutils.js
@@ -415,6 +415,7 @@ export const BrowserSelector = React.createClass({
         visualizeCfg: React.PropTypes.object.isRequired, // Assemblies, browsers, and browser URLs; visualize and visualize_batch contents
         disabled: React.PropTypes.bool, // `true` if button should be disabled; usually because more search results than we can handle
         title: React.PropTypes.string, // Title of Visualize button if "Visualize" isn't desired
+        annotationSource: React.PropTypes.bool, // v55rc3 only
     },
 
     getInitialState: function () {
@@ -474,7 +475,7 @@ export const BrowserSelector = React.createClass({
                                                 <div className="browser-selector__browsers">
                                                     {browserList.map(browser =>
                                                         <div key={browser} className="browser-selector__browser">
-                                                            <a href={assemblyBrowsers[browser]} onClick={this.handleClick} disabled={flyWormException && browser === 'Quick View'} rel="noopener noreferrer" target="_blank">
+                                                            <a href={assemblyBrowsers[browser]} onClick={this.handleClick} disabled={(flyWormException || this.props.annotationSource) && browser === 'Quick View'} rel="noopener noreferrer" target="_blank">
                                                                 {browser}
                                                                 {browser === 'Quick View' ? <span className="beta-badge">BETA</span> : null}
                                                             </a>


### PR DESCRIPTION
Temporarily pass a boolean property from the component for the dataset objects so that we know it came from a non-experiment dataset (I improperly called annotationSource before I realized it affected other datasets) which I’ll remove for 56. This boolean along with a check for fly/worm assemblies disables the Quick View button. I’ll also remove the fly/worm check for 56 or whenever that issue gets resolved.