### PR TITLE
4533 Disable Quick View for mm9

### DIFF
--- a/src/encoded/static/components/objectutils.js
+++ b/src/encoded/static/components/objectutils.js
@@ -465,7 +465,7 @@ export const BrowserSelector = React.createClass({
                                         const browserList = _(Object.keys(assemblyBrowsers)).sortBy(browser => _(globals.browserPriority).indexOf(browser));
 
                                         // Only for v55; see http://redmine.encodedcc.org/issues/4533#note-48
-                                        const flyWormException = ['ce10', 'ce11', 'dm3', 'dm6'].indexOf(assembly) !== -1;
+                                        const flyWormException = ['ce10', 'ce11', 'dm3', 'dm6', 'mm9'].indexOf(assembly) !== -1;
 
                                         return (
                                             <div key={assembly} className="browser-selector__assembly-option">


### PR DESCRIPTION
Just added mm9 to a list of assemblies for which we disable Quick View. Presumably, this whole mechanism will go away once these assemblies have genes in them (though the email from Alec makes me wonder?).