### PR TITLE
removing inactive pipeline audit from file

### DIFF
--- a/src/encoded/audit/file.py
+++ b/src/encoded/audit/file.py
@@ -25,23 +25,9 @@ paired_end_assays = [
     ]
 
 
-@audit_checker('File', frame=[
-    'analysis_step_version',
-    'analysis_step_version.analysis_step',
-    'analysis_step_version.analysis_step.pipelines'])
-def audit_file_pipeline_status(value, system):
-    if value['status'] not in ['released']:
-        return
-    if 'analysis_step_version' in value and \
-       'analysis_step' in value['analysis_step_version'] and \
-       'pipelines' in value['analysis_step_version']['analysis_step']:
-        for p in value['analysis_step_version']['analysis_step']['pipelines']:
-            if p['status'] not in ['active']:
-                detail = 'File {} with a status of {} '.format(value['@id'], value['status']) + \
-                         'is associated with a pipeline {} '.format(p['@id']) + \
-                         'that has a status of {}.'.format(p['status'])
-                yield AuditFailure('inconsistent pipeline status',
-                                   detail, level='INTERNAL_ACTION')
+# def audit_file_pipeline_status(value, system): removed at release 56
+# http://redmine.encodedcc.org/issues/5017
+
 
 '''
 @audit_checker('File', frame=['derived_from'])

--- a/src/encoded/tests/test_audit_file.py
+++ b/src/encoded/tests/test_audit_file.py
@@ -349,16 +349,6 @@ def test_audit_file_replicate_match(testapp, file1, file_rep2):
     assert any(error['category'] == 'inconsistent replicate' for error in errors_list)
 
 
-def test_audit_file_pipeline_status(testapp, file7, pipeline_bam):
-    testapp.patch_json(file7['@id'], {'status': 'released'})
-    res = testapp.get(file7['@id'] + '@@index-data')
-    errors = res.json['audit']
-    errors_list = []
-    for error_type in errors:
-        errors_list.extend(errors[error_type])
-    assert any(error['category'] == 'inconsistent pipeline status' for error in errors_list)
-
-
 def test_audit_file_insufficient_control_read_depth_chip_seq_paired_end(
     testapp,
     file_exp,


### PR DESCRIPTION
In our effort to remove as many as possible File audits, here we are removing audit_file_pipeline_status audit. It was flagging released files associated with non-active pipelines. Audit test was removed as well. The mission to detect these files moved into “releasenator” script from pyencoded tools.