### PR TITLE
5059 Fix display issues in file tables

### DIFF
--- a/src/encoded/schemas/file.json
+++ b/src/encoded/schemas/file.json
@@ -850,6 +850,9 @@
         "file_format": {
             "title": "File Format"
         },
+        "file_type": {
+            "title": "File type"
+        },
         "file_format_type": {
             "title": "Specific file format type"
         },
@@ -882,6 +885,9 @@
         },
         "mapped_read_length": {
             "title": "Mapped read length"
+        },
+        "read_length_units": {
+            "title": "Read length units"
         },
         "md5sum": {
             "title": "MD5 Sum"


### PR DESCRIPTION
The `file_type` and `read_length_units` properties were removed from the `columns` property of the file.json schema in [this commit](https://github.com/ENCODE-DCC/encoded/commit/1de6f10effed3a8a918acdb55fd272f8b9a11351). The dataset-page file tables use searches to get their data, so with this schema change that data went away, leading to blank “File type” displays, and corrupted “Read length” displays. Experiment [ENCSR000AEN](http://localhost:6543/experiments/ENCSR000AEN/) on a local instance provides a good demo of this while logged in or not within the annotated highlight:

<img width="1137" alt="screen shot 2017-05-03 at 16 23 55" src="https://cloud.githubusercontent.com/assets/1181324/25685581/5baa4a9c-301d-11e7-90d9-630a4a13c297.png">

This commit just returns these two properties to the schema so that the tables display correctly again:

<img width="1138" alt="screen shot 2017-05-03 at 16 30 20" src="https://cloud.githubusercontent.com/assets/1181324/25685785/a0a52738-301e-11e7-8f1c-2e508d1e3448.png">