### PR TITLE
5060 missing flowcell

### DIFF
--- a/src/encoded/audit/file.py
+++ b/src/encoded/audit/file.py
@@ -399,21 +399,8 @@ def audit_file_controlled_by(value, system):
                 return
 
 
-@audit_checker('file', frame='object')
-def audit_file_flowcells(value, system):
-    '''
-    A fastq file could have its flowcell details.
-    '''
-
-    if value['status'] in ['deleted', 'replaced', 'revoked']:
-        return
-
-    if value['file_format'] not in ['fastq']:
-        return
-
-    if 'flowcell_details' not in value or (value['flowcell_details'] == []):
-        detail = 'Fastq file {} is missing flowcell_details'.format(value['@id'])
-        raise AuditFailure('missing flowcell_details', detail, level='WARNING')
+# def audit_file_flowcells(value, system): # removed in version 56
+# http://redmine.encodedcc.org/issues/5060
 
 
 @audit_checker('file', frame=['paired_with'])


### PR DESCRIPTION
removing missing_flowcell_details audit in our effort to get rid of as many file audits as possible. Wranglers are not finding this audit useful.