### PR TITLE
4998 Fix file table display when replicates have no libraries

### DIFF
--- a/src/encoded/static/components/filegallery.js
+++ b/src/encoded/static/components/filegallery.js
@@ -471,7 +471,10 @@ const RawSequencingTable = React.createClass({
             let pairedRepKeys = [];
             if (pairedFiles.length) {
                 pairedRepGroups = _(pairedFiles).groupBy(file => (
-                    (file.biological_replicates && file.biological_replicates.length === 1) ? globals.zeroFill(file.biological_replicates[0]) + file.replicate.library.accession : 'Z'
+                    (file.biological_replicates && file.biological_replicates.length === 1) ?
+                        globals.zeroFill(file.biological_replicates[0]) + ((file.replicate && file.replicate.library) ? file.replicate.library.accession : '')
+                    :
+                        'Z'
                 ));
 
                 // Make a sorted list of keys


### PR DESCRIPTION
This bug fix addresses a highly unusual but possible situation in which an experiment page can partially render file tables, and the console shows a Javascript crash.

You can use the experiments @aditin14 modified on test and my demo.

To reproduce the bug, you need:
* an experiment with one and only one biological_replicate value
* replicates with no library reference
* paired sequencing files, e.g. paired fastq files, that refer to that replicate and experiment.

You should expect to see the replicate table with empty library and biosample columns, and a “Raw sequencing files” table showing your paired files.

With [ENCSR089CCK on test](https://test.encodedcc.org/experiments/ENCSR089CCK/) while logged in:

<img width="1440" alt="bad" src="https://cloud.githubusercontent.com/assets/1181324/25690207/baf025c8-3043-11e7-8b42-787380e2081d.png">

For this situation, the code references `file.replicate.library.accession` without first checking that `file.replicate` and `file.replicate.library` exist first, which leads to the crash displayed in the console. The modification simply involves first checking for both `file.replicate` and `file.replicate.library` before referencing `file.replicate.library.accession`, and displaying an empty string if the replicate and library are missing.

With [ENCSR089CCK on the demo](https://4998-rep-wo-lib-247a797-fytanaka.demo.encodedcc.org/experiments/ENCSR089CCK/) while logged in:

<img width="1440" alt="good" src="https://cloud.githubusercontent.com/assets/1181324/25690211/c6b31960-3043-11e7-92ca-d5e86c424aa7.png">

If you want to reproduce this bug locally, you an go to [ENCSR000AEN](http://localhost:6543/experiments/ENCSR000AEN/) and edit this experiment. Go down the edit form to find the experiment's two replicates and click their disclosure triangles to open them. Delete both of their libraries. You'll see the same Javascript crash for the master branch, and the lack of a crash in this branch.