### PR TITLE
removing derived_from_revoked duplication audit from FILE

### DIFF
--- a/src/encoded/audit/file.py
+++ b/src/encoded/audit/file.py
@@ -78,18 +78,8 @@ def audit_file_processed_derived_from(value, system):
                            detail, level='INTERNAL_ACTION')
 
 
-@audit_checker('File', frame=['derived_from'])
-def audit_file_derived_from_revoked(value, system):
-    if 'derived_from' in value and len(value['derived_from']) > 0:
-        for f in value['derived_from']:
-            if f['status'] == 'revoked':
-                detail = 'The file {} '.format(value['@id']) + \
-                         'with a status {} '.format(value['status']) + \
-                         'was derived from file {} '.format(f['@id']) + \
-                         'that has a status \'revoked\'.'
-                yield AuditFailure('mismatched file status',
-                                   detail, level='INTERNAL_ACTION')
-                return
+# def audit_file_derived_from_revoked(value, system): removed at release 56
+# http://redmine.encodedcc.org/issues/5018
 
 
 @audit_checker('File', frame=['derived_from'])

--- a/src/encoded/tests/test_audit_file.py
+++ b/src/encoded/tests/test_audit_file.py
@@ -495,19 +495,6 @@ def test_audit_file_assembly(testapp, file6, file7):
                for error in errors_list)
 
 
-def test_audit_file_derived_from_revoked(testapp, file6, file7):
-    testapp.patch_json(file6['@id'], {'assembly': 'hg19', 'status': 'revoked'})
-    testapp.patch_json(file7['@id'], {'derived_from': [file6['@id']],
-                                      'status': 'released'})
-    res = testapp.get(file7['@id'] + '@@index-data')
-    errors = res.json['audit']
-    errors_list = []
-    for error_type in errors:
-        errors_list.extend(errors[error_type])
-    assert any(error['category'] == 'mismatched file status'
-               for error in errors_list)
-
-
 def test_audit_file_derived_from_empty(testapp, file7):
     res = testapp.get(file7['@id'] + '@@index-data')
     errors = res.json['audit']


### PR DESCRIPTION
Removing audit checking for file derivation from revoked files. it is a duplication of an audit on item.
