### PR TITLE
5069 audit facets don’t display while logged out in v56rc1

### DIFF
--- a/src/encoded/static/components/search.js
+++ b/src/encoded/static/components/search.js
@@ -932,7 +932,7 @@ const FacetList = search.FacetList = createReactClass({
                     : null}
                     {this.props.mode === 'picker' && !this.props.hideTextFilter ? <TextFilter {...this.props} filters={filters} /> : ''}
                     {facets.map((facet) => {
-                        if ((hideTypes && facet.field === 'type') || (!loggedIn && facet.field.substring(0, 6) === 'audit.')) {
+                        if (hideTypes && facet.field === 'type') {
                             return <span key={facet.field} />;
                         }
                         return <Facet {...this.props} key={facet.field} facet={facet} filters={filters} width={width} />;


### PR DESCRIPTION
### Technical notes:

v56rc1 never shows audits on search result pages in the facet list while logged out, though they still appear on individual items that have them. Previous behavior always shows audit facets while logged in or logged out except for audit.INTERNAL_ACTION.category audits which only display while logged in.

I caused this during my removal of unused React context variables. We introduced one a while ago that prevented the display of audits while logged out. Once we got the approval to display them, I set this variable to false permanently. When moving to React 15, I removed this variable completely, but incorrectly changed an if statement during facet display that used it, causing any audit facets to always fall through to the case where no facet gets displayed.

### Steps to test

1. Go to to the demo to URI /search/?test=Experiment while logged out.
2. Look at the bottom of the facet list. audit.ERROR.category, audit.NOT_COMPLIANT.category, and audit.WARNING.category facets appear. The audit.INTERNAL_ACTION.category facet does not.
3. Log in and look at the same search page. All previous audits appear along with the audit.INTERNAL_ACTION.category.

![5069fix](https://cloud.githubusercontent.com/assets/1181324/25820898/cf0f7822-33e7-11e7-8505-218ff6183ee7.png)