### PR TITLE
5074 IE11 page-content-change alert

### DIFF
--- a/src/encoded/static/components/app.js
+++ b/src/encoded/static/components/app.js
@@ -720,7 +720,6 @@ class App extends React.Component {
         if (this.state.unsavedChanges.length) {
             return 'You have unsaved changes.';
         }
-        return null;
     }
 
     navigate(href, options) {


### PR DESCRIPTION
5074 IE11 page-change alert

## Technical notes

encoded taps into the browser's `onbeforeunload` event to insert a message into the page-contents-changed alert before navigating away from a page. The `<App>` component keeps an `unsavedChanges` state variable that gets updated with references to fields that have been modified when editing an object. `unsavedChanges` gets checked when our `onbeforeunload` handler gets called, and we either return a string to cause the warning alert to appear with that string, or "null" for the alert to not appear.

This turns out to be out of spec. You’re supposed to return nothing (undefined) when you don’t want the alert to appear. To most browsers, this didn’t matter. To Trident (IE11 but not MSEdge) browsers, this did.

The only modification to fix this was to remove the `return null;` from our `onbeforeunload` handler.

## Reproducing the bug

1. With Internet Explorer 11, go to any page of the [demo site](https://v56rc1-master.demo.encodedcc.org/) and let it load.
2. Now manually modify IE11’s URL bar to navigate to another page.
3. You will see the following alert. The “Message from webpage: null” was a very good clue in fixing this.

<img width="480" alt="screen shot 2017-05-09 at 17 28 52" src="https://cloud.githubusercontent.com/assets/1181324/25878166/76ef1958-34dd-11e7-96a0-d6277b8f0d84.png">

## Testing the fix

1. Load up the site with this branch as above, but this time the browser simply navigates to the page you entered rather than putting up the alert.