### PR TITLE
5071 React error when displaying replicate JSON pages

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -34,6 +34,7 @@
         "react/jsx-filename-extension": 0,
         "react/jsx-indent": 0,
         "react/jsx-indent-props": 0,
+        "react/no-array-index-key": 0,
         "react/no-danger": 0,
         "react/no-deprecated": 0,
         "react/no-did-mount-set-state": 0,

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -479,11 +479,6 @@
       "from": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz"
     },
-    "shortid": {
-      "version": "2.2.6",
-      "from": "https://registry.npmjs.org/shortid/-/shortid-2.2.6.tgz",
-      "resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.6.tgz"
-    },
     "source-map": {
       "version": "0.5.6",
       "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "react": "^15.5.3",
     "react-dom": "^15.5.3",
     "scriptjs": "^2.5.7",
-    "shortid": "^2.2.6",
     "source-map-support": "^0.4.11",
     "subprocess-middleware": "^0.1.0",
     "underscore": "^1.8.3",

--- a/src/encoded/static/components/audit.js
+++ b/src/encoded/static/components/audit.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import shortid from 'shortid';
 import _ from 'underscore';
 import { collapseIcon } from '../libs/svg-icons';
 import { Panel } from '../libs/bootstrap/panel';
@@ -203,8 +202,8 @@ class AuditGroup extends React.Component {
                 </div>
                 <div className="audit-details-section">
                     <div className="audit-details-decoration" />
-                    {group.map(audit =>
-                        <div className={alertItemClass} key={audit.id} role="alert">
+                    {group.map((audit, i) =>
+                        <div className={alertItemClass} key={i} role="alert">
                             <DetailEmbeddedLink detail={audit.detail} except={except} forcedEditLink={forcedEditLink} />
                         </div>,
                     )}
@@ -225,20 +224,6 @@ AuditGroup.defaultProps = {
     except: '',
     forcedEditLink: false,
 };
-
-
-// No necessarily distinguishing information for each audit, making it impossible to reliably key
-// them as React components. This takes an audit object as it arrives in a parent data object and
-// adds a unique id to each one that we can use as a key when rendering each one. Uses an npm
-// module that generates guaranteed unique values.
-function idAudits(audits) {
-    Object.keys(audits).forEach((auditType) => {
-        const typeAudits = audits[auditType];
-        typeAudits.forEach((audit) => {
-            audit.id = shortid.generate();
-        });
-    });
-}
 
 
 // Determine whether audits should be displayed or not, given the audits object from a data object,
@@ -280,9 +265,6 @@ export const auditDecor = AuditComponent => class extends React.Component {
         const loggedIn = !!(session && session['auth.userid']);
 
         if (auditsDisplayed(audits, session)) {
-            // Attach unique IDs to each audit to use as React keys.
-            idAudits(audits);
-
             // Sort the audit levels by their level number, using the first element of each warning
             // category.
             const sortedAuditLevels = _(Object.keys(audits)).sortBy(level => -audits[level][0].level);

--- a/src/encoded/static/components/file.js
+++ b/src/encoded/static/components/file.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
-import shortid from 'shortid';
 import _ from 'underscore';
 import Pager from '../libs/bootstrap/pager';
 import { Panel, PanelHeading, PanelBody } from '../libs/bootstrap/panel';
@@ -581,13 +580,6 @@ class SequenceFileInfo extends React.Component {
         const pairedWithAccession = file.paired_with ? globals.atIdToAccession(file.paired_with) : '';
         const platformAccession = file.platform ? decodeURIComponent(globals.atIdToAccession(file.platform)) : '';
 
-        // Generate keys for the flowcell details.
-        if (file.flowcell_details && file.flowcell_details.map) {
-            file.flowcell_details.forEach((detail) => {
-                detail.id = shortid.generate();
-            });
-        }
-
         return (
             <Panel>
                 <PanelHeading>
@@ -607,14 +599,14 @@ class SequenceFileInfo extends React.Component {
                             <div data-test="flowcelldetails">
                                 <dt>Flowcell</dt>
                                 <dd>
-                                    {file.flowcell_details.map((detail) => {
+                                    {file.flowcell_details.map((detail, i) => {
                                         const items = [
                                             detail.machine ? detail.machine : '',
                                             detail.flowcell ? detail.flowcell : '',
                                             detail.lane ? detail.lane : '',
                                             detail.barcode ? detail.barcode : '',
                                         ];
-                                        return <span className="line-item" key={detail.id}>{items.join(':')}</span>;
+                                        return <span className="line-item" key={i}>{items.join(':')}</span>;
                                     })}
                                 </dd>
                             </div>

--- a/src/encoded/static/components/item.js
+++ b/src/encoded/static/components/item.js
@@ -5,7 +5,6 @@ import createReactClass from 'create-react-class';
 var collection = require('./collection');
 var fetched = require('./fetched');
 var globals = require('./globals');
-import { auditDecor } from './audit';
 var form = require('./form');
 var _ = require('underscore');
 
@@ -41,7 +40,7 @@ var Fallback = module.exports.Fallback = createReactClass({
 });
 
 
-var ItemComponent = module.exports.Item = createReactClass({
+var Item = module.exports.Item = createReactClass({
     render: function() {
         var context = this.props.context;
         var itemClass = globals.itemClass(context, 'view-item');
@@ -57,12 +56,8 @@ var ItemComponent = module.exports.Item = createReactClass({
                     <div className="col-sm-12">
                         <h2>{title}</h2>
                         {altacc ? <h4 className="repl-acc">Replaces {altacc}</h4> : null}
-                        <div className="status-line">
-                            {this.props.auditIndicators(context.audit, 'item-audit')}
-                        </div>
                     </div>
                 </header>
-                {this.props.auditDetail(context.audit, 'item-audit', { except: context['@id'] })}
                 <div className="row item-row">
                     <div className="col-sm-12">
                         {context.description ? <p className="description">{context.description}</p> : null}
@@ -73,8 +68,6 @@ var ItemComponent = module.exports.Item = createReactClass({
         );
     }
 });
-
-const Item = auditDecor(ItemComponent);
 
 globals.content_views.register(Item, 'Item');
 


### PR DESCRIPTION
## Technical notes

I’m not clear why this problem only seemed to show up for replicate JSON pages, but the bug stems from an npm module I started using with React 15 to generate unique IDs. One of the AirBnB React rules involves not using Javascript loop indices as React component keys. [This article](https://medium.com/@robinpokorny/index-as-a-key-is-an-anti-pattern-e0349aece318) suggested using the “shortid” npm module to generate a unique ID instead of using the loop index. The problem is that shortid can generate different values on the server and client, so when loading a page you end up with an invariant violation because the corresponding client- and server-generated HTML had different keys.

I considered hashing each audit object to generate an ID that would be the same on both server and client, but that seems expensive. I didn’t think it practical to just extract part of each audit to hash either because it seems impossible to predict which parts change and which parts stay the same.

My solution involves just going back to using loop indices. This affects not only audits but file.flowcell_details — neither of which have any guaranteed unique properties to use as keys.

I also removed shortid from package.json and npm-shrinkwrap.

We might consider having the back-end audit code generate a unique ID for each audit, but I’m not sure that’s any easier or more efficient there than it would be on the front-end.

## Steps to reproduce

1. Bring up the Javascript console.
1. Go to an individual replicate page.
1. If you navigated there from another page, reload it (this problem only appears when loading the page fresh; not when you navigate there).
1. You’ll see the following error in the console, and no Javascript-driven controls on the page operate (drop-down menus).

![bugrep](https://cloud.githubusercontent.com/assets/1181324/25878383/360a1d14-34df-11e7-96fc-b9f025fd5746.png)

## Steps to test

Follow the above steps, but instead of the error, you’ll see no errors, and Javascript-driven controls continue to work as they should.

![fixrep](https://cloud.githubusercontent.com/assets/1181324/25878387/3d15bd34-34df-11e7-9f79-e4e9aa956016.png)
