### PR TITLE
4790 Fix vanished “not” facets

### DIFF
--- a/src/encoded/static/components/search.js
+++ b/src/encoded/static/components/search.js
@@ -775,35 +775,32 @@ const Facet = search.Facet = createReactClass({
             }
         }
 
-        if (terms.length && terms.some(term => term.doc_count)) {
-            return (
-                <div className="facet">
-                    <h5>{title}</h5>
-                    <ul className="facet-list nav">
-                        <div>
-                            {terms.slice(0, 5).map(term =>
+        return (
+            <div className="facet">
+                <h5>{title}</h5>
+                <ul className="facet-list nav">
+                    <div>
+                        {terms.slice(0, 5).map(term =>
+                            <TermComponent {...this.props} key={term.key} term={term} filters={filters} total={total} canDeselect={canDeselect} />
+                        )}
+                    </div>
+                    {terms.length > 5 ?
+                        <div id={termID} className={moreSecClass}>
+                            {moreTerms.map(term =>
                                 <TermComponent {...this.props} key={term.key} term={term} filters={filters} total={total} canDeselect={canDeselect} />
                             )}
                         </div>
-                        {terms.length > 5 ?
-                            <div id={termID} className={moreSecClass}>
-                                {moreTerms.map(term =>
-                                    <TermComponent {...this.props} key={term.key} term={term} filters={filters} total={total} canDeselect={canDeselect} />
-                                )}
-                            </div>
-                        : null}
-                        {(terms.length > 5 && !moreTermSelected) ?
-                            <label className="pull-right">
-                                <small>
-                                    <button type="button" className={seeMoreClass} data-toggle="collapse" data-target={'#'+termID} onClick={this.handleClick} />
-                                </small>
-                            </label>
-                        : null}
-                    </ul>
-                </div>
-            );
-        }
-        return null;
+                    : null}
+                    {(terms.length > 5 && !moreTermSelected) ?
+                        <label className="pull-right">
+                            <small>
+                                <button type="button" className={seeMoreClass} data-toggle="collapse" data-target={'#'+termID} onClick={this.handleClick} />
+                            </small>
+                        </label>
+                    : null}
+                </ul>
+            </div>
+        );
     }
 });
 


### PR DESCRIPTION
## Technical notes

This probably resulted from a merge error. The condition for empty doc_counts was removed for v55, but since 4755-react-15 branched before then, it kept it through subsequent merges, and got merged back into master.

## Testing

1. Go to any search page (e.g. "/search/?type=Experiment”).
1. nter a facet term to the URL with a `!=` operator (e.g. “/search/?type=Experiment&assay_title%21=DNase-seq”).
1. The bottom facet in the facet list should show that term with the bang after the title, but with no count.

<img width="269" alt="notterm" src="https://cloud.githubusercontent.com/assets/1181324/25917875/5e215f98-357e-11e7-8acd-7b69873ec3ba.png">