### PR TITLE
5070 Fix raw file table bugs

### DIFF
--- a/src/encoded/static/components/filegallery.js
+++ b/src/encoded/static/components/filegallery.js
@@ -694,18 +694,6 @@ const RawFileTable = createReactClass({
                                 const groupFiles = pairedGroups[pairedKey];
                                 const bottomClass = j < (pairedKeys.length - 1) ? 'merge-bottom' : '';
 
-                                // Render an array of biological replicate and library to display on
-                                // the first row of files, spanned to all rows for that replicate and
-                                // library
-                                const spanned = [
-                                    <td rowSpan={groupFiles.length} className={`${bottomClass} merge-right table-raw-merged table-raw-biorep`}>
-                                        {groupFiles[0].biological_replicates.length ? <span>{groupFiles[0].biological_replicates[0]}</span> : <i>N/A</i>}
-                                    </td>,
-                                    <td rowSpan={groupFiles.length} className={`${bottomClass} merge-right table-raw-merged`}>
-                                        {groupFiles[0].replicate && groupFiles[0].replicate.library ? <span>{groupFiles[0].replicate.library.accession}</span> : <i>N/A</i>}
-                                    </td>,
-                                ];
-
                                 // Render each file's row, with the biological replicate and library
                                 // cells only on the first row.
                                 return groupFiles.sort((a, b) => (a.title < b.title ? -1 : 1)).map((file, i) => {
@@ -721,8 +709,17 @@ const RawFileTable = createReactClass({
 
                                     // Prepare for run_type display
                                     return (
-                                        <tr key={pairedKey} className={file.restricted ? 'file-restricted' : ''}>
-                                            {i === 0 ? { spanned } : null}
+                                        <tr key={file['@id']} className={file.restricted ? 'file-restricted' : ''}>
+                                            {i === 0 ?
+                                                <td rowSpan={groupFiles.length} className={`${bottomClass} merge-right table-raw-merged table-raw-biorep`}>
+                                                    {groupFiles[0].biological_replicates.length ? <span>{groupFiles[0].biological_replicates[0]}</span> : <i>N/A</i>}
+                                                </td>
+                                            : null}
+                                            {i === 0 ?
+                                                <td rowSpan={groupFiles.length} className={`${bottomClass} merge-right table-raw-merged`}>
+                                                    {groupFiles[0].replicate && groupFiles[0].replicate.library ? <span>{groupFiles[0].replicate.library.accession}</span> : <i>N/A</i>}
+                                                </td>
+                                            : null}
                                             <td className={pairClass}>
                                                 <DownloadableAccession file={file} buttonEnabled={buttonEnabled} clickHandler={meta.fileClick ? meta.fileClick : null} loggedIn={loggedIn} adminUser={adminUser} />
                                             </td>


### PR DESCRIPTION
## Technical notes:

This problem resulted from two different but physically close bugs.
1. Using the same React key in both an inner and outer rendering loop when rendering a raw file table. React complains if you use the same component key twice within a loop, and using the same key in nested loops caused the inner loop’s components to all have the same key. I fixed this by changing the component to use file.@id as the key because that has guaranteed uniqueness.
2. Displaying an array of `<td>` components within a conditional expression. This used to work in React 0.12, but apparently not with React 15. I switched this code to use the same kind of method I used in `<RawSequencingTable>` — render each component within its own conditional expression.

## Steps to test:
1. Find an experiment page with a Raw file table. An example in local test data is /experiments/ENCSR000AAL/. It displays the raw file table and no errors in the console.

Without the fix, no file table gets displayed, and the console shows two errors:

1. “Warning: flattenChildren(...): Encountered two children with the same key, `0:0:$0002ENCLB000DAT`. Child keys must be unique; when two children share a key, only the first child will be used.”
2. “Uncaught (in promise) Error: Objects are not valid as a React child (found: object with keys {spanned}). If you meant to render a collection of children, use an array instead or wrap the object using createFragment(object) from the React add-ons.”

The first error comes from using identical keys multiple times. The second comes from rendering an array of React components in a conditional statement.