### PR TITLE
4998 Fix assumption of replicate library’s existence

### DIFF
--- a/src/encoded/static/components/filegallery.js
+++ b/src/encoded/static/components/filegallery.js
@@ -544,7 +544,7 @@ const RawSequencingTable = createReactClass({
                                                 <td rowSpan={groupFiles.length} className={`${bottomClass} merge-right table-raw-merged table-raw-biorep`}>{groupFiles[0].biological_replicates[0]}</td>
                                             : null}
                                             {i === 0 ?
-                                                <td rowSpan={groupFiles.length} className={`${bottomClass} merge-right + table-raw-merged`}>{groupFiles[0].replicate.library.accession}</td>
+                                                <td rowSpan={groupFiles.length} className={`${bottomClass} merge-right + table-raw-merged`}>{(groupFiles[0].replicate && groupFiles[0].replicate.library) ? groupFiles[0].replicate.library.accession : null}</td>
                                             : null}
                                             <td className={pairClass}>
                                                 <DownloadableAccession file={file} buttonEnabled={buttonEnabled} clickHandler={meta.fileClick ? meta.fileClick : null} loggedIn={loggedIn} adminUser={adminUser} />


### PR DESCRIPTION
This was fixed and merged earlier, but it appeared again in v56rc2 because of a similar problem in a different spot. The original issue happened while grouping paired files by replicate/library. That was fixed for v56rc1.

Why this didn’t appear at this spot until now, I’m not sure. The code did shift position between v56rc1 and v56rc2, but it’s the same code run under what I _think_ are the same circumstances.

The fix involves simply checking for the existence of a replicate and its library before retrieving the library’s accession.