### PR TITLE
5101 DCC Internal Audits not rendered regardless of login state

### DIFF
--- a/src/encoded/static/components/antibody.js
+++ b/src/encoded/static/components/antibody.js
@@ -27,6 +27,10 @@ var {DocumentsPanel, Document, DocumentPreview, DocumentFile} = doc;
 
 
 var LotComponent = createReactClass({
+    contextTypes: {
+        session: PropTypes.object, // Login information from <App>
+    },
+
     render: function() {
         var context = this.props.context;
 

--- a/src/encoded/static/components/biosample.js
+++ b/src/encoded/static/components/biosample.js
@@ -41,6 +41,10 @@ var PanelLookup = function (props) {
 
 
 var BiosampleComponent = module.exports.Biosample = createReactClass({
+    contextTypes: {
+        session: PropTypes.object, // Login information from <App>
+    },
+
     render: function() {
         var context = this.props.context;
         var itemClass = globals.itemClass(context, 'view-item');

--- a/src/encoded/static/components/experiment.js
+++ b/src/encoded/static/components/experiment.js
@@ -330,11 +330,11 @@ var ExperimentComponent = createReactClass({
                             <div className="characterization-status-labels">
                                 <StatusLabel status={statuses} />
                             </div>
-                            {this.props.auditIndicators(context.audit, 'experiment-audit')}
+                            {this.props.auditIndicators(context.audit, 'experiment-audit', { session: this.context.session })}
                         </div>
                    </div>
                 </header>
-                {this.props.auditDetail(context.audit, 'experiment-audit', { except: context['@id'] })}
+                {this.props.auditDetail(context.audit, 'experiment-audit', { session: this.context.session, except: context['@id'] })}
                 <Panel addClasses="data-display">
                     <PanelBody addClasses="panel-body-with-header">
                         <div className="flexrow">

--- a/src/encoded/static/components/filegallery.js
+++ b/src/encoded/static/components/filegallery.js
@@ -1478,7 +1478,7 @@ const FileGalleryRenderer = createReactClass({
                         infoNodeVisible={this.state.infoNodeVisible}
                         setInfoNodeVisible={this.setInfoNodeVisible}
                         schemas={schemas}
-                        adminUser={!!(this.context.session_properties && this.context.session_properties.admin)}
+                        sessionProperties={this.context.session_properties}
                         forceRedraw
                     />
                 : null}
@@ -1656,7 +1656,7 @@ const FileGraphComponent = createReactClass({
         infoNodeVisible: PropTypes.bool, // True if node's modal is vibible
         schemas: PropTypes.object, // System-wide schemas
         session: PropTypes.object, // Current user's login information
-        adminUser: PropTypes.bool, // True if logged in user is an admin
+        sessionProperties: PropTypes.object, // True if logged in user is an admin
         auditIndicators: PropTypes.func, // Inherited from auditDecor HOC
         auditDetail: PropTypes.func, // Inherited from auditDecor HOC
     },
@@ -1673,7 +1673,7 @@ const FileGraphComponent = createReactClass({
     // Render metadata if a graph node is selected.
     // jsonGraph: JSON graph data.
     // infoNodeId: ID of the selected node
-    detailNodes: function (jsonGraph, infoNodeId, loggedIn, adminUser) {
+    detailNodes: function (jsonGraph, infoNodeId, session, sessionProperties) {
         let meta;
 
         // Find data matching selected node, if any
@@ -1722,7 +1722,7 @@ const FileGraphComponent = createReactClass({
                         if (currContributing[node.metadata.contributing]) {
                             // We have this file's object in the cache, so just display it.
                             node.metadata.ref = currContributing[node.metadata.contributing];
-                            meta = globals.graph_detail.lookup(node)(node, this.handleNodeClick, this.loggedIn, adminUser);
+                            meta = globals.graph_detail.lookup(node)(node, this.handleNodeClick, this.props.auditIndicators, this.props.auditDetail, session, sessionProperties);
                             meta.type = node['@type'][0];
                         } else if (!this.contributingRequestOutstanding) {
                             // We don't have this file's object in the cache, so request it from
@@ -1741,7 +1741,7 @@ const FileGraphComponent = createReactClass({
                     } else {
                         // Regular File data in the node from when we generated the graph. Just
                         // display the file data from there.
-                        meta = globals.graph_detail.lookup(node)(node, this.handleNodeClick, this.props.auditIndicators, this.props.auditDetail, loggedIn, adminUser);
+                        meta = globals.graph_detail.lookup(node)(node, this.handleNodeClick, this.props.auditIndicators, this.props.auditDetail, session, sessionProperties);
                         meta.type = node['@type'][0];
                     }
                 }
@@ -1768,8 +1768,7 @@ const FileGraphComponent = createReactClass({
     },
 
     render: function () {
-        const { session, adminUser, items, graph, selectedAssembly, selectedAnnotation, infoNodeId, infoNodeVisible } = this.props;
-        const loggedIn = !!(session && session['auth.userid']);
+        const { session, sessionProperties, items, graph, selectedAssembly, selectedAnnotation, infoNodeId, infoNodeVisible } = this.props;
         const files = items;
         const modalTypeMap = {
             File: 'file',
@@ -1783,7 +1782,7 @@ const FileGraphComponent = createReactClass({
             const goodGraph = graph && Object.keys(graph).length;
             if (goodGraph) {
                 if (selectedAssembly || selectedAnnotation) {
-                    const meta = this.detailNodes(graph, infoNodeId, loggedIn, adminUser);
+                    const meta = this.detailNodes(graph, infoNodeId, session, sessionProperties);
                     const modalClass = meta ? `graph-modal-${modalTypeMap[meta.type]}` : '';
 
                     return (
@@ -1847,11 +1846,13 @@ const FileQCButton = createReactClass({
 
 
 // Display the metadata of the selected file in the graph
-const FileDetailView = function (node, qcClick, auditIndicators, auditDetail, loggedIn, adminUser) {
+const FileDetailView = function (node, qcClick, auditIndicators, auditDetail, session, sessionProperties) {
     // The node is for a file
     const selectedFile = node.metadata.ref;
     let body = null;
     let header = null;
+    const loggedIn = !!(session && session['auth.userid']);
+    const adminUser = !!(sessionProperties && sessionProperties.admin);
 
     if (selectedFile && Object.keys(selectedFile).length) {
         let contributingAccession;
@@ -1967,12 +1968,12 @@ const FileDetailView = function (node, qcClick, auditIndicators, auditDetail, lo
                     : null}
                 </dl>
 
-                {auditsDisplayed(selectedFile.audit) ?
+                {auditsDisplayed(selectedFile.audit, session) ?
                     <div className="row graph-modal-audits">
                         <div className="col-xs-12">
                             <h5>File audits:</h5>
-                            {auditIndicators(selectedFile.audit, 'file-audit')}
-                            {auditDetail(selectedFile.audit, 'file-audit', { except: selectedFile['@id'] })}
+                            {auditIndicators(selectedFile.audit, 'file-audit', { session: session })}
+                            {auditDetail(selectedFile.audit, 'file-audit', { session: session, except: selectedFile['@id'] })}
                         </div>
                     </div>
                 : null}

--- a/src/encoded/static/components/genetic_modification.js
+++ b/src/encoded/static/components/genetic_modification.js
@@ -72,6 +72,10 @@ export const GeneticModificationComponent = createReactClass({
         auditDetail: PropTypes.func.isRequired, // Audit HOC function to display audit details
     },
 
+    contextTypes: {
+        session: PropTypes.object, // Login information from <App>
+    },
+
     render: function () {
         const context = this.props.context;
         const itemClass = globals.itemClass(context, 'view-detail key-value');
@@ -136,11 +140,11 @@ export const GeneticModificationComponent = createReactClass({
                             <div className="characterization-status-labels">
                                 <StatusLabel title="Status" status={context.status} />
                             </div>
-                            {this.props.auditIndicators(context.audit, 'genetic-modification-audit')}
+                            {this.props.auditIndicators(context.audit, 'genetic-modification-audit', { session: this.context.session })}
                         </div>
                     </div>
                 </header>
-                {this.props.auditDetail(context.audit, 'genetic-modification-audit', { except: context['@id'] })}
+                {this.props.auditDetail(context.audit, 'genetic-modification-audit', { session: this.context.session, except: context['@id'] })}
                 <Panel addClasses="data-display">
                     <PanelBody addClasses="panel-body-with-header">
                         <div className="flexrow">
@@ -541,6 +545,10 @@ const ListingComponent = createReactClass({
         auditIndicators: PropTypes.func.isRequired, // Audit HOC function to display audit indicators
     },
 
+    contextTypes: {
+        session: PropTypes.object, // Login information from <App>
+    },
+
     render: function () {
         const result = this.props.context;
 
@@ -564,14 +572,14 @@ const ListingComponent = createReactClass({
                     <div className="pull-right search-meta">
                         <p className="type meta-title">Genetic modifications</p>
                         <p className="type meta-status">{` ${result.status}`}</p>
-                        {this.props.auditIndicators(result.audit, result['@id'], { search: true })}
+                        {this.props.auditIndicators(result.audit, result['@id'], { session: this.context.session, search: true })}
                     </div>
                     <div className="accession"><a href={result['@id']}>{result.modification_type}</a></div>
                     <div className="data-row">
                         {techniques.length ? <div><strong>Modification techniques: </strong>{techniques.join(', ')}</div> : null}
                     </div>
                 </div>
-                {this.props.auditDetail(result.audit, result['@id'], { except: result['@id'], forcedEditLink: true })}
+                {this.props.auditDetail(result.audit, result['@id'], { session: this.context.session, except: result['@id'], forcedEditLink: true })}
             </li>
         );
     },

--- a/src/encoded/static/components/pipeline.js
+++ b/src/encoded/static/components/pipeline.js
@@ -1,5 +1,6 @@
 'use strict';
 var React = require('react');
+import PropTypes from 'prop-types';
 var panel = require('../libs/bootstrap/panel');
 var {Modal, ModalHeader, ModalBody, ModalFooter} = require('../libs/bootstrap/modal');
 var url = require('url');
@@ -40,6 +41,10 @@ var PanelLookup = function (props) {
 
 
 var PipelineComponent = createReactClass({
+    contextTypes: {
+        session: PropTypes.object, // Login information from <App>
+    },
+
     getInitialState: function() {
         return {
             infoNodeId: '', // ID of node whose info panel is open
@@ -207,11 +212,11 @@ var PipelineComponent = createReactClass({
                             <div className="characterization-status-labels">
                                 <StatusLabel title="Status" status={context.status} />
                             </div>
-                            {this.props.auditIndicators(context.audit, 'pipeline-audit')}
+                            {this.props.auditIndicators(context.audit, 'pipeline-audit', { session: this.context.session })}
                         </div>
                     </div>
                 </header>
-                {this.props.auditDetail(context.audit, 'pipeline-audit', { except: context['@id'] })}
+                {this.props.auditDetail(context.audit, 'pipeline-audit', { session: this.context.session, except: context['@id'] })}
                 <Panel addClasses="data-display">
                     <PanelBody>
                         <dl className="key-value">
@@ -437,6 +442,10 @@ globals.graph_detail.register(StepDetailView, 'Step');
 
 
 var ListingComponent = createReactClass({
+    contextTypes: {
+        session: PropTypes.object, // Login information from <App>
+    },
+
     render: function() {
         var result = this.props.context;
         var publishedBy = [];
@@ -466,7 +475,7 @@ var ListingComponent = createReactClass({
                         <p className="type meta-title">Pipeline</p>
                         <p className="type">{' ' + result['accession']}</p>
                         {result.status ? <p className="type meta-status">{' ' + result.status}</p> : ''}
-                        {this.props.auditIndicators(result.audit, result['@id'], { search: true })}
+                        {this.props.auditIndicators(result.audit, result['@id'], { session: this.context.session, search: true })}
                     </div>
                     <div className="accession">
                         <a href={result['@id']}>{result['title']}</a>
@@ -481,7 +490,7 @@ var ListingComponent = createReactClass({
                         : null}
                     </div>
                 </div>
-                {this.props.auditDetail(result.audit, result['@id'], { forcedEditLink: true })}
+                {this.props.auditDetail(result.audit, result['@id'], { session: this.context.session, forcedEditLink: true })}
             </li>
         );
     }

--- a/src/encoded/static/components/publication.js
+++ b/src/encoded/static/components/publication.js
@@ -1,5 +1,6 @@
 'use strict';
 var React = require('react');
+import PropTypes from 'prop-types';
 import createReactClass from 'create-react-class';
 import { auditDecor } from './audit';
 var globals = require('./globals');
@@ -12,6 +13,10 @@ var DbxrefList = dbxref.DbxrefList;
 
 
 var PublicationComponent = createReactClass({
+    contextTypes: {
+        session: PropTypes.object, // Login information from <App>
+    },
+
     render: function() {
         var context = this.props.context;
         var itemClass = globals.itemClass(context, 'view-item');
@@ -30,8 +35,8 @@ var PublicationComponent = createReactClass({
             <div className={itemClass}>
                 <Breadcrumbs root='/search/?type=publication' crumbs={crumbs} />
                 <h2>{context.title}</h2>
-                {this.props.auditIndicators(context.audit, 'publication-audit')}
-                {this.props.auditDetail(context.audit, 'publication-audit', { except: context['@id'] })}
+                {this.props.auditIndicators(context.audit, 'publication-audit', { session: this.context.session })}
+                {this.props.auditDetail(context.audit, 'publication-audit', { session: this.context.session, except: context['@id'] })}
                 {context.authors ? <div className="authors">{context.authors}.</div> : null}
                 <div className="journal">
                     <Citation {...this.props} />
@@ -214,6 +219,10 @@ var SupplementaryDataListing = createReactClass({
 
 
 var ListingComponent = createReactClass({
+    contextTypes: {
+        session: PropTypes.object, // Login information from <App>
+    },
+
     render: function() {
         var result = this.props.context;
         var authorList = result.authors && result.authors.length ? result.authors.split(', ', 4) : [];
@@ -226,7 +235,7 @@ var ListingComponent = createReactClass({
                     <div className="pull-right search-meta">
                         <p className="type meta-title">Publication</p>
                         <p className="type meta-status">{' ' + result.status}</p>
-                        {this.props.auditIndicators(result.audit, result['@id'], { search: true })}
+                        {this.props.auditIndicators(result.audit, result['@id'], { session: this.context.session, search: true })}
                     </div>
                     <div className="accession"><a href={result['@id']}>{result.title}</a></div>
                     <div className="data-row">
@@ -242,7 +251,7 @@ var ListingComponent = createReactClass({
                         : null}
                     </div>
                 </div>
-                {this.props.auditDetail(result.audit, result['@id'], { forcedEditLink: true })}
+                {this.props.auditDetail(result.audit, result['@id'], { session: this.context.session, forcedEditLink: true })}
             </li>
         );
     }

--- a/src/encoded/static/components/search.js
+++ b/src/encoded/static/components/search.js
@@ -99,6 +99,10 @@ const PickerActions = module.exports.PickerActions = createReactClass ({
 });
 
 var ItemComponent = createReactClass({
+    contextTypes: {
+        session: PropTypes.object, // Login information from <App>
+    },
+
     render: function() {
         var result = this.props.context;
         var title = globals.listing_titles.lookup(result)({context: result});
@@ -120,7 +124,7 @@ var ItemComponent = createReactClass({
                         {result.description}
                     </div>
                 </div>
-                {this.props.auditDetail(result.audit, result['@id'], { except: result['@id'], forcedEditLink: true })}
+                {this.props.auditDetail(result.audit, result['@id'], { session: this.context.session, except: result['@id'], forcedEditLink: true })}
             </li>
         );
     },
@@ -224,6 +228,10 @@ const StatusIndicators = createReactClass({
 });
 
 var AntibodyComponent = createReactClass({
+    contextTypes: {
+        session: PropTypes.object, // Login information from <App>
+    },
+
     render: function() {
         var result = this.props.context;
 
@@ -263,7 +271,7 @@ var AntibodyComponent = createReactClass({
                         <p className="type meta-title">Antibody</p>
                         <p className="type">{` ${result.accession}`}</p>
                         <p className="type meta-status">{` ${result.status}`}</p>
-                        {this.props.auditIndicators(result.audit, result['@id'], { search: true })}
+                        {this.props.auditIndicators(result.audit, result['@id'], { session: this.context.session, search: true })}
                     </div>
                     <div className="accession">
                         {Object.keys(targetTree).map(target =>
@@ -281,7 +289,7 @@ var AntibodyComponent = createReactClass({
                         <div><strong>Product ID / Lot ID: </strong>{result.product_id} / {result.lot_id}</div>
                     </div>
                 </div>
-                {this.props.auditDetail(result.audit, result['@id'], { except: result['@id'], forcedEditLink: true })}
+                {this.props.auditDetail(result.audit, result['@id'], { session: this.context.session, except: result['@id'], forcedEditLink: true })}
             </li>
         );
     },
@@ -293,6 +301,10 @@ globals.listing_views.register(Antibody, 'AntibodyLot');
 
 
 var BiosampleComponent = createReactClass({
+    contextTypes: {
+        session: PropTypes.object, // Login information from <App>
+    },
+
     render: function() {
         const result = this.props.context;
         const lifeStage = (result.life_stage && result.life_stage !== 'unknown') ? ` ${result.life_stage}` : '';
@@ -327,7 +339,7 @@ var BiosampleComponent = createReactClass({
                         <p className="type meta-title">Biosample</p>
                         <p className="type">{` ${result.accession}`}</p>
                         <p className="type meta-status">{` ${result.status}`}</p>
-                        {this.props.auditIndicators(result.audit, result['@id'], { search: true })}
+                        {this.props.auditIndicators(result.audit, result['@id'], { session: this.context.session, search: true })}
                     </div>
                     <div className="accession">
                         <a href={result['@id']}>
@@ -349,7 +361,7 @@ var BiosampleComponent = createReactClass({
                         <div><strong>Source: </strong>{result.source.title}</div>
                     </div>
                 </div>
-                {this.props.auditDetail(result.audit, result['@id'], { except: result['@id'], forcedEditLink: true })}
+                {this.props.auditDetail(result.audit, result['@id'], { session: this.context.session, except: result['@id'], forcedEditLink: true })}
             </li>
         );
     },
@@ -361,6 +373,10 @@ globals.listing_views.register(Biosample, 'Biosample');
 
 
 var ExperimentComponent = createReactClass({
+    contextTypes: {
+        session: PropTypes.object, // Login information from <App>
+    },
+
     render: function() {
         var result = this.props.context;
 
@@ -393,7 +409,7 @@ var ExperimentComponent = createReactClass({
                         <p className="type meta-title">Experiment</p>
                         <p className="type">{` ${result.accession}`}</p>
                         <p className="type meta-status">{` ${result.status}`}</p>
-                        {this.props.auditIndicators(result.audit, result['@id'], { search: true })}
+                        {this.props.auditIndicators(result.audit, result['@id'], { session: this.context.session, search: true })}
                     </div>
                     <div className="accession">
                         <a href={result['@id']}>
@@ -433,7 +449,7 @@ var ExperimentComponent = createReactClass({
                         <div><strong>Project: </strong>{result.award.project}</div>
                     </div>
                 </div>
-                {this.props.auditDetail(result.audit, result['@id'], { except: result['@id'], forcedEditLink: true })}
+                {this.props.auditDetail(result.audit, result['@id'], { session: this.context.session, except: result['@id'], forcedEditLink: true })}
             </li>
         );
     },
@@ -445,6 +461,10 @@ globals.listing_views.register(Experiment, 'Experiment');
 
 
 var DatasetComponent =  createReactClass({
+    contextTypes: {
+        session: PropTypes.object, // Login information from <App>
+    },
+
     render: function() {
         const result = this.props.context;
         let biosampleTerm;
@@ -503,7 +523,7 @@ var DatasetComponent =  createReactClass({
                         <p className="type meta-title">{haveSeries ? 'Series' : (haveFileSet ? 'FileSet' : 'Dataset')}</p>
                         <p className="type">{` ${result.accession}`}</p>
                         <p className="type meta-status">{` ${result.status}`}</p>
-                        {this.props.auditIndicators(result.audit, result['@id'], { search: true })}
+                        {this.props.auditIndicators(result.audit, result['@id'], { session: this.context.session, search: true })}
                     </div>
                     <div className="accession">
                         <a href={result['@id']}>
@@ -532,7 +552,7 @@ var DatasetComponent =  createReactClass({
                         <div><strong>Project: </strong>{result.award.project}</div>
                     </div>
                 </div>
-                {this.props.auditDetail(result.audit, result['@id'], { except: result['@id'], forcedEditLink: true })}
+                {this.props.auditDetail(result.audit, result['@id'], { session: this.context.session, except: result['@id'], forcedEditLink: true })}
             </li>
         );
     },
@@ -544,6 +564,10 @@ globals.listing_views.register(Dataset, 'Dataset');
 
 
 var TargetComponent = createReactClass({
+    contextTypes: {
+        session: PropTypes.object, // Login information from <App>
+    },
+
     render: function() {
         const result = this.props.context;
         return (
@@ -552,7 +576,7 @@ var TargetComponent = createReactClass({
                     <PickerActions {...this.props} />
                     <div className="pull-right search-meta">
                         <p className="type meta-title">Target</p>
-                        {this.props.auditIndicators(result.audit, result['@id'], { search: true })}
+                        {this.props.auditIndicators(result.audit, result['@id'], { session: this.context.session, search: true })}
                     </div>
                     <div className="accession">
                         <a href={result['@id']}>
@@ -567,7 +591,7 @@ var TargetComponent = createReactClass({
                         : <em>None submitted</em> }
                     </div>
                 </div>
-                {this.props.auditDetail(result.audit, result['@id'], { except: result['@id'], forcedEditLink: true })}
+                {this.props.auditDetail(result.audit, result['@id'], { session: this.context.session, except: result['@id'], forcedEditLink: true })}
             </li>
         );
     },

--- a/src/encoded/static/components/software.js
+++ b/src/encoded/static/components/software.js
@@ -52,10 +52,10 @@ class SoftwareComponent extends React.Component {
                         <div className="characterization-status-labels">
                             <StatusLabel title="Status" status={context.status} />
                         </div>
-                        {this.props.auditIndicators(context.audit, 'software-audit')}
+                        {this.props.auditIndicators(context.audit, 'software-audit', { session: this.context.session })}
                     </div>
                 </header>
-                {this.props.auditDetail(context.audit, 'software-audit', { except: context['@id'] })}
+                {this.props.auditDetail(context.audit, 'software-audit', { session: this.context.session, except: context['@id'] })}
 
                 <div className="panel">
                     <dl className="key-value">
@@ -114,7 +114,9 @@ SoftwareComponent.propTypes = {
 
 SoftwareComponent.contextTypes = {
     location_href: PropTypes.string,
+    session: PropTypes.object,
 };
+
 
 // Note: need to export for Jest tests even though no other module imports it.
 export const Software = auditDecor(SoftwareComponent);
@@ -165,41 +167,46 @@ SoftwareVersionTable.defaultProps = {
 };
 
 
-const ListingComponent = (props) => {
-    const result = props.context;
-    return (
-        <li>
-            <div className="clearfix">
-                <search.PickerActions {...props} />
-                <div className="pull-right search-meta">
-                    <p className="type meta-title">Software</p>
-                    {result.status ? <p className="type meta-status">{` ${result.status}`}</p> : ''}
-                    {props.auditIndicators(result.audit, result['@id'], { search: true })}
+class ListingComponent extends React.Component {
+    render() {
+        const result = this.props.context;
+        return (
+            <li>
+                <div className="clearfix">
+                    <search.PickerActions {...this.props} />
+                    <div className="pull-right search-meta">
+                        <p className="type meta-title">Software</p>
+                        {result.status ? <p className="type meta-status">{` ${result.status}`}</p> : ''}
+                        {this.props.auditIndicators(result.audit, result['@id'], { session: this.context.session, search: true })}
+                    </div>
+                    <div className="accession">
+                        <a href={result['@id']}>{result.title}</a>
+                        {result.source_url ? <span className="accession-note"> &mdash; <a href={result.source_url}>source</a></span> : ''}
+                    </div>
+                    <div className="data-row">
+                        <div>{result.description}</div>
+                        {result.software_type && result.software_type.length ?
+                            <div>
+                                <strong>Software type: </strong>
+                                {result.software_type.join(', ')}
+                            </div>
+                        : null}
+                    </div>
                 </div>
-                <div className="accession">
-                    <a href={result['@id']}>{result.title}</a>
-                    {result.source_url ? <span className="accession-note"> &mdash; <a href={result.source_url}>source</a></span> : ''}
-                </div>
-                <div className="data-row">
-                    <div>{result.description}</div>
-                    {result.software_type && result.software_type.length ?
-                        <div>
-                            <strong>Software type: </strong>
-                            {result.software_type.join(', ')}
-                        </div>
-                    : null}
-
-                </div>
-            </div>
-            {props.auditDetail(result.audit, result['@id'], { except: result['@id'], forcedEditLink: true })}
-        </li>
-    );
-};
+                {this.props.auditDetail(result.audit, result['@id'], { session: this.context.session, except: result['@id'], forcedEditLink: true })}
+            </li>
+        );
+    }
+}
 
 ListingComponent.propTypes = {
     context: PropTypes.object.isRequired, // Software object being rendered as a search result.
     auditIndicators: PropTypes.func.isRequired, // From auditDecor
     auditDetail: PropTypes.func.isRequired, // From auditDecor
+};
+
+ListingComponent.contextTypes = {
+    session: PropTypes.object,
 };
 
 const Listing = auditDecor(ListingComponent);


### PR DESCRIPTION
## Background

This problem stemmed from modules not adapting to the new audit mechanism quite as readily as I had thought. With the Javascript mixin-shaming that the React team has engaged in, I had converted the audit module from an extensive mixin system to use High-Order Components (HOCs) instead.

Javascript mixins have the convenient feature of assimilating all the characteristics of the components they’re used in, including React props and states, and React context objects. They were able to use the encompassing component’s importing of _encoded_ login session information to get the user’s current login state.

With the transition to HOCs, this mechanism no longer works. The audit module’s wrapping of the components that use it means they share no props, state, nor React context. This left the audit module without that login information, making it think the user never logged in, and therefore never rending the DCC Internal audits.

## Fix

Now each component using audits has the responsibility to import the current user’s login information the `<App>`’s React context object, and explicitly pass it to the audit module and pass it in the `options` parameter of both `auditDetail` and `auditIndicators`.