### PR TITLE
5053 update readme addition

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ brew install libevent libmagic libxml2 libxslt openssl graphviz nginx
 brew install freetype libjpeg libtiff littlecms webp chromedriver
 brew tap petere/postgresql
 brew install postgresql@9.3
+brew link --force postgresql@9.3
 brew install --force node@6
 brew link node@6 --force
 brew cask install java


### PR DESCRIPTION
Small update to README:
 - `brew link --force` is required to make some packages "findable"/executable from from the commandline without manually modifying user's `.bash_profile`
- Added `brew link --force postgresql@9.3`