### PR TITLE
5111 update accessions

### DIFF
--- a/src/encoded/__init__.py
+++ b/src/encoded/__init__.py
@@ -1,7 +1,6 @@
 from future.standard_library import install_aliases
 install_aliases()  # NOQA
-import encoded.schema_formats # needed to import before snovault to add FormatCheckers
-import base64
+import encoded.schema_formats # needed to import before snovault to add FormatCheckersimport base64
 import codecs
 import json
 import netaddr

--- a/src/encoded/__init__.py
+++ b/src/encoded/__init__.py
@@ -1,5 +1,6 @@
 from future.standard_library import install_aliases
 install_aliases()  # NOQA
+import encoded.schema_formats # needed to import before snovault to add FormatCheckers
 import base64
 import codecs
 import json

--- a/src/encoded/__init__.py
+++ b/src/encoded/__init__.py
@@ -1,6 +1,7 @@
 from future.standard_library import install_aliases
 install_aliases()  # NOQA
-import encoded.schema_formats # needed to import before snovault to add FormatCheckersimport base64
+import encoded.schema_formats # needed to import before snovault to add FormatCheckers
+import base64
 import codecs
 import json
 import netaddr

--- a/src/encoded/schema_formats.py
+++ b/src/encoded/schema_formats.py
@@ -2,10 +2,6 @@ import re
 import rfc3987
 from jsonschema_serialize_fork import FormatChecker
 from pyramid.threadlocal import get_current_request
-from .server_defaults import (
-    ACCESSION_FACTORY,
-    test_accession,
-)
 from uuid import UUID
 
 accession_re = re.compile(r'^ENC(FF|SR|AB|BS|DO|LB|PL)[0-9][0-9][0-9][A-Z][A-Z][A-Z]$')
@@ -30,6 +26,10 @@ def is_accession(instance):
 
 @FormatChecker.cls_checks("accession")
 def is_accession_for_server(instance):
+    from .server_defaults import (
+        ACCESSION_FACTORY,
+        test_accession,
+    )
     # Unfortunately we cannot access the accessionType here
     if accession_re.match(instance):
         return True

--- a/src/encoded/schema_formats.py
+++ b/src/encoded/schema_formats.py
@@ -43,7 +43,8 @@ def is_accession_for_server(instance):
 @FormatChecker.cls_checks("gene_name")
 def is_gene_name(instance):
     ''' should check a webservice at HGNC/MGI for validation '''
-    return True
+    # FORCE FAILURE TO PROVE THIS DOESN'T LOAD
+    return False
 
 
 @FormatChecker.cls_checks("target_label")

--- a/src/encoded/schema_formats.py
+++ b/src/encoded/schema_formats.py
@@ -43,8 +43,7 @@ def is_accession_for_server(instance):
 @FormatChecker.cls_checks("gene_name")
 def is_gene_name(instance):
     ''' should check a webservice at HGNC/MGI for validation '''
-    # FORCE FAILURE TO PROVE THIS DOESN'T LOAD
-    return False
+    return True
 
 
 @FormatChecker.cls_checks("target_label")

--- a/src/encoded/tests/data/inserts/file.json
+++ b/src/encoded/tests/data/inserts/file.json
@@ -753,7 +753,7 @@
    },
    {
         "_project": "encode3",
-        "accession": "ENCFFM",
+        "accession": "ENCFF666MOO",
         "award":"U41HG006992",
         "file_size": 20,
         "dataset": "ENCSR000AER",

--- a/src/encoded/tests/test_accession_replacement.py
+++ b/src/encoded/tests/test_accession_replacement.py
@@ -29,3 +29,18 @@ def test_accession_replacement(testapp, human_donor):
 
     res = testapp.get('/' + donor1['accession']).maybe_follow()
     assert res.json['@id'] == donor2['@id']
+
+
+def test_admin_put_accession(human_donor, testapp):
+    url = '/human_donor'
+    # but coudl be any accessoned object
+    donor1 = testapp.post_json(url, human_donor, status=201).json['@graph'][0]
+
+    donor1.update({'accession': 'ENCDO111BBB'})
+    # initial test
+    testapp.put_json(donor1['@id'], donor1, status=200)
+    res = testapp.get(url)
+    assert(res.json['accession'] == "ENCDO111BBB")
+
+    donor1.update({'accession': 'somerstring'})
+    testapp.put_json(donor1['@id'], donor1, status=200)

--- a/src/encoded/tests/test_accession_replacement.py
+++ b/src/encoded/tests/test_accession_replacement.py
@@ -36,11 +36,9 @@ def test_admin_put_accession(human_donor, testapp):
     # but coudl be any accessoned object
     donor1 = testapp.post_json(url, human_donor, status=201).json['@graph'][0]
 
-    donor1.update({'accession': 'ENCDO111BBB'})
     # initial test
-    testapp.put_json(donor1['@id'], donor1, status=200)
-    res = testapp.get(url)
-    assert(res.json['accession'] == "ENCDO111BBB")
+    testapp.patch_json(donor1['@id'], {'accession': 'ENCDO111BBB'}, status=200)
+    res = testapp.get('/human-donors/ENCDO111BBB').maybe_follow()
+    assert res.json['uuid'] == donor1['uuid']
 
-    donor1.update({'accession': 'somerstring'})
-    testapp.put_json(donor1['@id'], donor1, status=200)
+    testapp.patch_json(res.json['@id'], {'accession': 'somestring'}, status=422)

--- a/src/encoded/tests/test_accession_replacement.py
+++ b/src/encoded/tests/test_accession_replacement.py
@@ -1,12 +1,13 @@
 import pytest
 
-
+# also tests schema_formats generally
 @pytest.fixture
 def human_donor(lab, award, organism):
     return {
         'award': award['uuid'],
         'lab': lab['uuid'],
         'organism': organism['uuid'],
+        'url': 'http://www.test.org',
     }
 
 
@@ -31,7 +32,7 @@ def test_accession_replacement(testapp, human_donor):
     assert res.json['@id'] == donor2['@id']
 
 
-def test_admin_put_accession(human_donor, testapp):
+def test_schema_formats(human_donor, testapp):
     url = '/human_donor'
     # but coudl be any accessoned object
     donor1 = testapp.post_json(url, human_donor, status=201).json['@graph'][0]
@@ -41,4 +42,7 @@ def test_admin_put_accession(human_donor, testapp):
     res = testapp.get('/human-donors/ENCDO111BBB').maybe_follow()
     assert res.json['uuid'] == donor1['uuid']
 
+    # test accession schema_format
     testapp.patch_json(res.json['@id'], {'accession': 'somestring'}, status=422)
+
+    testapp.patch_json(res.json['@id'], {'url': '/relative/url/'}, status=422)

--- a/src/encoded/types/base.py
+++ b/src/encoded/types/base.py
@@ -19,8 +19,8 @@ def _award_viewing_group(award_uuid, root):
     award = root.get_by_uuid(award_uuid)
     return award.upgrade_properties().get('viewing_group')
 
-# Item acls
 
+# Item acls
 ONLY_ADMIN_VIEW = [
     (Allow, 'group.admin', ['view', 'edit']),
     (Allow, 'group.read-only-admin', ['view']),

--- a/src/encoded/types/base.py
+++ b/src/encoded/types/base.py
@@ -11,6 +11,7 @@ from pyramid.traversal import (
     find_root,
     traverse,
 )
+from ..schema_formats import *
 import snovault
 
 

--- a/src/encoded/types/base.py
+++ b/src/encoded/types/base.py
@@ -11,7 +11,6 @@ from pyramid.traversal import (
     find_root,
     traverse,
 )
-from ..schema_formats import *
 import snovault
 
 

--- a/src/encoded/types/base.py
+++ b/src/encoded/types/base.py
@@ -12,7 +12,6 @@ from pyramid.traversal import (
     traverse,
 )
 import snovault
-from ..schema_formats import is_accession
 
 
 @lru_cache()


### PR DESCRIPTION
encoded/schema_formats.py contains some jsonschema.FormatChecker objects that are supposed to validate particular fields (type: accession, type: uuid, type: gene_name, etc.).    This module was not getting imported at the right time and the FormatChecker was not picking them up.

This PR includes tests for the operational formatcheckers (accessions and uuid) and with Laurence's help I managed to get the imports in the right sequence.

Note that the change to file.json is just to allow that file to be loaded, as it had an invalid accession!

To test this you can try to patch/put an existing accession; it must  correspond to the RE: '^ENC(FF|SR|AB|BS|DO|LB|PL)[0-9][0-9][0-9][A-Z][A-Z][A-Z]$' in production or ^TST(FF|SR|AB|BS|DO|LB|PL)[0-9][0-9][0-9]([0-9][0-9][0-9]|[A-Z][A-Z][A-Z])$' in a demo or test.

Note that the object type is not checked so you can change an FF to an AB.

Similarly all uri types in JSON schema must be global (://).   The gene_name and target_label Checkers are not implemented, they always return True (require a source for gene names)