### PR TITLE
(5132) modifying derived_from audit to accept derivation from revoked deleted files for revoked deleted files

### DIFF
--- a/src/encoded/audit/file.py
+++ b/src/encoded/audit/file.py
@@ -53,12 +53,15 @@ def audit_file_processed_derived_from(value, system):
     derived_from_files = value.get('derived_from')
     fastq_bam_counter = 0
     for f in derived_from_files:
-        if f['status'] not in ['deleted', 'replaced', 'revoked'] and \
-           (f['file_format'] == 'bam' or
+        if (f['file_format'] == 'bam' or
             f['file_format'] == 'fastq' or (f['file_format'] == 'fasta' and
                                             f['output_type'] == 'reads' and
                                             f['output_category'] == 'raw data')):
-            fastq_bam_counter += 1
+
+            if f['status'] not in ['deleted', 'replaced', 'revoked'] or \
+               f['status'] == value['status']:
+                fastq_bam_counter += 1
+
             if f['dataset'] != value['dataset']:
                 detail = 'derived_from is a list of files that were used to create a given file; ' + \
                          'for example, fastq file(s) will appear in the derived_from list of an alignments file. ' + \

--- a/src/encoded/tests/test_audit_file.py
+++ b/src/encoded/tests/test_audit_file.py
@@ -535,6 +535,40 @@ def test_audit_file_bam_derived_from_bam_no_fastq(testapp, file7, file6):
                for error in errors_list)
 
 
+def test_audit_file_bam_derived_from_revoked_bam_no_fastq(testapp, file7, file6):
+    testapp.patch_json(file6['@id'], {'derived_from': [file7['@id']],
+                                      'status': 'released',
+                                      'file_format': 'bam',
+                                      'assembly': 'hg19'})
+    testapp.patch_json(file7['@id'], {'file_format': 'bam',
+                                      'assembly': 'hg19',
+                                      'status': 'revoked'})
+    res = testapp.get(file6['@id'] + '@@index-data')
+    errors = res.json['audit']
+    errors_list = []
+    for error_type in errors:
+        errors_list.extend(errors[error_type])
+    assert any(error['category'] == 'missing derived_from'
+               for error in errors_list)
+
+
+def test_audit_file_revoked_bam_derived_from_revoked_bam_no_fastq(testapp, file7, file6):
+    testapp.patch_json(file6['@id'], {'derived_from': [file7['@id']],
+                                      'status': 'revoked',
+                                      'file_format': 'bam',
+                                      'assembly': 'hg19'})
+    testapp.patch_json(file7['@id'], {'file_format': 'bam',
+                                      'assembly': 'hg19',
+                                      'status': 'revoked'})
+    res = testapp.get(file6['@id'] + '@@index-data')
+    errors = res.json['audit']
+    errors_list = []
+    for error_type in errors:
+        errors_list.extend(errors[error_type])
+    assert all(error['category'] != 'missing derived_from'
+               for error in errors_list)
+
+
 def test_audit_file_bam_derived_from_different_experiment(testapp, file6, file4, file_exp):
     testapp.patch_json(file4['@id'], {'dataset': file_exp['@id']})
     testapp.patch_json(file6['@id'], {'derived_from': [file4['@id']],


### PR DESCRIPTION
currently missing derived_from audit is triggered for revoked/deleted/replaced files, when they are derived from revoked/deleted and replaced files. This behavior started after application of audits on all Files (without dependency on their status). To fix this situation and not trigger the audit - it was modified to not flag deleted/revoked and replaced files that are derived from these statuses.