### PR TITLE
5151 Remove biodalliance login restriction

### DIFF
--- a/src/encoded/static/components/search.js
+++ b/src/encoded/static/components/search.js
@@ -1012,10 +1012,6 @@ const ResultTable = search.ResultTable = createReactClass({
 
     childContextTypes: { actions: PropTypes.array },
 
-    contextTypes: {
-        session: React.PropTypes.object,
-    },
-
     getDefaultProps: function () {
         return {
             restrictions: {},
@@ -1076,7 +1072,6 @@ const ResultTable = search.ResultTable = createReactClass({
         const filters = context.filters;
         const label = 'results';
         const trimmedSearchBase = searchBase.replace(/[\?|&]limit=all/, '');
-        const loggedIn = this.context.session && this.context.session['auth.userid'];
         let browseAllFiles = true; // True to pass all files to browser
         let browserAssembly = ''; // Assembly to pass to ResultsBrowser component
         let browserDatasets = []; // Datasets will be used to get vis_json blobs
@@ -1133,7 +1128,7 @@ const ResultTable = search.ResultTable = createReactClass({
 
         // If we have only one "type" term in the query string and it's for File, then we can
         // display the List/Browser tabs. Otherwise we just get the list.
-        let browserAvail = counter === 1 && typeFilter && typeFilter.term === 'File' && assemblies.length === 1 && loggedIn;
+        let browserAvail = counter === 1 && typeFilter && typeFilter.term === 'File' && assemblies.length === 1;
         if (browserAvail) {
             // If dataset is in the query string, we can show all files.
             const datasetFilter = filters.find(filter => filter.field === 'dataset');

--- a/src/encoded/types/dataset.py
+++ b/src/encoded/types/dataset.py
@@ -8,7 +8,6 @@ from .base import (
     Item,
     paths_filtered_by_status,
 )
-from pyramid.security import effective_principals
 
 from urllib.parse import quote_plus
 from urllib.parse import urljoin
@@ -194,7 +193,6 @@ class Dataset(Item):
         "type": "string",
     })
     def visualize(self, request, hub, assembly, status):
-        principals = effective_principals(request)
         hub_url = urljoin(request.resource_url(request.root), hub)
         viz = {}
         for assembly_name in assembly:
@@ -210,7 +208,7 @@ class Dataset(Item):
                     browser_urls['Ensembl'] = ensembl_url
             # Now for biodalliance.  bb and bw already known?  How about non-deleted?
             # TODO: define (in visualization.py?) supported assemblies list
-            if 'group.submitter' in principals and assembly_name in ['hg19', 'GRCh38', 'mm10', 'mm10-minimal' ,'mm9','dm6','dm3','ce10','ce11']:
+            if assembly_name in ['hg19', 'GRCh38', 'mm10', 'mm10-minimal' ,'mm9','dm6','dm3','ce10','ce11']:
                 if status not in ["proposed", "started", "deleted", "revoked", "replaced"]:
                     file_formats = '&file_format=bigBed&file_format=bigWig'
                     file_inclusions = '&status=released&status=in+progress'


### PR DESCRIPTION
The back end controlled whether the Quick View button could render or not based on the user’s logged-in state, so the primary change happened in dataset.py which now doesn’t check the logged-in state before offering the Quick View data in the `visualize` calculated property.

search.js also checked the logged-in state to decide whether to draw the tabbed search results or not. This check was similarly removed so that it always displays when requested regardless of logged-in state.