### PR TITLE
5070 Fix search import/export for forms

### DIFF
--- a/src/encoded/static/components/blocks/search.js
+++ b/src/encoded/static/components/blocks/search.js
@@ -4,10 +4,8 @@ import createReactClass from 'create-react-class';
 var fetched = require('../fetched');
 var collection = require('../collection');
 var globals = require('../globals');
-var search = require('../search');
+import { Listing, ResultTable } from '../search';
 
-var Listing = search.Listing;
-var ResultTable = search.ResultTable;
 var Table = collection.Table;
 
 

--- a/src/encoded/static/components/search.js
+++ b/src/encoded/static/components/search.js
@@ -1153,7 +1153,7 @@ BatchDownload.propTypes = {
 };
 
 
-class ResultTable extends React.Component {
+export class ResultTable extends React.Component {
     constructor(props) {
         super(props);
 


### PR DESCRIPTION
Editing search fields in forms caused Javascript errors. I had updated search.js to AirBnB/ES6 and updated most of the references to it, but forgot about files in components/blocks. This updates components/blocks/search.js to import things the correct way, and also now exporting ResultTable from search.js as this file needs it.