### PR TITLE
ENCD-3387 (RM5200) fixing dataset linkTo in File.json

### DIFF
--- a/src/encoded/schemas/file.json
+++ b/src/encoded/schemas/file.json
@@ -894,7 +894,7 @@
             "description": "The experiment or dataset the file belongs to.",
             "comment": "Required. See dataset.json for available identifiers.",
             "type": "string",
-            "linkTo": ["Dataset"]
+            "linkTo": "Dataset"
         },
         "replicate": {
             "title": "Replicate",


### PR DESCRIPTION
fixing in File.json the dataset linkTo property, it was a list without a real reason, so I turned it back into a single link instead.