### PR TITLE
ENCD-3426 Fix improper use of this.props

### DIFF
--- a/src/encoded/static/components/filegallery.js
+++ b/src/encoded/static/components/filegallery.js
@@ -806,14 +806,14 @@ RawFileTable.propTypes = {
 };
 
 
-// Called once searches for unreleased files returns results in this.props.items. Displays both released and
+// Called once searches for unreleased files returns results in props.items. Displays both released and
 // unreleased files.
 export const DatasetFiles = (props) => {
     const { items } = props;
 
     const files = _.uniq((items && items.length) ? items : []);
     if (files.length) {
-        return <FileTable {...this.props} items={files} />;
+        return <FileTable {...props} items={files} />;
     }
     return null;
 };


### PR DESCRIPTION
We often (and AirBnB forces us to) use stateless components where component properties come from `props` instead of `this.props`. In this place I forgot to convert our old stateful implementaiton with 1this.props1 to the new stateless implementation as 1props1. Fixed this by using `props` instead of `this.props` in that component.