### PR TITLE
ENCD-3427 Fix changed property name

### DIFF
--- a/src/encoded/static/components/item.js
+++ b/src/encoded/static/components/item.js
@@ -214,7 +214,7 @@ export const RelatedItems = (props) => {
     return (
         <FetchedData>
             <Param name="context" url={limitedUrl} />
-            <FetchedRelatedItems {...props} url={unlimitedUrl} />
+            <FetchedRelatedItems {...props} itemUrl={unlimitedUrl} />
         </FetchedData>
     );
 };


### PR DESCRIPTION
AirBnB prohibits using variable names matching parent scope variable names, including the global scope. Because `url` already existed in the global scope from the `url` npm package, I had to change that to `itemUrl`. Unfortunately, I forgot to change that usage within the calling <RelatedItems> component.