### PR TITLE
ENCD-3431 Restore tags code

### DIFF
--- a/src/encoded/static/components/biosample.js
+++ b/src/encoded/static/components/biosample.js
@@ -569,6 +569,21 @@ const Construct = (props) => {
                     </div>
                 : null}
 
+                {context.tags.length ?
+                    <div data-test="tags">
+                        <dt>Tags</dt>
+                        <dd>
+                            <ul>
+                                {context.tags.map((tag, index) => (
+                                    <li key={index}>
+                                        {tag.name} (Location: {tag.location})
+                                    </li>
+                                ))}
+                            </ul>
+                        </dd>
+                    </div>
+                : null}
+
                 {context.source.title ?
                     <div data-test="source">
                         <dt>Source</dt>


### PR DESCRIPTION
Not sure why I deleted the tag display code with the AirBnB update. It’s back now, and badder than ever — it now uses an arrow function callback as AirBnB requires.