### PR TITLE
ENCD-3437 truncation incorrect

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,6 @@ env:
     - PATH="/usr/share/elasticsearch/bin:/usr/lib/postgresql/9.3/bin:$PATH"
 matrix:
   include:
-    - python: "2.7"
-      env: BROWSER=
     - python: "3.4"
       env: BROWSER=Chrome
     - python: "3.4"

--- a/src/encoded/static/components/globals.js
+++ b/src/encoded/static/components/globals.js
@@ -69,7 +69,7 @@ export function truncateString(str, len) {
         localStr = localStr.substr(0, len - 1); // Truncate to length ignoring word boundary
         localStr = `${!isOneWord ? localStr.substr(0, localStr.lastIndexOf(' ')) : localStr}…`; // Back up to word boundary
     }
-    return str;
+    return localStr;
 }
 
 // Given an array of objects with @id properties, this returns the same array but with any

--- a/src/encoded/tests/data/inserts/image.json
+++ b/src/encoded/tests/data/inserts/image.json
@@ -14,31 +14,31 @@
     {
         "caption": "ENCBS000AAA",
         "attachment": "ENCBS000AAA.png",
-        "submitted_by": "cricketsloan@stanford.edu",
+        "submitted_by": "crickets@stanford.edu",
         "uuid": "1a0df3d4-2496-4d1f-ba4f-519bc2a22cfd"
     },
     {
         "caption": "ENCBS000AAA JSON",
         "attachment": "ENCBS000AAA-json.png",
-        "submitted_by": "cricketsloan@stanford.edu",
+        "submitted_by": "crickets@stanford.edu",
         "uuid": "218ffd6c-d595-4bbc-8fa4-7c82a5855d4a"
     },
     {
         "caption": "curl output",
         "attachment": "curl-output.png",
-        "submitted_by": "cricketsloan@stanford.edu",
+        "submitted_by": "crickets@stanford.edu",
         "uuid": "5bc125bf-cff4-4129-87ed-56d23d983dc1"
     },
     {
         "caption": "Search result example",
         "attachment": "search-result-bone-chip.png",
-        "submitted_by": "cricketsloan@stanford.edu",
+        "submitted_by": "crickets@stanford.edu",
         "uuid": "6e4bca66-a415-4823-9d48-d9a18b81b775"
     },
     {
         "caption": "ENCODE library object structure",
         "attachment": "encode-library-object-structure.jpg",
-        "submitted_by": "cricketsloan@stanford.edu",
+        "submitted_by": "crickets@stanford.edu",
         "uuid": "498ce836-3050-47b6-b4cf-b0ac911a7d38"
     }
 ]

--- a/src/encoded/tests/data/inserts/user.json
+++ b/src/encoded/tests/data/inserts/user.json
@@ -1139,6 +1139,21 @@
         "uuid": "7dfbe70c-995d-4bc5-94c3-7d39d2baf001"
     },
     {
+        "email": "ksgraham@stanford.edu",
+        "first_name": "Keenan",
+        "groups": [
+            "admin"
+        ],
+        "job_title": "Research Data Analyst",
+        "lab": "/labs/j-michael-cherry/",
+        "last_name": "Graham",
+        "status": "current",
+        "submits_for": [
+            "/labs/j-michael-cherry/"
+        ],
+        "timezone": "US/Pacific"
+    },
+    {
         "email": "kritijn21@gmail.com",
         "first_name": "Kriti",
         "groups": [

--- a/src/encoded/tests/data/inserts/user.json
+++ b/src/encoded/tests/data/inserts/user.json
@@ -1137,6 +1137,21 @@
         ],
         "timezone": "US/Pacific",
         "uuid": "7dfbe70c-995d-4bc5-94c3-7d39d2baf001"
+    },
+    {
+        "email": "kritijn21@gmail.com",
+        "first_name": "Kriti",
+        "groups": [
+            "admin"
+        ],
+        "job_title": "Software Engineer",
+        "lab": "/labs/j-michael-cherry/",
+        "last_name": "Jain",
+        "status": "current",
+        "submits_for": [
+            "/labs/j-michael-cherry/"
+        ],
+        "timezone": "US/Pacific",
+        "uuid": "4136f132-304e-4ddd-b87a-db04605f47b7"
     }
-
 ]

--- a/src/encoded/tests/data/inserts/user.json
+++ b/src/encoded/tests/data/inserts/user.json
@@ -1151,7 +1151,8 @@
         "submits_for": [
             "/labs/j-michael-cherry/"
         ],
-        "timezone": "US/Pacific"
+        "timezone": "US/Pacific",
+        "uuid": "7e95dcd6-9c35-4082-9c53-09d14c5752be"
     },
     {
         "email": "kritijn21@gmail.com",


### PR DESCRIPTION
This was another AirBnB conversion bug caused by the rule against mutating parameters. I changed the routine to truncate strings to copy the incoming parameter so I could mutate that at will, but then returned the original parameter string just like it used to. This changes it to return the mutated, truncated string. I also merged my “new-users” branch so that local instances can start up without validation errors, as well as the ENCD-3435-remove-2.7-from-travis branch.