### PR TITLE
ENCD-3464 Remove timezone from local user test data

### DIFF
--- a/src/encoded/tests/data/inserts/user.json
+++ b/src/encoded/tests/data/inserts/user.json
@@ -832,7 +832,6 @@
         "submits_for": [
             "/labs/j-michael-cherry/"
         ],
-        "timezone": "US/Pacific",
         "uuid": "7e95dcd6-9c35-4082-9c53-09d14c5752be"
     },
     {
@@ -848,7 +847,6 @@
         "submits_for": [
             "/labs/j-michael-cherry/"
         ],
-        "timezone": "US/Pacific",
         "uuid": "4136f132-304e-4ddd-b87a-db04605f47b7"
     }
 ]


### PR DESCRIPTION
Including timezone now causes server startup errors. PRing this before Travis CI is done because I need to catch the bus before it’ll be done.