### PR TITLE
ENCD-2704 file graph updates

### DIFF
--- a/src/encoded/static/components/filegallery.js
+++ b/src/encoded/static/components/filegallery.js
@@ -1172,7 +1172,7 @@ export function assembleGraph(context, session, infoNodeId, files, filterAssembl
         const file = matchingFiles[fileId];
         const fileNodeId = `file:${file['@id']}`;
         const fileNodeLabel = `${file.title} (${file.output_type})`;
-        const fileCssClass = `pipeline-node-file${infoNodeId === fileNodeId ? ' active' : ''}`;
+        const fileCssClass = `pipeline-node-file${infoNodeId === fileNodeId ? ' active' : ''}${file.status === 'revoked' ? ' revoked' : ''}${file.status === 'archived' ? ' archived' : ''}`;
         const fileRef = file;
         const replicateNode = (file.biological_replicates && file.biological_replicates.length === 1) ? jsonGraph.getNode(`rep:${file.biological_replicates[0]}`) : null;
         let metricsInfo;

--- a/src/encoded/static/scss/encoded/modules/_characterizations.scss
+++ b/src/encoded/static/scss/encoded/modules/_characterizations.scss
@@ -549,6 +549,7 @@ $detail-switch-width: 30px;
             line-height: $detail-switch-height;
             max-width: $detail-switch-width;
             background-color: #e8e8e8;
+            border: none;
 
             &:hover {
                 background-color: #b8c7d5;

--- a/src/encoded/static/scss/encoded/modules/_pipeline.scss
+++ b/src/encoded/static/scss/encoded/modules/_pipeline.scss
@@ -27,10 +27,6 @@ $pipeline-node-types:
             fill: #ffc0c0;
         }
 
-        &.error {
-            fill: #ffc300;
-        }
-
         &.revoked {
             fill: #B24342;
 

--- a/src/encoded/static/scss/encoded/modules/_pipeline.scss
+++ b/src/encoded/static/scss/encoded/modules/_pipeline.scss
@@ -27,6 +27,22 @@ $pipeline-node-types:
             fill: #ffc0c0;
         }
 
+        &.error {
+            fill: #ffc300;
+        }
+
+        &.revoked {
+            fill: #B24342;
+
+            g.label {
+                fill: #fff;
+            }
+        }
+
+        &.archived {
+            fill: #c0c0c0;
+        }
+
         &:hover {
             cursor: pointer;
         }


### PR DESCRIPTION
This update just changes the color of missing files. There’s also one more CSS change I haven’t yet looked into why I needed. It seemed I must have deleted a line of CSS with the document disclosure buttons, so they didn’t appear correctly though they still worked correctly.