### PR TITLE
ENCD-3396

### DIFF
--- a/checkfiles/checkfiles.py
+++ b/checkfiles/checkfiles.py
@@ -799,7 +799,7 @@ def check_file(config, session, url, job):
     else:
         check_format(config['encValData'], job, local_path)
 
-    if item['file_format'] == 'fastq':
+    if item['file_format'] == 'fastq' and not errors.get('validateFiles'):
         try:
             process_fastq_file(job,
                                subprocess.Popen(['gunzip --stdout {}'.format(

--- a/checkfiles/checkfiles.py
+++ b/checkfiles/checkfiles.py
@@ -981,7 +981,7 @@ def run(out, err, url, username, password, encValData, mirror, search_query, fil
     except multiprocessing.NotImplmentedError:
         nprocesses = 1
 
-    version = '1.16'
+    version = '1.17'
 
     try:
         ip_output = subprocess.check_output(

--- a/checkfiles/cloud-config.yml
+++ b/checkfiles/cloud-config.yml
@@ -43,7 +43,7 @@ runcmd:
 - chown build:build /opt/encValData
 - sudo -u build git clone --depth 1 https://github.com/ENCODE-DCC/encValData /opt/encValData
 
-- curl -sS -L -o /usr/local/bin/validateFiles https://github.com/ENCODE-DCC/kentUtils/raw/master/bin/linux.x86_64/validateFiles
+- curl -sS -L -o /usr/local/bin/validateFiles http://hgdownload.cse.ucsc.edu/admin/exe/linux.x86_64/validateFiles
 - chmod +x /usr/local/bin/validateFiles
 
 - mkdir /opt/encoded


### PR DESCRIPTION
- replaced validateFiles by new UCSC version instead of our outdated version 3 years old
- introduced a condition on FASTQ validation. Only if validate files goes through we will check the fastqs further, otherwise there is no point in the analysis
- bumpd the version to be 1.17