### PR TITLE
ENCD-3436 Updates/corrections for award pages

### DIFF
--- a/src/encoded/static/components/__tests__/experiment-test.js
+++ b/src/encoded/static/components/__tests__/experiment-test.js
@@ -35,7 +35,7 @@ describe('Experiment Page', () => {
         test('has proper release date', () => {
             const item = summary.at(0).find('[data-test="date-released"]');
             const desc = item.find('dd');
-            expect(desc.at(0).text()).toEqual('2011-10-29');
+            expect(desc.at(0).text()).toEqual('October 29, 2011');
         });
 
         test('has one experiment status element in header', () => {

--- a/src/encoded/static/components/award.js
+++ b/src/encoded/static/components/award.js
@@ -1655,6 +1655,7 @@ const ExperimentDate = (props) => {
             const standardDate = moment(term.key, ['MMMM, YYYY', 'YYYY-MM']).format('YYYY-MM');
             return { key: standardDate, doc_count: term.doc_count };
         });
+
         // Sort arrays chronologically
         const sortedTerms = standardTerms.sort((termA, termB) => {
             if (termA.key < termB.key) {
@@ -1668,10 +1669,13 @@ const ExperimentDate = (props) => {
             sortedTerms
         );
     }
+
     function fillDates(sortedArray, fillArray, difference, deduplicated) {
         let monthdiff = difference;
+
         // Add an object with the award start date to both arrays
         sortedArray.unshift({ key: award.start_date, doc_count: 0 });
+
         // Add objects to the array with doc_count 0 for the missing months
         const sortedTermsLength = sortedArray.length;
         for (let j = 0; j < sortedTermsLength - 1; j += 1) {
@@ -1686,6 +1690,7 @@ const ExperimentDate = (props) => {
             }
         }
         fillArray.push(sortedArray[sortedArray - 1]);
+
         // Remove any objects with keys before the start date of the award
         const arrayLength = fillArray.length;
         const assayStart = award.start_date;
@@ -1709,6 +1714,7 @@ const ExperimentDate = (props) => {
         });
         return (deduplicated);
     }
+
     function createDataset(deduplicated, accumulatorType, cumulativeData) {
         let cumulativedataset = cumulativeData;
         let accumulator = accumulatorType;
@@ -1723,10 +1729,10 @@ const ExperimentDate = (props) => {
         return (accumulatedData);
     }
 
+    const sortedreleasedTerms = sortTerms(releasedDates);
+    const sortedsubmittedTerms = sortTerms(submittedDates);
 
-    const sortedsubmittedTerms = sortTerms(releasedDates);
-    const sortedreleasedTerms = sortTerms(submittedDates);
-    // Add an object with the most current date to one of the arrays
+    // Add an object with the most current date to one of the arrays.
     if ((releasedDates && releasedDates.length) && (submittedDates && submittedDates.length)) {
         if (moment(sortedsubmittedTerms[sortedsubmittedTerms.length - 1].key).isAfter(sortedreleasedTerms[sortedreleasedTerms.length - 1].key, 'date')) {
             sortedreleasedTerms.push({ key: sortedsubmittedTerms[sortedsubmittedTerms.length - 1].key, doc_count: 0 });
@@ -1736,7 +1742,8 @@ const ExperimentDate = (props) => {
     }
     deduplicatedreleased = fillDates(sortedreleasedTerms, fillreleasedDates, monthreleaseddiff, deduplicatedreleased);
     deduplicatedsubmitted = fillDates(sortedsubmittedTerms, fillsubmittedDates, monthsubmitteddiff, deduplicatedsubmitted);
-    // Create an array of dates
+
+    // Create an array of dates.
     const date = Object.keys(deduplicatedreleased).map(term => term);
     const accumulatedDataReleased = createDataset(deduplicatedreleased, accumulatorreleased, cumulativedatasetReleased);
     const accumulatedDataSubmitted = createDataset(deduplicatedsubmitted, accumulatorsubmitted, cumulativedatasetSubmitted);
@@ -1745,16 +1752,14 @@ const ExperimentDate = (props) => {
         <div>
             {experiments && experiments.facets && experiments.facets.length ?
                 <Panel>
-                <PanelHeading>
-                    <h4>Cumulative Number of Experiments</h4>
-                </PanelHeading>
-                <PanelBody>
-                    <CumulativeGraph releaseddatavalue={accumulatedDataReleased} submitteddatavalue={accumulatedDataSubmitted} monthReleased={date} />
-                </PanelBody>
+                    <PanelHeading>
+                        <h4>Cumulative Number of Experiments</h4>
+                    </PanelHeading>
+                    <PanelBody>
+                        <CumulativeGraph releaseddatavalue={accumulatedDataReleased} submitteddatavalue={accumulatedDataSubmitted} monthReleased={date} />
+                    </PanelBody>
                 </Panel>
-            :
-                null
-            }
+            : null}
         </div>
     );
 };
@@ -1925,14 +1930,14 @@ class CumulativeGraph extends React.Component {
                 data: {
                     labels: monthReleased,
                     datasets: [{
-                        label: 'Date Submitted',
-                        data: submitteddatavalue,
-                        backgroundColor: 'rgba(54, 162, 235, 0.2)',
-                    },
-                    {
                         label: 'Date Released',
                         data: releaseddatavalue,
-                        backgroundColor: 'rgba(75, 192, 192, 0.2)',
+                        backgroundColor: '#604a7b',
+                    },
+                    {
+                        label: 'Date Submitted',
+                        data: submitteddatavalue,
+                        backgroundColor: '#ccc1da',
                     }],
                 },
             });

--- a/src/encoded/static/components/award.js
+++ b/src/encoded/static/components/award.js
@@ -1603,7 +1603,6 @@ const milestonesTableColumns = {
         title: 'Proposed count',
     },
 
-
     deliverable_unit: {
         title: 'Biosample',
     },
@@ -1996,11 +1995,12 @@ AffiliatedLabs.propTypes = {
 };
 
 class Award extends React.Component {
-
     render() {
         // const { award } = this.props;
         const { context } = this.props;
         const statuses = [{ status: context.status, title: 'Status' }];
+        const loggedIn = !!(this.context.session && this.context.session['auth.userid']);
+
         return (
             <div className={globals.itemClass(context, 'view-item')}>
                 <header className="row">
@@ -2072,11 +2072,11 @@ class Award extends React.Component {
                         </div>
                     </PanelBody>
                 </Panel>
-                {context.milestones ?
+
+                {context.milestones && loggedIn ?
                     <MilestonesTable award={context} />
-                :
-                null
-                }
+                : null}
+
                 <LineChart award={context} />
             </div>
         );
@@ -2085,6 +2085,10 @@ class Award extends React.Component {
 
 Award.propTypes = {
     context: PropTypes.object.isRequired, // Award object being rendered
+};
+
+Award.contextTypes = {
+    session: PropTypes.object, // Login information
 };
 
 globals.contentViews.register(Award, 'Award');

--- a/src/encoded/static/components/experiment.js
+++ b/src/encoded/static/components/experiment.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import moment from 'moment';
 import _ from 'underscore';
 import { Panel, PanelBody } from '../libs/bootstrap/panel';
 import { auditDecor } from './audit';
@@ -600,10 +601,17 @@ class ExperimentComponent extends React.Component {
                                         </div>
                                     : null}
 
+                                    {context.date_submitted ?
+                                        <div data-test="date-submitted">
+                                            <dt>Date submitted</dt>
+                                            <dd>{moment(context.date_submitted).format('MMMM D, YYYY')}</dd>
+                                        </div>
+                                    : null}
+
                                     {context.date_released ?
                                         <div data-test="date-released">
                                             <dt>Date released</dt>
-                                            <dd>{context.date_released}</dd>
+                                            <dd>{moment(context.date_released).format('MMMM D, YYYY')}</dd>
                                         </div>
                                     : null}
 


### PR DESCRIPTION
Many of the changes are just slight source-code styling changes, and very small ones. The main change here was reversing the released and submitted variables so that each one receives the right data.

The change for the cumulative chart not only involved changing the colors to avoid the transparent ones, which also meant changing the order of the data given to chart.js so that the submitted chart wouldn’t hide the released chart now that they’re not transparent. That’s why you see the change to the array of objects to `new Chart`.

Also in this branch is the addition of a “Date submitted” display in the experiment page summary box, and a reformatting of the date to display in MMMM D, YYYY format instead of the existing YYYY-MM-DD format. The data hasn’t changed — just the display.