### PR TITLE
ENCD-3512 pipeline assay_term_names update

### DIFF
--- a/src/encoded/static/components/pipeline.js
+++ b/src/encoded/static/components/pipeline.js
@@ -363,12 +363,15 @@ class PipelineComponent extends React.Component {
         const context = this.props.context;
         const itemClass = globals.itemClass(context, 'view-item');
 
-        const assayTerm = context.assay_term_name ? 'assay_term_name' : 'assay_term_id';
-        const assayName = context[assayTerm];
-        const crumbs = [
-            { id: 'Pipelines' },
-            { id: assayName, query: `${assayTerm}=${assayName}`, tip: assayName },
-        ];
+        let crumbs;
+        const assayName = (context.assay_term_names && context.assay_term_names.length) ? context.assay_term_names.join(' + ') : null;
+        if (assayName) {
+            const query = context.assay_term_names.map(name => `assay_term_names=${name}`).join('&');
+            crumbs = [
+                { id: 'Pipelines' },
+                { id: assayName, query, tip: assayName },
+            ];
+        }
 
         const documents = {};
         if (context.documents) {
@@ -396,7 +399,7 @@ class PipelineComponent extends React.Component {
             <div className={itemClass}>
                 <header className="row">
                     <div className="col-sm-12">
-                        <Breadcrumbs root="/search/?type=pipeline" crumbs={crumbs} />
+                        {crumbs ? <Breadcrumbs root="/search/?type=Pipeline" crumbs={crumbs} /> : null}
                         <h2>{context.title}</h2>
                         <div className="characterization-status-labels">
                             <div className="characterization-status-labels">
@@ -415,10 +418,10 @@ class PipelineComponent extends React.Component {
                                 <dd>{context.title}</dd>
                             </div>
 
-                            {context.assay_term_name ?
+                            {context.assay_term_names && context.assay_term_names.length ?
                                 <div data-test="assay">
                                     <dt>Assay</dt>
-                                    <dd>{context.assay_term_name}</dd>
+                                    <dd>{context.assay_term_names.join(', ')}</dd>
                                 </div>
                             : null}
 
@@ -546,8 +549,8 @@ class ListingComponent extends React.Component {
                         <a href={result['@id']}>{result.title}</a>
                     </div>
                     <div className="data-row">
-                        {result.assay_term_name ?
-                            <div><strong>Assay: </strong>{result.assay_term_name}</div>
+                        {result.assay_term_names && result.assay_term_names.length ?
+                            <div><strong>Assays: </strong>{result.assay_term_names.join(', ')}</div>
                         : null}
 
                         {swTitle.length ?

--- a/src/encoded/static/components/pipeline.js
+++ b/src/encoded/static/components/pipeline.js
@@ -420,7 +420,7 @@ class PipelineComponent extends React.Component {
 
                             {context.assay_term_names && context.assay_term_names.length ?
                                 <div data-test="assay">
-                                    <dt>Assay</dt>
+                                    <dt>Assays</dt>
                                     <dd>{context.assay_term_names.join(', ')}</dd>
                                 </div>
                             : null}


### PR DESCRIPTION
The `assay_term_name` string property no longer exists in pipeline objects. Instead, `assay_term_names` exists and is an array of strings. This led to these changes:

1. The Pipeline page summary panel now shows “Assays” instead of “Assay,” and it shows a comma-separated list of `assay_term_names` elements.
1. Pipeline object search results also displayed `assay_term_name` in the little summary. It now displays a list of `assay_term_names` comma separated.
1. The breadcrumbs at the top of the pipeline page now shows the assay_term_names elements separated by a plus sign, as AntibodyLot pages have done for a while. Clicking it brings up a search page with all the displayed assay_term_names selected in the facets. If no assay_term_names are available, then no breadcrumbs get displayed at all.