### PR TITLE
ENCD-3516Restore info button

### DIFF
--- a/src/encoded/static/components/filegallery.js
+++ b/src/encoded/static/components/filegallery.js
@@ -1368,326 +1368,6 @@ export function assembleGraph(context, session, infoNodeId, files, filterAssembl
 }
 
 
-// Displays the file filtering controls for the file association graph and file tables.
-
-class FilterControls extends React.Component {
-    constructor() {
-        super();
-
-        // Bind this to non-React methods.
-        this.handleAssemblyAnnotationChange = this.handleAssemblyAnnotationChange.bind(this);
-        this.handleInclusionChange = this.handleInclusionChange.bind(this);
-    }
-
-    handleAssemblyAnnotationChange(e) {
-        this.props.handleAssemblyAnnotationChange(e.target.value);
-    }
-
-    // Called when the switch button is clicked.
-    handleInclusionChange() {
-        this.props.handleInclusionChange(!this.props.inclusionOn);
-    }
-
-    render() {
-        const { filterOptions, selectedFilterValue, inclusionOn } = this.props;
-
-        if (filterOptions.length) {
-            return (
-                <div className="file-gallery-controls">
-                    <div className="file-gallery-controls__assembly-selector">
-                        <FilterMenu selectedFilterValue={selectedFilterValue} filterOptions={filterOptions} handleFilterChange={this.handleAssemblyAnnotationChange} />
-                    </div>
-                    <div className="file-gallery-controls__inclusion-selector">
-                        <div className="checkbox--right">
-                            <label htmlFor="filterIncArchive">Include revoked / archived files
-                                <input name="filterIncArchive" type="checkbox" checked={inclusionOn} onChange={this.handleInclusionChange} />
-                            </label>
-                        </div>
-                    </div>
-                </div>
-            );
-        }
-
-        return null;
-    }
-}
-
-FilterControls.propTypes = {
-    filterOptions: PropTypes.array.isRequired,
-    selectedFilterValue: PropTypes.string,
-    handleAssemblyAnnotationChange: PropTypes.func.isRequired,
-    handleInclusionChange: PropTypes.func.isRequired,
-    inclusionOn: PropTypes.bool, // True to make the inclusion box checked
-};
-
-FilterControls.defaultProps = {
-    selectedFilterValue: '0',
-    inclusionOn: false,
-};
-
-
-// Function to render the file gallery, and it gets called after the file search results (for files associated with
-// the displayed experiment) return.
-
-class FileGalleryRenderer extends React.Component {
-    constructor() {
-        super();
-
-        // Initialize React state variables.
-        this.state = {
-            selectedFilterValue: 'default', // <select> value of selected filter
-            infoNodeId: '', // @id of node whose info panel is open
-            infoModalOpen: false, // True if info modal is open
-            relatedFiles: [],
-            inclusionOn: false, // True to exclude files with certain statuses
-        };
-
-        // Bind `this` to non-React methods.
-        this.setInfoNodeId = this.setInfoNodeId.bind(this);
-        this.setInfoNodeVisible = this.setInfoNodeVisible.bind(this);
-        this.setFilter = this.setFilter.bind(this);
-        this.handleAssemblyAnnotationChange = this.handleAssemblyAnnotationChange.bind(this);
-        this.handleInclusionChange = this.handleInclusionChange.bind(this);
-        this.filterForInclusion = this.filterForInclusion.bind(this);
-    }
-
-    componentWillMount() {
-        const { context, data } = this.props;
-        const relatedFileIds = context.related_files && context.related_files.length ? context.related_files : [];
-        if (relatedFileIds.length) {
-            const searchedFiles = data ? data['@graph'] : []; // Array of searched files arrives in data.@graph result
-            requestFiles(relatedFileIds, searchedFiles).then((relatedFiles) => {
-                this.setState({ relatedFiles });
-            });
-        }
-    }
-
-    // Set the default filter after the graph has been analyzed once.
-    componentDidMount() {
-        if (!this.props.altFilterDefault) {
-            this.setFilter('0');
-        }
-    }
-
-    componentDidUpdate() {
-        const { context, data } = this.props;
-        const relatedFileIds = context.related_files && context.related_files.length ? context.related_files : [];
-        if (relatedFileIds.length) {
-            const searchedFiles = data ? data['@graph'] : []; // Array of searched files arrives in data.@graph result
-            requestFiles(relatedFileIds, searchedFiles).then((relatedFiles) => {
-                if (relatedFiles.length !== this.state.relatedFiles.length) {
-                    this.setState({ relatedFiles });
-                }
-            });
-        }
-    }
-
-    // Called from child components when the selected node changes.
-    setInfoNodeId(nodeId) {
-        this.setState({ infoNodeId: nodeId });
-    }
-
-    setInfoNodeVisible(visible) {
-        this.setState({ infoNodeVisible: visible });
-    }
-
-    // Set the graph filter based on the given <option> value
-    setFilter(value) {
-        this.setState({ selectedFilterValue: value });
-    }
-
-    // React to a filter menu selection. The synthetic event given in `e`
-    handleAssemblyAnnotationChange(value) {
-        this.setFilter(value);
-    }
-
-    // When the exclusion filter changes from typcially the user clicking the checkbox in
-    // <FilterControls>,
-    handleInclusionChange(checked) {
-        this.setState({ inclusionOn: checked });
-    }
-
-    // If the inclusionOn state property is enabled, we'll just display all the files we got. If
-    // inclusionOn is disabled, we filter out any files with states in
-    // FileGalleryRenderer.inclusionStatuses.
-    filterForInclusion(files) {
-        if (!this.state.inclusionOn) {
-            // The user has chosen to not see file swith statuses in
-            // FileGalleryRenderer.inclusionStatuses. Create an array with files having those
-            // statuses filtered out. Start by making an array of files with a filtered-out status
-            return files.filter(file => FileGalleryRenderer.inclusionStatuses.indexOf(file.status) === -1);
-        }
-
-        // The user requested seeing everything including revoked and archived files, so just
-        // return the unmodified array.
-        return files;
-    }
-
-    render() {
-        const { context, data, schemas, hideGraph } = this.props;
-        let selectedAssembly = '';
-        let selectedAnnotation = '';
-        let jsonGraph;
-        let allGraphedFiles;
-        const files = (data ? data['@graph'] : []).concat(this.state.relatedFiles); // Array of searched files arrives in data.@graph result
-        if (files.length === 0) {
-            return null;
-        }
-
-        const filterOptions = files.length ? collectAssembliesAnnotations(files) : [];
-
-        if (this.state.selectedFilterValue && filterOptions[this.state.selectedFilterValue]) {
-            selectedAssembly = filterOptions[this.state.selectedFilterValue].assembly;
-            selectedAnnotation = filterOptions[this.state.selectedFilterValue].annotation;
-        }
-
-        // Get a list of files for the graph (filters out excluded files if requested by the user).
-        const graphFiles = this.filterForInclusion(files);
-
-        // Build node graph of the files and analysis steps with this experiment
-        if (graphFiles && graphFiles.length && !hideGraph) {
-            try {
-                const { graph, graphedFiles } = assembleGraph(context, this.context.session, this.state.infoNodeId, graphFiles, selectedAssembly, selectedAnnotation);
-                jsonGraph = graph;
-                allGraphedFiles = (selectedAssembly || selectedAnnotation) ? graphedFiles : {};
-            } catch (e) {
-                jsonGraph = null;
-                allGraphedFiles = {};
-                console.warn(e.message + (e.file0 ? ` -- file0:${e.file0}` : '') + (e.file1 ? ` -- file1:${e.file1}` : ''));
-            }
-        }
-
-        return (
-            <Panel>
-                <PanelHeading addClasses="file-gallery-heading">
-                    <h4>Files</h4>
-                    <div className="file-gallery-visualize">
-                        {context.visualize ?
-                            <BrowserSelector visualizeCfg={context.visualize} />
-                        : null}
-                    </div>
-                </PanelHeading>
-
-                {/* Display the strip of filgering controls */}
-                <FilterControls
-                    selectedFilterValue={this.state.selectedFilterValue}
-                    filterOptions={filterOptions}
-                    inclusionOn={this.state.inclusionOn}
-                    handleAssemblyAnnotationChange={this.handleAssemblyAnnotationChange}
-                    handleInclusionChange={this.handleInclusionChange}
-                />
-
-                <TabPanel tabs={{ graph: 'Association graph', tables: 'File details' }}>
-                    <TabPanelPane key="graph">
-                        {!hideGraph ?
-                            <FileGraph
-                                context={context}
-                                items={graphFiles}
-                                graph={jsonGraph}
-                                selectedAssembly={selectedAssembly}
-                                selectedAnnotation={selectedAnnotation}
-                                session={this.context.session}
-                                infoNodeId={this.state.infoNodeId}
-                                setInfoNodeId={this.setInfoNodeId}
-                                infoNodeVisible={this.state.infoNodeVisible}
-                                setInfoNodeVisible={this.setInfoNodeVisible}
-                                schemas={schemas}
-                                sessionProperties={this.context.session_properties}
-                                forceRedraw
-                            />
-                        : null}
-                    </TabPanelPane>
-
-                    <TabPanelPane key="tables">
-                        {/* If logged in and dataset is released, need to combine search of files that reference
-                            this dataset to get released and unreleased ones. If not logged in, then just get
-                            files from dataset.files */}
-                        <FileTable
-                            {...this.props}
-                            items={graphFiles}
-                            selectedFilterValue={this.state.selectedFilterValue}
-                            filterOptions={filterOptions}
-                            graphedFiles={allGraphedFiles}
-                            handleFilterChange={this.handleFilterChange}
-                            encodevers={globals.encodeVersion(context)}
-                            session={this.context.session}
-                            infoNodeId={this.state.infoNodeId}
-                            setInfoNodeId={this.setInfoNodeId}
-                            infoNodeVisible={this.state.infoNodeVisible}
-                            setInfoNodeVisible={this.setInfoNodeVisible}
-                            showFileCount
-                            noDefaultClasses
-                            adminUser={!!(this.context.session_properties && this.context.session_properties.admin)}
-                        />
-                    </TabPanelPane>
-                </TabPanel>
-            </Panel>
-        );
-    }
-}
-
-// Keeps a list of file statuses to include or exclude based on the checkbox in FilterControls.
-FileGalleryRenderer.inclusionStatuses = [
-    'archived',
-    'revoked',
-];
-
-FileGalleryRenderer.propTypes = {
-    context: PropTypes.object, // Dataset whose files we're rendering
-    data: PropTypes.object, // File data retrieved from search request
-    schemas: PropTypes.object, // Schemas for the entire system; used for QC property titles
-    hideGraph: PropTypes.bool, // T to hide graph display
-    altFilterDefault: PropTypes.bool, // T to default to All Assemblies and Annotations
-};
-
-FileGalleryRenderer.contextTypes = {
-    session: PropTypes.object,
-    session_properties: PropTypes.object,
-    location_href: PropTypes.string,
-};
-
-
-const CollapsingTitle = (props) => {
-    const { title, handleCollapse, collapsed } = props;
-    return (
-        <div className="collapsing-title">
-            <button className="collapsing-title-trigger pull-left" data-trigger onClick={handleCollapse}>{collapseIcon(collapsed, 'collapsing-title-icon')}</button>
-            <h4>{title}</h4>
-        </div>
-    );
-};
-
-CollapsingTitle.propTypes = {
-    title: PropTypes.string.isRequired, // Title to display in the title bar
-    handleCollapse: PropTypes.func.isRequired, // Function to call to handle click in collapse button
-    collapsed: PropTypes.bool, // T if the panel this is over has been collapsed
-};
-
-
-// Display a filtering <select>. `filterOptions` is an array of objects with two properties:
-// `assembly` and `annotation`. Both are strings that get concatenated to form each menu item. The
-// value of each <option> is its zero-based index.
-const FilterMenu = (props) => {
-    const { filterOptions, handleFilterChange, selectedFilterValue } = props;
-
-    return (
-        <select className="form-control" value={selectedFilterValue} onChange={handleFilterChange}>
-            <option value="default">All Assemblies and Annotations</option>
-            <option disabled="disabled" />
-            {filterOptions.map((option, i) =>
-                <option key={`${option.assembly}${option.annotation}`} value={i}>{`${option.assembly + (option.annotation ? ` ${option.annotation}` : '')}`}</option>,
-            )}
-        </select>
-    );
-};
-
-FilterMenu.propTypes = {
-    selectedFilterValue: PropTypes.string, // Currently selected filter
-    filterOptions: PropTypes.array.isRequired, // Contents of the filtering menu
-    handleFilterChange: PropTypes.func.isRequired, // Call when a filtering option changes
-};
-
-
 export function qcDetailsView(metrics, schemas) {
     const qc = metrics.ref;
 
@@ -1768,20 +1448,168 @@ function coalescedDetailsView(node) {
     return { header, body };
 }
 
-class FileGraphComponent extends React.Component {
+
+// Displays the file filtering controls for the file association graph and file tables.
+
+class FilterControls extends React.Component {
+    constructor() {
+        super();
+
+        // Bind this to non-React methods.
+        this.handleAssemblyAnnotationChange = this.handleAssemblyAnnotationChange.bind(this);
+        this.handleInclusionChange = this.handleInclusionChange.bind(this);
+    }
+
+    handleAssemblyAnnotationChange(e) {
+        this.props.handleAssemblyAnnotationChange(e.target.value);
+    }
+
+    // Called when the switch button is clicked.
+    handleInclusionChange() {
+        this.props.handleInclusionChange(!this.props.inclusionOn);
+    }
+
+    render() {
+        const { filterOptions, selectedFilterValue, inclusionOn } = this.props;
+
+        if (filterOptions.length) {
+            return (
+                <div className="file-gallery-controls">
+                    <div className="file-gallery-controls__assembly-selector">
+                        <FilterMenu selectedFilterValue={selectedFilterValue} filterOptions={filterOptions} handleFilterChange={this.handleAssemblyAnnotationChange} />
+                    </div>
+                    <div className="file-gallery-controls__inclusion-selector">
+                        <div className="checkbox--right">
+                            <label htmlFor="filterIncArchive">Include revoked / archived files
+                                <input name="filterIncArchive" type="checkbox" checked={inclusionOn} onChange={this.handleInclusionChange} />
+                            </label>
+                        </div>
+                    </div>
+                </div>
+            );
+        }
+
+        return null;
+    }
+}
+
+FilterControls.propTypes = {
+    filterOptions: PropTypes.array.isRequired,
+    selectedFilterValue: PropTypes.string,
+    handleAssemblyAnnotationChange: PropTypes.func.isRequired,
+    handleInclusionChange: PropTypes.func.isRequired,
+    inclusionOn: PropTypes.bool, // True to make the inclusion box checked
+};
+
+FilterControls.defaultProps = {
+    selectedFilterValue: '0',
+    inclusionOn: false,
+};
+
+
+// Function to render the file gallery, and it gets called after the file search results (for files associated with
+// the displayed experiment) return.
+
+class FileGalleryRendererComponent extends React.Component {
     constructor() {
         super();
 
         // Initialize React state variables.
         this.state = {
-            contributingFiles: {}, // List of contributing file objects we've requested; acts as a cache too
-            coalescedFiles: {}, // List of coalesced files we've requested; acts as a cache too
-            infoModalOpen: false, // Graph information modal open
+            selectedFilterValue: 'default', // <select> value of selected filter
+            infoNodeId: '', // @id of node whose info panel is open
+            infoModalOpen: false, // True if info modal is open
+            relatedFiles: [],
+            inclusionOn: false, // True to exclude files with certain statuses
         };
 
         // Bind `this` to non-React methods.
-        this.handleNodeClick = this.handleNodeClick.bind(this);
+        this.setInfoNodeId = this.setInfoNodeId.bind(this);
+        this.setInfoNodeVisible = this.setInfoNodeVisible.bind(this);
+        this.setFilter = this.setFilter.bind(this);
+        this.handleAssemblyAnnotationChange = this.handleAssemblyAnnotationChange.bind(this);
+        this.handleInclusionChange = this.handleInclusionChange.bind(this);
+        this.filterForInclusion = this.filterForInclusion.bind(this);
         this.closeModal = this.closeModal.bind(this);
+        this.handleNodeClick = this.handleNodeClick.bind(this);
+    }
+
+    componentWillMount() {
+        const { context, data } = this.props;
+        const relatedFileIds = context.related_files && context.related_files.length ? context.related_files : [];
+        if (relatedFileIds.length) {
+            const searchedFiles = data ? data['@graph'] : []; // Array of searched files arrives in data.@graph result
+            requestFiles(relatedFileIds, searchedFiles).then((relatedFiles) => {
+                this.setState({ relatedFiles });
+            });
+        }
+    }
+
+    // Set the default filter after the graph has been analyzed once.
+    componentDidMount() {
+        if (!this.props.altFilterDefault) {
+            this.setFilter('0');
+        }
+    }
+
+    componentDidUpdate() {
+        const { context, data } = this.props;
+        const relatedFileIds = context.related_files && context.related_files.length ? context.related_files : [];
+        if (relatedFileIds.length) {
+            const searchedFiles = data ? data['@graph'] : []; // Array of searched files arrives in data.@graph result
+            requestFiles(relatedFileIds, searchedFiles).then((relatedFiles) => {
+                if (relatedFiles.length !== this.state.relatedFiles.length) {
+                    this.setState({ relatedFiles });
+                }
+            });
+        }
+    }
+
+    // Called from child components when the selected node changes.
+    setInfoNodeId(nodeId) {
+        this.setState({ infoNodeId: nodeId });
+    }
+
+    setInfoNodeVisible(visible) {
+        this.setState({ infoNodeVisible: visible });
+    }
+
+    // Set the graph filter based on the given <option> value
+    setFilter(value) {
+        this.setState({ selectedFilterValue: value });
+    }
+
+    // React to a filter menu selection. The synthetic event given in `e`
+    handleAssemblyAnnotationChange(value) {
+        this.setFilter(value);
+    }
+
+    // When the exclusion filter changes from typcially the user clicking the checkbox in
+    // <FilterControls>,
+    handleInclusionChange(checked) {
+        this.setState({ inclusionOn: checked });
+    }
+
+    // If the inclusionOn state property is enabled, we'll just display all the files we got. If
+    // inclusionOn is disabled, we filter out any files with states in
+    // FileGalleryRenderer.inclusionStatuses.
+    filterForInclusion(files) {
+        if (!this.state.inclusionOn) {
+            // The user has chosen to not see file swith statuses in
+            // FileGalleryRenderer.inclusionStatuses. Create an array with files having those
+            // statuses filtered out. Start by making an array of files with a filtered-out status
+            return files.filter(file => FileGalleryRendererComponent.inclusionStatuses.indexOf(file.status) === -1);
+        }
+
+        // The user requested seeing everything including revoked and archived files, so just
+        // return the unmodified array.
+        return files;
+    }
+
+    // Handle a click in a graph node
+    handleNodeClick(nodeId) {
+        this.setInfoNodeId(nodeId);
+        this.setInfoNodeVisible(true);
     }
 
     // Render metadata if a graph node is selected.
@@ -1865,25 +1693,212 @@ class FileGraphComponent extends React.Component {
         return meta;
     }
 
-    // Handle a click in a graph node
-    handleNodeClick(nodeId) {
-        this.props.setInfoNodeId(nodeId);
-        this.props.setInfoNodeVisible(true);
-    }
-
     closeModal() {
         // Called when user wants to close modal somehow
-        this.props.setInfoNodeVisible(false);
+        this.setInfoNodeVisible(false);
     }
 
     render() {
-        const { session, sessionProperties, items, graph, selectedAssembly, selectedAnnotation, infoNodeId, infoNodeVisible } = this.props;
-        const files = items;
+        const { context, data, schemas, hideGraph } = this.props;
+        let selectedAssembly = '';
+        let selectedAnnotation = '';
+        let jsonGraph;
+        let allGraphedFiles;
+        const files = (data ? data['@graph'] : []).concat(this.state.relatedFiles); // Array of searched files arrives in data.@graph result
+        if (files.length === 0) {
+            return null;
+        }
+
+        const filterOptions = files.length ? collectAssembliesAnnotations(files) : [];
+
+        if (this.state.selectedFilterValue && filterOptions[this.state.selectedFilterValue]) {
+            selectedAssembly = filterOptions[this.state.selectedFilterValue].assembly;
+            selectedAnnotation = filterOptions[this.state.selectedFilterValue].annotation;
+        }
+
+        // Get a list of files for the graph (filters out excluded files if requested by the user).
+        const graphFiles = this.filterForInclusion(files);
+
+        // Build node graph of the files and analysis steps with this experiment
+        if (graphFiles && graphFiles.length && !hideGraph) {
+            try {
+                const { graph, graphedFiles } = assembleGraph(context, this.context.session, this.state.infoNodeId, graphFiles, selectedAssembly, selectedAnnotation);
+                jsonGraph = graph;
+                allGraphedFiles = (selectedAssembly || selectedAnnotation) ? graphedFiles : {};
+            } catch (e) {
+                jsonGraph = null;
+                allGraphedFiles = {};
+                console.warn(e.message + (e.file0 ? ` -- file0:${e.file0}` : '') + (e.file1 ? ` -- file1:${e.file1}` : ''));
+            }
+        }
+
+        // Prepare to display the file information modal.
         const modalTypeMap = {
             File: 'file',
             Step: 'analysis-step',
             QualityMetric: 'quality-metric',
         };
+        const meta = this.detailNodes(jsonGraph, this.state.infoNodeId, this.context.session, this.context.session_properties);
+        const modalClass = meta ? `graph-modal-${modalTypeMap[meta.type]}` : '';
+
+        return (
+            <Panel>
+                <PanelHeading addClasses="file-gallery-heading">
+                    <h4>Files</h4>
+                    <div className="file-gallery-visualize">
+                        {context.visualize ?
+                            <BrowserSelector visualizeCfg={context.visualize} />
+                        : null}
+                    </div>
+                </PanelHeading>
+
+                {/* Display the strip of filgering controls */}
+                <FilterControls
+                    selectedFilterValue={this.state.selectedFilterValue}
+                    filterOptions={filterOptions}
+                    inclusionOn={this.state.inclusionOn}
+                    handleAssemblyAnnotationChange={this.handleAssemblyAnnotationChange}
+                    handleInclusionChange={this.handleInclusionChange}
+                />
+
+                <TabPanel tabs={{ graph: 'Association graph', tables: 'File details' }}>
+                    <TabPanelPane key="graph">
+                        {!hideGraph ?
+                            <FileGraph
+                                context={context}
+                                items={graphFiles}
+                                graph={jsonGraph}
+                                selectedAssembly={selectedAssembly}
+                                selectedAnnotation={selectedAnnotation}
+                                handleNodeClick={this.handleNodeClick}
+                                setInfoNodeId={this.setInfoNodeId}
+                                setInfoNodeVisible={this.setInfoNodeVisible}
+                                schemas={schemas}
+                                forceRedraw
+                            />
+                        : null}
+                    </TabPanelPane>
+
+                    <TabPanelPane key="tables">
+                        {/* If logged in and dataset is released, need to combine search of files that reference
+                            this dataset to get released and unreleased ones. If not logged in, then just get
+                            files from dataset.files */}
+                        <FileTable
+                            {...this.props}
+                            items={graphFiles}
+                            selectedFilterValue={this.state.selectedFilterValue}
+                            filterOptions={filterOptions}
+                            graphedFiles={allGraphedFiles}
+                            handleFilterChange={this.handleFilterChange}
+                            encodevers={globals.encodeVersion(context)}
+                            session={this.context.session}
+                            infoNodeId={this.state.infoNodeId}
+                            setInfoNodeId={this.setInfoNodeId}
+                            infoNodeVisible={this.state.infoNodeVisible}
+                            setInfoNodeVisible={this.setInfoNodeVisible}
+                            showFileCount
+                            noDefaultClasses
+                            adminUser={!!(this.context.session_properties && this.context.session_properties.admin)}
+                        />
+                    </TabPanelPane>
+                </TabPanel>
+                {meta && this.state.infoNodeVisible ?
+                    <Modal closeModal={this.closeModal}>
+                        <ModalHeader closeModal={this.closeModal} addCss={modalClass}>
+                            {meta ? meta.header : null}
+                        </ModalHeader>
+                        <ModalBody>
+                            {meta ? meta.body : null}
+                        </ModalBody>
+                        <ModalFooter closeModal={<button className="btn btn-info" onClick={this.closeModal}>Close</button>} />
+                    </Modal>
+                : null}
+            </Panel>
+        );
+    }
+}
+
+// Keeps a list of file statuses to include or exclude based on the checkbox in FilterControls.
+FileGalleryRendererComponent.inclusionStatuses = [
+    'archived',
+    'revoked',
+];
+
+FileGalleryRendererComponent.propTypes = {
+    context: PropTypes.object, // Dataset whose files we're rendering
+    data: PropTypes.object, // File data retrieved from search request
+    schemas: PropTypes.object, // Schemas for the entire system; used for QC property titles
+    hideGraph: PropTypes.bool, // T to hide graph display
+    altFilterDefault: PropTypes.bool, // T to default to All Assemblies and Annotations
+    auditIndicators: PropTypes.func, // Inherited from auditDecor HOC
+    auditDetail: PropTypes.func, // Inherited from auditDecor HOC
+};
+
+FileGalleryRendererComponent.contextTypes = {
+    session: PropTypes.object,
+    session_properties: PropTypes.object,
+    location_href: PropTypes.string,
+};
+
+const FileGalleryRenderer = auditDecor(FileGalleryRendererComponent);
+
+
+const CollapsingTitle = (props) => {
+    const { title, handleCollapse, collapsed } = props;
+    return (
+        <div className="collapsing-title">
+            <button className="collapsing-title-trigger pull-left" data-trigger onClick={handleCollapse}>{collapseIcon(collapsed, 'collapsing-title-icon')}</button>
+            <h4>{title}</h4>
+        </div>
+    );
+};
+
+CollapsingTitle.propTypes = {
+    title: PropTypes.string.isRequired, // Title to display in the title bar
+    handleCollapse: PropTypes.func.isRequired, // Function to call to handle click in collapse button
+    collapsed: PropTypes.bool, // T if the panel this is over has been collapsed
+};
+
+
+// Display a filtering <select>. `filterOptions` is an array of objects with two properties:
+// `assembly` and `annotation`. Both are strings that get concatenated to form each menu item. The
+// value of each <option> is its zero-based index.
+const FilterMenu = (props) => {
+    const { filterOptions, handleFilterChange, selectedFilterValue } = props;
+
+    return (
+        <select className="form-control" value={selectedFilterValue} onChange={handleFilterChange}>
+            <option value="default">All Assemblies and Annotations</option>
+            <option disabled="disabled" />
+            {filterOptions.map((option, i) =>
+                <option key={`${option.assembly}${option.annotation}`} value={i}>{`${option.assembly + (option.annotation ? ` ${option.annotation}` : '')}`}</option>,
+            )}
+        </select>
+    );
+};
+
+FilterMenu.propTypes = {
+    selectedFilterValue: PropTypes.string, // Currently selected filter
+    filterOptions: PropTypes.array.isRequired, // Contents of the filtering menu
+    handleFilterChange: PropTypes.func.isRequired, // Call when a filtering option changes
+};
+
+
+class FileGraph extends React.Component {
+    constructor() {
+        super();
+
+        // Initialize React state variables.
+        this.state = {
+            contributingFiles: {}, // List of contributing file objects we've requested; acts as a cache too
+            coalescedFiles: {}, // List of coalesced files we've requested; acts as a cache too
+            infoModalOpen: false, // Graph information modal open
+        };
+    }
+
+    render() {
+        const { items, graph, selectedAssembly, selectedAnnotation, handleNodeClick } = this.props;
+        const files = items;
 
         // Build node graph of the files and analysis steps with this experiment
         if (files && files.length) {
@@ -1891,25 +1906,7 @@ class FileGraphComponent extends React.Component {
             const goodGraph = graph && Object.keys(graph).length;
             if (goodGraph) {
                 if (selectedAssembly || selectedAnnotation) {
-                    const meta = this.detailNodes(graph, infoNodeId, session, sessionProperties);
-                    const modalClass = meta ? `graph-modal-${modalTypeMap[meta.type]}` : '';
-
-                    return (
-                        <div>
-                            <Graph graph={graph} nodeClickHandler={this.handleNodeClick} nodeMouseenterHandler={this.handleHoverIn} nodeMouseleaveHandler={this.handleHoverOut} noDefaultClasses forceRedraw />
-                            {meta && infoNodeVisible ?
-                                <Modal closeModal={this.closeModal}>
-                                    <ModalHeader closeModal={this.closeModal} addCss={modalClass}>
-                                        {meta ? meta.header : null}
-                                    </ModalHeader>
-                                    <ModalBody>
-                                        {meta ? meta.body : null}
-                                    </ModalBody>
-                                    <ModalFooter closeModal={<button className="btn btn-info" onClick={this.closeModal}>Close</button>} />
-                                </Modal>
-                            : null}
-                        </div>
-                    );
+                    return <Graph graph={graph} nodeClickHandler={handleNodeClick} nodeMouseenterHandler={this.handleHoverIn} nodeMouseleaveHandler={this.handleHoverOut} noDefaultClasses forceRedraw />;
                 }
                 return <p className="browser-error">Choose an assembly to see file association graph</p>;
             }
@@ -1919,23 +1916,13 @@ class FileGraphComponent extends React.Component {
     }
 }
 
-FileGraphComponent.propTypes = {
+FileGraph.propTypes = {
     items: PropTypes.array, // Array of files we're graphing
     graph: PropTypes.object, // JsonGraph object generated from files
     selectedAssembly: PropTypes.string, // Currently selected assembly
     selectedAnnotation: PropTypes.string, // Currently selected annotation
-    setInfoNodeId: PropTypes.func, // Function to call to set the currently selected node ID
-    setInfoNodeVisible: PropTypes.func, // Function to call to set the visibility of the node's modal
-    infoNodeId: PropTypes.string, // ID of selected node in graph
-    infoNodeVisible: PropTypes.bool, // True if node's modal is vibible
-    schemas: PropTypes.object, // System-wide schemas
-    session: PropTypes.object, // Current user's login information
-    sessionProperties: PropTypes.object, // True if logged in user is an admin
-    auditIndicators: PropTypes.func, // Inherited from auditDecor HOC
-    auditDetail: PropTypes.func, // Inherited from auditDecor HOC
+    handleNodeClick: PropTypes.func, // Parent function to call when a graph node is clicked
 };
-
-const FileGraph = auditDecor(FileGraphComponent);
 
 
 // Display a QC button in the file modal.


### PR DESCRIPTION
I had already made these changes, but don’t know what happened to them. The modals were based in the graphing function which worked when there was always a graph, but not when there’s sometimes a graph. This moves the modal to a parent component, so we have no new code — just code that’s moved from a child component to the parent so that both tables and graphs share the state that brings up the modal.