### PR TITLE
ENCD-3472 Link to pipeline standards pages

### DIFF
--- a/src/encoded/schemas/pipeline.json
+++ b/src/encoded/schemas/pipeline.json
@@ -168,6 +168,12 @@
             "type": "string",
             "format": "uri"
         },
+        "standards_page": {
+            "title": "Standards page for this pipeline",
+            "description": "An link to a page describing the standards for this pipeline.",
+            "type": "string",
+            "linkTo": "Page"
+        },
         "pipeline_version": {
             "title": "Pipeline version",
             "description": "The pipeline version.",

--- a/src/encoded/static/components/pipeline.js
+++ b/src/encoded/static/components/pipeline.js
@@ -447,6 +447,13 @@ class PipelineComponent extends React.Component {
                                     <dd><a href={context.source_url}>{context.source_url}</a></dd>
                                 </div>
                             : null}
+
+                            {context.standards_page ?
+                                <div data-test="standardspage">
+                                    <dt>Pipeline standards</dt>
+                                    <dd><a href={context.standards_page['@id']}>{context.standards_page.title}</a></dd>
+                                </div>
+                            : null}
                         </dl>
                     </PanelBody>
                 </Panel>

--- a/src/encoded/types/pipeline.py
+++ b/src/encoded/types/pipeline.py
@@ -39,6 +39,7 @@ class Pipeline(Item):
         'analysis_steps.versions.software_versions.software',
         'lab',
         'award.pi.lab',
+        'standards_page'
     ]
 
 


### PR DESCRIPTION
Adds a non-required property to the pipeline schema that links to a page in the DB. This property, if it exists for a particular pipeline object, gets displayed in the summary panel of the pipeline’s individual page.