### PR TITLE
ENCD-3571 updates to the genetic modification UI

### DIFF
--- a/src/encoded/static/components/biosample.js
+++ b/src/encoded/static/components/biosample.js
@@ -50,10 +50,6 @@ class BiosampleComponent extends React.Component {
         }
         combinedDocs = globals.uniqueObjectsArray(combinedDocs);
 
-        // Collect up biosample and model organism donor constructs
-        const constructs = ((context.constructs && context.constructs.length) ? context.constructs : [])
-            .concat((context.model_organism_donor_constructs && context.model_organism_donor_constructs.length) ? context.model_organism_donor_constructs : []);
-
         // Make string of alternate accessions
         const altacc = context.alternate_accessions ? context.alternate_accessions.join(', ') : undefined;
 
@@ -352,28 +348,6 @@ class BiosampleComponent extends React.Component {
                                 <hr />
                                 <h4>Treatment details</h4>
                                 {context.treatments.map(treatment => treatmentDisplay(treatment))}
-                            </section>
-                        : null}
-
-                        {constructs.length ?
-                            <section>
-                                <hr />
-                                <h4>Construct details</h4>
-                                <div>
-                                    {constructs.map(construct =>
-                                        <div key={construct.uuid} className="subpanel">
-                                            {PanelLookup(construct)}
-                                        </div>
-                                    )}
-                                </div>
-                            </section>
-                        : null}
-
-                        {context.rnais.length ?
-                            <section>
-                                <hr />
-                                <h4>RNAi details</h4>
-                                {context.rnais.map(PanelLookup)}
                             </section>
                         : null}
                     </PanelBody>

--- a/src/encoded/static/components/genetic_modification.js
+++ b/src/encoded/static/components/genetic_modification.js
@@ -239,13 +239,13 @@ const ModificationMethod = (props) => {
                     <div data-test="reagent">
                         <dt>Reagents</dt>
                         <dd>
-                            <ul className="multi-value">
+                            <ul className="multi-value-line">
                                 {geneticModification.reagents.map((reagent, i) => {
                                     const reagentId = <span>{globals.atIdToAccession(reagent.source)} &mdash; {reagent.identifier}</span>;
                                     if (reagent.url) {
-                                        return <a key={i} href={reagent.url}>{reagentId}</a>;
+                                        return <li key={i}><a href={reagent.url}>{reagentId}</a></li>;
                                     }
-                                    return <span key={i}>{reagentId}</span>;
+                                    return <li key={i}>{reagentId}</li>;
                                 })}
                             </ul>
                         </dd>

--- a/src/encoded/static/scss/encoded/modules/_key-value-display.scss
+++ b/src/encoded/static/scss/encoded/modules/_key-value-display.scss
@@ -128,6 +128,22 @@ dd ul, .multi-value {
     }
 }
 
+dd ul, .multi-value-line {
+    display: block;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+
+    li {
+        display: block;
+        margin-right: 5px;
+
+        span {
+            font-weight: normal;
+        }
+    }
+}
+
 .multi-comma {
     margin-right: 0;
 


### PR DESCRIPTION
* Removed the construct and RNAi sections from the summary panel.
* Changed the `reagents` display on the GM pages so that they each display on their own line instead of all smooshed together like they appear on production now. This applies regardless of whether they’re linked or not.