### PR TITLE
ENCD-3489 Remove NBP from dbxrefs

### DIFF
--- a/src/encoded/schemas/worm_donor.json
+++ b/src/encoded/schemas/worm_donor.json
@@ -71,7 +71,7 @@
                 "title": "External identifier",
                 "description": "Identifier from an external resource that may have 1-to-1 or 1-to-many relationships with ENCODE objects.",
                 "type":  "string",
-                "pattern": "^(((CGC|WormBase|NBP):.+)|(GEO:SAMN\\d+))$"
+                "pattern": "^(((CGC|WormBase):.+)|(GEO:SAMN\\d+))$"
             }
         }
     },

--- a/src/encoded/static/components/__tests__/dbxref-test.js
+++ b/src/encoded/static/components/__tests__/dbxref-test.js
@@ -236,25 +236,6 @@ describe('Test individual dbxref types', () => {
         });
     });
 
-    describe('Test NBP', () => {
-        let dbxLinks;
-
-        beforeAll(() => {
-            const context = { '@type': 'WormDonor' };
-            const wrapper = mount(
-                <DbxrefList context={context} dbxrefs={['NBP:292', 'NBP:300']} />
-            );
-
-            dbxLinks = wrapper.find('a');
-        });
-
-        it('has the correct links', () => {
-            expect(dbxLinks.length).toBe(2);
-            expect(dbxLinks.at(0).prop('href')).toEqual('http://shigen.nig.ac.jp/c.elegans/mutants/DetailsSearch?lang=english&seq=292');
-            expect(dbxLinks.at(1).prop('href')).toEqual('http://shigen.nig.ac.jp/c.elegans/mutants/DetailsSearch?lang=english&seq=300');
-        });
-    });
-
     describe('Test CGC', () => {
         let dbxLinks;
 
@@ -560,7 +541,6 @@ describe('Test individual dbxref types', () => {
             expect(dbxLinks.at(1).prop('href')).toEqual('https://search.usa.gov/search?utf8=%E2%9C%93&affiliate=grants.nih.gov&query=NIHhESC-10-0063');
         });
     });
-
 
     describe('Test no matching dbxref prefix', () => {
         let dbxLinks;

--- a/src/encoded/static/components/dbxref.js
+++ b/src/encoded/static/components/dbxref.js
@@ -119,9 +119,6 @@ export const dbxrefPrefixMap = {
             return {};
         },
     },
-    NBP: {
-        pattern: 'http://shigen.nig.ac.jp/c.elegans/mutants/DetailsSearch?lang=english&seq={0}',
-    },
     CGC: {
         pattern: 'https://cgc.umn.edu/strain/{0}',
     },


### PR DESCRIPTION
NBP is currently unused, and duplicated by NBRP, so I removed it from front-end processing, as well as the schema.