### PR TITLE
ENCD-3587 filtering

### DIFF
--- a/src/encoded/static/components/filegallery.js
+++ b/src/encoded/static/components/filegallery.js
@@ -1472,24 +1472,22 @@ class FilterControls extends React.Component {
     render() {
         const { filterOptions, selectedFilterValue, inclusionOn } = this.props;
 
-        if (filterOptions.length) {
-            return (
-                <div className="file-gallery-controls">
-                    <div className="file-gallery-controls__assembly-selector">
+        return (
+            <div className="file-gallery-controls">
+                <div className="file-gallery-controls__assembly-selector">
+                    {filterOptions.length ?
                         <FilterMenu selectedFilterValue={selectedFilterValue} filterOptions={filterOptions} handleFilterChange={this.handleAssemblyAnnotationChange} />
-                    </div>
-                    <div className="file-gallery-controls__inclusion-selector">
-                        <div className="checkbox--right">
-                            <label htmlFor="filterIncArchive">Include revoked / archived files
-                                <input name="filterIncArchive" type="checkbox" checked={inclusionOn} onChange={this.handleInclusionChange} />
-                            </label>
-                        </div>
+                    : null}
+                </div>
+                <div className="file-gallery-controls__inclusion-selector">
+                    <div className="checkbox--right">
+                        <label htmlFor="filterIncArchive">Include revoked / archived files
+                            <input name="filterIncArchive" type="checkbox" checked={inclusionOn} onChange={this.handleInclusionChange} />
+                        </label>
                     </div>
                 </div>
-            );
-        }
-
-        return null;
+            </div>
+        );
     }
 }
 

--- a/src/encoded/static/components/filegallery.js
+++ b/src/encoded/static/components/filegallery.js
@@ -1878,7 +1878,7 @@ const FilterMenu = (props) => {
     const { filterOptions, handleFilterChange, selectedFilterValue } = props;
 
     return (
-        <select className="form-control" value={selectedFilterValue} onChange={handleFilterChange}>
+        <select className="form-control--select" value={selectedFilterValue} onChange={handleFilterChange}>
             <option value="default">All Assemblies and Annotations</option>
             <option disabled="disabled" />
             {filterOptions.map((option, i) =>

--- a/src/encoded/static/scss/encoded/modules/_forms.scss
+++ b/src/encoded/static/scss/encoded/modules/_forms.scss
@@ -13,6 +13,34 @@ $inputFocusBorderColor: darken(#fff, 26%) !default;
 	padding: 4px 6px;
 }
 
+.form-control--select {
+	@extend .form-control;
+
+	select {
+		position: relative;
+		height: 30px;
+		padding-right: 30px;
+		font-size: 0.9rem;
+		-webkit-appearance: none;
+		-moz-appearance: none;
+
+		&:after {
+			content: '\f0dc';
+			font-family: FontAwesome;
+			padding: 8px;
+			position: absolute;
+			right: 10px;
+			top: 5px;
+			z-index: 1;
+			width: 10px;
+			line-height: 50%;
+			font-size: 0.86rem;
+			color: #428bca;
+			pointer-events: none;
+		}
+	}
+}
+
 input[type="text"], input[type="password"], input[type="date"], input[type="datetime"], input[type="email"], input[type="number"], input[type="search"], input[type="tel"], input[type="time"], input[type="url"], textarea, select {
 	font-family: inherit;
 	font-size: 1rem;

--- a/src/encoded/static/scss/encoded/modules/_panels.scss
+++ b/src/encoded/static/scss/encoded/modules/_panels.scss
@@ -291,32 +291,8 @@ a[href^="http://encodedcc.sdsc.edu/warehouse/"]:after {
 
     @at-root #{&}__assembly-selector {
         flex: 0 1 auto;
-        position: relative;
         vertical-align: bottom;
         margin-right: 5px;
-
-        select {
-            height: 30px;
-            padding-right: 30px;
-            font-size: 0.9rem;
-            -webkit-appearance: none;
-            -moz-appearance: none;
-        }
-
-        &:after {
-            content: '\f0dc';
-            font-family: FontAwesome;
-            padding: 8px;
-            position: absolute;
-            right: 10px;
-            top: 5px;
-            z-index: 1;
-            width: 10px;
-            line-height: 50%;
-            font-size: 0.86rem;
-            color: #428bca;
-            pointer-events: none;
-        }
     }
 
     @at-root #{&}__inclusion-selector {


### PR DESCRIPTION
No longer gating both the assembly/annotation menu _and_ the inclusion checkbox based on the existence of more than one assembly and/or annotation. The inclusion checkbox now always gets displayed. This also involved adding a new CSS style because the inclusion checkbox always expected the assembly/annotation menu to its left.