### PR TITLE
ENCD-3595-missing-derived-from-audit-refactor

### DIFF
--- a/src/encoded/audit/file.py
+++ b/src/encoded/audit/file.py
@@ -36,6 +36,10 @@ def audit_file_processed_derived_from(value, system):
                 and f['output_type'] == 'reads'
                 and f['output_category'] == 'raw data')):
 
+            # Audit shouldn't trigger if status isn't registered in STATUS_LEVEL dict.
+            if f['status'] not in STATUS_LEVEL or value['status'] not in STATUS_LEVEL:
+                return
+
             if STATUS_LEVEL[f['status']] >= STATUS_LEVEL[value['status']]:
                 fastq_bam_counter += 1
 

--- a/src/encoded/audit/file.py
+++ b/src/encoded/audit/file.py
@@ -3,6 +3,8 @@ from snovault import (
     audit_checker,
 )
 
+from .item import STATUS_LEVEL
+
 
 def audit_file_processed_derived_from(value, system):
     if value['output_category'] in ['raw data',
@@ -34,8 +36,7 @@ def audit_file_processed_derived_from(value, system):
                 and f['output_type'] == 'reads'
                 and f['output_category'] == 'raw data')):
 
-            if f['status'] not in ['deleted', 'replaced', 'revoked'] or \
-               f['status'] == value['status']:
+            if STATUS_LEVEL[f['status']] >= STATUS_LEVEL[value['status']]:
                 fastq_bam_counter += 1
 
             if f['dataset'] != value['dataset'].get('@id'):

--- a/src/encoded/audit/file.py
+++ b/src/encoded/audit/file.py
@@ -24,11 +24,11 @@ def audit_file_processed_derived_from(value, system):
 
     fastq_bam_counter = 0
     for f in value.get('derived_from'):
-        if (f['file_format'] == 'bam' or
-                f['file_format'] == 'fastq' or
-                (f['file_format'] == 'fasta' and
-                 f['output_type'] == 'reads' and
-                 f['output_category'] == 'raw data')):
+        if (f['file_format'] == 'bam'
+            or f['file_format'] == 'fastq'
+            or (f['file_format'] in ['fasta', 'csfasta', 'csqual']
+                and f['output_type'] == 'reads'
+                and f['output_category'] == 'raw data')):
 
             if f['status'] not in ['deleted', 'replaced', 'revoked'] or \
                f['status'] == value['status']:
@@ -64,11 +64,11 @@ def audit_file_assembly(value, system):
         if f.get('assembly') and value.get('assembly') and \
            f.get('assembly') != value.get('assembly'):
             detail = 'Processed file {} '.format(value['@id']) + \
-                        'assembly {} '.format(value['assembly']) + \
-                        'does not match assembly {} of the file {} '.format(
-                            f['assembly'],
-                            f['@id']) + \
-                        'it was derived from.'
+                'assembly {} '.format(value['assembly']) + \
+                'does not match assembly {} of the file {} '.format(
+                f['assembly'],
+                f['@id']) + \
+                'it was derived from.'
             yield AuditFailure('inconsistent assembly',
                                detail, level='INTERNAL_ACTION')
             return
@@ -151,7 +151,7 @@ def audit_file_format_specifications(value, system):
             detail = 'File {} has document {} not of type file format specification'.format(
                 value['@id'],
                 doc['@id']
-                )
+            )
             yield AuditFailure('inconsistent document_type', detail, level='ERROR')
             return
 
@@ -249,7 +249,7 @@ def audit_file_controlled_by(value, system):
                     run_type,
                     ff['@id'],
                     control_run
-                    )
+                )
                 yield AuditFailure('inconsistent control run_type',
                                    detail, level='WARNING')
 
@@ -265,7 +265,7 @@ def audit_file_controlled_by(value, system):
                     value['read_length'],
                     ff['@id'],
                     ff['read_length']
-                    )
+                )
                 yield AuditFailure('inconsistent control read length',
                                    detail, level='WARNING')
                 return
@@ -316,7 +316,7 @@ def audit_file(value, system):
 # def audit_file_derived_from_revoked(value, system): removed at release 56
 # http://redmine.encodedcc.org/issues/5018
 
-# def audit_file_biological_replicate_number_match 
+# def audit_file_biological_replicate_number_match
 # https://encodedcc.atlassian.net/browse/ENCD-3493
 
 # def audit_file_platform(value, system): removed from release v56

--- a/src/encoded/audit/file.py
+++ b/src/encoded/audit/file.py
@@ -21,6 +21,10 @@ def audit_file_processed_derived_from(value, system):
 
     if value['file_format'] != 'bam':
         return
+    # Ignore replaced BAMs because missing derived_from logic should be applied to their
+    # replacements instead (ENCD-3595).
+    if value['status'] == 'replaced':
+        return
 
     fastq_bam_counter = 0
     for f in value.get('derived_from'):

--- a/src/encoded/audit/item.py
+++ b/src/encoded/audit/item.py
@@ -78,6 +78,7 @@ STATUS_LEVEL = {
     'content error': 50,
     'pending dcc review': 50,
     'awaiting lab characterization': 50,
+    'in preparation': 50,
 
     # invisible statuses (visible for admins only)
     'deleted': 0,

--- a/src/encoded/audit/item.py
+++ b/src/encoded/audit/item.py
@@ -60,6 +60,7 @@ STATUS_LEVEL = {
     'eligible for new data': 100,
     'not eligible for new data': 100,
     'not pursued': 100,
+    'virtual': 100,
 
     # 'discouraged for use' public statuses
     'archived': 40,

--- a/src/encoded/audit/item.py
+++ b/src/encoded/audit/item.py
@@ -61,6 +61,7 @@ STATUS_LEVEL = {
     'not eligible for new data': 100,
     'not pursued': 100,
     'virtual': 100,
+    'active': 100,
 
     # 'discouraged for use' public statuses
     'archived': 40,

--- a/src/encoded/audit/item.py
+++ b/src/encoded/audit/item.py
@@ -79,6 +79,7 @@ STATUS_LEVEL = {
     'pending dcc review': 50,
     'awaiting lab characterization': 50,
     'in preparation': 50,
+    'preliminary': 50,
 
     # invisible statuses (visible for admins only)
     'deleted': 0,

--- a/src/encoded/audit/item.py
+++ b/src/encoded/audit/item.py
@@ -28,7 +28,8 @@ def audit_item_schema(value, system):
         except RuntimeError:
             raise
         except Exception as e:
-            detail = '%r upgrading from %r to %r' % (e, current_version, target_version)
+            detail = '%r upgrading from %r to %r' % (
+                e, current_version, target_version)
             yield AuditFailure('upgrade failure', detail, level='INTERNAL_ACTION')
             return
 
@@ -41,7 +42,8 @@ def audit_item_schema(value, system):
         path = list(error.path)
         if path:
             category += ': ' + '/'.join(str(elem) for elem in path)
-        detail = 'Object {} has schema error {}'.format(value['@id'], error.message)
+        detail = 'Object {} has schema error {}'.format(
+            value['@id'], error.message)
         yield AuditFailure(category, detail, level='INTERNAL_ACTION')
 
 
@@ -72,6 +74,7 @@ STATUS_LEVEL = {
     'ready for review': 50,
     'uploading': 50,
     'upload failed': 50,
+    'content error': 50,
     'pending dcc review': 50,
     'awaiting lab characterization': 50,
 
@@ -79,7 +82,7 @@ STATUS_LEVEL = {
     'deleted': 0,
     'replaced': 0,
     'disabled': 0
-    }
+}
 
 
 @audit_checker('Item', frame='object')
@@ -107,7 +110,7 @@ def audit_item_relations_status(value, system):
                             value['status'],
                             linked_value['@id'],
                             linked_value['status']
-                            )
+                        )
                     if level == 100 and linked_level in [0, 50, 100]:
                         yield AuditFailure(
                             'mismatched status',
@@ -147,7 +150,7 @@ def audit_item_relations_status(value, system):
                                 message,
                                 linked_value['@id'],
                                 linked_value['status']
-                                )
+                            )
                         yield AuditFailure(
                             'mismatched status',
                             detail,

--- a/src/encoded/schemas/changelogs/publication.md
+++ b/src/encoded/schemas/changelogs/publication.md
@@ -1,5 +1,10 @@
 ## Changelog for publication.json
 
+### Schema version 5
+
+* Remove in press, in revision, planned, replaced from statuses
+
+
 ### Schema version 4
 
 * *aliases* now must be properly namespaced according lab.name:alphanumeric characters with no leading or trailing spaces

--- a/src/encoded/schemas/publication.json
+++ b/src/encoded/schemas/publication.json
@@ -15,7 +15,7 @@
     ],
     "properties": {
         "schema_version": {
-            "default": "4"
+            "default": "5"
         },
         "title": {
             "title": "Title",
@@ -72,11 +72,7 @@
             "enum" : [
                 "deleted",
                 "in preparation",
-                "in press",
-                "in revision",
-                "planned",
                 "published",
-                "replaced",
                 "submitted"
             ]
         },

--- a/src/encoded/tests/test_audit_file.py
+++ b/src/encoded/tests/test_audit_file.py
@@ -476,6 +476,22 @@ def test_audit_file_bam_derived_from_csqual(testapp, file4, file6):
                for error in errors_list)
 
 
+def test_audit_file_released_bam_derived_from_revoked_fastq(testapp, file4, file6):
+    testapp.patch_json(file6['@id'], {'derived_from': [file4['@id']],
+                                      'status': 'released',
+                                      'file_format': 'bam',
+                                      'assembly': 'hg19'})
+
+    testapp.patch_json(file4['@id'], {'status': 'revoked'})
+    res = testapp.get(file6['@id'] + '@@index-data')
+    errors = res.json['audit']
+    errors_list = []
+    for error_type in errors:
+        errors_list.extend(errors[error_type])
+    assert any(error['category'] == 'missing derived_from'
+               for error in errors_list)
+
+
 def test_audit_file_missing_derived_from_ignores_replaced_bams(testapp, file4, file6):
     testapp.patch_json(file6['@id'], {'derived_from': [file4['@id']],
                                       'status': 'replaced',

--- a/src/encoded/tests/test_audit_file.py
+++ b/src/encoded/tests/test_audit_file.py
@@ -694,24 +694,6 @@ def test_audit_experiment_insufficient_control_read_depth_chip_seq_paired_end(
                'control extremely low read depth' for error in errors_list)
 
 
-def test_audit_file_status_level_dict_contains_file_status_enum():
-    # Missing derived_from audit relies on STATUS_LEVEL dict from audit/item.py.
-    # This dict should not get out of sync with allowable statuses in file schema.
-    from snovault.schema_utils import load_schema
-    from ..audit.item import STATUS_LEVEL
-    status_level_keys = STATUS_LEVEL.keys()
-    file_status_enum = load_schema('encoded:schemas/file.json').get('properties',
-                                                                    {}).get('status',
-                                                                            {}).get('enum')
-    # If this assertion fails update schema path to statuses above.
-    assert file_status_enum is not None, 'File status enum not found.'
-    # Statuses that are in schema but not in STATUS_LEVEL.
-    schema_dict_diff = set(file_status_enum) - set(status_level_keys)
-    # If this assertion fails update STATUS_LEVEL dict with new statuses in file schema.
-    assert not schema_dict_diff, '{} in file schema but not in STATUS_LEVEL dict.'.format(
-        schema_dict_diff)
-
-
 def test_audit_file_missing_derived_from_audit_with_made_up_status(testapp, file4, file6):
     # This tests that a status that's not in STATUS_LEVEL dict won't break missing derived_from
     # audit.

--- a/src/encoded/tests/test_audit_file.py
+++ b/src/encoded/tests/test_audit_file.py
@@ -561,8 +561,7 @@ def test_audit_file_missing_derived_from_ignores_replaced_bams(testapp, file4, f
                                       'status': 'replaced',
                                       'file_format': 'bam',
                                       'assembly': 'hg19'})
-    testapp.patch_json(file4['@id'], {'file_format': 'fastq',
-                                      'status': 'deleted'})
+    testapp.patch_json(file4['@id'], {'status': 'deleted'})
     res = testapp.get('/{}/@@index-data'.format(file6['uuid']))
     errors = res.json['audit']
     errors_list = []

--- a/src/encoded/tests/test_audit_file.py
+++ b/src/encoded/tests/test_audit_file.py
@@ -704,7 +704,7 @@ def test_audit_file_status_level_dict_contains_file_status_enum():
                                                                     {}).get('status',
                                                                             {}).get('enum')
     # If this assertion fails update schema path to statuses above.
-    assert (file_status_enum is not None), 'File status enum not found.'
+    assert file_status_enum is not None, 'File status enum not found.'
     # Statuses that are in schema but not in STATUS_LEVEL.
     schema_dict_diff = set(file_status_enum) - set(status_level_keys)
     # If this assertion fails update STATUS_LEVEL dict with new statuses in file schema.
@@ -727,5 +727,5 @@ def test_audit_file_missing_derived_from_audit_with_made_up_status(testapp, file
     errors_list = []
     for error_type in errors:
         errors_list.extend(errors[error_type])
-    assert any(error['category'] == 'missing derived_from'
+    assert all(error['category'] != 'missing derived_from'
                for error in errors_list)

--- a/src/encoded/tests/test_audit_file.py
+++ b/src/encoded/tests/test_audit_file.py
@@ -692,3 +692,21 @@ def test_audit_experiment_insufficient_control_read_depth_chip_seq_paired_end(
         #    print (e)
     assert any(error['category'] ==
                'control extremely low read depth' for error in errors_list)
+
+
+def test_audit_file_status_level_dict_contains_file_status_enum():
+    # Missing derived_from audit relies on STATUS_LEVEL dict from audit/item.py.
+    # This dict should not get out of sync with allowable statuses in file schema.
+    from snovault.schema_utils import load_schema
+    from ..audit.item import STATUS_LEVEL
+    status_level_keys = STATUS_LEVEL.keys()
+    file_status_enum = load_schema('encoded:schemas/file.json').get('properties',
+                                                                    {}).get('status',
+                                                                            {}).get('enum')
+    # If this assertion fails update schema path to statuses above.
+    assert (file_status_enum is not None), 'File status enum not found.'
+    # Statuses that are in schema but not in STATUS_LEVEL.
+    schema_dict_diff = set(file_status_enum) - set(status_level_keys)
+    # If this assertion fails update STATUS_LEVEL dict with new statuses in file schema.
+    assert not schema_dict_diff, '{} in file schema but not in STATUS_LEVEL dict.'.format(
+        schema_dict_diff)

--- a/src/encoded/tests/test_audit_file.py
+++ b/src/encoded/tests/test_audit_file.py
@@ -14,7 +14,7 @@ def file_exp(lab, award, testapp, experiment):
         'possible_controls': [experiment['uuid']],
         'status': 'released',
         'date_released': '2016-01-01'
-        }
+    }
     return testapp.post_json('/experiment', item, status=201).json['@graph'][0]
 
 
@@ -24,7 +24,7 @@ def file_rep(replicate, file_exp, testapp):
         'experiment': file_exp['uuid'],
         'biological_replicate_number': 1,
         'technical_replicate_number': 1
-        }
+    }
     return testapp.post_json('/replicate', item, status=201).json['@graph'][0]
 
 
@@ -39,7 +39,7 @@ def file_exp2(lab, award, testapp):
         'biosample_term_name': 'Some other body part',
         'status': 'released',
         'date_released': '2016-01-01'
-        }
+    }
     return testapp.post_json('/experiment', item, status=201).json['@graph'][0]
 
 
@@ -49,7 +49,7 @@ def file_rep2(replicate, file_exp2, testapp):
         'experiment': file_exp2['uuid'],
         'biological_replicate_number': 1,
         'technical_replicate_number': 1
-        }
+    }
     return testapp.post_json('/replicate', item, status=201).json['@graph'][0]
 
 
@@ -59,7 +59,7 @@ def file_rep1_2(replicate, file_exp, testapp):
         'experiment': file_exp['uuid'],
         'biological_replicate_number': 2,
         'technical_replicate_number': 1
-        }
+    }
     return testapp.post_json('/replicate', item, status=201).json['@graph'][0]
 
 
@@ -241,13 +241,15 @@ def pipeline_short_rna(testapp, lab, award, analysis_step_bam):
 
 
 def test_audit_file_mismatched_paired_with(testapp, file1, file4):
-    testapp.patch_json(file1['@id'], {'run_type': 'paired-ended', 'paired_end': '2', 'paired_with': file4['uuid']})
+    testapp.patch_json(file1['@id'], {
+                       'run_type': 'paired-ended', 'paired_end': '2', 'paired_with': file4['uuid']})
     res = testapp.get(file1['@id'] + '@@index-data')
     errors = res.json['audit']
     errors_list = []
     for error_type in errors:
         errors_list.extend(errors[error_type])
-    assert any(error['category'] == 'inconsistent paired_with' for error in errors_list)
+    assert any(error['category'] ==
+               'inconsistent paired_with' for error in errors_list)
 
 
 def test_audit_file_missing_controlled_by(testapp, file3):
@@ -256,7 +258,8 @@ def test_audit_file_missing_controlled_by(testapp, file3):
     errors_list = []
     for error_type in errors:
         errors_list.extend(errors[error_type])
-    assert any(error['category'] == 'missing controlled_by' for error in errors_list)
+    assert any(error['category'] ==
+               'missing controlled_by' for error in errors_list)
 
 
 def test_audit_file_mismatched_controlled_by(testapp, file1):
@@ -265,7 +268,8 @@ def test_audit_file_mismatched_controlled_by(testapp, file1):
     errors_list = []
     for error_type in errors:
         errors_list.extend(errors[error_type])
-    assert any(error['category'] == 'inconsistent control' for error in errors_list)
+    assert any(error['category'] ==
+               'inconsistent control' for error in errors_list)
 
 
 def test_audit_file_read_length_controlled_by(testapp, file1_2,
@@ -276,7 +280,8 @@ def test_audit_file_read_length_controlled_by(testapp, file1_2,
     testapp.patch_json(file2['@id'], {'read_length': 150,
                                       'run_type': 'single-ended'})
     testapp.patch_json(file1_2['@id'], {'controlled_by': [file2['@id']]})
-    testapp.patch_json(file_exp['@id'], {'possible_controls': [file_exp2['@id']]})
+    testapp.patch_json(file_exp['@id'], {
+                       'possible_controls': [file_exp2['@id']]})
     testapp.patch_json(file_exp2['@id'], {'assay_term_name': 'RAMPAGE',
                                           'biosample_term_id': 'NTR:000012',
                                           'biosample_term_name': 'Some body part'})
@@ -285,7 +290,8 @@ def test_audit_file_read_length_controlled_by(testapp, file1_2,
     errors_list = []
     for error_type in errors:
         errors_list.extend(errors[error_type])
-    assert any(error['category'] == 'inconsistent control read length' for error in errors_list)
+    assert any(error['category'] ==
+               'inconsistent control read length' for error in errors_list)
 
 
 def test_audit_file_read_length_controlled_by_exclusion(testapp, file1_2,
@@ -296,7 +302,8 @@ def test_audit_file_read_length_controlled_by_exclusion(testapp, file1_2,
     testapp.patch_json(file2['@id'], {'read_length': 52,
                                       'run_type': 'single-ended'})
     testapp.patch_json(file1_2['@id'], {'controlled_by': [file2['@id']]})
-    testapp.patch_json(file_exp['@id'], {'possible_controls': [file_exp2['@id']]})
+    testapp.patch_json(file_exp['@id'], {
+                       'possible_controls': [file_exp2['@id']]})
     testapp.patch_json(file_exp2['@id'], {'assay_term_name': 'RAMPAGE',
                                           'biosample_term_id': 'NTR:000012',
                                           'biosample_term_name': 'Some body part'})
@@ -305,7 +312,8 @@ def test_audit_file_read_length_controlled_by_exclusion(testapp, file1_2,
     errors_list = []
     for error_type in errors:
         errors_list.extend(errors[error_type])
-    assert any(error['category'] != 'inconsistent control read length' for error in errors_list)
+    assert any(error['category'] !=
+               'inconsistent control read length' for error in errors_list)
 
 
 def test_audit_file_replicate_match_inconsistent(testapp, file1, file_rep2):
@@ -315,7 +323,9 @@ def test_audit_file_replicate_match_inconsistent(testapp, file1, file_rep2):
     errors_list = []
     for error_type in errors:
         errors_list.extend(errors[error_type])
-    assert any(error['category'] == 'inconsistent replicate' for error in errors_list)
+    assert any(error['category'] ==
+               'inconsistent replicate' for error in errors_list)
+
 
 def test_audit_file_replicate_match_consistent(testapp, file1, file_rep2):
     #testapp.patch_json(file1['@id'], {'replicate': file_rep2['uuid']})
@@ -324,7 +334,9 @@ def test_audit_file_replicate_match_consistent(testapp, file1, file_rep2):
     errors_list = []
     for error_type in errors:
         errors_list.extend(errors[error_type])
-    assert all(error['category'] != 'inconsistent replicate' for error in errors_list)
+    assert all(error['category'] !=
+               'inconsistent replicate' for error in errors_list)
+
 
 '''
 def test_audit_modERN_missing_step_run(testapp, file_exp, file3, award):
@@ -380,6 +392,7 @@ def test_audit_modERN_unexpected_step_run(testapp, file_exp, file2, award, analy
     assert any(error['category'] == 'unexpected step_run' for error in errors_list)
 '''
 
+
 def test_audit_file_assembly(testapp, file6, file7):
     testapp.patch_json(file6['@id'], {'assembly': 'GRCh38'})
     testapp.patch_json(file7['@id'], {'derived_from': [file6['@id']],
@@ -408,7 +421,8 @@ def test_audit_file_bam_derived_from_no_fastq(testapp, file7, file6):
                                       'status': 'released',
                                       'file_format': 'bam',
                                       'assembly': 'hg19'})
-    testapp.patch_json(file7['@id'], {'file_format': 'tsv', 'assembly': 'hg19'})
+    testapp.patch_json(
+        file7['@id'], {'file_format': 'tsv', 'assembly': 'hg19'})
     res = testapp.get(file6['@id'] + '@@index-data')
     errors = res.json['audit']
     errors_list = []
@@ -418,12 +432,57 @@ def test_audit_file_bam_derived_from_no_fastq(testapp, file7, file6):
                for error in errors_list)
 
 
+def test_audit_file_bam_derived_from_fastq(testapp, file4, file6):
+    testapp.patch_json(file6['@id'], {'derived_from': [file4['@id']],
+                                      'status': 'released',
+                                      'file_format': 'bam',
+                                      'assembly': 'hg19'})
+    res = testapp.get(file6['@id'] + '@@index-data')
+    errors = res.json['audit']
+    errors_list = []
+    for error_type in errors:
+        errors_list.extend(errors[error_type])
+    assert all(error['category'] != 'missing derived_from'
+               for error in errors_list)
+
+
+def test_audit_file_bam_derived_from_csfasta(testapp, file4, file6):
+    testapp.patch_json(file6['@id'], {'derived_from': [file4['@id']],
+                                      'status': 'released',
+                                      'file_format': 'bam',
+                                      'assembly': 'hg19'})
+    testapp.patch_json(file4['@id'], {'file_format': 'csfasta'})
+    res = testapp.get(file6['@id'] + '@@index-data')
+    errors = res.json['audit']
+    errors_list = []
+    for error_type in errors:
+        errors_list.extend(errors[error_type])
+    assert all(error['category'] != 'missing derived_from'
+               for error in errors_list)
+
+
+def test_audit_file_bam_derived_from_csqual(testapp, file4, file6):
+    testapp.patch_json(file6['@id'], {'derived_from': [file4['@id']],
+                                      'status': 'released',
+                                      'file_format': 'bam',
+                                      'assembly': 'hg19'})
+    testapp.patch_json(file4['@id'], {'file_format': 'csqual'})
+    res = testapp.get(file6['@id'] + '@@index-data')
+    errors = res.json['audit']
+    errors_list = []
+    for error_type in errors:
+        errors_list.extend(errors[error_type])
+    assert all(error['category'] != 'missing derived_from'
+               for error in errors_list)
+
+
 def test_audit_file_bam_derived_from_bam_no_fastq(testapp, file7, file6):
     testapp.patch_json(file6['@id'], {'derived_from': [file7['@id']],
                                       'status': 'released',
                                       'file_format': 'bam',
                                       'assembly': 'hg19'})
-    testapp.patch_json(file7['@id'], {'file_format': 'bam', 'assembly': 'hg19'})
+    testapp.patch_json(
+        file7['@id'], {'file_format': 'bam', 'assembly': 'hg19'})
     res = testapp.get(file6['@id'] + '@@index-data')
     errors = res.json['audit']
     errors_list = []
@@ -480,6 +539,7 @@ def test_audit_file_bam_derived_from_different_experiment(testapp, file6, file4,
     assert any(error['category'] == 'inconsistent derived_from'
                for error in errors_list)
 
+
 '''
 def test_audit_file_md5sum(testapp, file1):
     testapp.patch_json(file1['@id'], {'md5sum': 'some_random_text'})
@@ -491,6 +551,7 @@ def test_audit_file_md5sum(testapp, file1):
     assert any(error['category'] == 'inconsistent md5sum'
                for error in errors_list)
 '''
+
 
 def test_audit_experiment_insufficient_control_read_depth_chip_seq_paired_end(
         testapp, file_exp,
@@ -532,6 +593,7 @@ def test_audit_experiment_insufficient_control_read_depth_chip_seq_paired_end(
     for error_type in errors:
         errors_list.extend(errors[error_type])
         #print (error_type)
-        #for e in errors[error_type]:
+        # for e in errors[error_type]:
         #    print (e)
-    assert any(error['category'] == 'control extremely low read depth' for error in errors_list)
+    assert any(error['category'] ==
+               'control extremely low read depth' for error in errors_list)

--- a/src/encoded/tests/test_audit_file.py
+++ b/src/encoded/tests/test_audit_file.py
@@ -476,6 +476,22 @@ def test_audit_file_bam_derived_from_csqual(testapp, file4, file6):
                for error in errors_list)
 
 
+def test_audit_file_missing_derived_from_ignores_replaced_bams(testapp, file4, file6):
+    testapp.patch_json(file6['@id'], {'derived_from': [file4['@id']],
+                                      'status': 'replaced',
+                                      'file_format': 'bam',
+                                      'assembly': 'hg19'})
+    testapp.patch_json(file4['@id'], {'file_format': 'fastq',
+                                      'status': 'deleted'})
+    res = testapp.get('/{}/@@index-data'.format(file6['uuid']))
+    errors = res.json['audit']
+    errors_list = []
+    for error_type in errors:
+        errors_list.extend(errors[error_type])
+    assert all(error['category'] != 'missing derived_from'
+               for error in errors_list)
+
+
 def test_audit_file_bam_derived_from_bam_no_fastq(testapp, file7, file6):
     testapp.patch_json(file6['@id'], {'derived_from': [file7['@id']],
                                       'status': 'released',

--- a/src/encoded/tests/test_audit_file.py
+++ b/src/encoded/tests/test_audit_file.py
@@ -492,6 +492,70 @@ def test_audit_file_released_bam_derived_from_revoked_fastq(testapp, file4, file
                for error in errors_list)
 
 
+def test_audit_file_deleted_bam_derived_from_revoked_fastq(testapp, file4, file6):
+    testapp.patch_json(file6['@id'], {'derived_from': [file4['@id']],
+                                      'status': 'deleted',
+                                      'file_format': 'bam',
+                                      'assembly': 'hg19'})
+
+    testapp.patch_json(file4['@id'], {'status': 'revoked'})
+    res = testapp.get(file6['@id'] + '@@index-data')
+    errors = res.json['audit']
+    errors_list = []
+    for error_type in errors:
+        errors_list.extend(errors[error_type])
+    assert all(error['category'] != 'missing derived_from'
+               for error in errors_list)
+
+
+def test_audit_file_released_bam_derived_from_deleted_fastq(testapp, file4, file6):
+    testapp.patch_json(file6['@id'], {'derived_from': [file4['@id']],
+                                      'status': 'released',
+                                      'file_format': 'bam',
+                                      'assembly': 'hg19'})
+
+    testapp.patch_json(file4['@id'], {'status': 'deleted'})
+    res = testapp.get(file6['@id'] + '@@index-data')
+    errors = res.json['audit']
+    errors_list = []
+    for error_type in errors:
+        errors_list.extend(errors[error_type])
+    assert any(error['category'] == 'missing derived_from'
+               for error in errors_list)
+
+
+def test_audit_file_deleted_bam_derived_from_deleted_fastq(testapp, file4, file6):
+    testapp.patch_json(file6['@id'], {'derived_from': [file4['@id']],
+                                      'status': 'deleted',
+                                      'file_format': 'bam',
+                                      'assembly': 'hg19'})
+
+    testapp.patch_json(file4['@id'], {'status': 'deleted'})
+    res = testapp.get(file6['@id'] + '@@index-data')
+    errors = res.json['audit']
+    errors_list = []
+    for error_type in errors:
+        errors_list.extend(errors[error_type])
+    assert all(error['category'] != 'missing derived_from'
+               for error in errors_list)
+
+
+def test_audit_file_deleted_bam_derived_from_released_fastq(testapp, file4, file6):
+    testapp.patch_json(file6['@id'], {'derived_from': [file4['@id']],
+                                      'status': 'deleted',
+                                      'file_format': 'bam',
+                                      'assembly': 'hg19'})
+
+    testapp.patch_json(file4['@id'], {'status': 'released'})
+    res = testapp.get(file6['@id'] + '@@index-data')
+    errors = res.json['audit']
+    errors_list = []
+    for error_type in errors:
+        errors_list.extend(errors[error_type])
+    assert all(error['category'] != 'missing derived_from'
+               for error in errors_list)
+
+
 def test_audit_file_missing_derived_from_ignores_replaced_bams(testapp, file4, file6):
     testapp.patch_json(file6['@id'], {'derived_from': [file4['@id']],
                                       'status': 'replaced',

--- a/src/encoded/tests/test_audit_item.py
+++ b/src/encoded/tests/test_audit_item.py
@@ -1,5 +1,6 @@
 def test_audit_item_schema_validation(testapp, organism):
-    testapp.patch_json(organism['@id'] + '?validate=false', {'disallowed': 'errs'})
+    testapp.patch_json(organism['@id'] +
+                       '?validate=false', {'disallowed': 'errs'})
     res = testapp.get(organism['@id'] + '@@index-data')
     errors = res.json['audit']
     errors_list = []
@@ -11,7 +12,8 @@ def test_audit_item_schema_validation(testapp, organism):
 
 
 def test_audit_item_schema_upgrade_failure(testapp, organism):
-    testapp.patch_json(organism['@id'] + '?validate=false', {'schema_version': '999'})
+    testapp.patch_json(organism['@id'] +
+                       '?validate=false', {'schema_version': '999'})
     res = testapp.get(organism['@id'] + '@@index-data')
     errors = res.json['audit']
     errors_list = []
@@ -35,7 +37,8 @@ def test_audit_item_schema_upgrade_ok(testapp, organism):
     errors_list = []
     for error_type in errors:
         errors_list.extend(errors[error_type])
-    assert not any(error['name'] == 'audit_item_schema' for error in errors_list)
+    assert not any(error['name'] ==
+                   'audit_item_schema' for error in errors_list)
 
 
 def test_audit_item_schema_upgrade_validation_failure(testapp, organism):
@@ -63,4 +66,29 @@ def test_audit_item_schema_permission(testapp, file, embed_testapp):
     testapp.patch_json(file['@id'], patch)
     res = embed_testapp.get(file['@id'] + '/@@audit-self')
     errors_list = res.json['audit']
-    assert not any(error['name'] == 'audit_item_schema' for error in errors_list)
+    assert not any(error['name'] ==
+                   'audit_item_schema' for error in errors_list)
+
+
+def test_audit_item_status_level_dict_contains_all_statuses_in_schema(testapp):
+    # This checks that STATUS_LEVEL dict contains all statuses enumerated in schema.
+    from ..audit.item import STATUS_LEVEL
+    status_level_keys = STATUS_LEVEL.keys()
+    schemas = testapp.get('/profiles/').json
+    for title, schema in schemas.items():
+        # Assumes all statuses are in properties.status.enum.
+        schema_statuses = schema.get(
+            'properties', {}).get('status', {}).get('enum')
+        # Missing derived_from file audit relies on STATUS_LEVEL dict from audit/item.py.
+        # This dict should not get out of sync with allowable statuses in file schema.
+        # Explicit check that file statuses found:
+        if title == 'File':
+            # If this assertion fails update file schema path to statuses above.
+            assert schema_statuses is not None, 'File status enum not found.'
+        if schema_statuses is not None:
+            print(title)
+            # Statuses that are in schema but not in STATUS_LEVEL.
+            schema_dict_diff = set(schema_statuses) - set(status_level_keys)
+            # If this assertion fails update STATUS_LEVEL dict with new statuses in schema.
+            assert not schema_dict_diff, '{} in {} schema but not in STATUS_LEVEL dict.'.format(
+                schema_dict_diff, title)

--- a/src/encoded/tests/test_audit_item.py
+++ b/src/encoded/tests/test_audit_item.py
@@ -86,7 +86,6 @@ def test_audit_item_status_level_dict_contains_all_statuses_in_schema(testapp):
             # If this assertion fails update file schema path to statuses above.
             assert schema_statuses is not None, 'File status enum not found.'
         if schema_statuses is not None:
-            print(title)
             # Statuses that are in schema but not in STATUS_LEVEL.
             schema_dict_diff = set(schema_statuses) - set(status_level_keys)
             # If this assertion fails update STATUS_LEVEL dict with new statuses in schema.


### PR DESCRIPTION
This changes the logic for the missing derived_from audit. Before the raw files in the derived_from field of BAMs were only counted if they were FASTQs with the same status as the BAM _or_ if they were not deleted, replaced, revoked. This led to undesirable triggering of audit in some cases. For example:

- BAMs that came from CSFASTA/CSQUAL/FASTA instead of FASTQ.
- Deleted BAMs that came from revoked FASTQs.

Now raw files (still excluding tars) are counted if they have a higher or equal status-level value compared to BAM, based on STATUS_LEVEL dict in audit/items.py:
<img width="430" alt="screen shot 2017-10-03 at 7 07 29 pm" src="https://user-images.githubusercontent.com/16053922/31511002-321f3f96-af3b-11e7-83a1-3ff423af1ff1.png">

Have also added tests of the audit to tests/test_audit_file.py.
