### PR TITLE
ENCD-3489 Restore RefSeq dbxref

### DIFF
--- a/src/encoded/static/components/dbxref.js
+++ b/src/encoded/static/components/dbxref.js
@@ -136,6 +136,9 @@ export const dbxrefPrefixMap = {
             (context['@type'][0] === 'Experiment' ? urlPattern.replace(/\{1\}/g, context.biosample_term_name) : urlPattern)
         ),
     },
+    RefSeq: {
+        pattern: 'https://www.ncbi.nlm.nih.gov/gene/?term={0}',
+    },
     JAX: {
         pattern: 'https://www.jax.org/strain/{0}',
     },


### PR DESCRIPTION
Accidentally removed this dbxref prefix for v62rc3. Maybe a good way to demonstrate that new dbxrefs in this new system are very easy to add, as long as they’re easy URLs at least.