### PR TITLE
ENCD-3578-content-eror-audit

### DIFF
--- a/src/encoded/audit/experiment.py
+++ b/src/encoded/audit/experiment.py
@@ -267,10 +267,10 @@ def audit_experiment_with_uploading_files(value, system, files_structure):
                     'contains a file {} '.format(file_object['@id']) + \
                     'with the status {}.'.format(file_object['status'])
                 yield AuditFailure('file validation error', detail, level='INTERNAL_ACTION')
-            if file_object['status'] in ['uploading']:
+            elif file_object['status'] == 'uploading':
                 detail = 'Experiment {} '.format(value['@id']) + \
-                        'contains a file {} '.format(file_object['@id']) + \
-                        'with the status {}.'.format(file_object['status'])
+                    'contains a file {} '.format(file_object['@id']) + \
+                    'with the status {}.'.format(file_object['status'])
                 yield AuditFailure('file in uploading state', detail, level='INTERNAL_ACTION')
     return
 
@@ -2268,7 +2268,7 @@ def audit_experiment_control(value, system, excluded_types):
 
     # single cell RNA-seq in E4 do not require controls (ticket WOLD-6)
     if value.get('assay_term_name') == 'single cell isolation followed by RNA-seq' and \
-        check_award_condition(value, ["ENCODE4"]):
+            check_award_condition(value, ["ENCODE4"]):
         return
 
     # We do not want controls

--- a/src/encoded/audit/experiment.py
+++ b/src/encoded/audit/experiment.py
@@ -262,11 +262,16 @@ def audit_experiment_missing_unfiltered_bams(value, system, files_structure):
 def audit_experiment_with_uploading_files(value, system, files_structure):
     if files_structure.get('original_files'):
         for file_object in files_structure.get('original_files').values():
-            if file_object['status'] in ['uploading', 'upload failed', 'content error']:
+            if file_object['status'] in ['upload failed', 'content error']:
                 detail = 'Experiment {} '.format(value['@id']) + \
                     'contains a file {} '.format(file_object['@id']) + \
                     'with the status {}.'.format(file_object['status'])
                 yield AuditFailure('file validation error', detail, level='INTERNAL_ACTION')
+            if file_object['status'] in ['uploading']:
+                detail = 'Experiment {} '.format(value['@id']) + \
+                        'contains a file {} '.format(file_object['@id']) + \
+                        'with the status {}.'.format(file_object['status'])
+                yield AuditFailure('file in uploading state', detail, level='INTERNAL_ACTION')
     return
 
 

--- a/src/encoded/audit/experiment.py
+++ b/src/encoded/audit/experiment.py
@@ -262,15 +262,13 @@ def audit_experiment_missing_unfiltered_bams(value, system, files_structure):
 def audit_experiment_with_uploading_files(value, system, files_structure):
     if files_structure.get('original_files'):
         for file_object in files_structure.get('original_files').values():
+            detail = ('Experiment {} contains a file {} '
+                      'with the status {}.'.format(value['@id'],
+                                                   file_object['@id'],
+                                                   file_object['status']))
             if file_object['status'] in ['upload failed', 'content error']:
-                detail = 'Experiment {} '.format(value['@id']) + \
-                    'contains a file {} '.format(file_object['@id']) + \
-                    'with the status {}.'.format(file_object['status'])
                 yield AuditFailure('file validation error', detail, level='INTERNAL_ACTION')
             elif file_object['status'] == 'uploading':
-                detail = 'Experiment {} '.format(value['@id']) + \
-                    'contains a file {} '.format(file_object['@id']) + \
-                    'with the status {}.'.format(file_object['status'])
                 yield AuditFailure('file in uploading state', detail, level='INTERNAL_ACTION')
     return
 

--- a/src/encoded/audit/experiment.py
+++ b/src/encoded/audit/experiment.py
@@ -262,14 +262,18 @@ def audit_experiment_missing_unfiltered_bams(value, system, files_structure):
 def audit_experiment_with_uploading_files(value, system, files_structure):
     if files_structure.get('original_files'):
         for file_object in files_structure.get('original_files').values():
-            detail = ('Experiment {} contains a file {} '
-                      'with the status {}.'.format(value['@id'],
-                                                   file_object['@id'],
-                                                   file_object['status']))
+            category = None
             if file_object['status'] in ['upload failed', 'content error']:
-                yield AuditFailure('file validation error', detail, level='INTERNAL_ACTION')
+                category = 'file validation error'
             elif file_object['status'] == 'uploading':
-                yield AuditFailure('file in uploading state', detail, level='INTERNAL_ACTION')
+                category = 'file in uploading state'
+            if category:
+                detail = ('Experiment {} contains a file {} '
+                          'with the status {}.'.format(value['@id'],
+                                                       file_object['@id'],
+                                                       file_object['status']))
+                yield AuditFailure(category, detail, level='INTERNAL_ACTION')
+
     return
 
 

--- a/src/encoded/tests/test_audit_experiment.py
+++ b/src/encoded/tests/test_audit_experiment.py
@@ -1195,6 +1195,18 @@ def test_audit_experiment_not_uploaded_files(testapp, file_bam,
                for error in collect_audit_errors(res))
 
 
+def test_audit_experiment_uploading_files(testapp, file_bam,
+                                          base_experiment,
+                                          base_replicate,
+                                          base_library):
+    testapp.patch_json(file_bam['@id'], {'status': 'uploading'})
+    res = testapp.get(base_experiment['@id'] + '@@index-data')
+    assert all(error['category'] != 'file validation error'
+               for error in collect_audit_errors(res))
+    assert any(error['category'] == 'file in uploading state'
+               for error in collect_audit_errors(res))
+
+
 def test_audit_experiment_replicate_with_no_fastq_files(testapp, file_bam,
                                                         base_experiment,
                                                         base_replicate,


### PR DESCRIPTION
Submitting for Idan. Uploading files return _file in uploading state_ audit instead of _file validation error_ audit. 