### PR TITLE
Encd 3648 fix buildout setuptool versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ before_install:
   - node --version
   - npm config set python /usr/bin/python2.7
 install:
-  - python bootstrap.py --buildout-version 2.4.1 --setuptools-version 18.5
+  - python bootstrap.py --buildout-version 2.9.5 --setuptools-version 18.5
   - bin/buildout -c buildout-travis.cfg || (echo "Retrying buildout" && bin/buildout -c buildout-travis.cfg)
 before_script:
   - >

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ brew install elasticsearch@1.7
 
 ### **4. Run buildout:**
 
-- `python3 bootstrap.py --buildout-version 2.4.1 --setuptools-version 18.5`
+- `python3 bootstrap.py --buildout-version 2.9.5 --setuptools-version 18.5`
 - `bin/buildout`
 
 > :star: _Note_: If you have issues with postgres or the python interface to it (psycogpg2) you probably need to install postgresql via homebrew (as above)  

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -53,7 +53,7 @@ snovault = git https://github.com/ENCODE-DCC/snovault.git rev=0.30
 # Hand set versions
 pyramid = 1.6a2
 # Update .travis.yml and cloud-config.yml when updating buildout
-zc.buildout = 2.4.1
+zc.buildout = 2.9.5
 setuptools = 18.5
 # https://github.com/Pylons/venusuian/issues/40
 venusian = 1.0.1.dev40

--- a/cloud-config-cluster.yml
+++ b/cloud-config-cluster.yml
@@ -191,7 +191,7 @@ runcmd:
 - sudo -u postgres /opt/wal-e/bin/wal-e --aws-instance-profile --s3-prefix="$(cat /etc/postgresql/9.3/main/wale_s3_prefix)" backup-fetch /var/lib/postgresql/9.3/main LATEST
 - sudo -u postgres ln -s /etc/postgresql/9.3/main/recovery.conf /var/lib/postgresql/9.3/main/
 - /etc/init.d/postgresql start
-- sudo -u encoded python3.4 bootstrap.py --buildout-version 2.4.1 --setuptools-version 18.1
+- sudo -u encoded python3.4 bootstrap.py --buildout-version 2.9.5 --setuptools-version 18.5
 - sudo -u encoded LANG=en_US.UTF-8 bin/buildout -c %(ROLE)s.cfg production-ini:region_search_instance=localhost:9200
 - sudo -u encoded bin/aws s3 cp --recursive s3://encoded-conf-prod/.aws .aws
 - until sudo -u postgres psql postgres -c ""; do sleep 10; done

--- a/cloud-config.yml
+++ b/cloud-config.yml
@@ -189,7 +189,7 @@ runcmd:
 - sudo -u postgres /opt/wal-e/bin/wal-e --aws-instance-profile --s3-prefix="$(cat /etc/postgresql/9.3/main/wale_s3_prefix)" backup-fetch /var/lib/postgresql/9.3/main LATEST
 - sudo -u postgres ln -s /etc/postgresql/9.3/main/recovery.conf /var/lib/postgresql/9.3/main/
 - /etc/init.d/postgresql start
-- sudo -u encoded python3.4 bootstrap.py --buildout-version 2.4.1 --setuptools-version 18.1
+- sudo -u encoded python3.4 bootstrap.py --buildout-version 2.9.5 --setuptools-version 18.5
 - sudo -u encoded LANG=en_US.UTF-8 bin/buildout -c %(ROLE)s.cfg
 - sudo -u encoded bin/aws s3 cp --recursive s3://encoded-conf-prod/.aws .aws
 - until sudo -u postgres psql postgres -c ""; do sleep 10; done


### PR DESCRIPTION
PR for fixing the inconsistent buildout and setup tools version.  

The updated version
zc.buildout==2.9.5
setuptools==18.5