### PR TITLE
ENCD-3646-fix-publication-upgrade

### DIFF
--- a/src/encoded/tests/test_upgrade_publication.py
+++ b/src/encoded/tests/test_upgrade_publication.py
@@ -18,6 +18,14 @@ def publication_1(publication):
     return item
 
 
+@pytest.fixture
+def publication_4():
+    return {
+        'title': 'Fake paper',
+        'schema_version': '4'
+    }
+
+
 def test_publication_upgrade(upgrader, publication_1):
     value = upgrader.upgrade('publication', publication_1, target_version='2')
     assert value['schema_version'] == '2'
@@ -25,3 +33,25 @@ def test_publication_upgrade(upgrader, publication_1):
     assert value['identifiers'] == ['PMID:25409824']
     assert value['lab'] == "cb0ef1f6-3bd3-4000-8636-1c5b9f7000dc"
     assert value['award'] == "b5736134-3326-448b-a91a-894aafb77876"
+
+
+def test_publication_upgrade_4_5(upgrader, publication_4):
+    publication_4['status'] = 'planned'
+    value = upgrader.upgrade('publication', publication_4,
+                             current_version='4', target_version='5')
+    assert value['status'] == 'in preparation'
+
+    publication_4['status'] = 'replaced'
+    value = upgrader.upgrade('publication', publication_4,
+                             current_version='4', target_version='5')
+    assert value['status'] == 'deleted'
+
+    publication_4['status'] = 'in press'
+    value = upgrader.upgrade('publication', publication_4,
+                             current_version='4', target_version='5')
+    assert value['status'] == 'submitted'
+
+    publication_4['status'] = 'in revision'
+    value = upgrader.upgrade('publication', publication_4,
+                             current_version='4', target_version='5')
+    assert value['status'] == 'submitted'

--- a/src/encoded/upgrade/publication.py
+++ b/src/encoded/upgrade/publication.py
@@ -36,3 +36,17 @@ def publication_2_3(value, system):
 
     if 'published_by' in value:
         value['published_by'] = list(set(value['published_by']))
+
+
+# Upgrade 3 to 4 in item.py.
+
+
+@upgrade_step('publication', '4', '5')
+def publication_4_5(value, system):
+    # https://encodedcc.atlassian.net/browse/ENCD-3646
+    if value['status'] == 'planned':
+        value['status'] = 'in preparation'
+    elif value['status'] == 'replaced':
+        value['status'] = 'deleted'
+    elif value['status'] in ['in press', 'in revision']:
+        value['status'] = 'submitted'


### PR DESCRIPTION
This gets rid of batchupgrade errors of Publication objects in cloud-init-output.log (Publication schema version bump requires upgrade function).