### PR TITLE
ENCD-3609 updating file.json dependency

### DIFF
--- a/src/encoded/schemas/file.json
+++ b/src/encoded/schemas/file.json
@@ -224,7 +224,7 @@
                     "required": ["read_length"],
                     "properties": {
                         "file_format": {
-                            "enum": ["fastq", "fasta", "csfasta", "csqual","sra"]
+                            "enum": ["fastq", "fasta", "csfasta", "csqual", "sra"]
                         },
                         "output_type": {
                              "enum": ["reads"]
@@ -242,13 +242,77 @@
                 }
             ]
         },
+        "assembly": {
+             "allOf": [
+                 {
+                    "not": {
+                        "properties": {
+                            "file_format": {
+                                "enum": ["fasta"]
+                            },
+                            "output_type": {
+                                "enum": ["reads"]
+                            }
+                        }
+                    }
+                 },
+                 {
+                    "not": {
+                        "properties": {
+                            "file_format": {
+                                "enum": ["fasta"]
+                            },
+                            "output_type": {
+                                "enum": ["rejected reads"]
+                            }
+                        }
+                    }
+                 }
+             ]
+        },
         "file_format":{
             "comment": "Fastq and sra files require run_type and replicate but should not have assembly. Raw data files require platform to be specified. Processed files require assembly to be specified.",
             "oneOf": [
                 {
+                    "required": [ "platform"],
+                    "properties": {
+                        "file_format": {
+                            "enum": [
+                                "rcc",
+                                "idat",
+                                "CEL"]
+                        }
+                    }
+                },
+                {
                     "allOf": [
                         {
-                            "required": ["replicate", "run_type"],
+                            "required": ["platform"],
+                            "properties": {
+                                "file_format": {
+                                    "enum": ["csfasta", "csqual"]
+                                }
+                            }
+                        },
+                        {
+                            "not": {
+                                "required": ["assembly"],
+                                "properties": {
+                                    "file_format": {
+                                        "enum": ["csfasta", "csqual"]
+                                    }
+                                }                    
+                            }
+                        }
+                    ]
+                },
+                {
+                    "allOf": [
+                        {
+                            "required": [
+                                "replicate",
+                                "run_type",
+                                "platform"],
                             "properties": {
                                 "file_format": {
                                     "enum": ["fastq","sra"]
@@ -260,23 +324,9 @@
                                 "required": ["assembly"],
                                 "properties": {
                                     "file_format": {
-                                        "enum": ["fastq","sra"]
+                                        "enum": ["fastq", "sra"]
                                     }
-                                }
-                            }
-                        },
-                        {
-                            "required": ["platform"],
-                            "properties": {
-                                "file_format": {
-                                    "enum": ["sra",
-                                             "fastq",
-                                             "csfasta",
-                                             "csqual",
-                                             "rcc",
-                                             "idat",
-                                             "CEL"]
-                                }
+                                }                    
                             }
                         }
                     ]
@@ -301,7 +351,21 @@
                     "not": {
                         "properties": {
                             "file_format": {
-                                "enum": ["fastq", "gff", "gtf", "bed", "bigBed", "bam", "sam", "sra", "bigWig"]
+                                "enum": [
+                                    "rcc",
+                                    "idat",
+                                    "CEL",
+                                    "fastq",
+                                    "gff",
+                                    "gtf",
+                                    "bed",
+                                    "bigBed",
+                                    "bam",
+                                    "sam",
+                                    "sra",
+                                    "bigWig",
+                                    "csfasta",
+                                    "csqual"]
                             }
                         }
                     }

--- a/src/encoded/schemas/file.json
+++ b/src/encoded/schemas/file.json
@@ -255,11 +255,11 @@
                     {
                         "properties": {
                             "output_type": {
-                            "enum": ["rejected reads"]
+                                "enum": ["rejected reads"]
                             }
                         }
                     }
-                ]                        
+                ]
             }
         },
         "file_format":{
@@ -340,7 +340,8 @@
                                     "sra",
                                     "bigWig",
                                     "csfasta",
-                                    "csqual"]
+                                    "csqual"
+                                ]
                             }
                         }
                     }

--- a/src/encoded/schemas/file.json
+++ b/src/encoded/schemas/file.json
@@ -468,7 +468,7 @@
             "permission": "import_items"
         },
         "schema_version": {
-            "default": "11"
+            "default": "12"
         },
         "accession": {
             "accessionType": "FF"

--- a/src/encoded/schemas/file.json
+++ b/src/encoded/schemas/file.json
@@ -243,32 +243,24 @@
             ]
         },
         "assembly": {
-             "allOf": [
-                 {
-                    "not": {
+            "not": {
+                "anyOf": [
+                    {
                         "properties": {
-                            "file_format": {
-                                "enum": ["fasta"]
-                            },
                             "output_type": {
                                 "enum": ["reads"]
                             }
                         }
-                    }
-                 },
-                 {
-                    "not": {
+                    },
+                    {
                         "properties": {
-                            "file_format": {
-                                "enum": ["fasta"]
-                            },
                             "output_type": {
-                                "enum": ["rejected reads"]
+                            "enum": ["rejected reads"]
                             }
                         }
                     }
-                 }
-             ]
+                ]                        
+            }
         },
         "file_format":{
             "comment": "Fastq and sra files require run_type and replicate but should not have assembly. Raw data files require platform to be specified. Processed files require assembly to be specified.",
@@ -280,62 +272,40 @@
                             "enum": [
                                 "rcc",
                                 "idat",
-                                "CEL"]
+                                "CEL",
+                                "csfasta",
+                                "csqual"
+                            ]
                         }
                     }
                 },
                 {
-                    "allOf": [
-                        {
-                            "required": ["platform"],
-                            "properties": {
-                                "file_format": {
-                                    "enum": ["csfasta", "csqual"]
-                                }
-                            }
-                        },
-                        {
-                            "not": {
-                                "required": ["assembly"],
-                                "properties": {
-                                    "file_format": {
-                                        "enum": ["csfasta", "csqual"]
-                                    }
-                                }                    
-                            }
-                        }
-                    ]
-                },
-                {
-                    "allOf": [
-                        {
-                            "required": [
-                                "replicate",
-                                "run_type",
-                                "platform"],
-                            "properties": {
-                                "file_format": {
-                                    "enum": ["fastq","sra"]
-                                }
-                            }
-                        },
-                        {
-                            "not": {
-                                "required": ["assembly"],
-                                "properties": {
-                                    "file_format": {
-                                        "enum": ["fastq", "sra"]
-                                    }
-                                }                    
-                            }
-                        }
-                    ]
-                },
-                {
-                    "required": ["file_format_type", "assembly"],
+                    "required": [
+                        "replicate",
+                        "run_type",
+                        "platform"
+                    ],
                     "properties": {
                         "file_format": {
-                            "enum": ["gff","bed","bigBed"]
+                            "enum": [
+                                "fastq",
+                                "sra"
+                            ]
+                        }
+                    }
+                },
+                {
+                    "required": [
+                        "file_format_type",
+                        "assembly"
+                    ],
+                    "properties": {
+                        "file_format": {
+                            "enum": [
+                                "gff",
+                                "bed",
+                                "bigBed"
+                            ]
                         }
                     }
                 },
@@ -343,7 +313,12 @@
                     "required": ["assembly"],
                     "properties": {
                         "file_format": {
-                            "enum": ["bam", "sam", "gtf", "bigWig"]
+                            "enum": [
+                                "bam",
+                                "sam",
+                                "gtf",
+                                "bigWig"
+                            ]
                         }
                     }
                 },


### PR DESCRIPTION
files with output_type "reads" and "rejected reads" should not be allowed to specify "assembly"