### PR TITLE
ENCD-3637 Change alternate accessions display

### DIFF
--- a/src/encoded/static/components/__tests__/experiment-test.js
+++ b/src/encoded/static/components/__tests__/experiment-test.js
@@ -94,7 +94,7 @@ describe('Experiment Page', () => {
         });
 
         test('displays two alternate accessions', () => {
-            expect(alt.text()).toEqual('Replaces ENCSR000ACT, ENCSR999NOF');
+            expect(alt.text()).toEqual('Alternate accessions: ENCSR000ACT, ENCSR999NOF');
         });
     });
 });

--- a/src/encoded/static/components/antibody.js
+++ b/src/encoded/static/components/antibody.js
@@ -83,7 +83,7 @@ const LotComponent = (props, reactContext) => {
                 <div className="col-sm-12">
                     <Breadcrumbs root="/search/?type=antibody_lot" crumbs={crumbs} />
                     <h2>{context.accession}</h2>
-                    {altacc ? <h4 className="repl-acc">Replaces {altacc}</h4> : null}
+                    {altacc ? <h4 className="repl-acc">Alternate accessions: {altacc}</h4> : null}
                     <h3>
                         {targetKeys.length ?
                             <span>Antibody against {Object.keys(targets).map((target, i) => {

--- a/src/encoded/static/components/antibody.js
+++ b/src/encoded/static/components/antibody.js
@@ -11,6 +11,7 @@ import { ExperimentTable } from './dataset';
 import { DbxrefList } from './dbxref';
 import { DocumentsPanel, Document, DocumentPreview } from './doc';
 import { RelatedItems } from './item';
+import { AlternateAccession } from './objectutils';
 import StatusLabel from './statuslabel';
 
 
@@ -74,16 +75,13 @@ const LotComponent = (props, reactContext) => {
         { id: geneComponents.length ? geneComponents : null, query: geneQuery, tip: geneTips.join(' + ') },
     ];
 
-    // Make string of alternate accessions
-    const altacc = context.alternate_accessions ? context.alternate_accessions.join(', ') : undefined;
-
     return (
         <div className={globals.itemClass(context, 'view-item')}>
             <header className="row">
                 <div className="col-sm-12">
                     <Breadcrumbs root="/search/?type=antibody_lot" crumbs={crumbs} />
                     <h2>{context.accession}</h2>
-                    {altacc ? <h4 className="repl-acc">Alternate accessions: {altacc}</h4> : null}
+                    <AlternateAccession altAcc={context.alternate_accessions} />
                     <h3>
                         {targetKeys.length ?
                             <span>Antibody against {Object.keys(targets).map((target, i) => {

--- a/src/encoded/static/components/biosample.js
+++ b/src/encoded/static/components/biosample.js
@@ -70,7 +70,7 @@ class BiosampleComponent extends React.Component {
                         <h2>
                             {context.accession}{' / '}<span className="sentence-case">{context.biosample_type}</span>
                         </h2>
-                        {altacc ? <h4 className="repl-acc">Replaces {altacc}</h4> : null}
+                        {altacc ? <h4 className="repl-acc">Alternate accessions: {altacc}</h4> : null}
                         <div className="status-line">
                             <div className="characterization-status-labels">
                                 <StatusLabel title="Status" status={context.status} />

--- a/src/encoded/static/components/biosample.js
+++ b/src/encoded/static/components/biosample.js
@@ -10,7 +10,7 @@ import * as globals from './globals';
 import { ProjectBadge } from './image';
 import { RelatedItems } from './item';
 import { Breadcrumbs } from './navigation';
-import { singleTreatment, treatmentDisplay, PanelLookup } from './objectutils';
+import { singleTreatment, treatmentDisplay, PanelLookup, AlternateAccession } from './objectutils';
 import pubReferenceList from './reference';
 import StatusLabel from './statuslabel';
 import { BiosampleSummaryString, CollectBiosampleDocs, BiosampleTable } from './typeutils';
@@ -50,9 +50,6 @@ class BiosampleComponent extends React.Component {
         }
         combinedDocs = globals.uniqueObjectsArray(combinedDocs);
 
-        // Make string of alternate accessions
-        const altacc = context.alternate_accessions ? context.alternate_accessions.join(', ') : undefined;
-
         // Get a list of reference links, if any
         const references = pubReferenceList(context.references);
 
@@ -70,7 +67,7 @@ class BiosampleComponent extends React.Component {
                         <h2>
                             {context.accession}{' / '}<span className="sentence-case">{context.biosample_type}</span>
                         </h2>
-                        {altacc ? <h4 className="repl-acc">Alternate accessions: {altacc}</h4> : null}
+                        <AlternateAccession altAcc={context.alternate_accessions} />
                         <div className="status-line">
                             <div className="characterization-status-labels">
                                 <StatusLabel title="Status" status={context.status} />

--- a/src/encoded/static/components/dataset.js
+++ b/src/encoded/static/components/dataset.js
@@ -106,7 +106,7 @@ class AnnotationComponent extends React.Component {
                     <div className="col-sm-12">
                         <Breadcrumbs crumbs={crumbs} />
                         <h2>Summary for annotation file set {context.accession}</h2>
-                        {altacc ? <h4 className="repl-acc">Replaces {altacc}</h4> : null}
+                        {altacc ? <h4 className="repl-acc">Alternate accessions: {altacc}</h4> : null}
                         {supersededBys.length ? <h4 className="superseded-acc">Superseded by {supersededBys.join(', ')}</h4> : null}
                         {supersedes.length ? <h4 className="superseded-acc">Supersedes {supersedes.join(', ')}</h4> : null}
                         <div className="status-line">
@@ -304,7 +304,7 @@ class PublicationDataComponent extends React.Component {
                     <div className="col-sm-12">
                         <Breadcrumbs crumbs={crumbs} />
                         <h2>Summary for publication file set {context.accession}</h2>
-                        {altacc ? <h4 className="repl-acc">Replaces {altacc}</h4> : null}
+                        {altacc ? <h4 className="repl-acc">Alternate accessions: {altacc}</h4> : null}
                         <div className="status-line">
                             <div className="characterization-status-labels">
                                 <StatusLabel status={statuses} />
@@ -468,7 +468,7 @@ class ReferenceComponent extends React.Component {
                     <div className="col-sm-12">
                         <Breadcrumbs crumbs={crumbs} />
                         <h2>Summary for reference file set {context.accession}</h2>
-                        {altacc ? <h4 className="repl-acc">Replaces {altacc}</h4> : null}
+                        {altacc ? <h4 className="repl-acc">Alternate accessions: {altacc}</h4> : null}
                         <div className="status-line">
                             <div className="characterization-status-labels">
                                 <StatusLabel status={statuses} />
@@ -635,7 +635,7 @@ class ProjectComponent extends React.Component {
                     <div className="col-sm-12">
                         <Breadcrumbs crumbs={crumbs} />
                         <h2>Summary for project file set {context.accession}</h2>
-                        {altacc ? <h4 className="repl-acc">Replaces {altacc}</h4> : null}
+                        {altacc ? <h4 className="repl-acc">Alternate accessions: {altacc}</h4> : null}
                         <div className="status-line">
                             <div className="characterization-status-labels">
                                 <StatusLabel status={statuses} />
@@ -823,7 +823,7 @@ class UcscBrowserCompositeComponent extends React.Component {
                     <div className="col-sm-12">
                         <Breadcrumbs crumbs={crumbs} />
                         <h2>Summary for UCSC browser composite file set {context.accession}</h2>
-                        {altacc ? <h4 className="repl-acc">Replaces {altacc}</h4> : null}
+                        {altacc ? <h4 className="repl-acc">Alternate accessions: {altacc}</h4> : null}
                         <div className="status-line">
                             <div className="characterization-status-labels">
                                 <StatusLabel status={statuses} />
@@ -1314,7 +1314,7 @@ export class SeriesComponent extends React.Component {
                     <div className="col-sm-12">
                         <Breadcrumbs crumbs={crumbs} />
                         <h2>Summary for {seriesTitle} {context.accession}</h2>
-                        {altacc ? <h4 className="repl-acc">Replaces {altacc}</h4> : null}
+                        {altacc ? <h4 className="repl-acc">Alternate accessions: {altacc}</h4> : null}
                         <div className="status-line">
                             <div className="characterization-status-labels">
                                 <StatusLabel status={statuses} />

--- a/src/encoded/static/components/dataset.js
+++ b/src/encoded/static/components/dataset.js
@@ -11,7 +11,7 @@ import { FetchedItems } from './fetched';
 import { auditDecor } from './audit';
 import StatusLabel from './statuslabel';
 import pubReferenceList from './reference';
-import { donorDiversity, publicDataset } from './objectutils';
+import { donorDiversity, publicDataset, AlternateAccession } from './objectutils';
 import { softwareVersionList } from './software';
 import { SortTablePanel, SortTable } from './sorttable';
 import { ProjectBadge } from './image';
@@ -76,9 +76,6 @@ class AnnotationComponent extends React.Component {
             { id: breakSetName(filesetType), uri: `/search/?type=${filesetType}`, wholeTip: `Search for ${filesetType}` },
         ];
 
-        // Make string of alternate accessions
-        const altacc = context.alternate_accessions.join(', ');
-
         // Make array of superseded_by accessions
         let supersededBys = [];
         if (context.superseded_by && context.superseded_by.length) {
@@ -106,7 +103,7 @@ class AnnotationComponent extends React.Component {
                     <div className="col-sm-12">
                         <Breadcrumbs crumbs={crumbs} />
                         <h2>Summary for annotation file set {context.accession}</h2>
-                        {altacc ? <h4 className="repl-acc">Alternate accessions: {altacc}</h4> : null}
+                        <AlternateAccession altAcc={context.alternate_accessions} />
                         {supersededBys.length ? <h4 className="superseded-acc">Superseded by {supersededBys.join(', ')}</h4> : null}
                         {supersedes.length ? <h4 className="superseded-acc">Supersedes {supersedes.join(', ')}</h4> : null}
                         <div className="status-line">
@@ -286,9 +283,6 @@ class PublicationDataComponent extends React.Component {
             { id: breakSetName(filesetType), uri: `/search/?type=${filesetType}`, wholeTip: `Search for ${filesetType}` },
         ];
 
-        // Make string of alternate accessions
-        const altacc = context.alternate_accessions.join(', ');
-
         // Render the publication links
         const referenceList = pubReferenceList(context.references);
 
@@ -304,7 +298,7 @@ class PublicationDataComponent extends React.Component {
                     <div className="col-sm-12">
                         <Breadcrumbs crumbs={crumbs} />
                         <h2>Summary for publication file set {context.accession}</h2>
-                        {altacc ? <h4 className="repl-acc">Alternate accessions: {altacc}</h4> : null}
+                        <AlternateAccession altAcc={context.alternate_accessions} />
                         <div className="status-line">
                             <div className="characterization-status-labels">
                                 <StatusLabel status={statuses} />
@@ -450,9 +444,6 @@ class ReferenceComponent extends React.Component {
             { id: breakSetName(filesetType), uri: `/search/?type=${filesetType}`, wholeTip: `Search for ${filesetType}` },
         ];
 
-        // Make string of alternate accessions
-        const altacc = context.alternate_accessions.join(', ');
-
         // Get a list of reference links, if any
         const references = pubReferenceList(context.references);
 
@@ -468,7 +459,7 @@ class ReferenceComponent extends React.Component {
                     <div className="col-sm-12">
                         <Breadcrumbs crumbs={crumbs} />
                         <h2>Summary for reference file set {context.accession}</h2>
-                        {altacc ? <h4 className="repl-acc">Alternate accessions: {altacc}</h4> : null}
+                        <AlternateAccession altAcc={context.alternate_accessions} />
                         <div className="status-line">
                             <div className="characterization-status-labels">
                                 <StatusLabel status={statuses} />
@@ -617,9 +608,6 @@ class ProjectComponent extends React.Component {
             { id: breakSetName(filesetType), uri: `/search/?type=${filesetType}`, wholeTip: `Search for ${filesetType}` },
         ];
 
-        // Make string of alternate accessions
-        const altacc = context.alternate_accessions.join(', ');
-
         // Get a list of reference links
         const references = pubReferenceList(context.references);
 
@@ -635,7 +623,7 @@ class ProjectComponent extends React.Component {
                     <div className="col-sm-12">
                         <Breadcrumbs crumbs={crumbs} />
                         <h2>Summary for project file set {context.accession}</h2>
-                        {altacc ? <h4 className="repl-acc">Alternate accessions: {altacc}</h4> : null}
+                        <AlternateAccession altAcc={context.alternate_accessions} />
                         <div className="status-line">
                             <div className="characterization-status-labels">
                                 <StatusLabel status={statuses} />
@@ -805,9 +793,6 @@ class UcscBrowserCompositeComponent extends React.Component {
             { id: breakSetName(filesetType), uri: `/search/?type=${filesetType}`, wholeTip: `Search for ${filesetType}` },
         ];
 
-        // Make string of alternate accessions
-        const altacc = context.alternate_accessions.join(', ');
-
         // Get a list of reference links, if any
         const references = pubReferenceList(context.references);
 
@@ -823,7 +808,7 @@ class UcscBrowserCompositeComponent extends React.Component {
                     <div className="col-sm-12">
                         <Breadcrumbs crumbs={crumbs} />
                         <h2>Summary for UCSC browser composite file set {context.accession}</h2>
-                        {altacc ? <h4 className="repl-acc">Alternate accessions: {altacc}</h4> : null}
+                        <AlternateAccession altAcc={context.alternate_accessions} />
                         <div className="status-line">
                             <div className="characterization-status-labels">
                                 <StatusLabel status={statuses} />
@@ -1269,9 +1254,6 @@ export class SeriesComponent extends React.Component {
             { id: breakSetName(seriesType), uri: `/search/?type=${seriesType}`, wholeTip: `Search for ${seriesType}` },
         ];
 
-        // Make string of alternate accessions
-        const altacc = context.alternate_accessions.join(', ');
-
         // Get a list of reference links, if any
         const references = pubReferenceList(context.references);
 
@@ -1314,7 +1296,7 @@ export class SeriesComponent extends React.Component {
                     <div className="col-sm-12">
                         <Breadcrumbs crumbs={crumbs} />
                         <h2>Summary for {seriesTitle} {context.accession}</h2>
-                        {altacc ? <h4 className="repl-acc">Alternate accessions: {altacc}</h4> : null}
+                        <AlternateAccession altAcc={context.alternate_accessions} />
                         <div className="status-line">
                             <div className="characterization-status-labels">
                                 <StatusLabel status={statuses} />

--- a/src/encoded/static/components/donor.js
+++ b/src/encoded/static/components/donor.js
@@ -569,7 +569,7 @@ class Donor extends React.Component {
                     <div className="col-sm-12">
                         <Breadcrumbs crumbs={crumbs} />
                         <h2>{context.accession}</h2>
-                        {altacc ? <h4 className="repl-acc">Replaces {altacc}</h4> : null}
+                        {altacc ? <h4 className="repl-acc">Alternate accessions: {altacc}</h4> : null}
                         <div className="status-line">
                             <div className="characterization-status-labels">
                                 <StatusLabel title="Status" status={context.status} />

--- a/src/encoded/static/components/donor.js
+++ b/src/encoded/static/components/donor.js
@@ -10,7 +10,7 @@ import { GeneticModificationSummary } from './genetic_modification';
 import * as globals from './globals';
 import { RelatedItems } from './item';
 import { Breadcrumbs } from './navigation';
-import { requestObjects } from './objectutils';
+import { requestObjects, AlternateAccession } from './objectutils';
 import pubReferenceList from './reference';
 import { SortTablePanel, SortTable } from './sorttable';
 import StatusLabel from './statuslabel';
@@ -539,7 +539,6 @@ class Donor extends React.Component {
     render() {
         const { context } = this.props;
         const itemClass = globals.itemClass(context, 'view-item');
-        const altacc = context.alternate_accessions ? context.alternate_accessions.join(', ') : undefined;
         const PanelView = globals.panelViews.lookup(context);
         let characterizationDocuments = [];
         let donorDocuments = [];
@@ -569,7 +568,7 @@ class Donor extends React.Component {
                     <div className="col-sm-12">
                         <Breadcrumbs crumbs={crumbs} />
                         <h2>{context.accession}</h2>
-                        {altacc ? <h4 className="repl-acc">Alternate accessions: {altacc}</h4> : null}
+                        <AlternateAccession altAcc={context.alternate_accessions} />
                         <div className="status-line">
                             <div className="characterization-status-labels">
                                 <StatusLabel title="Status" status={context.status} />

--- a/src/encoded/static/components/experiment.js
+++ b/src/encoded/static/components/experiment.js
@@ -445,7 +445,7 @@ class ExperimentComponent extends React.Component {
                     <div className="col-sm-12">
                         <Breadcrumbs root="/search/?type=Experiment" crumbs={crumbs} />
                         <h2>Experiment summary for {context.accession}</h2>
-                        {altacc ? <h4 className="repl-acc">Replaces {altacc}</h4> : null}
+                        {altacc ? <h4 className="repl-acc">Alternate accessions: {altacc}</h4> : null}
                         {supersededBys.length ? <h4 className="superseded-acc">Superseded by {supersededBys.join(', ')}</h4> : null}
                         {supersedes.length ? <h4 className="superseded-acc">Supersedes {supersedes.join(', ')}</h4> : null}
                         <div className="status-line">

--- a/src/encoded/static/components/experiment.js
+++ b/src/encoded/static/components/experiment.js
@@ -12,7 +12,7 @@ import { FetchedItems } from './fetched';
 import { FileGallery } from './filegallery';
 import { ProjectBadge } from './image';
 import { Breadcrumbs } from './navigation';
-import { singleTreatment } from './objectutils';
+import { singleTreatment, AlternateAccession } from './objectutils';
 import pubReferenceList from './reference';
 import { SortTablePanel, SortTable } from './sorttable';
 import StatusLabel from './statuslabel';
@@ -373,9 +373,6 @@ class ExperimentComponent extends React.Component {
             statuses.push({ status: context.internal_status, title: 'Internal' });
         }
 
-        // Make string of alternate accessions.
-        const altacc = context.alternate_accessions ? context.alternate_accessions.join(', ') : undefined;
-
         // Make array of superseded_by accessions.
         let supersededBys = [];
         if (context.superseded_by && context.superseded_by.length) {
@@ -445,7 +442,7 @@ class ExperimentComponent extends React.Component {
                     <div className="col-sm-12">
                         <Breadcrumbs root="/search/?type=Experiment" crumbs={crumbs} />
                         <h2>Experiment summary for {context.accession}</h2>
-                        {altacc ? <h4 className="repl-acc">Alternate accessions: {altacc}</h4> : null}
+                        <AlternateAccession altAcc={context.alternate_accessions} />
                         {supersededBys.length ? <h4 className="superseded-acc">Superseded by {supersededBys.join(', ')}</h4> : null}
                         {supersedes.length ? <h4 className="superseded-acc">Supersedes {supersedes.join(', ')}</h4> : null}
                         <div className="status-line">

--- a/src/encoded/static/components/file.js
+++ b/src/encoded/static/components/file.js
@@ -8,7 +8,7 @@ import { auditDecor } from './audit';
 import { DbxrefList } from './dbxref';
 import { DocumentsPanel } from './doc';
 import * as globals from './globals';
-import { requestFiles, requestObjects, requestSearch, RestrictedDownloadButton } from './objectutils';
+import { requestFiles, requestObjects, requestSearch, RestrictedDownloadButton, AlternateAccession } from './objectutils';
 import { ProjectBadge } from './image';
 import { QualityMetricsPanel } from './quality_metric';
 import { SortTablePanel, SortTable } from './sorttable';
@@ -332,7 +332,6 @@ class FileComponent extends React.Component {
     render() {
         const { context } = this.props;
         const itemClass = globals.itemClass(context, 'view-item');
-        const altacc = (context.alternate_accessions && context.alternate_accessions.length) ? context.alternate_accessions.join(', ') : null;
         const aliasList = (context.aliases && context.aliases.length) ? context.aliases.join(', ') : '';
         const datasetAccession = globals.atIdToAccession(context.dataset);
         const adminUser = !!this.context.session_properties.admin;
@@ -360,7 +359,7 @@ class FileComponent extends React.Component {
                 <header className="row">
                     <div className="col-sm-12">
                         <h2>File summary for {context.title} (<span className="sentence-case">{context.file_format}</span>)</h2>
-                        {altacc ? <h4 className="repl-acc">Alternate accessions: {altacc}</h4> : null}
+                        <AlternateAccession altAcc={context.alternate_accessions} />
                         {context.restricted ? <h4 className="superseded-acc">Restricted file</h4> : null}
                         {supersededBys.length ? <h4 className="superseded-acc">Superseded by {supersededBys.join(', ')}</h4> : null}
                         {supersedes.length ? <h4 className="superseded-acc">Supersedes {supersedes.join(', ')}</h4> : null}

--- a/src/encoded/static/components/file.js
+++ b/src/encoded/static/components/file.js
@@ -360,7 +360,7 @@ class FileComponent extends React.Component {
                 <header className="row">
                     <div className="col-sm-12">
                         <h2>File summary for {context.title} (<span className="sentence-case">{context.file_format}</span>)</h2>
-                        {altacc ? <h4 className="repl-acc">Replaces {altacc}</h4> : null}
+                        {altacc ? <h4 className="repl-acc">Alternate accessions: {altacc}</h4> : null}
                         {context.restricted ? <h4 className="superseded-acc">Restricted file</h4> : null}
                         {supersededBys.length ? <h4 className="superseded-acc">Superseded by {supersededBys.join(', ')}</h4> : null}
                         {supersedes.length ? <h4 className="superseded-acc">Supersedes {supersedes.join(', ')}</h4> : null}

--- a/src/encoded/static/components/item.js
+++ b/src/encoded/static/components/item.js
@@ -50,7 +50,7 @@ const Item = (props) => {
             <header className="row">
                 <div className="col-sm-12">
                     <h2>{title}</h2>
-                    {altacc ? <h4 className="repl-acc">Replaces {altacc}</h4> : null}
+                    {altacc ? <h4 className="repl-acc">Alternate accessions: {altacc}</h4> : null}
                 </div>
             </header>
             <div className="row item-row">

--- a/src/encoded/static/components/item.js
+++ b/src/encoded/static/components/item.js
@@ -3,8 +3,9 @@ import PropTypes from 'prop-types';
 import url from 'url';
 import Table from './collection';
 import { FetchedData, Param } from './fetched';
-import * as globals from './globals';
 import { JSONSchemaForm } from './form';
+import * as globals from './globals';
+import { AlternateAccession } from './objectutils';
 
 
 const Fallback = (props, reactContext) => {
@@ -42,16 +43,13 @@ const Item = (props) => {
     const title = globals.listingTitles.lookup(context)({ context });
     const ItemPanel = globals.panelViews.lookup(context);
 
-    // Make string of alternate accessions
-    const altacc = context.alternate_accessions ? context.alternate_accessions.join(', ') : undefined;
-
     return (
         <div className={itemClass}>
             <header className="row">
                 <div className="col-sm-12">
                     <h2>{title}</h2>
-                    {altacc ? <h4 className="repl-acc">Alternate accessions: {altacc}</h4> : null}
-                </div>
+                    <AlternateAccession altAcc={context.alternate_accessions} />
+                    </div>
             </header>
             <div className="row item-row">
                 <div className="col-sm-12">

--- a/src/encoded/static/components/item.js
+++ b/src/encoded/static/components/item.js
@@ -49,7 +49,7 @@ const Item = (props) => {
                 <div className="col-sm-12">
                     <h2>{title}</h2>
                     <AlternateAccession altAcc={context.alternate_accessions} />
-                    </div>
+                </div>
             </header>
             <div className="row item-row">
                 <div className="col-sm-12">

--- a/src/encoded/static/components/objectutils.js
+++ b/src/encoded/static/components/objectutils.js
@@ -566,3 +566,28 @@ export function PanelLookup(properties) {
     const PanelView = globals.panelViews.lookup(localProps.context);
     return <PanelView key={localProps.context.uuid} {...localProps} />;
 }
+
+
+// Display the alternate accessions, normally below the header line in objects.
+export const AlternateAccession = (props) => {
+    const { altAcc } = props;
+
+    if (altAcc && altAcc.length) {
+        return (
+            <h4 className="repl-acc">
+                {altAcc.length === 1 ?
+                    <span>Alternate accession: {altAcc[0]}</span>
+                :
+                    <span>Alternate accessions: {altAcc.join(', ')}</span>
+                }
+            </h4>
+        );
+    }
+
+    // No alternate accessions to display.
+    return null;
+};
+
+AlternateAccession.propTypes = {
+    altAcc: PropTypes.array, // Array of alternate accession strings
+};

--- a/src/encoded/tests/data/inserts/file.json
+++ b/src/encoded/tests/data/inserts/file.json
@@ -997,7 +997,6 @@
         "md5sum": "da020ee1443358bff9219104d27a1a11",
         "accession": "ENCFF019HBG",
         "file_format": "tar",
-        "file_size": 20,
         "award": "/awards/U54HG006998/",
         "dataset": "ENCSR001REF",
         "flowcell_details": [],


### PR DESCRIPTION
All components that display the `alternate_accessions` property now call a new React component called `<AlternateAccession>` that takes an array of `alternate_accessions` strings and outputs elements meant for below the header line on individual object pages.

The modification to file.json test data was because I noticed that object had two `file_size` properties in it, so I got rid of the first one since the second would override it.