### PR TITLE
ENCD-3669 Specify reverse link properties which should not be submittable

### DIFF
--- a/src/encoded/static/components/form.js
+++ b/src/encoded/static/components/form.js
@@ -84,14 +84,14 @@ const filterValue = function filterValue(value) {
 // Given a schema, construct a default object.
 // The default object includes the `default` value
 // for any property that defines one,
-// with the exception of read-only and calculated properties.
+// with the exception of read-only and non-submittable properties.
 const defaultValue = function defaultValue(schema) {
     if (schema.default !== undefined) {
         return schema.default !== undefined ? schema.default : undefined;
     } else if (schema.properties !== undefined) {
         const value = {};
         _.each(schema.properties, (property, name) => {
-            if (property.calculatedProperty) return;
+            if (property.notSubmittable) return;
             if (!property.readonly) {
                 const propertyDefault = defaultValue(property);
                 if (propertyDefault !== undefined) {
@@ -624,7 +624,7 @@ export class Field extends UpdateChildMixin(React.Component) {
             Object.keys(schema.properties).forEach((key) => {
                 if (key === 'uuid' || key === 'schema_version') return;
                 const subschema = schema.properties[key];
-                if (subschema.calculatedProperty) return;
+                if (subschema.notSubmittable || subschema.hideFromForms) return;
                 // Readonly fields are omitted when showReadOnly is false
                 // (i.e. when adding a new object).
                 if (!this.context.showReadOnly && subschema.readonly) return;

--- a/src/encoded/types/biosample.py
+++ b/src/encoded/types/biosample.py
@@ -284,6 +284,7 @@ class Biosample(Item, CalculatedBiosampleSlims, CalculatedBiosampleSynonyms):
             "type": ['string', 'object'],
             "linkFrom": "Biosample.part_of",
         },
+        'notSubmittable': True,
     })
     def parent_of(self, request, parent_of):
         return paths_filtered_by_status(request, parent_of)

--- a/src/encoded/types/dataset.py
+++ b/src/encoded/types/dataset.py
@@ -95,6 +95,7 @@ class Dataset(Item):
             "type": ['string', 'object'],
             "linkFrom": "File.dataset",
         },
+        "notSubmittable": True,
     })
     def original_files(self, request, original_files):
         return paths_filtered_by_status(request, original_files)
@@ -329,6 +330,7 @@ class Annotation(FileSet, CalculatedBiosampleSlims, CalculatedBiosampleSynonyms,
             "type": ['string', 'object'],
             "linkFrom": "Annotation.supersedes",
         },
+        "notSubmittable": True,
     })
     def superseded_by(self, request, superseded_by):
         return paths_filtered_by_status(request, superseded_by)

--- a/src/encoded/types/donor.py
+++ b/src/encoded/types/donor.py
@@ -134,7 +134,8 @@ class HumanDonor(Donor):
         "items": {
             "type": ['string', 'object'],
             "linkFrom": "HumanDonor.parents"
-        }
+        },
+        "notSubmittable": True,
     })
     def children(self, request, parents):
         return paths_filtered_by_status(request, parents)

--- a/src/encoded/types/experiment.py
+++ b/src/encoded/types/experiment.py
@@ -339,6 +339,7 @@ class Experiment(Dataset,
             "type": ['string', 'object'],
             "linkFrom": "Series.related_datasets",
         },
+        "notSubmittable": True,
     })
     def related_series(self, request, related_series):
         return paths_filtered_by_status(request, related_series)
@@ -350,6 +351,7 @@ class Experiment(Dataset,
             "type": ['string', 'object'],
             "linkFrom": "Experiment.supersedes",
         },
+        "notSubmittable": True,
     })
     def superseded_by(self, request, superseded_by):
         return paths_filtered_by_status(request, superseded_by)

--- a/src/encoded/types/file.py
+++ b/src/encoded/types/file.py
@@ -314,6 +314,7 @@ class File(Item):
             "type": ['string', 'object'],
             "linkFrom": "QualityMetric.quality_metric_of",
         },
+        "notSubmittable": True,
     })
     def quality_metrics(self, request, quality_metrics):
         return paths_filtered_by_status(request, quality_metrics)
@@ -339,6 +340,7 @@ class File(Item):
             "type": ['string', 'object'],
             "linkFrom": "File.supersedes",
         },
+        "notSubmittable": True,
     })
     def superseded_by(self, request, superseded_by):
         return paths_filtered_by_status(request, superseded_by)

--- a/src/encoded/types/genetic_modification.py
+++ b/src/encoded/types/genetic_modification.py
@@ -42,6 +42,7 @@ class GeneticModification(Item):
             "type": ['string', 'object'],
             "linkFrom": "Biosample.genetic_modifications",
         },
+        "notSubmittable": True,
     })
     def biosamples_modified(self, request, biosamples_modified):
         return paths_filtered_by_status(request, biosamples_modified)
@@ -54,6 +55,7 @@ class GeneticModification(Item):
             "type": ['string', 'object'],
             "linkFrom": "Donor.genetic_modifications",
         },
+        "notSubmittable": True,
     })
     def donors_modified(self, request, donors_modified):
         return paths_filtered_by_status(request, donors_modified)


### PR DESCRIPTION
This also includes 2 related changes:
1. Rename calculatedProperty to notSubmittable which is a better description of its meaning
2. Add support for hiding a property from the forms without preventing submission using hideFromForms