### PR TITLE
ENCD-3673 Add new redacted output_types

### DIFF
--- a/src/encoded/schemas/file.json
+++ b/src/encoded/schemas/file.json
@@ -821,6 +821,8 @@
                         "raw signal",
                         "read-depth normalized signal",
                         "reads",
+                        "redacted alignments",
+                        "redacted unfiltered alignments",
                         "reference variants",
                         "relative replication signal",
                         "replicated peaks",
@@ -1143,6 +1145,8 @@
 
         "alignments": "alignment",
         "unfiltered alignments": "alignment",
+        "redacted alignments": "alignment",
+        "redacted unfiltered alignments": "alignment",
         "transcriptome alignments": "alignment",
         "spike-in alignments": "alignment",
         "maternal haplotype mapping": "alignment",


### PR DESCRIPTION
ENCD-3673 new output_type for de-identified bams (dbGaP)

* Added new output_types for bams: redacted alignments and redacted unfiltered alignments.