### PR TITLE
ENCD-3656 include ssh keys in deploy

### DIFF
--- a/cloud-config-cluster.yml
+++ b/cloud-config-cluster.yml
@@ -1,6 +1,8 @@
 #cloud-config
 
 # Instance
+ssh_authorized_keys:
+  - %(LOCAL_SSH_KEY)s
 
 apt_sources:
 - source: "ppa:webupd8team/java"
@@ -94,7 +96,6 @@ apt_sources:
 
 bootcmd:
 - set -ex
-- cloud-init-per once ssh-users-ca echo "TrustedUserCAKeys /etc/ssh/users_ca.pub" >> /etc/ssh/sshd_config
 - cloud-init-per once accepted-oracle-license-v1-1 echo "oracle-java8-installer shared/accepted-oracle-license-v1-1 select true" | debconf-set-selections
 - cloud-init-per once fallocate-swapfile fallocate -l 4G /swapfile
 - cloud-init-per once chmod-swapfile chmod 600 /swapfile
@@ -116,6 +117,7 @@ package_upgrade: true
 
 packages:
 - apache2-mpm-worker
+- awscli
 - bsdtar
 - build-essential
 - elasticsearch
@@ -158,6 +160,8 @@ output:
   all: '| tee -a /var/log/cloud-init-output.log'
 
 runcmd:
+- mv /home/ubuntu/.ssh/authorized_keys /home/ubuntu/.ssh/authorized_keys2
+- aws s3 cp --region=us-west-2 %(S3_AUTH_KEYS)s /home/ubuntu/.ssh/authorized_keys
 # Ideally this would build as a different user so encoded only has read
 # permissions
 - set -ex
@@ -325,6 +329,3 @@ write_files:
 
 - path: /etc/postgresql/9.3/main/wale_s3_prefix
   content: "%(WALE_S3_PREFIX)s"
-
-- path: /etc/ssh/users_ca.pub
-  content: ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAv/ymOcnN4LhM4NACc3Or116XXJ6KytuOgB/+1qNkOFBqBosrn7cmJ35rsoNHRgYNrCsRE9ch74RKsN6H72FtSJgBhGh/9oUK7Os6Fqt3/ZZXxgxIx6ubs/MTgrxrAnujiBxUXMXQhLKMriNMpo8mt4nGYVtLk9PBjiyfncaS8H9ZKoNio9dhP8bmTuYvioAI35dqKdSlVLyzr/XkZxia8Ki+pQ0N6uuiEwMR3ToM+LSp8wpFOOAiu4PEAujRW7us/+1hlpKWfn0J7/V3826joHE+I967Vg/+ikcVhF77JjK1nib879VgCWfmn1HPQosIpk4yJfVgGvRVI7I2nfBPVw== encoded@demo-l.encodedcc.org

--- a/cloud-config-elasticsearch.yml
+++ b/cloud-config-elasticsearch.yml
@@ -1,6 +1,8 @@
 #cloud-config
 
 # Instance
+ssh_authorized_keys:
+  - %(LOCAL_SSH_KEY)s
 
 apt_sources:
 - source: "ppa:webupd8team/java"
@@ -40,7 +42,6 @@ apt_sources:
 
 bootcmd:
 - set -ex
-- cloud-init-per once ssh-users-ca echo "TrustedUserCAKeys /etc/ssh/users_ca.pub" >> /etc/ssh/sshd_config
 - cloud-init-per once accepted-oracle-license-v1-1 echo "oracle-java8-installer shared/accepted-oracle-license-v1-1 select true" | debconf-set-selections
 - cloud-init-per once fallocate-swapfile fallocate -l 4G /swapfile
 - cloud-init-per once chmod-swapfile chmod 600 /swapfile
@@ -58,6 +59,7 @@ bootcmd:
 package_upgrade: true
 
 packages:
+- awscli
 - build-essential
 - elasticsearch
 - libssl-dev
@@ -79,6 +81,8 @@ output:
   all: '| tee -a /var/log/cloud-init-output.log'
 
 runcmd:
+- mv /home/ubuntu/.ssh/authorized_keys /home/ubuntu/.ssh/authorized_keys2
+- aws s3 cp --region=us-west-2 %(S3_AUTH_KEYS)s /home/ubuntu/.ssh/authorized_keys
 # Ideally this would build as a different user so encoded only has read
 # permissions
 - set -ex
@@ -166,6 +170,3 @@ write_files:
     else
         echo "argument error"
     fi
-
-- path: /etc/ssh/users_ca.pub
-  content: ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAv/ymOcnN4LhM4NACc3Or116XXJ6KytuOgB/+1qNkOFBqBosrn7cmJ35rsoNHRgYNrCsRE9ch74RKsN6H72FtSJgBhGh/9oUK7Os6Fqt3/ZZXxgxIx6ubs/MTgrxrAnujiBxUXMXQhLKMriNMpo8mt4nGYVtLk9PBjiyfncaS8H9ZKoNio9dhP8bmTuYvioAI35dqKdSlVLyzr/XkZxia8Ki+pQ0N6uuiEwMR3ToM+LSp8wpFOOAiu4PEAujRW7us/+1hlpKWfn0J7/V3826joHE+I967Vg/+ikcVhF77JjK1nib879VgCWfmn1HPQosIpk4yJfVgGvRVI7I2nfBPVw== encoded@demo-l.encodedcc.org

--- a/cloud-config.yml
+++ b/cloud-config.yml
@@ -1,6 +1,8 @@
 #cloud-config
 
 # Instance
+ssh_authorized_keys:
+  - %(LOCAL_SSH_KEY)s
 
 apt_sources:
 - source: "ppa:webupd8team/java"
@@ -94,7 +96,6 @@ apt_sources:
 
 bootcmd:
 - set -ex
-- cloud-init-per once ssh-users-ca echo "TrustedUserCAKeys /etc/ssh/users_ca.pub" >> /etc/ssh/sshd_config
 - cloud-init-per once accepted-oracle-license-v1-1 echo "oracle-java8-installer shared/accepted-oracle-license-v1-1 select true" | debconf-set-selections
 - cloud-init-per once fallocate-swapfile fallocate -l 4G /swapfile
 - cloud-init-per once chmod-swapfile chmod 600 /swapfile
@@ -116,6 +117,7 @@ package_upgrade: true
 
 packages:
 - apache2-mpm-worker
+- awscli
 - bsdtar
 - build-essential
 - elasticsearch
@@ -158,6 +160,8 @@ output:
   all: '| tee -a /var/log/cloud-init-output.log'
 
 runcmd:
+- mv /home/ubuntu/.ssh/authorized_keys /home/ubuntu/.ssh/authorized_keys2
+- aws s3 cp --region=us-west-2 %(S3_AUTH_KEYS)s /home/ubuntu/.ssh/authorized_keys
 # Ideally this would build as a different user so encoded only has read
 # permissions
 - set -ex
@@ -298,6 +302,3 @@ write_files:
 
 - path: /etc/postgresql/9.3/main/wale_s3_prefix
   content: "%(WALE_S3_PREFIX)s"
-
-- path: /etc/ssh/users_ca.pub
-  content: ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAv/ymOcnN4LhM4NACc3Or116XXJ6KytuOgB/+1qNkOFBqBosrn7cmJ35rsoNHRgYNrCsRE9ch74RKsN6H72FtSJgBhGh/9oUK7Os6Fqt3/ZZXxgxIx6ubs/MTgrxrAnujiBxUXMXQhLKMriNMpo8mt4nGYVtLk9PBjiyfncaS8H9ZKoNio9dhP8bmTuYvioAI35dqKdSlVLyzr/XkZxia8Ki+pQ0N6uuiEwMR3ToM+LSp8wpFOOAiu4PEAujRW7us/+1hlpKWfn0J7/V3826joHE+I967Vg/+ikcVhF77JjK1nib879VgCWfmn1HPQosIpk4yJfVgGvRVI7I2nfBPVw== encoded@demo-l.encodedcc.org


### PR DESCRIPTION
Change to merge with v64rc4

This PR
- adds the deployer's ssh key to the cloud-config through deploy.py string format templating
- fixes pylint issues in deploy script
- removes key signing from all cloud configs
- download an authorized_keys file from an s3 bucket that should contain everyone's ssh key.

This will move the deployer's ssh key into authorized_keys2 as a backup but this will only work with dsa and rsa keys.  The s3 authorized_keys is written to ~/.ssh/authorized_keys.  