### PR TITLE
ENCD-3707-scrub-proposed-preliminary

### DIFF
--- a/src/encoded/audit/experiment.py
+++ b/src/encoded/audit/experiment.py
@@ -2135,7 +2135,7 @@ def audit_experiment_documents(value, system, excluded_types):
     '''
     Experiments should have documents.  Protocol documents or some sort of document.
     '''
-    if value['status'] in ['deleted', 'replaced', 'preliminary']:
+    if value['status'] in ['deleted', 'replaced']:
         return
 
     # If the experiment has documents, we are good

--- a/src/encoded/audit/item.py
+++ b/src/encoded/audit/item.py
@@ -70,7 +70,6 @@ STATUS_LEVEL = {
     # private statuses (visible for consortium members only)
     'in progress': 50,
     'pending dcc review': 50,
-    'proposed': 50,
     'started': 50,
     'submitted': 50,
     'ready for review': 50,
@@ -80,7 +79,6 @@ STATUS_LEVEL = {
     'pending dcc review': 50,
     'awaiting lab characterization': 50,
     'in preparation': 50,
-    'preliminary': 50,
 
     # invisible statuses (visible for admins only)
     'deleted': 0,

--- a/src/encoded/static/components/award.js
+++ b/src/encoded/static/components/award.js
@@ -794,7 +794,7 @@ function StatusData(experiments, unreplicated, isogenic, anisogenic) {
         isogenicArray = (isogenicFacet && isogenicFacet.terms && isogenicFacet.terms.length) ? isogenicFacet.terms : [];
         anisogenicArray = (anisogenicFacet && anisogenicFacet.terms && anisogenicFacet.terms.length) ? anisogenicFacet.terms : [];
     }
-    const labels = ['proposed', 'started', 'submitted', 'released', 'deleted', 'replaced', 'archived', 'revoked'];
+    const labels = ['started', 'submitted', 'released', 'deleted', 'replaced', 'archived', 'revoked'];
 
     // Check existence of data for each of the keys in array labels
     // Ensures that for each replicate type there exists the same set of labels and the corresponding data values (in order)
@@ -1597,10 +1597,6 @@ GenusButtons.defaultProps = {
 const milestonesTableColumns = {
     assay_term_name: {
         title: 'Assay name',
-    },
-
-    proposed_count: {
-        title: 'Proposed count',
     },
 
     deliverable_unit: {

--- a/src/encoded/static/components/award.js
+++ b/src/encoded/static/components/award.js
@@ -1599,6 +1599,10 @@ const milestonesTableColumns = {
         title: 'Assay name',
     },
 
+    proposed_count: {
+        title: 'Proposed count',
+    },
+
     deliverable_unit: {
         title: 'Biosample',
     },

--- a/src/encoded/static/components/item.js
+++ b/src/encoded/static/components/item.js
@@ -206,7 +206,7 @@ FetchedRelatedItems.defaultProps = {
 
 
 export const RelatedItems = (props) => {
-    const itemUrl = globals.encodedURI(`${props.url}&status=released&status=started&status=proposed&status=submitted&status=ready+for+review&status=in+progress`);
+    const itemUrl = globals.encodedURI(`${props.url}&status=released&status=started&status=submitted&status=ready+for+review&status=in+progress`);
     const limitedUrl = `${itemUrl}&limit=${props.limit}`;
     const unlimitedUrl = `${itemUrl}&limit=all`;
     return (

--- a/src/encoded/types/base.py
+++ b/src/encoded/types/base.py
@@ -183,7 +183,7 @@ class Item(snovault.Item):
 
 
 class SharedItem(Item):
-    ''' An Item visible to all authenticated users while "proposed" or "in progress".
+    ''' An Item visible to all authenticated users while "in progress".
     '''
     def __ac_local_roles__(self):
         roles = {}

--- a/src/encoded/visualization.py
+++ b/src/encoded/visualization.py
@@ -132,7 +132,7 @@ BIGWIG_FILE_TYPES = ['bigWig']
 BIGBED_FILE_TYPES = ['bigBed']
 
 VISIBLE_DATASET_STATUSES = ["released"]
-QUICKVIEW_STATUSES_BLOCKED = ["proposed", "started", "deleted", "revoked", "replaced"]
+QUICKVIEW_STATUSES_BLOCKED = ["started", "deleted", "revoked", "replaced"]
 VISIBLE_FILE_STATUSES = ["released"]
 VISIBLE_DATASET_TYPES = ["Experiment", "Annotation"]
 VISIBLE_DATASET_TYPES_LC = ["experiment", "annotation"]


### PR DESCRIPTION
Remove a few more mentions of proposed and preliminary statuses where they are no longer needed. You'll still find them mentioned in changelogs and upgrades but this is expected.