### PR TITLE
holding for 3704: ENCD-3705 limit collection

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -6,7 +6,6 @@ extends = versions.cfg
 allow-hosts =
     *.python.org
     github.com
-index = https://pypi.python.org/simple/
 find-links =
     https://github.com/lrowe/venusian/tarball/1.0.1.dev40#egg=venusian-1.0.1.dev40
     https://github.com/lrowe/splinter/tarball/0.7.3.dev20150610#egg=splinter-0.7.3.dev20150610

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -6,6 +6,7 @@ extends = versions.cfg
 allow-hosts =
     *.python.org
     github.com
+index = https://pypi.python.org/simple/
 find-links =
     https://github.com/lrowe/venusian/tarball/1.0.1.dev40#egg=venusian-1.0.1.dev40
     https://github.com/lrowe/splinter/tarball/0.7.3.dev20150610#egg=splinter-0.7.3.dev20150610

--- a/src/encoded/static/components/collection.js
+++ b/src/encoded/static/components/collection.js
@@ -5,8 +5,9 @@ import * as globals from './globals';
 import DataColors from './datacolors';
 
 
-// Maximum number of facet charts to display.
-const MAX_FACET_CHARTS = 3;
+
+const MAX_FACET_CHARTS = 3; // Maximum number of facet charts to display.
+const MAX_CHART_ITEMS = 9; // Maximum number of items to display in a chart; combine rest into "Other."
 
 // Initialize a list of colors to use in the chart.
 const collectionColors = new DataColors(); // Get a list of colors to use for the lab chart
@@ -109,6 +110,15 @@ class FacetChart extends React.Component {
 
     render() {
         const { chartId, facet } = this.props;
+        let terms;
+
+        // If we have more facet terms than we allow to be displayed (determined through
+        // MAX_CHART_ITEMS), 
+        if (facet.terms.length > MAX_CHART_ITEMS) {
+            terms = facet.terms.splice(0, MAX_CHART_ITEMS);
+        } else {
+            terms = facet.terms;
+        }
 
         // Extract the arrays of labels from the facet keys, and the arrays of corresponding counts
         // from the facet doc_counts. Only use non-zero facet terms in the charts. IF we have no
@@ -116,7 +126,7 @@ class FacetChart extends React.Component {
         // have been populated.
         this.values = [];
         this.labels = [];
-        facet.terms.forEach((term) => {
+        terms.forEach((term) => {
             if (term.doc_count) {
                 this.values.push(term.doc_count);
                 this.labels.push(term.key);

--- a/src/encoded/static/components/collection.js
+++ b/src/encoded/static/components/collection.js
@@ -192,7 +192,7 @@ class FacetChart extends React.Component {
         }
 
         // Check whether we have usable values in one array or the other we just collected (we'll
-        // just use `this;values` here) to see if we need to render a chart or not.
+        // just use `this.values` here) to see if we need to render a chart or not.
         if (this.values.length) {
             return (
                 <div className="collection-charts__chart">

--- a/src/encoded/static/components/collection.js
+++ b/src/encoded/static/components/collection.js
@@ -119,6 +119,8 @@ class FacetChart extends React.Component {
                                     // query string that combines all the "other" terms.
                                     queryString = generateMultipleQuery(facet.field, this.otherTerms);
                                 } else {
+                                    // The click was in an individual (not "other") term, so
+                                    // generate a single-term query string.
                                     queryString = generateQuery(facet.field, chartLabels[clickedElementIndex]);
                                 }
                                 const searchUri = `${baseSearchUri}&${queryString}`;
@@ -138,7 +140,7 @@ class FacetChart extends React.Component {
     render() {
         const { chartId, facet } = this.props;
         let terms = [];
-        let otherTerms = [];
+        let otherTerms;
 
         // If we have more facet terms than we allow to be displayed (determined through
         // MAX_CHART_ITEMS), then just get MAX_CHART_ITEMS to display as usual, and collect the
@@ -154,6 +156,7 @@ class FacetChart extends React.Component {
             // We don't have enough facet terms for an "other" category, so just use the whole
             // array of facet terms.
             terms = facet.terms;
+            otherTerms = [];
         }
 
         // Extract the arrays of labels from the facet keys, and the arrays of corresponding counts
@@ -175,14 +178,15 @@ class FacetChart extends React.Component {
             this.values.push(otherTerms.reduce((sum, term) => sum + term.doc_count, 0));
             this.labels.push('other');
 
-            // Keep track of the "other" terms and its location in the values/labels arrays so that
-            // the callbacks to handle clicks in the legend and the doughnut slices can handle the
-            // "other" term.
+            // Keep track of the "other" terms and its location (stored in this.otherTermsIndex) in
+            // the values/labels arrays so that the callbacks to handle clicks in the legend and
+            // the doughnut slices can handle the "other" term.
             this.otherTerms = otherTerms;
             this.otherTermsIndex = this.labels.length - 1;
         } else {
             // Remember we don't have enough terms to need an "other" term.
             this.otherTerms = [];
+            this.otherTermsIndex = 0;
         }
 
         // Check whether we have usable values in one array or the other we just collected (we'll

--- a/src/encoded/static/components/collection.js
+++ b/src/encoded/static/components/collection.js
@@ -93,6 +93,8 @@ class FacetChart extends React.Component {
                                     // query string that combines all the "other" terms.
                                     queryString = generateMultipleQuery(facet.field, this.otherTerms);
                                 } else {
+                                    // Handle a click in an individual term by generating a single-
+                                    // term query string.
                                     queryString = generateQuery(facet.field, chartLabels[i]);
                                 }
                                 const searchUri = `${baseSearchUri}&${queryString}`;


### PR DESCRIPTION
The key to this ticket is in the FacetChart component which now splits the facet terms into individual and “other” sections, if the number of terms exceeds the MAX_CHART_ITEMS constant. I store the values and labels as properties of the FacetChart component so that they’re accessible from the callbacks that actually draw the charts. Note that I _could_ store them as React component state too, but changing React state triggers a redraw, which would be unnecessary because these component properties are needed to draw the charts in the first place.

Changing MAX_CHART_ITEMS alone and rebuilding changes the number of items displayed before “other.”

Added two nested functions to the componentDidUpdate() method to generate query strings because both the legend-rendering callback and the doughnut-rendering click callback need to generate the same query strings under the same circumstances.