### PR TITLE
ENCD-3740-duplicate-quality-metric-audit

### DIFF
--- a/src/encoded/audit/file.py
+++ b/src/encoded/audit/file.py
@@ -306,7 +306,6 @@ def audit_duplicate_quality_metrics(value, system):
                 detail,
                 level='INTERNAL_ACTION'
             )
-    return
 
 
 function_dispatcher = {

--- a/src/encoded/audit/file.py
+++ b/src/encoded/audit/file.py
@@ -332,7 +332,9 @@ function_dispatcher = {
                       'controlled_by.dataset',
                       'controlled_by.paired_with',
                       'controlled_by.platform',
-                      'quality_metrics', ])
+                      'quality_metrics',
+                      ]
+               )
 def audit_file(value, system):
     for function_name in function_dispatcher.keys():
         for failure in function_dispatcher[function_name](value, system):

--- a/src/encoded/tests/test_audit_file.py
+++ b/src/encoded/tests/test_audit_file.py
@@ -748,11 +748,7 @@ def test_audit_file_duplicate_quality_metrics(testapp,
             'output_type': 'alignments',
             'assembly': 'GRCh38',
             'derived_from': [file2['@id']],
-            'step_run': analysis_step_run_bam['@id'],
-            'quality_metrics': [
-                chipseq_bam_quality_metric['@id'],
-                chipseq_bam_quality_metric_2['@id']
-            ]
+            'step_run': analysis_step_run_bam['@id']
         }
     )
     res = testapp.get(file6['@id'] + '@@index-data')
@@ -799,11 +795,7 @@ def test_audit_file_no_duplicate_quality_metrics(testapp,
             'output_type': 'alignments',
             'assembly': 'GRCh38',
             'derived_from': [file2['@id']],
-            'step_run': analysis_step_run_bam['@id'],
-            'quality_metrics': [
-                chipseq_bam_quality_metric['@id'],
-                chipseq_bam_quality_metric_2['@id']
-            ]
+            'step_run': analysis_step_run_bam['@id']
         }
     )
     res = testapp.get(file6['@id'] + '@@index-data')

--- a/src/encoded/tests/test_audit_file.py
+++ b/src/encoded/tests/test_audit_file.py
@@ -757,9 +757,7 @@ def test_audit_file_duplicate_quality_metrics(testapp,
     )
     res = testapp.get(file6['@id'] + '@@index-data')
     errors = res.json['audit']
-    errors_list = []
-    for error_type in errors:
-        errors_list.extend(errors[error_type])
+    errors_list = [error for v in errors.values() for error in v]
     assert any(
         error['category'] == 'duplicate quality metric'
         for error in errors_list
@@ -810,9 +808,7 @@ def test_audit_file_no_duplicate_quality_metrics(testapp,
     )
     res = testapp.get(file6['@id'] + '@@index-data')
     errors = res.json['audit']
-    errors_list = []
-    for error_type in errors:
-        errors_list.extend(errors[error_type])
+    errors_list = [error for v in errors.values() for error in v]
     assert all(
         error['category'] != 'duplicate quality metric'
         for error in errors_list


### PR DESCRIPTION
This checks if the list of quality metrics in a file is redundant based on the following signature which should be unique: 

`(analysis_name, assay_term_name, file_format, output_type, @type[0], processing_stage)`

For example a BAM should only have one of these:
`('ChIP-seq', 'bam', 'bwa-alignment-step-v-1', 'unfiltered alignments', 'SamtoolsFlagstatsQualityMetric', 'filtered')`

This avoid comparing numerical values between metrics to see if they are duplicates, which misses cases where the metrics are the same but the values are different.

On demo:
<img width="359" alt="screen shot 2017-11-28 at 5 08 25 pm" src="https://user-images.githubusercontent.com/16053922/33352651-d0e053f2-d45e-11e7-8ad4-d50acd6d9ac1.png">
