### PR TITLE
ENCD-3734 file audit escalation

### DIFF
--- a/src/encoded/audit/experiment.py
+++ b/src/encoded/audit/experiment.py
@@ -272,7 +272,7 @@ def audit_experiment_with_uploading_files(value, system, files_structure):
                           'with the status {}.'.format(value['@id'],
                                                        file_object['@id'],
                                                        file_object['status']))
-                yield AuditFailure(category, detail, level='INTERNAL_ACTION')
+                yield AuditFailure(category, detail, level='WARNING')
 
     return
 

--- a/src/encoded/audit/file.py
+++ b/src/encoded/audit/file.py
@@ -79,7 +79,7 @@ def audit_file_assembly(value, system):
                 f['@id']) + \
                 'it was derived from.'
             yield AuditFailure('inconsistent assembly',
-                               detail, level='INTERNAL_ACTION')
+                               detail, level='WARNING')
             return
 
 


### PR DESCRIPTION
escalating the audit from DCC_ACTION to WARNING for:
1. file upload/validation errors
2. file inconsistent assemblies