### PR TITLE
list.pop('blah',None) is an error that must be squashed.

### DIFF
--- a/src/encoded/visualization.py
+++ b/src/encoded/visualization.py
@@ -2329,10 +2329,10 @@ def object_is_visualizable(
         files = obj.get('files', [])
     browsers = browsers_available(obj.get('status', 'none'),  assemblies,
                                   obj.get('@type', []), files=files)
-    if exclude_quickview:
-        browsers.pop('quickview', None)
-
-    return len(browsers) > 0
+    if exclude_quickview and 'quickview' in browsers:
+        return len(browsers) > 1
+    else:
+        return len(browsers) > 0
 
 
 def vis_format_url(browser, path, assembly, position=None):


### PR DESCRIPTION
Both v64rc2 and es5 demos could be patched with small fix.  Without it, the secondary indexer is failing to fill vis_cache and large trackhubs are failing.  I have tested locally and on a demo (though it was an impure demo with region_indexer v2 changes). 