### PR TITLE
ENCD-3708 Update publication states

### DIFF
--- a/src/encoded/audit/item.py
+++ b/src/encoded/audit/item.py
@@ -51,7 +51,6 @@ STATUS_LEVEL = {
     # public statuses
     'released': 100,
     'current': 100,
-    'published': 100,
     'compliant': 100,
     'not compliant': 100,
     'not reviewed': 100,
@@ -78,7 +77,6 @@ STATUS_LEVEL = {
     'content error': 50,
     'pending dcc review': 50,
     'awaiting lab characterization': 50,
-    'in preparation': 50,
 
     # invisible statuses (visible for admins only)
     'deleted': 0,

--- a/src/encoded/schemas/changelogs/publication.md
+++ b/src/encoded/schemas/changelogs/publication.md
@@ -2,7 +2,7 @@
 
 ### Schema version 6
 
-* Changed available enum options for status from *in preparation*, *submitted*, *published* and *deleted* to *in progress*, *released* and *deleted*.
+* Changed available enum options for status from *in preparation*, *submitted*, *published* and *deleted* to *in progress*, *released* and *deleted*, where *in preparation* and *submitted* now map to *in progress* and *published* now maps to *released*.
 
 ### Schema version 5
 

--- a/src/encoded/schemas/changelogs/publication.md
+++ b/src/encoded/schemas/changelogs/publication.md
@@ -1,5 +1,9 @@
 ## Changelog for publication.json
 
+### Schema version 6
+
+* Changed available enum options for status from *in preparation*, *submitted*, *published* and *deleted* to *in progress*, *released* and *deleted*.
+
 ### Schema version 5
 
 * Remove in press, in revision, planned, replaced from statuses

--- a/src/encoded/schemas/publication.json
+++ b/src/encoded/schemas/publication.json
@@ -15,7 +15,7 @@
     ],
     "properties": {
         "schema_version": {
-            "default": "5"
+            "default": "6"
         },
         "title": {
             "title": "Title",
@@ -68,12 +68,11 @@
         "status": {
             "title": "Status",
             "type": "string",
-            "default": "in preparation",
+            "default": "in progress",
             "enum" : [
                 "deleted",
-                "in preparation",
-                "published",
-                "submitted"
+                "in progress",
+                "released"
             ]
         },
         "identifiers": {

--- a/src/encoded/static/components/testdata/publication/PMID16395128.js
+++ b/src/encoded/static/components/testdata/publication/PMID16395128.js
@@ -5,7 +5,7 @@ module.exports = {
     "identifiers": [
         "PMID:16395128"
     ],
-    "status": "published",
+    "status": "released",
     "title": "Possible association between response inhibition and a variant in the brain-expressed tryptophan hydroxylase-2 gene.",
     "uuid": "b163ba10-bd4a-11e4-bb52-0800200c9a66"
 };

--- a/src/encoded/static/components/testdata/publication/PMID23000965.js
+++ b/src/encoded/static/components/testdata/publication/PMID23000965.js
@@ -5,7 +5,7 @@ module.exports = {
     "identifiers": [
         "PMID:23000965"
     ],
-    "status": "published",
+    "status": "released",
     "title": "Systems-wide analysis of ubiquitylation dynamics reveals a key role for PAF15 ubiquitylation in DNA-damage bypass.",
     "uuid": "4cb65ec0-bd49-11e4-bb52-0800200c9a66"
 };

--- a/src/encoded/tests/data/inserts/publication.json
+++ b/src/encoded/tests/data/inserts/publication.json
@@ -9,7 +9,7 @@
         "volume": "489",
         "issue": "7414",
         "page": "57-74",
-        "status": "published",
+        "status": "released",
         "published_by": ["ENCODE"],
         "categories": ["integrative analysis"],
         "data_used": "ENCODE main paper",
@@ -18,7 +18,7 @@
         "uuid": "52e85c70-fe2d-11e3-9191-0800200c9a66"
     },
     {
-        "status":"in preparation",
+        "status":"in progress",
         "uuid":"baf202c2-b7af-4c43-b135-15104394daac",
         "title":"DNase-seq: a high-resolution technique for mapping active gene regulatory elements across the genome from mammalian cells.",
         "issue":"2",
@@ -34,7 +34,7 @@
         "categories": ["data standard"]
     },
     {
-        "status":"in preparation",
+        "status":"in progress",
         "uuid":"a63c94e8-4b64-425b-a5b5-86e4f0bdf4c2",
         "title":"The reality of pervasive transcription.",
         "issue":"7",
@@ -49,7 +49,7 @@
         "authors":"Clark MB, Amaral PP, Schlesinger FJ, Dinger ME, Taft RJ, Rinn JL, Ponting CP, Stadler PF, Morris KV, Morillon A, Rozowsky JS, Gerstein MB, Wahlestedt C, Hayashizaki Y, Carninci P, Gingeras TR, Mattick JS"
     },
     {
-        "status":"in preparation",
+        "status":"in progress",
         "uuid":"e9b33b63-3a85-47cf-9fc5-b1904c56d7ee",
         "title":"Missing lincs in the transcriptome.",
         "issue":"4",
@@ -64,7 +64,7 @@
         "authors":"Gingeras T"
     },
     {
-        "status":"in preparation",
+        "status":"in progress",
         "uuid":"f1d4ec0c-9c90-437e-a6e2-4688791abeea",
         "title":"Molecular biology: RNA discrimination.",
         "issue":"7385",
@@ -80,7 +80,7 @@
         "authors":"Kowalczyk MS, Higgs DR, Gingeras TR"
     },
     {
-        "status":"in preparation",
+        "status":"in progress",
         "uuid":"8c578e87-e4b1-432e-b58a-921c6933c1ea",
         "title":"Nucleosome positioning: bringing order to the eukaryotic genome.",
         "issue":"5",
@@ -96,7 +96,7 @@
         "abstract":"Nucleosomes are an essential component of eukaryotic chromosomes. The impact of nucleosomes is seen not just on processes that directly access the genome, such as transcription, but also on an evolutionary timescale. Recent studies in various organisms have provided high-resolution maps of nucleosomes throughout the genome. Computational analysis, in conjunction with many other kinds of data, has shed light on several aspects of nucleosome biology. Nucleosomes are positioned by several means, including intrinsic sequence biases, by stacking against a fixed barrier, by DNA-binding proteins and by chromatin remodelers. These studies underscore the important organizational role of nucleosomes in all  eukaryotic genomes. This paper reviews recent genomic studies that have shed light on the determinants of nucleosome positioning and their impact on the genome. AU"
     },
     {
-        "status":"in preparation",
+        "status":"in progress",
         "uuid":"46169636-fe8b-4823-bc73-49b6fcd6b484",
         "title":"Cross-talk between site-specific transcription factors and DNA methylation states.",
         "issue":"48",
@@ -112,7 +112,7 @@
         "abstract":"DNA methylation, which occurs predominantly at CpG dinucleotides, is a potent epigenetic repressor of transcription. Because DNA methylation is reversible, there is much interest in understanding the mechanisms by which it can be regulated by DNA-binding transcription factors. We discuss several models that, by incorporating sequence motifs, CpG density, and methylation levels, attempt to link the binding of a transcription factor with the acquisition or loss of DNA methylation at promoters and distal regulatory elements. Additional in vivo genome-wide characterization of transcription factor binding patterns and high-resolution DNA methylation analyses are clearly required for stronger support of each model. AU"
     },
     {
-        "status":"in preparation",
+        "status":"in progress",
         "uuid":"6af11fd9-c0d3-486a-afcb-6c350d20222c",
         "title":"Genome-wide epigenetic data facilitate understanding of disease susceptibility association studies.",
         "issue":"37",
@@ -145,7 +145,7 @@
             "PMID:23104886",
             "PMCID:PMC3530905"
         ],
-        "status": "published",
+        "status": "released",
         "title": "STAR: ultrafast universal RNA-seq aligner.",
         "volume": "29",
         "award": "U41HG006992",
@@ -200,7 +200,7 @@
                 "file_format": "BED"
             }
         ],
-        "status": "published",
+        "status": "released",
         "title": "HaploReg: a resource for exploring chromatin states, conservation, and regulatory motif alterations within sets of genetically linked variants.",
         "volume": "40",
         "award": "U41HG006992",
@@ -225,7 +225,7 @@
             "PMID:20110278",
             "PMCID:PMC2832824"
         ],
-        "status": "published",
+        "status": "released",
         "title": "BEDTools: a flexible suite of utilities for comparing genomic features.",
         "volume": "26",
         "award": "U41HG006992",
@@ -238,7 +238,7 @@
         "identifiers": [
             "PMID:23000965"
         ],
-        "status": "published",
+        "status": "released",
         "award": "U41HG006992",
         "lab": "j-michael-cherry",
         "title": "Systems-wide analysis of ubiquitylation dynamics reveals a key role for PAF15 ubiquitylation in DNA-damage bypass.",
@@ -250,7 +250,7 @@
         "identifiers": [
             "PMID:16395128"
         ],
-        "status": "published",
+        "status": "released",
         "award": "U41HG006992",
         "lab": "j-michael-cherry",
         "title": "Possible association between response inhibition and a variant in the brain-expressed tryptophan hydroxylase-2 gene.",
@@ -262,7 +262,7 @@
         "identifiers": [
              "PMID:22955991"
         ],
-        "status": "published",
+        "status": "released",
         "award": "U41HG006992",
         "lab": "j-michael-cherry",
         "title": "ChIP-seq guidelines and practices of the ENCODE and modENCODE consortia.",
@@ -274,7 +274,7 @@
         "identifiers": [
             "PMID:19966280"
         ],
-        "status": "published",
+        "status": "released",
         "award": "U41HG006992",
         "lab": "j-michael-cherry",
         "title": "Sequencing newly replicated DNA reveals widespread plasticity in human replication timing.",
@@ -286,7 +286,7 @@
         "identifiers": [
             "PMID:19261174"
         ],
-        "status": "published",
+        "status": "released",
         "award": "U41HG006992",
         "lab": "j-michael-cherry",
         "title": "Ultrafast and memory-efficient alignment of short DNA sequences to the human genome.",
@@ -298,7 +298,7 @@
         "identifiers": [
             "doi:10.1038/nphys1170"
         ],
-        "status": "published",
+        "status": "released",
         "award": "U41HG006992",
         "lab": "j-michael-cherry",
         "title": "Quantum tomography: Measured measurement",
@@ -310,7 +310,7 @@
         "identifiers": [
             "PMID:21131981"
         ],
-        "status": "published",
+        "status": "released",
         "award": "U41HG006992",
         "lab": "j-michael-cherry",
         "title":  "The three-dimensional folding of the α-globin gene domain reveals formation of chromatin globules.",
@@ -322,7 +322,7 @@
         "identifiers": [
             "PMID:16369547"
         ],
-        "status": "published",
+        "status": "released",
         "award": "U41HG006992",
         "lab": "j-michael-cherry",
         "title": "The three 'C' s of chromosome conformation capture: controls, controls, controls.",
@@ -334,7 +334,7 @@
         "identifiers": [
             "PMID:11847345"
         ],
-        "status": "published",
+        "status": "released",
         "award": "U41HG006992",
         "lab": "j-michael-cherry",
         "title": "Capturing chromosome conformation.",
@@ -346,7 +346,7 @@
         "identifiers": [
             "PMID:17446898"
         ],
-        "status": "published",
+        "status": "released",
         "award": "U41HG006992",
         "lab": "j-michael-cherry",
         "title": "Mapping networks of physical interactions between genomic elements using 5C technology.",
@@ -358,7 +358,7 @@
         "identifiers": [
             "PMID:16954542"
         ],
-        "status": "published",
+        "status": "released",
         "award": "U41HG006992",
         "lab": "j-michael-cherry",
         "title": "Chromosome Conformation Capture Carbon Copy (5C): a massively parallel solution for mapping interactions between genomic elements.",
@@ -369,7 +369,7 @@
         "identifiers": [
             "PMID:19789528"
         ],
-        "status": "published",
+        "status": "released",
         "award": "U41HG006992",
         "lab": "j-michael-cherry",
         "title": "My5C: web tools for chromosome conformation capture studies.",
@@ -381,7 +381,7 @@
         "identifiers": [
             "PMID:19706456"
         ],
-        "status": "published",
+        "status": "released",
         "award": "U41HG006992",
         "lab": "j-michael-cherry",
         "title": "Mapping accessible chromatin regions using Sono-Seq.",
@@ -393,7 +393,7 @@
         "identifiers": [
             "PMID:17568005"
         ],
-        "status": "published",
+        "status": "released",
         "award": "U41HG006992",
         "lab": "j-michael-cherry",
         "title": "Mapping of transcription factor binding regions in mammalian cells by ChIP: comparison of array- and sequencing-based technologies.",
@@ -405,7 +405,7 @@
         "identifiers": [
             "PMID:14527995"
         ],
-        "status": "published",
+        "status": "released",
         "award": "U41HG006992",
         "lab": "j-michael-cherry",
         "title": "Distribution of NF-kappaB-binding sites across human chromosome 22.",
@@ -417,7 +417,7 @@
         "identifiers": [
             "PMID:17558387"
         ],
-        "status": "published",
+        "status": "released",
         "award": "U41HG006992",
         "lab": "j-michael-cherry",
         "title": "Genome-wide profiles of STAT1 DNA association using chromatin immunoprecipitation and massively parallel sequencing.",
@@ -429,7 +429,7 @@
         "identifiers": [
             "PMID:19122651"
         ],
-        "status": "published",
+        "status": "released",
         "award": "U41HG006992",
         "lab": "j-michael-cherry",
         "title": "PeakSeq enables systematic scoring of ChIP-seq experiments relative to controls.",

--- a/src/encoded/tests/features/generics.feature
+++ b/src/encoded/tests/features/generics.feature
@@ -26,7 +26,7 @@ Feature: Generics
         | Experiment                    | DNA binding                           |
         | File                          | released                              |
         | Library                       | released                              |
-        | Publication                   | published                             |
+        | Publication                   | released                              |
         | Software                      | aligner                               |
         | Target                        | Homo sapiens                          |
 

--- a/src/encoded/tests/test_upgrade_publication.py
+++ b/src/encoded/tests/test_upgrade_publication.py
@@ -26,6 +26,16 @@ def publication_4():
     }
 
 
+@pytest.fixture
+def publication_5(publication):
+    item = publication.copy()
+    item.update({
+        'schema_version': '5',
+        'status': 'in preparation'
+    })
+    return item
+
+
 def test_publication_upgrade(upgrader, publication_1):
     value = upgrader.upgrade('publication', publication_1, target_version='2')
     assert value['schema_version'] == '2'
@@ -55,3 +65,24 @@ def test_publication_upgrade_4_5(upgrader, publication_4):
     value = upgrader.upgrade('publication', publication_4,
                              current_version='4', target_version='5')
     assert value['status'] == 'submitted'
+
+
+def test_publication_upgrade_5_6(upgrader, publication_5):
+    value = upgrader.upgrade('publication', publication_5, current_version='5', target_version='6')
+    assert value['schema_version'] == '6'
+    assert value['status'] == 'in progress'
+    
+    publication_5['status'] = 'published'
+    value = upgrader.upgrade('publication', publication_5, current_version='5', target_version='6')
+    assert value['schema_version'] == '6'
+    assert value['status'] == 'released'
+
+    publication_5['status'] = 'submitted'
+    value = upgrader.upgrade('publication', publication_5, current_version='5', target_version='6')
+    assert value['schema_version'] == '6'
+    assert value['status'] == 'in progress'
+
+    publication_5['status'] = 'deleted'
+    value = upgrader.upgrade('publication', publication_5, current_version='5', target_version='6')
+    assert value['schema_version'] == '6'
+    assert value['status'] == 'deleted'

--- a/src/encoded/types/base.py
+++ b/src/encoded/types/base.py
@@ -136,9 +136,6 @@ class Item(snovault.Item):
         'revoked': ALLOW_CURRENT,
         'in review': ALLOW_CURRENT_AND_SUBMITTER_EDIT,
 
-        # publication
-        'published': ALLOW_CURRENT,
-
         # pipeline
         'active': ALLOW_CURRENT,
         'archived': ALLOW_CURRENT,

--- a/src/encoded/upgrade/publication.py
+++ b/src/encoded/upgrade/publication.py
@@ -50,3 +50,16 @@ def publication_4_5(value, system):
         value['status'] = 'deleted'
     elif value['status'] in ['in press', 'in revision']:
         value['status'] = 'submitted'
+
+
+@upgrade_step('publication', '5', '6')
+def publication_5_6(value, system):
+    # https://encodedcc.atlassian.net/browse/ENCD-3708
+    if value['status'] == 'published':
+        value['status'] = 'released'
+    elif value['status'] == 'submitted':
+        value['status'] = 'in progress'
+    elif value['status'] == 'in preparation':
+        value['status'] = 'in progress'
+    else:
+        pass


### PR DESCRIPTION
Changes include:
- reduced enums to in progress, released and deleted
- bumped up the schema_version number to 6 and updated changelog
- added an upgrade to migrate existing statuses to new statuses
- added upgrade test, updated fixtures and generic features test
- scrubbing/updating in preparation and published statuses elsewhere in the codebase