### PR TITLE
ENCD-3724 Adjust facet term display check

### DIFF
--- a/src/encoded/static/components/search.js
+++ b/src/encoded/static/components/search.js
@@ -889,7 +889,7 @@ class Facet extends React.Component {
             if (term.key) {
                 // See if the facet term also exists in the search result filters (i.e. the term
                 // exists in the URL query string).
-                const found = filters.some(filter => filter.term === term.key);
+                const found = filters.some(filter => filter.field === facet.field && filter.term === term.key);
 
                 // If the term wasn't in the filters list, allow its display only if it has a non-
                 // zero doc_count. If the term *does* exist in the filters list, display it


### PR DESCRIPTION
When displaying the list of facets, now check both the term _and_ the facet.field against the search results filter to make sure we’re not matching the same term from a different facet. This prevents the 0-count term from displaying only because it happens to have the same term value as one in the /search/ query string.