### PR TITLE
ENCD-3741 Search for objects based on associated grant number

### DIFF
--- a/src/encoded/schemas/annotation.json
+++ b/src/encoded/schemas/annotation.json
@@ -380,6 +380,7 @@
         "software_used.software.name": 1.0,
         "award.title": 1.0,
         "award.project": 1.0,
+        "award.name": 1.0,
         "submitted_by.email": 1.0,
         "submitted_by.first_name": 1.0,
         "submitted_by.last_name": 1.0,

--- a/src/encoded/schemas/biosample.json
+++ b/src/encoded/schemas/biosample.json
@@ -923,6 +923,7 @@
         "donor.organism.taxon_id": 1.0,
         "award.title": 1.0,
         "award.project": 1.0,
+        "award.name": 1.0,
         "submitted_by.email": 1.0,
         "submitted_by.first_name": 1.0,
         "submitted_by.last_name": 1.0,

--- a/src/encoded/schemas/experiment.json
+++ b/src/encoded/schemas/experiment.json
@@ -509,6 +509,7 @@
         "replicates.library.nucleic_acid_term_name": 1.0,
         "award.title": 1.0,
         "award.project": 1.0,
+        "award.name": 1.0,
         "submitted_by.email": 1.0,
         "submitted_by.first_name": 1.0,
         "submitted_by.last_name": 1.0,

--- a/src/encoded/schemas/organism_development_series.json
+++ b/src/encoded/schemas/organism_development_series.json
@@ -245,6 +245,7 @@
         "organism.taxon_id": 1.0,
         "award.title": 1.0,
         "award.project": 1.0,
+        "award.name": 1.0,
         "submitted_by.email": 1.0,
         "submitted_by.first_name": 1.0,
         "submitted_by.last_name": 1.0,

--- a/src/encoded/schemas/project.json
+++ b/src/encoded/schemas/project.json
@@ -155,6 +155,7 @@
         "aliases": 1.0,
         "award.title": 1.0,
         "award.project": 1.0,
+        "award.name": 1.0,
         "submitted_by.email": 1.0,
         "submitted_by.first_name": 1.0,
         "submitted_by.last_name": 1.0,

--- a/src/encoded/schemas/publication_data.json
+++ b/src/encoded/schemas/publication_data.json
@@ -136,6 +136,7 @@
         "aliases": 1.0,
         "award.title": 1.0,
         "award.project": 1.0,
+        "award.name": 1.0,
         "submitted_by.email": 1.0,
         "submitted_by.first_name": 1.0,
         "submitted_by.last_name": 1.0,

--- a/src/encoded/schemas/reference.json
+++ b/src/encoded/schemas/reference.json
@@ -152,6 +152,7 @@
         "aliases": 1.0,
         "award.title": 1.0,
         "award.project": 1.0,
+        "award.name": 1.0,
         "submitted_by.email": 1.0,
         "submitted_by.first_name": 1.0,
         "submitted_by.last_name": 1.0,

--- a/src/encoded/schemas/reference_epigenome.json
+++ b/src/encoded/schemas/reference_epigenome.json
@@ -259,6 +259,7 @@
         "organism.taxon_id": 1.0,
         "award.title": 1.0,
         "award.project": 1.0,
+        "award.name": 1.0,
         "submitted_by.email": 1.0,
         "submitted_by.first_name": 1.0,
         "submitted_by.last_name": 1.0,

--- a/src/encoded/schemas/replication_timing_series.json
+++ b/src/encoded/schemas/replication_timing_series.json
@@ -279,6 +279,7 @@
         "organism.taxon_id": 1.0,
         "award.title": 1.0,
         "award.project": 1.0,
+        "award.name": 1.0,
         "submitted_by.email": 1.0,
         "submitted_by.first_name": 1.0,
         "submitted_by.last_name": 1.0,

--- a/src/encoded/schemas/treatment_concentration_series.json
+++ b/src/encoded/schemas/treatment_concentration_series.json
@@ -251,6 +251,7 @@
         "organism.taxon_id": 1.0,
         "award.title": 1.0,
         "award.project": 1.0,
+        "award.name": 1.0,
         "submitted_by.email": 1.0,
         "submitted_by.first_name": 1.0,
         "submitted_by.last_name": 1.0,

--- a/src/encoded/schemas/treatment_time_series.json
+++ b/src/encoded/schemas/treatment_time_series.json
@@ -255,6 +255,7 @@
         "organism.taxon_id": 1.0,
         "award.title": 1.0,
         "award.project": 1.0,
+        "award.name": 1.0,
         "submitted_by.email": 1.0,
         "submitted_by.first_name": 1.0,
         "submitted_by.last_name": 1.0,

--- a/src/encoded/schemas/ucsc_browser_composite.json
+++ b/src/encoded/schemas/ucsc_browser_composite.json
@@ -131,6 +131,7 @@
         "aliases": 1.0,
         "award.title": 1.0,
         "award.project": 1.0,
+        "award.name": 1.0,
         "submitted_by.email": 1.0,
         "submitted_by.first_name": 1.0,
         "submitted_by.last_name": 1.0,

--- a/src/encoded/search.py
+++ b/src/encoded/search.py
@@ -40,6 +40,7 @@ audit_facets = [
 
 DEFAULT_DOC_TYPES = [
     'AntibodyLot',
+    'Award',
     'Biosample',
     'Dataset',
     'Page',


### PR DESCRIPTION
There are basically two changes in this branch:

1. Add “award.name” to the boost values of the schemas of all objects we wanted to appear when searching for an associated award name.
1. Make awards searchable by adding it to DEFAULT_DOC_TYPES in search.py.

Because this affects searching, I also merged this change into an ES5 branch as a test, and found it works the same way as it does in ES1.7 with no changes. This branch is ES1.7 though.