### PR TITLE
ENCD-2567 New report page column selector modal

### DIFF
--- a/src/encoded/static/components/report.js
+++ b/src/encoded/static/components/report.js
@@ -400,9 +400,10 @@ class ColumnSelector extends React.Component {
             // Toggle the `visible` state corresponding to the column whose checkbox was toggled.
             // Then set that as the new React state which causes a redraw of the modal with all the
             // checkboxes in the correct state.
-            const oldColumns = Object.assign({}, prevState.columns);
-            oldColumns[columnPath].visible = !oldColumns[columnPath].visible;
-            return { columns: oldColumns };
+            const columns = Object.assign({}, prevState.columns);
+            columns[columnPath] = Object.assign({}, columns[columnPath]);
+            columns[columnPath].visible = !columns[columnPath].visible;
+            return { columns };
         });
     }
 
@@ -416,11 +417,12 @@ class ColumnSelector extends React.Component {
         // Called when the "Select all" button is clicked.
         this.setState((prevState) => {
             // For every column in this.state.columns, set its `visible` property to true.
-            const oldColumns = Object.assign({}, prevState.columns);
-            Object.keys(oldColumns).forEach((columnPath) => {
-                oldColumns[columnPath].visible = true;
+            const columns = Object.assign({}, prevState.columns);
+            Object.keys(columns).forEach((columnPath) => {
+                columns[columnPath] = Object.assign({}, columns[columnPath]);
+                columns[columnPath].visible = true;
             });
-            return { columns: oldColumns };
+            return { columns };
         });
     }
 
@@ -428,15 +430,16 @@ class ColumnSelector extends React.Component {
         // Called when the "Select (first) only" button is clicked.
         this.setState((prevState) => {
             // Set all columns to invisible first.
-            const oldColumns = Object.assign({}, prevState.columns);
-            const columnPaths = Object.keys(oldColumns);
+            const columns = Object.assign({}, prevState.columns);
+            const columnPaths = Object.keys(columns);
             columnPaths.forEach((columnPath) => {
-                oldColumns[columnPath].visible = false;
+                columns[columnPath] = Object.assign({}, columns[columnPath]);
+                columns[columnPath].visible = false;
             });
 
             // Now set the column for the first key to true so that only it's selected.
-            oldColumns[columnPaths[0]].visible = true;
-            return { columns: oldColumns };
+            columns[columnPaths[0]].visible = true;
+            return { columns };
         });
     }
 
@@ -575,7 +578,7 @@ class Report extends React.Component {
         // `newColumns` has the user's chosen columns from the modal, while `columns` has the
         // columns selected by the query string.
         const parsedUrl = url.parse(this.context.location_href, true);
-        parsedUrl.query.field = Object.keys(newColumns).filter(columnPath => newColumns[columnPath].visible);;
+        parsedUrl.query.field = Object.keys(newColumns).filter(columnPath => newColumns[columnPath].visible);
         delete parsedUrl.search;
         this.context.navigate(url.format(parsedUrl));
     }

--- a/src/encoded/static/components/report.js
+++ b/src/encoded/static/components/report.js
@@ -296,8 +296,10 @@ class ColumnSelectorControls extends React.Component {
         this.handleSortChange = this.handleSortChange.bind(this);
     }
 
-    // Called when the user changes the sorting option.
     handleSortChange(e) {
+        // Called when the user changes the sorting option. Sets a component state so that the
+        // controlled <select> component renders properly. It then calls the parent's callback to
+        // react to the new sorting option.
         this.setState({ selectedSort: e.target.value });
         this.props.handleSortChange(e.target.value);
     }
@@ -368,7 +370,11 @@ class ColumnSelector extends React.Component {
         }
 
         // Either a checkbox is being turned on, or it's being turned off and another checkbox is
-        // still checked. Change the component state to reflect the new checkbox states.
+        // still checked. Change the component state to reflect the new checkbox states. Presumably
+        // if the setState callback returned no properties setState becomes a null op, so the above
+        // test could be done inside the setState callback. The React docs don't say what happens
+        // if you return no properties (https://reactjs.org/docs/react-component.html#setstate) so
+        // I avoided doing this.
         this.setState((prevState) => {
             // Toggle the `visible` state corresponding to the column whose checkbox was toggled.
             // Then set that as the new React state which causes a redraw of the modal with all the
@@ -396,7 +402,7 @@ class ColumnSelector extends React.Component {
     }
 
     handleSelectOne() {
-        // Called when the "Select first only" button is clicked.
+        // Called when the "Select (first) only" button is clicked.
         this.setState((prevState) => {
             // Set all columns to invisible first.
             const columnPaths = Object.keys(prevState.columns);

--- a/src/encoded/static/components/report.js
+++ b/src/encoded/static/components/report.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'underscore';
 import url from 'url';
+import { Modal, ModalHeader, ModalBody, ModalFooter } from '../libs/bootstrap/modal';
 import { svgIcon } from '../libs/svg-icons';
 import { FetchedData, Param } from './fetched';
 import * as globals from './globals';
@@ -283,45 +284,55 @@ ColumnHeader.propTypes = {
 
 
 class ColumnSelector extends React.Component {
-    constructor() {
+    constructor(props) {
         super();
 
-        // Set initial React state.
+        // Set the initial React states.
         this.state = {
-            open: false,
+            columns: props.columns, // Make a local mutatable copy of the columns
         };
 
-        // Bind this to non-React methods.
-        this.toggle = this.toggle.bind(this);
+        // Bind `this` to non-React methods.
+        this.submitHandler = this.submitHandler.bind(this);
         this.toggleColumn = this.toggleColumn.bind(this);
     }
 
-    toggle(e) {
-        e.preventDefault();
-        this.setState(prevState => ({
-            open: !prevState.open,
-        }));
+    toggleColumn(columnPath) {
+        this.setState((prevState, props) => {
+            return {counter: prevState.counter + props.step};
+        });
     }
 
-    toggleColumn(path) {
-        this.props.toggleColumn(path);
+    submitHandler(e) {
     }
 
     render() {
-        const columnPaths = Object.keys(this.props.columns);
+        const { columns } = this.props;
+        const columnPaths = Object.keys(columns);
+
         return (
-            <div style={{ display: 'inline-block', position: 'relative' }}>
-                <button className={`btn btn-info btn-sm${this.state.open ? ' active' : ''}`} onClick={this.toggle} title="Choose columns">
-                    <i className="icon icon-columns" /> Columns
-                </button>
-                {this.state.open && <div style={{ position: 'absolute', top: '30px', width: '230px', backgroundColor: '#fff', padding: '.5em', border: 'solid 1px #ccc', borderRadius: 3, zIndex: 1 }}>
-                    <h4>Columns</h4>
-                    {columnPaths.map((columnPath) => {
-                        const column = this.props.columns[columnPath];
-                        return <ColumnItem key={columnPath} columnPath={columnPath} column={column} toggleColumn={this.toggleColumn} />;
-                    })}
-                </div>}
-            </div>
+            <Modal
+                actuator={
+                    <button className="btn btn-info btn-sm" title="Choose columns">
+                        <i className="icon icon-columns" /> Columns
+                    </button>
+                }
+                addClasses="column-selector"
+            >
+                <ModalHeader title="Select columns to view" closeModal />
+                <ModalBody>
+                    <div className="column-selector__selectors">
+                        {columnPaths.map((columnPath) => {
+                            const column = this.props.columns[columnPath];
+                            return <ColumnItem key={columnPath} columnPath={columnPath} column={column} toggleColumn={this.toggleColumn} />;
+                        })}
+                    </div>
+                </ModalBody>
+                <ModalFooter
+                    closeModal
+                    submitBtn={<button className="btn btn-info" onClick={this.submitHandler}>Set</button>}
+                />
+            </Modal>
         );
     }
 }
@@ -349,7 +360,7 @@ class ColumnItem extends React.Component {
         const { column } = this.props;
 
         return (
-            <div>
+            <div className="column-selector__selector-item">
                 <input type="checkbox" onChange={this.toggleColumn} checked={column.visible} />&nbsp;
                 <span onClick={this.toggleColumn} style={{ cursor: 'pointer' }}>{column.title}</span>
             </div>

--- a/src/encoded/static/components/report.js
+++ b/src/encoded/static/components/report.js
@@ -340,6 +340,7 @@ class ColumnSelector extends React.Component {
                 <ModalFooter
                     closeModal
                     submitBtn={this.submitHandler}
+                    submitTitle="Select"
                 />
             </Modal>
         );

--- a/src/encoded/static/components/report.js
+++ b/src/encoded/static/components/report.js
@@ -311,10 +311,12 @@ class ColumnSelectorControls extends React.Component {
                     <button onClick={handleSelectAll} className="btn btn-info">Select all</button>
                     <button onClick={handleSelectOne} className="btn btn-info">Select {firstColumnTitle} only</button>
                 </div>
-                <select className="column-selector__select" value={this.state.selectedSort} onChange={this.handleSortChange}>
-                    <option value="default">Default sort</option>
-                    <option value="alpha">Alphabetical sort</option>
-                </select>
+                <div className="column-selector__sort-selector">
+                    <select className="form-control--select" value={this.state.selectedSort} onChange={this.handleSortChange}>
+                        <option value="default">Default sort</option>
+                        <option value="alpha">Alphabetical sort</option>
+                    </select>
+                </div>
             </div>
         );
     }
@@ -414,11 +416,18 @@ class ColumnSelector extends React.Component {
     }
 
     render() {
-        const { columns } = this.props;
-        const firstColumnKey = Object.keys(this.state.columns)[0];
+        const { columns } = this.state;
+        const firstColumnKey = Object.keys(columns)[0];
+
+        // Get the column paths, sorting them by the corresponding column title if the user asked
+        // for that.
         let columnPaths = Object.keys(columns);
-        if (this.state.sortOptions === 'alpha') {
-            columnPaths = columnPaths.sort();
+        if (this.state.sortOption === 'alpha') {
+            columnPaths = columnPaths.sort((aKey, bKey) => {
+                const aTitle = columns[aKey].title;
+                const bTitle = columns[bKey].title;
+                return (aTitle < bTitle ? -1 : (bTitle < aTitle ? 1 : 0));
+            });
         }
 
         return (
@@ -431,16 +440,16 @@ class ColumnSelector extends React.Component {
                 addClasses="column-selector"
             >
                 <ModalHeader title="Select columns to view" closeModal />
+                <ColumnSelectorControls
+                    handleSelectAll={this.handleSelectAll}
+                    handleSelectOne={this.handleSelectOne}
+                    handleSortChange={this.handleSortChange}
+                    firstColumnTitle={columns[firstColumnKey].title}
+                />
                 <ModalBody>
-                    <ColumnSelectorControls
-                        handleSelectAll={this.handleSelectAll}
-                        handleSelectOne={this.handleSelectOne}
-                        handleSortChange={this.handleSortChange}
-                        firstColumnTitle={this.state.columns[firstColumnKey].title}
-                    />
                     <div className="column-selector__selectors">
                         {columnPaths.map((columnPath) => {
-                            const column = this.state.columns[columnPath];
+                            const column = columns[columnPath];
                             return <ColumnItem key={columnPath} columnPath={columnPath} column={column} toggleColumn={this.toggleColumn} />;
                         })}
                     </div>
@@ -449,7 +458,6 @@ class ColumnSelector extends React.Component {
                     closeModal
                     submitBtn={this.submitHandler}
                     submitTitle="Select"
-                    addCss="column-selector__controls"
                 />
             </Modal>
         );

--- a/src/encoded/static/components/report.js
+++ b/src/encoded/static/components/report.js
@@ -431,15 +431,8 @@ class ColumnSelector extends React.Component {
         }
 
         return (
-            <Modal
-                actuator={
-                    <button className="btn btn-info btn-sm" title="Choose columns">
-                        <i className="icon icon-columns" /> Columns
-                    </button>
-                }
-                addClasses="column-selector"
-            >
-                <ModalHeader title="Select columns to view" closeModal />
+            <Modal addClasses="column-selector">
+                <ModalHeader title="Select columns to view" closeModal={this.props.closeSelector} />
                 <ColumnSelectorControls
                     handleSelectAll={this.handleSelectAll}
                     handleSelectOne={this.handleSelectOne}
@@ -455,7 +448,7 @@ class ColumnSelector extends React.Component {
                     </div>
                 </ModalBody>
                 <ModalFooter
-                    closeModal
+                    closeModal={this.props.closeSelector}
                     submitBtn={this.submitHandler}
                     submitTitle="Select"
                 />
@@ -467,6 +460,7 @@ class ColumnSelector extends React.Component {
 ColumnSelector.propTypes = {
     columns: PropTypes.object.isRequired,
     setColumnState: PropTypes.func.isRequired,
+    closeSelector: PropTypes.func.isRequired,
 };
 
 
@@ -516,12 +510,15 @@ class Report extends React.Component {
             to: from + size,
             loading: false,
             more: [],
+            selectorOpen: false, // True if column selector modal is open
         };
 
         // Bind this to non-React methods.
         this.setSort = this.setSort.bind(this);
         this.setColumnState = this.setColumnState.bind(this);
         this.loadMore = this.loadMore.bind(this);
+        this.handleSelectorClick = this.handleSelectorClick.bind(this);
+        this.closeSelector = this.closeSelector.bind(this);
     }
 
     componentWillReceiveProps(nextProps, nextContext) {
@@ -592,6 +589,16 @@ class Report extends React.Component {
         });
     }
 
+    handleSelectorClick() {
+        // Handle click on the column selector button by opening the modal.
+        this.setState({ selectorOpen: true });
+    }
+
+    closeSelector() {
+        // Close the column selector modal.
+        this.setState({ selectorOpen: false });
+    }
+
     render() {
         const parsedUrl = url.parse(this.context.location_href, true);
         if (parsedUrl.pathname.indexOf('/report') !== 0) return false;  // avoid breaking on re-render when navigate changes href before context is changed
@@ -636,7 +643,9 @@ class Report extends React.Component {
                                         return <a href={href} className="btn btn-info btn-sm btn-svgicon" title={view.title} key={i}>{svgIcon(view2svg[view.icon])}</a>;
                                     })}
                                 </div>
-                                <ColumnSelector columns={columns} setColumnState={this.setColumnState} />
+                                <button className="btn btn-info btn-sm" title="Choose columns" onClick={this.handleSelectorClick}>
+                                    <i className="icon icon-columns" /> Columns
+                                </button>
                                 <a className="btn btn-info btn-sm" href={context.download_tsv} data-bypass>Download TSV</a>
                             </div>
                             <Table context={context} more={this.state.more} columns={columns} setSort={this.setSort} />
@@ -651,6 +660,13 @@ class Report extends React.Component {
                         </div>
                     </div>
                 </div>
+                {this.state.selectorOpen ?
+                    <ColumnSelector
+                        columns={columns}
+                        setColumnState={this.setColumnState}
+                        closeSelector={this.closeSelector}
+                    />
+                : null}
             </div>
         );
     }

--- a/src/encoded/static/components/report.js
+++ b/src/encoded/static/components/report.js
@@ -289,7 +289,7 @@ class ColumnSelector extends React.Component {
 
         // Set the initial React states.
         this.state = {
-            columns: props.columns, // Make a local mutatable copy of the columns
+            columns: props.columns, // Make (effectively) a local mutatable copy of the columns
         };
 
         // Bind `this` to non-React methods.
@@ -298,8 +298,9 @@ class ColumnSelector extends React.Component {
     }
 
     toggleColumn(columnPath) {
-        this.setState((prevState, props) => {
-            return {counter: prevState.counter + props.step};
+        this.setState((prevState) => {
+            prevState.columns[columnPath].visible = !prevState.columns[columnPath].visible;
+            return { columns: prevState.columns };
         });
     }
 
@@ -323,7 +324,7 @@ class ColumnSelector extends React.Component {
                 <ModalBody>
                     <div className="column-selector__selectors">
                         {columnPaths.map((columnPath) => {
-                            const column = this.props.columns[columnPath];
+                            const column = this.state.columns[columnPath];
                             return <ColumnItem key={columnPath} columnPath={columnPath} column={column} toggleColumn={this.toggleColumn} />;
                         })}
                     </div>

--- a/src/encoded/static/components/report.js
+++ b/src/encoded/static/components/report.js
@@ -283,15 +283,61 @@ ColumnHeader.propTypes = {
 };
 
 
+class ColumnSelectorControls extends React.Component {
+    constructor() {
+        super();
+
+        // Set initial React state.
+        this.state = {
+            selectedSort: 'default',
+        };
+
+        // Bind `this` to non-React methods.
+        this.handleSortChange = this.handleSortChange.bind(this);
+    }
+
+    // Called when the user changes the sorting option.
+    handleSortChange(e) {
+        this.setState({ selectedSort: e.target.value });
+        this.props.handleSortChange(e.target.value);
+    }
+
+    render() {
+        const { handleSelectAll, handleSelectOne, firstColumnTitle } = this.props;
+
+        return (
+            <div className="column-selector__controls">
+                <div className="column-selector__utility-buttons">
+                    <button onClick={handleSelectAll} className="btn btn-info">Select all</button>
+                    <button onClick={handleSelectOne} className="btn btn-info">Select {firstColumnTitle} only</button>
+                </div>
+                <select className="column-selector__select" value={this.state.selectedSort} onChange={this.handleSortChange}>
+                    <option value="default">Default sort</option>
+                    <option value="alpha">Alphabetical sort</option>
+                </select>
+            </div>
+        );
+    }
+}
+
+ColumnSelectorControls.propTypes = {
+    handleSelectAll: PropTypes.func.isRequired, // Callback when Select All button clicked
+    handleSelectOne: PropTypes.func.isRequired, // Callback when SelectOne button clicked
+    handleSortChange: PropTypes.func.isRequired, // Callback when sorting option changed
+    firstColumnTitle: PropTypes.string.isRequired, // Title of first column
+};
+
+
 // Displays a modal dialog with every possible column for the type of object being displayed.
 // This lets you choose which columns you want to appear in the report.
 class ColumnSelector extends React.Component {
     constructor(props) {
-        super();
+        super(props);
 
         // Set the initial React states.
         this.state = {
             columns: props.columns, // Make (effectively) a local mutatable copy of the columns
+            sortOption: 'default', // Default sorting option
         };
 
         // Bind `this` to non-React methods.
@@ -299,6 +345,7 @@ class ColumnSelector extends React.Component {
         this.toggleColumn = this.toggleColumn.bind(this);
         this.handleSelectAll = this.handleSelectAll.bind(this);
         this.handleSelectOne = this.handleSelectOne.bind(this);
+        this.handleSortChange = this.handleSortChange.bind(this);
     }
 
     toggleColumn(columnPath) {
@@ -361,10 +408,18 @@ class ColumnSelector extends React.Component {
         });
     }
 
+    // Called when the sorting option gets changed.
+    handleSortChange(sortOption) {
+        this.setState({ sortOption });
+    }
+
     render() {
         const { columns } = this.props;
-        const columnPaths = Object.keys(columns);
         const firstColumnKey = Object.keys(this.state.columns)[0];
+        let columnPaths = Object.keys(columns);
+        if (this.state.sortOptions === 'alpha') {
+            columnPaths = columnPaths.sort();
+        }
 
         return (
             <Modal
@@ -377,6 +432,12 @@ class ColumnSelector extends React.Component {
             >
                 <ModalHeader title="Select columns to view" closeModal />
                 <ModalBody>
+                    <ColumnSelectorControls
+                        handleSelectAll={this.handleSelectAll}
+                        handleSelectOne={this.handleSelectOne}
+                        handleSortChange={this.handleSortChange}
+                        firstColumnTitle={this.state.columns[firstColumnKey].title}
+                    />
                     <div className="column-selector__selectors">
                         {columnPaths.map((columnPath) => {
                             const column = this.state.columns[columnPath];
@@ -389,12 +450,7 @@ class ColumnSelector extends React.Component {
                     submitBtn={this.submitHandler}
                     submitTitle="Select"
                     addCss="column-selector__controls"
-                >
-                    <div className="column-selector__utility-buttons">
-                        <button onClick={this.handleSelectAll} className="btn btn-info">Select all</button>
-                        <button onClick={this.handleSelectOne} className="btn btn-info">Select {this.state.columns[firstColumnKey].title} only</button>
-                    </div>
-                </ModalFooter>
+                />
             </Modal>
         );
     }

--- a/src/encoded/static/components/report.js
+++ b/src/encoded/static/components/report.js
@@ -430,8 +430,8 @@ class ColumnSelector extends React.Component {
         let columnPaths = Object.keys(columns);
         if (this.state.sortOption === 'alpha') {
             columnPaths = columnPaths.sort((aKey, bKey) => {
-                const aTitle = columns[aKey].title;
-                const bTitle = columns[bKey].title;
+                const aTitle = columns[aKey].title.toLowerCase();
+                const bTitle = columns[bKey].title.toLowerCase();
                 return (aTitle < bTitle ? -1 : (bTitle < aTitle ? 1 : 0));
             });
         }

--- a/src/encoded/static/components/report.js
+++ b/src/encoded/static/components/report.js
@@ -437,10 +437,6 @@ class Report extends React.Component {
         // `newColumn s`has the user's chosen columns from the modal, while `columns` has the
         // columns selected by the query string.
         const parsedUrl = url.parse(this.context.location_href, true);
-        const type = parsedUrl.query.type;
-        const schema = this.props.schemas[type];
-        const queryFields = parsedUrl.query.field ? (typeof parsedUrl.query.field === 'object' ? parsedUrl.query.field : [parsedUrl.query.field]) : undefined;
-        const columns = columnChoices(schema, queryFields);
 
         const fields = Object.keys(newColumns).filter(columnPath => newColumns[columnPath].visible);
         parsedUrl.query.field = fields;

--- a/src/encoded/static/libs/bootstrap/modal.js
+++ b/src/encoded/static/libs/bootstrap/modal.js
@@ -207,7 +207,7 @@ export class ModalFooter extends React.Component {
         // given function. Note: if you pass `null` in the submitBtn property, this component
         // thinks that's a function because of an old Javascript characteristic.
         if (submitBtn) {
-            submitBtnComponent = (typeof submitBtn === 'object') ? submitBtn : <button className="btn btn-info" onClick={this.submitModal}>{submitTitle || 'Submit'}</button>;
+            submitBtnComponent = (typeof submitBtn === 'object') ? submitBtn : <button className="btn btn-info" onClick={this.submitModal}>{submitTitle}</button>;
         }
 
         // If the given closeModal property is a component, make sure it calls the close function
@@ -265,7 +265,7 @@ ModalFooter.propTypes = {
 
 ModalFooter.defaultProps = {
     submitBtn: null,
-    submitTitle: '',
+    submitTitle: 'Submit',
     addCss: '',
     closeModal: undefined,
     dontClose: false,

--- a/src/encoded/static/libs/bootstrap/modal.js
+++ b/src/encoded/static/libs/bootstrap/modal.js
@@ -198,7 +198,7 @@ export class ModalFooter extends React.Component {
     }
 
     render() {
-        const { submitBtn, submitTitle } = this.props;
+        const { submitBtn, submitTitle, addCss } = this.props;
         let { closeModal } = this.props;
         let submitBtnComponent = null;
         let closeBtnComponent = null;
@@ -233,15 +233,14 @@ export class ModalFooter extends React.Component {
         }
 
         return (
-            <div className="modal-footer">
+            <div className={`modal-footer${addCss ? ` ${addCss}` : ''}`}>
                 {this.props.children ? this.props.children : null}
                 {submitBtnComponent || closeBtnComponent ?
                     <div className="modal-footer-controls">
                         {closeBtnComponent}
                         {submitBtnComponent}
                     </div>
-                    : null}
-                {this.props.children}
+                : null}
             </div>
         );
     }
@@ -253,6 +252,7 @@ ModalFooter.propTypes = {
         PropTypes.func, // Function to call when default-rendered Submit button clicked
     ]),
     submitTitle: PropTypes.string, // Title for default submit button
+    addCss: PropTypes.string, // CSS classes to add to modal header
     closeModal: PropTypes.oneOfType([
         PropTypes.bool, // Use default-rendered Cancel button that closes the modal
         PropTypes.object, // Cancel button is a React component; just render it
@@ -266,6 +266,7 @@ ModalFooter.propTypes = {
 ModalFooter.defaultProps = {
     submitBtn: null,
     submitTitle: '',
+    addCss: '',
     closeModal: undefined,
     dontClose: false,
     c_closeModal: null,

--- a/src/encoded/static/libs/bootstrap/modal.js
+++ b/src/encoded/static/libs/bootstrap/modal.js
@@ -198,7 +198,7 @@ export class ModalFooter extends React.Component {
     }
 
     render() {
-        const { submitBtn } = this.props;
+        const { submitBtn, submitTitle } = this.props;
         let { closeModal } = this.props;
         let submitBtnComponent = null;
         let closeBtnComponent = null;
@@ -207,7 +207,7 @@ export class ModalFooter extends React.Component {
         // given function. Note: if you pass `null` in the submitBtn property, this component
         // thinks that's a function because of an old Javascript characteristic.
         if (submitBtn) {
-            submitBtnComponent = (typeof submitBtn === 'object') ? submitBtn : <button className="btn btn-info" onClick={this.submitModal}>Submit</button>;
+            submitBtnComponent = (typeof submitBtn === 'object') ? submitBtn : <button className="btn btn-info" onClick={this.submitModal}>{submitTitle || 'Submit'}</button>;
         }
 
         // If the given closeModal property is a component, make sure it calls the close function
@@ -252,6 +252,7 @@ ModalFooter.propTypes = {
         PropTypes.object, // Submit button is a React component; just render it
         PropTypes.func, // Function to call when default-rendered Submit button clicked
     ]),
+    submitTitle: PropTypes.string, // Title for default submit button
     closeModal: PropTypes.oneOfType([
         PropTypes.bool, // Use default-rendered Cancel button that closes the modal
         PropTypes.object, // Cancel button is a React component; just render it
@@ -264,6 +265,7 @@ ModalFooter.propTypes = {
 
 ModalFooter.defaultProps = {
     submitBtn: null,
+    submitTitle: '',
     closeModal: undefined,
     dontClose: false,
     c_closeModal: null,

--- a/src/encoded/static/libs/bootstrap/modal.js
+++ b/src/encoded/static/libs/bootstrap/modal.js
@@ -252,7 +252,7 @@ ModalFooter.propTypes = {
         PropTypes.func, // Function to call when default-rendered Submit button clicked
     ]),
     submitTitle: PropTypes.string, // Title for default submit button
-    addCss: PropTypes.string, // CSS classes to add to modal header
+    addCss: PropTypes.string, // CSS classes to add to modal footer
     closeModal: PropTypes.oneOfType([
         PropTypes.bool, // Use default-rendered Cancel button that closes the modal
         PropTypes.object, // Cancel button is a React component; just render it

--- a/src/encoded/static/scss/encoded/modules/_report.scss
+++ b/src/encoded/static/scss/encoded/modules/_report.scss
@@ -1,15 +1,24 @@
 // CSS class for the contents of the column-selector modal.
 .column-selector {
     // Container for all the selector checkboxes.
-    @at-root #{&}__selectors {
-        display: flex;
-        flex-wrap: wrap;
+    @media screen and (min-width: $screen-sm-min) {
+        @at-root #{&}__selectors {
+            display: flex;
+            flex-wrap: wrap;
+        }
     }
 
     // Each selector checkbox/label combo.
     @at-root #{&}__selector-item {
-        flex: 0 1 33.33%;
-        width: 33.33%;
+        @media screen and (min-width: $screen-sm-min) {
+            flex: 0 1 50%;
+            width: 50%;
+        }
+
+        @media screen and (min-width: $screen-md-min) {
+            flex: 0 1 33.33%;
+            width: 33.33%;
+        }
     }
 
     @at-root #{&}__controls {

--- a/src/encoded/static/scss/encoded/modules/_report.scss
+++ b/src/encoded/static/scss/encoded/modules/_report.scss
@@ -11,4 +11,22 @@
         flex: 0 1 33.33%;
         width: 33.33%;
     }
+
+    @at-root #{&}__controls {
+        .modal-footer-controls {
+            flex: 0 1 50%;
+            width: 50%;
+            text-align: right;
+        }
+    }
+
+    @at-root #{&}__controls {
+        display: flex;
+    }
+
+    @at-root #{&}__utility-buttons {
+        flex: 0 1 50%;
+        width: 50%;
+        text-align: left;
+    }
 }

--- a/src/encoded/static/scss/encoded/modules/_report.scss
+++ b/src/encoded/static/scss/encoded/modules/_report.scss
@@ -1,0 +1,14 @@
+// CSS class for the contents of the column-selector modal.
+.column-selector {
+    // Container for all the selector checkboxes.
+    @at-root #{&}__selectors {
+        display: flex;
+        flex-wrap: wrap;
+    }
+
+    // Each selector checkbox/label combo.
+    @at-root #{&}__selector-item {
+        flex: 0 1 33.33%;
+        width: 33.33%;
+    }
+}

--- a/src/encoded/static/scss/encoded/modules/_report.scss
+++ b/src/encoded/static/scss/encoded/modules/_report.scss
@@ -22,11 +22,28 @@
 
     @at-root #{&}__controls {
         display: flex;
+        padding: 5px;
+        border-bottom: 1px solid #a0a0a0;
+
+        button {
+            display: inline-block;
+            margin-right: 5px;
+        }
     }
 
     @at-root #{&}__utility-buttons {
         flex: 0 1 50%;
         width: 50%;
         text-align: left;
+    }
+
+    @at-root #{&}__sort-selector {
+        flex: 0 1 50%;
+        width: 50%;
+
+        > .form-control--select {
+            width: auto; // So the select only takes up as much room as it needs
+            margin-left: auto; // To right justify within a flex box
+        }
     }
 }

--- a/src/encoded/static/scss/style.scss
+++ b/src/encoded/static/scss/style.scss
@@ -103,6 +103,7 @@ $brand-info: #4F689E;
         "encoded/modules/award",
         "encoded/modules/pipeline",
         "encoded/modules/quality_metric",
+        "encoded/modules/report",
         "encoded/modules/tooltip",
         "encoded/modules/badge",
         "encoded/modules/news",


### PR DESCRIPTION
I used the existing Modal module used in several other places of the portal. Mostly this involved changing the existing ColumnSelector component to bring up this modal instead of the drop-down menu. I use the Modal in self-managed mode rather than plug-and-play mode so that its set of selected columns can be updated on mount — in plug-and-play mode, the modal doesn’t get mounted and unmounted as it gets displayed and dismissed, leaving its state with the selected columns potentially behind the reality coming from the URL query string.

I removed the toggleColumn method from the Report component because the columns no longer update as you select which columns you want to include or not. Instead a new setColumnState method gets called when the Modal gets dismissed, with the new set of selected columns set in there.

I also modified the Modal module itself to add custom CSS classes to the footer, as well as a custom title to the default Submit button, needed because the new report modal uses the default Submit button but renames it “Select.”