### PR TITLE
ENCD-3421 Properly link home chart to matrix

### DIFF
--- a/src/encoded/static/components/home.js
+++ b/src/encoded/static/components/home.js
@@ -628,12 +628,11 @@ class HomepageChart2 extends React.Component {
                         },
                         onClick: (e) => {
                             // React to clicks on pie sections
-                            const query = this.computationalPredictions ? 'biosample_type=' : 'replicates.library.biosample.biosample_type=';
                             const activePoints = this.myPieChart.getElementAtEvent(e);
                             if (activePoints[0]) {
                                 const clickedElementIndex = activePoints[0]._index;
                                 const term = this.myPieChart.data.labels[clickedElementIndex];
-                                this.context.navigate(`/matrix/${this.props.query}&${query}${term}`); // go to matrix view
+                                this.context.navigate(`/matrix/${this.props.query}&biosample_type=${term}`); // go to matrix view
                             }
                         },
                     },

--- a/src/encoded/static/components/matrix.js
+++ b/src/encoded/static/components/matrix.js
@@ -268,7 +268,7 @@ class Matrix extends React.Component {
                                                 parsed.query['y.limit'] = null;
                                                 delete parsed.search; // this makes format compose the search string out of the query object
                                                 const groupHref = url.format(parsed);
-                                                const rows = [<tr key={group.key}>
+                                                const rows = [<tr key={`group-${group.key}`}>
                                                     <th colSpan={colCount + 1} style={{ textAlign: 'left', backgroundColor: groupColor }}>
                                                         <a href={groupHref} style={{ color: '#fff' }}>{group.key}</a>
                                                     </th>
@@ -283,7 +283,7 @@ class Matrix extends React.Component {
                                                 rows.push(...groupRows.map((yb) => {
                                                     const href = `${searchBase}&${secondaryYGrouping}=${globals.encodedURIComponent(yb.key)}`;
                                                     return (
-                                                        <tr key={yb.key}>
+                                                        <tr key={`yb-${yb.key}`}>
                                                             <th style={{ backgroundColor: '#ddd', border: 'solid 1px white' }}><a href={href}>{yb.key}</a></th>
                                                             {xBuckets.map((xb, k) => {
                                                                 if (k < xLimit) {


### PR DESCRIPTION
We no longer need to take the Computational Prediction option to decide whether to use experiment.biosample_type or replicate.library.biosample.biosample_type — we now always use experiment.biosample_type. That lets us properly link from the home page chart to the matrix. Also, fix a React warning caused by having biosample_type and biosample_term_name having the same text value, something we’ve not had before.