### PR TITLE
ENCD-3456 Stringify array and object items in a cell

### DIFF
--- a/src/encoded/static/components/report.js
+++ b/src/encoded/static/components/report.js
@@ -122,6 +122,12 @@ function lookupColumn(result, column) {
     if (nodes.length && nodes[0]['@id'] !== undefined) {
         nodes = nodes.map(node => node['@id']);
     }
+
+    // Stringify any nodes that are objects or arrays. Objects and arrays have typeof `object`.
+    if (nodes.length) {
+        nodes = nodes.map(item => (typeof item === 'object' ? JSON.stringify(item) : item));
+    }
+
     return _.uniq(nodes).join(', ');
 }
 


### PR DESCRIPTION
When displaying the report, stringify any values of type object to make them appear as JSON in the table.