### PR TITLE
ENCD-3815 fix test search

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 These are the primary software versions used in production, and you should be able to use them locally:
 - Python 3.4.3
 - Node 6
-- Elasticsearch 1.7
+- Elasticsearch 5.4 (or later?)
 - Java VM 1.8
 - Ubuntu 14.04
 

--- a/src/encoded/tests/test_search.py
+++ b/src/encoded/tests/test_search.py
@@ -448,7 +448,7 @@ def test_set_facets():
                         'field': 'embedded.@type',
                         'exclude': ['Item'],
                         'min_doc_count': 0,
-                        'size': 100,
+                        'size': 200,
                     },
                 },
             },
@@ -470,7 +470,7 @@ def test_set_facets():
                     'terms': {
                         'field': 'audit.foo',
                         'min_doc_count': 0,
-                        'size': 100,
+                        'size': 200,
                     },
                 },
             },
@@ -491,7 +491,7 @@ def test_set_facets():
                     'terms': {
                         'field': 'embedded.facet1',
                         'min_doc_count': 0,
-                        'size': 100,
+                        'size': 200,
                     },
                 },
             },
@@ -530,7 +530,7 @@ def test_set_facets_negated_filter():
                     'terms': {
                         'field': 'embedded.facet1',
                         'min_doc_count': 0,
-                        'size': 100,
+                        'size': 200,
                     },
                 },
             },

--- a/versions.cfg
+++ b/versions.cfg
@@ -25,7 +25,6 @@ repoze.debug = 1.0.2
 repoze.lru = 0.6
 rubygemsrecipe = 0.2.2
 rutter = 0.2
-selenium = 3.4.3
 splinter = 0.7.5
 translationstring = 1.3
 urllib3 = 1.14
@@ -254,3 +253,6 @@ boto = 2.48.0
 # Required by:
 # encoded==0.1
 elasticsearch = 5.4.0
+
+# Added by buildout at 2018-01-17 17:26:37.230945
+selenium = 3.8.1


### PR DESCRIPTION
This just upgrades python selenium module and adds a correction to README re: ES5.  
BDD tests seem to pass locally now on Mac.