### PR TITLE
ENCD-3827 Fix ES5 version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 These are the primary software versions used in production, and you should be able to use them locally:
 - Python 3.4.3
 - Node 6
-- Elasticsearch 1.7
+- Elasticsearch 5.4 (or later?)
 - Java VM 1.8
 - Ubuntu 14.04
 


### PR DESCRIPTION
Split from ENCD-3815 fix test search  #2112 