### PR TITLE
ENCD-3820 Biosample: PMI property

### DIFF
--- a/src/encoded/schemas/biosample.json
+++ b/src/encoded/schemas/biosample.json
@@ -176,22 +176,6 @@
                 }
             }
         },
-        "PMI": {
-            "comment": "The PMI property is restricted to biosamples with biosample_type = tissue.",
-            "properties": {
-                "biosample_type": {
-                    "enum": ["tissue"]
-                }
-            }
-        },
-        "PMI_units": {
-            "comment": "The PMI_units property is restricted to biosamples with biosample_type = tissue.",
-            "properties": {
-                "biosample_type": {
-                    "enum": ["tissue"]
-                }
-            }
-        },
         "starting_amount":{
             "required": ["starting_amount_units"],
             "comment": "Biosamples with a specified starting_amount require starting_amount_units to also be specified."
@@ -202,11 +186,23 @@
         },
         "PMI":{
             "required": ["PMI_units"],
-            "comment": "Tissue biosamples with a specified PMI require PMI_units to also be specified."
+            "comment": "Tissue biosamples with a specified PMI require PMI_units to also be specified.",
+            "properties": {
+                "biosample_type": {
+                    "comment": "The PMI property is restricted to biosamples with biosample_type = tissue.",
+                    "enum": ["tissue"]
+                }
+            }
         },
         "PMI_units": {
             "required":["PMI"],
-            "comment": "Tissue biosamples with a specified PMI_units require PMI to also be specified."
+            "comment": "Tissue biosamples with a specified PMI_units require PMI to also be specified.",
+            "properties": {
+                "biosample_type": {
+                    "comment": "The PMI_units property is restricted to biosamples with biosample_type = tissue.",
+                    "enum": ["tissue"]
+                }
+            }
         },
         "model_organism_age_units": {
             "required":["model_organism_age"],

--- a/src/encoded/schemas/biosample.json
+++ b/src/encoded/schemas/biosample.json
@@ -164,7 +164,7 @@
             "comment": "The culture_harvest_date property is restricted to biosamples with biosample_type that belongs to [primary cell, immortalized cell line, in vitro differentiated cells, induced pluripotent stem cell line, stem cell].",
             "properties": {
                 "biosample_type": {
-                    "enum": ["tissue", "primary cell", "immortalized cell line", "in vitro differentiated cells", "stem cell", "induced pluripotent stem cell line"]
+                    "enum": ["primary cell", "immortalized cell line", "in vitro differentiated cells", "stem cell", "induced pluripotent stem cell line"]
                 }
             }
         },
@@ -172,17 +172,41 @@
             "comment": "The culture_start_date property is restricted to biosamples with biosample_type that belongs to [primary cell, immortalized cell line, in vitro differentiated cells, induced pluripotent stem cell line, stem cell].",
             "properties": {
                 "biosample_type": {
-                    "enum": ["tissue", "primary cell", "immortalized cell line", "in vitro differentiated cells", "stem cell", "induced pluripotent stem cell line"]
+                    "enum": ["primary cell", "immortalized cell line", "in vitro differentiated cells", "stem cell", "induced pluripotent stem cell line"]
+                }
+            }
+        },
+        "PMI": {
+            "comment": "The PMI property is restricted to biosamples with biosample_type = tissue.",
+            "properties": {
+                "biosample_type": {
+                    "enum": ["tissue"]
+                }
+            }
+        },
+        "PMI_units": {
+            "comment": "The PMI_units property is restricted to biosamples with biosample_type = tissue.",
+            "properties": {
+                "biosample_type": {
+                    "enum": ["tissue"]
                 }
             }
         },
         "starting_amount":{
             "required": ["starting_amount_units"],
-            "comment": "Biosample with a specified starting_amount requires starting_amount_units specification."
+            "comment": "Biosamples with a specified starting_amount require starting_amount_units to also be specified."
         },
         "starting_amount_units": {
             "required":["starting_amount"],
-            "comment": "Biosample with a specified starting_amount_units requires starting_amount specification."
+            "comment": "Biosamples with a specified starting_amount_units require starting_amount to also be specified."
+        },
+        "PMI":{
+            "required": ["PMI_units"],
+            "comment": "Tissue biosamples with a specified PMI require PMI_units to also be specified."
+        },
+        "PMI_units": {
+            "required":["PMI"],
+            "comment": "Tissue biosamples with a specified PMI_units require PMI to also be specified."
         },
         "model_organism_age_units": {
             "required":["model_organism_age"],
@@ -614,6 +638,23 @@
                 "whole animals",
                 "whole embryos",
                 "μg"
+            ]
+        },
+        "PMI": {
+            "title": "Post-mortem interval",
+            "description": "The amount of time elapsed since death.",
+            "type": "integer"
+        },
+        "PMI_units": {
+            "title": "Post-mortem interval units",
+            "description": "The unit in which the PMI time was reported.",
+            "type": "string",
+            "enum": [
+                "second",
+                "minute",
+                "hour",
+                "day",
+                "week"
             ]
         },
         "model_organism_sex": {

--- a/src/encoded/schemas/changelogs/biosample.md
+++ b/src/encoded/schemas/changelogs/biosample.md
@@ -1,5 +1,11 @@
 ## Changelog for biosample.json
 
+### Minor changes since schema version 19
+
+* *PMI* and *PMI_units* were added as new properties, with dependencies enforcing their interdependent use.
+* *PMI* and *PMI_units* are additionally restricted to only be used for tissue biosamples.
+* *culture_harvest_date* and *culture_start_date* no longer can be used for tissues (a mistake introduced recently and now corrected within the dependencies).
+
 ### Schema version 19
 
 * Links to *constructs* and *rnais* via those properties of the same name have been removed.


### PR DESCRIPTION
Added PMI and PMI_units properties to biosample.json, along with dependencies to limit its use to tissue biosamples and only in tandem. Also removed tissue biosamples from culture_start and end date properties inappropriately included in that dependency.