### PR TITLE
ENCD-3757 Adjust histone broad peak read depth audit

### DIFF
--- a/src/encoded/audit/experiment.py
+++ b/src/encoded/audit/experiment.py
@@ -133,9 +133,9 @@ def check_control_read_depth_standards(value,
                     'histone mark {} '.format(control_to_target) + \
                     'is 35 million usable fragments, the recommended number of usable ' + \
                     'fragments is > 45 million. (See /data-standards/chip-seq/ )'
-            if read_depth >= marks['broad']['minimal'] and read_depth < marks['broad']['recommended']:
+            if read_depth >= 35000000 and read_depth < marks['broad']:
                 yield AuditFailure('control low read depth', detail, level='WARNING')
-            elif read_depth >= marks['broad']['low'] and read_depth < marks['broad']['minimal']:
+            elif read_depth >= 5000000 and read_depth < 35000000:
                 yield AuditFailure('control insufficient read depth', detail, level='NOT_COMPLIANT')
             elif read_depth < marks['broad']['low']:
                 yield AuditFailure('control extremely low read depth', detail, level='ERROR')
@@ -187,9 +187,9 @@ def check_control_read_depth_standards(value,
                     'fragments is > 20 million. (See /data-standards/chip-seq/ )'
             if read_depth >= marks['TF']['minimal'] and read_depth < marks['TF']['recommended']:
                 yield AuditFailure('control low read depth', detail, level='WARNING')
-            elif read_depth >= marks['TF']['low'] and read_depth < marks['TF']['minimal']:
+            elif read_depth >= 5000000 and read_depth < 10000000:
                 yield AuditFailure('control low read depth', detail, level='NOT_COMPLIANT')
-            elif read_depth < marks['TF']['low']:
+            elif read_depth < 5000000:
                 yield AuditFailure('control extremely low read depth', detail, level='ERROR')
     return
 
@@ -1410,7 +1410,7 @@ def check_file_chip_seq_read_depth(file_to_check,
                         'fragments is > 20 million. (See /data-standards/chip-seq/ )'
                 if read_depth >= marks['narrow']['minimal']:
                     yield AuditFailure('low read depth', detail, level='WARNING')
-                elif read_depth >= marks['narrow']['low'] and read_depth < marks['narrow']['minimal']:
+                elif read_depth >= 5000000 and read_depth < 10000000:
                     yield AuditFailure('insufficient read depth',
                                        detail, level='NOT_COMPLIANT')
                 else:
@@ -1447,10 +1447,10 @@ def check_file_chip_seq_read_depth(file_to_check,
                             'a broad histone mark is 35 million mapped reads. ' + \
                             'The recommended value is > 45 million, but > 35 million is ' + \
                             'acceptable. (See /data-standards/chip-seq/ )'
-                    if read_depth >= marks['broad']['minimal']:
+                    if read_depth >= 35000000:
                         yield AuditFailure('low read depth',
                                            detail, level='WARNING')
-                    elif read_depth >= 100 and read_depth < marks['broad']['minimal']:
+                    elif read_depth >= 5000000 and read_depth < 35000000:
                         yield AuditFailure('insufficient read depth',
                                            detail, level='NOT_COMPLIANT')
                     elif read_depth < 100:
@@ -1482,10 +1482,10 @@ def check_file_chip_seq_read_depth(file_to_check,
                         'The recommended value is > 45 million, but > 35 million is ' + \
                         'acceptable. (See /data-standards/chip-seq/ )'
 
-                if read_depth >= marks['broad']['minimal'] and read_depth < marks['broad']['recommended']:
+                if read_depth >= 35000000 and read_depth < marks['broad']:
                     yield AuditFailure('low read depth',
                                        detail, level='WARNING')
-                elif read_depth < marks['broad']['minimal'] and read_depth >= marks['broad']['low']:
+                elif read_depth < 35000000 and read_depth >= 5000000:
                     yield AuditFailure('insufficient read depth',
                                        detail, level='NOT_COMPLIANT')
                 elif read_depth < marks['broad']['low']:
@@ -1570,10 +1570,10 @@ def check_file_chip_seq_read_depth(file_to_check,
                         'acceptable. (See /data-standards/chip-seq/ )'
                 if read_depth >= marks['TF']['minimal'] and read_depth < marks['TF']['recommended']:
                     yield AuditFailure('low read depth', detail, level='WARNING')
-                elif read_depth < marks['TF']['minimal'] and read_depth >= marks['TF']['low']:
+                elif read_depth < 10000000 and read_depth >= 5000000:
                     yield AuditFailure('insufficient read depth',
                                        detail, level='NOT_COMPLIANT')
-                elif read_depth < marks['TF']['low']:
+                elif read_depth < 5000000:
                     yield AuditFailure('extremely low read depth',
                                        detail, level='ERROR')
     return

--- a/src/encoded/audit/experiment.py
+++ b/src/encoded/audit/experiment.py
@@ -133,9 +133,9 @@ def check_control_read_depth_standards(value,
                     'histone mark {} '.format(control_to_target) + \
                     'is 35 million usable fragments, the recommended number of usable ' + \
                     'fragments is > 45 million. (See /data-standards/chip-seq/ )'
-            if read_depth >= 35000000 and read_depth < marks['broad']:
+            if read_depth >= marks['broad']['minimal'] and read_depth < marks['broad']['recommended']:
                 yield AuditFailure('control low read depth', detail, level='WARNING')
-            elif read_depth >= 5000000 and read_depth < 35000000:
+            elif read_depth >= marks['broad']['low'] and read_depth < marks['broad']['minimal']:
                 yield AuditFailure('control insufficient read depth', detail, level='NOT_COMPLIANT')
             elif read_depth < marks['broad']['low']:
                 yield AuditFailure('control extremely low read depth', detail, level='ERROR')
@@ -162,7 +162,7 @@ def check_control_read_depth_standards(value,
             if read_depth >= marks['narrow']['minimal'] and read_depth < marks['narrow']['recommended']:
                 yield AuditFailure('control low read depth', detail, level='WARNING')
             elif read_depth >= marks['narrow']['low'] and read_depth < marks['narrow']['minimal']:
-                yield AuditFailure('control insufficient read depth', detail, level='NOT_COMPLIANT')
+                yield AuditFailure('control low read depth', detail, level='NOT_COMPLIANT')
             elif read_depth < marks['narrow']['low']:
                 yield AuditFailure('control extremely low read depth', detail, level='ERROR')
         else:
@@ -187,9 +187,9 @@ def check_control_read_depth_standards(value,
                     'fragments is > 20 million. (See /data-standards/chip-seq/ )'
             if read_depth >= marks['TF']['minimal'] and read_depth < marks['TF']['recommended']:
                 yield AuditFailure('control low read depth', detail, level='WARNING')
-            elif read_depth >= 5000000 and read_depth < 10000000:
+            elif read_depth >= marks['TF']['low'] and read_depth < marks['TF']['minimal']:
                 yield AuditFailure('control low read depth', detail, level='NOT_COMPLIANT')
-            elif read_depth < 5000000:
+            elif read_depth < marks['TF']['low']:
                 yield AuditFailure('control extremely low read depth', detail, level='ERROR')
     return
 
@@ -1380,7 +1380,7 @@ def check_file_chip_seq_read_depth(file_to_check,
                         'histone marks ' + \
                         'is 20 million usable fragments, the recommended number of usable ' + \
                         'fragments is > 45 million. (See /data-standards/chip-seq/ )'
-                yield AuditFailure('insufficient read depth for broad peaks control', detail, level='INTERNAL_ACTION')
+                yield AuditFailure('low read depth', detail, level='INTERNAL_ACTION')
             if read_depth < marks['narrow']['recommended']:
                 if 'assembly' in file_to_check:
                     detail = 'Control alignment file {} mapped using {} assembly has {} '.format(
@@ -1410,7 +1410,7 @@ def check_file_chip_seq_read_depth(file_to_check,
                         'fragments is > 20 million. (See /data-standards/chip-seq/ )'
                 if read_depth >= marks['narrow']['minimal']:
                     yield AuditFailure('low read depth', detail, level='WARNING')
-                elif read_depth >= 5000000 and read_depth < 10000000:
+                elif read_depth >= marks['narrow']['low'] and read_depth < marks['narrow']['minimal']:
                     yield AuditFailure('insufficient read depth',
                                        detail, level='NOT_COMPLIANT')
                 else:
@@ -1447,15 +1447,12 @@ def check_file_chip_seq_read_depth(file_to_check,
                             'a broad histone mark is 35 million mapped reads. ' + \
                             'The recommended value is > 45 million, but > 35 million is ' + \
                             'acceptable. (See /data-standards/chip-seq/ )'
-                    if read_depth >= 35000000:
+                    if read_depth >= marks['broad']['minimal']:
                         yield AuditFailure('low read depth',
                                            detail, level='WARNING')
-                    elif read_depth >= 5000000 and read_depth < 35000000:
+                    elif read_depth < marks['broad']['minimal']:
                         yield AuditFailure('insufficient read depth',
                                            detail, level='NOT_COMPLIANT')
-                    elif read_depth < 100:
-                        yield AuditFailure('extremely low read depth',
-                                           detail, level='ERROR')
             else:
                 if 'assembly' in file_to_check:
                     detail = 'Alignment file {} '.format(file_to_check['@id']) + \
@@ -1482,10 +1479,10 @@ def check_file_chip_seq_read_depth(file_to_check,
                         'The recommended value is > 45 million, but > 35 million is ' + \
                         'acceptable. (See /data-standards/chip-seq/ )'
 
-                if read_depth >= 35000000 and read_depth < marks['broad']:
+                if read_depth >= marks['broad']['minimal'] and read_depth < marks['broad']['recommended']:
                     yield AuditFailure('low read depth',
                                        detail, level='WARNING')
-                elif read_depth < 35000000 and read_depth >= 5000000:
+                elif read_depth < marks['broad']['minimal'] and read_depth >= marks['broad']['low']:
                     yield AuditFailure('insufficient read depth',
                                        detail, level='NOT_COMPLIANT')
                 elif read_depth < marks['broad']['low']:
@@ -1570,10 +1567,10 @@ def check_file_chip_seq_read_depth(file_to_check,
                         'acceptable. (See /data-standards/chip-seq/ )'
                 if read_depth >= marks['TF']['minimal'] and read_depth < marks['TF']['recommended']:
                     yield AuditFailure('low read depth', detail, level='WARNING')
-                elif read_depth < 10000000 and read_depth >= 5000000:
+                elif read_depth < marks['TF']['minimal'] and read_depth >= marks['TF']['low']:
                     yield AuditFailure('insufficient read depth',
                                        detail, level='NOT_COMPLIANT')
-                elif read_depth < 5000000:
+                elif read_depth < marks['TF']['low']:
                     yield AuditFailure('extremely low read depth',
                                        detail, level='ERROR')
     return

--- a/src/encoded/audit/experiment.py
+++ b/src/encoded/audit/experiment.py
@@ -122,7 +122,7 @@ def check_control_read_depth_standards(value,
                     'usable fragments. ' + \
                     'The minimum ENCODE standard for a control of ChIP-seq assays targeting broad ' + \
                     'histone mark {} '.format(control_to_target) + \
-                    'is 40 million usable fragments, the recommended number of usable ' + \
+                    'is 35 million usable fragments, the recommended number of usable ' + \
                     'fragments is > 45 million. (See /data-standards/chip-seq/ )'
             else:
                 detail = 'Control alignment file {} has {} '.format(
@@ -131,11 +131,11 @@ def check_control_read_depth_standards(value,
                     'usable fragments. ' + \
                     'The minimum ENCODE standard for a control of ChIP-seq assays targeting broad ' + \
                     'histone mark {} '.format(control_to_target) + \
-                    'is 40 million usable fragments, the recommended number of usable ' + \
+                    'is 35 million usable fragments, the recommended number of usable ' + \
                     'fragments is > 45 million. (See /data-standards/chip-seq/ )'
-            if read_depth >= 40000000 and read_depth < marks['broad']:
+            if read_depth >= 35000000 and read_depth < marks['broad']:
                 yield AuditFailure('control low read depth', detail, level='WARNING')
-            elif read_depth >= 5000000 and read_depth < 40000000:
+            elif read_depth >= 5000000 and read_depth < 35000000:
                 yield AuditFailure('control insufficient read depth', detail, level='NOT_COMPLIANT')
             elif read_depth < 5000000:
                 yield AuditFailure('control extremely low read depth', detail, level='ERROR')
@@ -187,9 +187,9 @@ def check_control_read_depth_standards(value,
                     'fragments is > 20 million. (See /data-standards/chip-seq/ )'
             if read_depth >= 10000000 and read_depth < marks['narrow']:
                 yield AuditFailure('control low read depth', detail, level='WARNING')
-            elif read_depth >= 3000000 and read_depth < 10000000:
-                yield AuditFailure('control insufficient read depth', detail, level='NOT_COMPLIANT')
-            elif read_depth < 3000000:
+            elif read_depth >= 5000000 and read_depth < 10000000:
+                yield AuditFailure('control low read depth', detail, level='NOT_COMPLIANT')
+            elif read_depth < 5000000:
                 yield AuditFailure('control extremely low read depth', detail, level='ERROR')
     return
 
@@ -1410,7 +1410,7 @@ def check_file_chip_seq_read_depth(file_to_check,
                         'fragments is > 20 million. (See /data-standards/chip-seq/ )'
                 if read_depth >= 10000000:
                     yield AuditFailure('low read depth', detail, level='WARNING')
-                elif read_depth >= 3000000 and read_depth < 10000000:
+                elif read_depth >= 5000000 and read_depth < 10000000:
                     yield AuditFailure('insufficient read depth',
                                        detail, level='NOT_COMPLIANT')
                 else:
@@ -1433,8 +1433,8 @@ def check_file_chip_seq_read_depth(file_to_check,
                             'mapped reads. ' + \
                             'The minimum ENCODE standard for each replicate in a ChIP-seq ' + \
                             'experiment targeting {} and investigated as '.format(target_name) + \
-                            'a broad histone mark is 40 million mapped reads. ' + \
-                            'The recommended value is > 45 million, but > 40 million is ' + \
+                            'a broad histone mark is 35 million mapped reads. ' + \
+                            'The recommended value is > 45 million, but > 35 million is ' + \
                             'acceptable. (See /data-standards/chip-seq/ )'
                     else:
                         detail = 'Alignment file {} '.format(file_to_check['@id']) + \
@@ -1444,13 +1444,13 @@ def check_file_chip_seq_read_depth(file_to_check,
                             'mapped reads. ' + \
                             'The minimum ENCODE standard for each replicate in a ChIP-seq ' + \
                             'experiment targeting {} and investigated as '.format(target_name) + \
-                            'a broad histone mark is 40 million mapped reads. ' + \
-                            'The recommended value is > 45 million, but > 40 million is ' + \
+                            'a broad histone mark is 35 million mapped reads. ' + \
+                            'The recommended value is > 45 million, but > 35 million is ' + \
                             'acceptable. (See /data-standards/chip-seq/ )'
-                    if read_depth >= 40000000:
+                    if read_depth >= 35000000:
                         yield AuditFailure('low read depth',
                                            detail, level='WARNING')
-                    elif read_depth >= 5000000 and read_depth < 40000000:
+                    elif read_depth >= 5000000 and read_depth < 35000000:
                         yield AuditFailure('insufficient read depth',
                                            detail, level='NOT_COMPLIANT')
                     elif read_depth < 5000000:
@@ -1468,7 +1468,7 @@ def check_file_chip_seq_read_depth(file_to_check,
                         'The minimum ENCODE standard for each replicate in a ChIP-seq ' + \
                         'experiment targeting {} and investigated as '.format(target_name) + \
                         'a broad histone mark is 20 million usable fragments. ' + \
-                        'The recommended value is > 45 million, but > 40 million is ' + \
+                        'The recommended value is > 45 million, but > 35 million is ' + \
                         'acceptable. (See /data-standards/chip-seq/ )'
                 else:
                     detail = 'Alignment file {} '.format(file_to_check['@id']) + \
@@ -1479,13 +1479,13 @@ def check_file_chip_seq_read_depth(file_to_check,
                         'The minimum ENCODE standard for each replicate in a ChIP-seq ' + \
                         'experiment targeting {} and investigated as '.format(target_name) + \
                         'a broad histone mark is 20 million usable fragments. ' + \
-                        'The recommended value is > 45 million, but > 40 million is ' + \
+                        'The recommended value is > 45 million, but > 35 million is ' + \
                         'acceptable. (See /data-standards/chip-seq/ )'
 
-                if read_depth >= 40000000 and read_depth < marks['broad']:
+                if read_depth >= 35000000 and read_depth < marks['broad']:
                     yield AuditFailure('low read depth',
                                        detail, level='WARNING')
-                elif read_depth < 40000000 and read_depth >= 5000000:
+                elif read_depth < 35000000 and read_depth >= 5000000:
                     yield AuditFailure('insufficient read depth',
                                        detail, level='NOT_COMPLIANT')
                 elif read_depth < 5000000:
@@ -1570,10 +1570,10 @@ def check_file_chip_seq_read_depth(file_to_check,
                         'acceptable. (See /data-standards/chip-seq/ )'
                 if read_depth >= 10000000 and read_depth < marks['narrow']:
                     yield AuditFailure('low read depth', detail, level='WARNING')
-                elif read_depth < 10000000 and read_depth >= 3000000:
+                elif read_depth < 10000000 and read_depth >= 5000000:
                     yield AuditFailure('insufficient read depth',
                                        detail, level='NOT_COMPLIANT')
-                elif read_depth < 3000000:
+                elif read_depth < 5000000:
                     yield AuditFailure('extremely low read depth',
                                        detail, level='ERROR')
     return

--- a/src/encoded/audit/experiment.py
+++ b/src/encoded/audit/experiment.py
@@ -133,11 +133,11 @@ def check_control_read_depth_standards(value,
                     'histone mark {} '.format(control_to_target) + \
                     'is 35 million usable fragments, the recommended number of usable ' + \
                     'fragments is > 45 million. (See /data-standards/chip-seq/ )'
-            if read_depth >= 35000000 and read_depth < marks['broad']:
+            if read_depth >= marks['broad']['minimal'] and read_depth < marks['broad']['recommended']:
                 yield AuditFailure('control low read depth', detail, level='WARNING')
-            elif read_depth >= 5000000 and read_depth < 35000000:
+            elif read_depth >= marks['broad']['low'] and read_depth < marks['broad']['minimal']:
                 yield AuditFailure('control insufficient read depth', detail, level='NOT_COMPLIANT')
-            elif read_depth < 5000000:
+            elif read_depth < marks['broad']['low']:
                 yield AuditFailure('control extremely low read depth', detail, level='ERROR')
         elif 'narrow histone mark' in target_investigated_as:  # else:
             if 'assembly' in value:
@@ -159,11 +159,11 @@ def check_control_read_depth_standards(value,
                     'histone mark {} '.format(control_to_target) + \
                     'is 10 million usable fragments, the recommended number of usable ' + \
                     'fragments is > 20 million. (See /data-standards/chip-seq/ )'
-            if read_depth >= 10000000 and read_depth < marks['narrow']:
+            if read_depth >= marks['narrow']['minimal'] and read_depth < marks['narrow']['recommended']:
                 yield AuditFailure('control low read depth', detail, level='WARNING')
-            elif read_depth >= 5000000 and read_depth < 10000000:
-                yield AuditFailure('control insufficient read depth', detail, level='NOT_COMPLIANT')
-            elif read_depth < 5000000:
+            elif read_depth >= marks['narrow']['low'] and read_depth < marks['narrow']['minimal']:
+                yield AuditFailure('control low read depth', detail, level='NOT_COMPLIANT')
+            elif read_depth < marks['narrow']['low']:
                 yield AuditFailure('control extremely low read depth', detail, level='ERROR')
         else:
             if 'assembly' in value:
@@ -185,11 +185,11 @@ def check_control_read_depth_standards(value,
                     '{} and investigated as a transcription factor '.format(control_to_target) + \
                     'is 10 million usable fragments, the recommended number of usable ' + \
                     'fragments is > 20 million. (See /data-standards/chip-seq/ )'
-            if read_depth >= 10000000 and read_depth < marks['narrow']:
+            if read_depth >= marks['TF']['minimal'] and read_depth < marks['TF']['recommended']:
                 yield AuditFailure('control low read depth', detail, level='WARNING')
-            elif read_depth >= 5000000 and read_depth < 10000000:
+            elif read_depth >= marks['TF']['low'] and read_depth < marks['TF']['minimal']:
                 yield AuditFailure('control low read depth', detail, level='NOT_COMPLIANT')
-            elif read_depth < 5000000:
+            elif read_depth < marks['TF']['low']:
                 yield AuditFailure('control extremely low read depth', detail, level='ERROR')
     return
 
@@ -1361,7 +1361,7 @@ def check_file_chip_seq_read_depth(file_to_check,
                 yield AuditFailure('insufficient read depth',
                                    detail, level='NOT_COMPLIANT')
         else:
-            if read_depth >= marks['narrow'] and read_depth < marks['broad']:
+            if read_depth >= marks['narrow']['recommended'] and read_depth < marks['broad']['recommended']:
                 if 'assembly' in file_to_check:
                     detail = 'Control alignment file {} mapped using {} assembly has {} '.format(
                         file_to_check['@id'],
@@ -1381,7 +1381,7 @@ def check_file_chip_seq_read_depth(file_to_check,
                         'is 20 million usable fragments, the recommended number of usable ' + \
                         'fragments is > 45 million. (See /data-standards/chip-seq/ )'
                 yield AuditFailure('low read depth', detail, level='INTERNAL_ACTION')
-            if read_depth < marks['narrow']:
+            if read_depth < marks['narrow']['recommended']:
                 if 'assembly' in file_to_check:
                     detail = 'Control alignment file {} mapped using {} assembly has {} '.format(
                         file_to_check['@id'],
@@ -1408,9 +1408,9 @@ def check_file_chip_seq_read_depth(file_to_check,
                         'histone marks or transcription factors ' + \
                         'is 10 million usable fragments, the recommended number of usable ' + \
                         'fragments is > 20 million. (See /data-standards/chip-seq/ )'
-                if read_depth >= 10000000:
+                if read_depth >= marks['narrow']['minimal']:
                     yield AuditFailure('low read depth', detail, level='WARNING')
-                elif read_depth >= 5000000 and read_depth < 10000000:
+                elif read_depth >= marks['narrow']['low'] and read_depth < marks['narrow']['minimal']:
                     yield AuditFailure('insufficient read depth',
                                        detail, level='NOT_COMPLIANT')
                 else:
@@ -1422,7 +1422,7 @@ def check_file_chip_seq_read_depth(file_to_check,
             pipeline_objects, 'ChIP-seq read mapping')
         if pipeline_object:
             if target_name in ['H3K9me3-human', 'H3K9me3-mouse']:
-                if read_depth < 45000000:
+                if read_depth < marks['broad']['recommended']:
                     if 'assembly' in file_to_check:
                         detail = 'Alignment file {} '.format(file_to_check['@id']) + \
                             'produced by {} '.format(pipeline_object['title']) + \
@@ -1447,15 +1447,12 @@ def check_file_chip_seq_read_depth(file_to_check,
                             'a broad histone mark is 35 million mapped reads. ' + \
                             'The recommended value is > 45 million, but > 35 million is ' + \
                             'acceptable. (See /data-standards/chip-seq/ )'
-                    if read_depth >= 35000000:
+                    if read_depth >= marks['broad']['minimal']:
                         yield AuditFailure('low read depth',
                                            detail, level='WARNING')
-                    elif read_depth >= 5000000 and read_depth < 35000000:
+                    elif read_depth < marks['broad']['minimal']:
                         yield AuditFailure('insufficient read depth',
                                            detail, level='NOT_COMPLIANT')
-                    elif read_depth < 5000000:
-                        yield AuditFailure('extremely low read depth',
-                                           detail, level='WARNING')
             else:
                 if 'assembly' in file_to_check:
                     detail = 'Alignment file {} '.format(file_to_check['@id']) + \
@@ -1482,13 +1479,13 @@ def check_file_chip_seq_read_depth(file_to_check,
                         'The recommended value is > 45 million, but > 35 million is ' + \
                         'acceptable. (See /data-standards/chip-seq/ )'
 
-                if read_depth >= 35000000 and read_depth < marks['broad']:
+                if read_depth >= marks['broad']['minimal'] and read_depth < marks['broad']['recommended']:
                     yield AuditFailure('low read depth',
                                        detail, level='WARNING')
-                elif read_depth < 35000000 and read_depth >= 5000000:
+                elif read_depth < marks['broad']['minimal'] and read_depth >= marks['broad']['low']:
                     yield AuditFailure('insufficient read depth',
                                        detail, level='NOT_COMPLIANT')
-                elif read_depth < 5000000:
+                elif read_depth < marks['broad']['low']:
                     yield AuditFailure('extremely low read depth',
                                        detail, level='ERROR')
     elif 'narrow histone mark' in target_investigated_as and \
@@ -1520,12 +1517,12 @@ def check_file_chip_seq_read_depth(file_to_check,
                     'a narrow histone mark is 10 million usable fragments. ' + \
                     'The recommended value is > 20 million, but > 10 million is ' + \
                     'acceptable. (See /data-standards/chip-seq/ )'
-            if read_depth >= 10000000 and read_depth < marks['narrow']:
+            if read_depth >= marks['narrow']['minimal'] and read_depth < marks['narrow']['recommended']:
                 yield AuditFailure('low read depth', detail, level='WARNING')
-            elif read_depth < 10000000 and read_depth >= 5000000:
+            elif read_depth < marks['narrow']['minimal'] and read_depth >= marks['narrow']['low']:
                 yield AuditFailure('insufficient read depth',
                                    detail, level='NOT_COMPLIANT')
-            elif read_depth < 5000000:
+            elif read_depth < marks['narrow']['low']:
                 yield AuditFailure('extremely low read depth',
                                    detail, level='ERROR')
     else:
@@ -1568,12 +1565,12 @@ def check_file_chip_seq_read_depth(file_to_check,
                         'a transcription factor is 10 million usable fragments. ' + \
                         'The recommended value is > 20 million, but > 10 million is ' + \
                         'acceptable. (See /data-standards/chip-seq/ )'
-                if read_depth >= 10000000 and read_depth < marks['narrow']:
+                if read_depth >= marks['TF']['minimal'] and read_depth < marks['TF']['recommended']:
                     yield AuditFailure('low read depth', detail, level='WARNING')
-                elif read_depth < 10000000 and read_depth >= 5000000:
+                elif read_depth < marks['TF']['minimal'] and read_depth >= marks['TF']['low']:
                     yield AuditFailure('insufficient read depth',
                                        detail, level='NOT_COMPLIANT')
-                elif read_depth < 5000000:
+                elif read_depth < marks['TF']['low']:
                     yield AuditFailure('extremely low read depth',
                                        detail, level='ERROR')
     return

--- a/src/encoded/audit/experiment.py
+++ b/src/encoded/audit/experiment.py
@@ -188,7 +188,7 @@ def check_control_read_depth_standards(value,
             if read_depth >= marks['TF']['minimal'] and read_depth < marks['TF']['recommended']:
                 yield AuditFailure('control low read depth', detail, level='WARNING')
             elif read_depth >= marks['TF']['low'] and read_depth < marks['TF']['minimal']:
-                yield AuditFailure('control low read depth', detail, level='NOT_COMPLIANT')
+                yield AuditFailure('control insufficient read depth', detail, level='NOT_COMPLIANT')
             elif read_depth < marks['TF']['low']:
                 yield AuditFailure('control extremely low read depth', detail, level='ERROR')
     return

--- a/src/encoded/audit/experiment.py
+++ b/src/encoded/audit/experiment.py
@@ -162,7 +162,7 @@ def check_control_read_depth_standards(value,
             if read_depth >= marks['narrow']['minimal'] and read_depth < marks['narrow']['recommended']:
                 yield AuditFailure('control low read depth', detail, level='WARNING')
             elif read_depth >= marks['narrow']['low'] and read_depth < marks['narrow']['minimal']:
-                yield AuditFailure('control low read depth', detail, level='NOT_COMPLIANT')
+                yield AuditFailure('control insufficient read depth', detail, level='NOT_COMPLIANT')
             elif read_depth < marks['narrow']['low']:
                 yield AuditFailure('control extremely low read depth', detail, level='ERROR')
         else:
@@ -1380,7 +1380,7 @@ def check_file_chip_seq_read_depth(file_to_check,
                         'histone marks ' + \
                         'is 20 million usable fragments, the recommended number of usable ' + \
                         'fragments is > 45 million. (See /data-standards/chip-seq/ )'
-                yield AuditFailure('low read depth', detail, level='INTERNAL_ACTION')
+                yield AuditFailure('insufficient read depth for broad peaks control', detail, level='INTERNAL_ACTION')
             if read_depth < marks['narrow']['recommended']:
                 if 'assembly' in file_to_check:
                     detail = 'Control alignment file {} mapped using {} assembly has {} '.format(
@@ -1450,9 +1450,12 @@ def check_file_chip_seq_read_depth(file_to_check,
                     if read_depth >= marks['broad']['minimal']:
                         yield AuditFailure('low read depth',
                                            detail, level='WARNING')
-                    elif read_depth < marks['broad']['minimal']:
+                    elif read_depth >= 100 and read_depth < marks['broad']['minimal']:
                         yield AuditFailure('insufficient read depth',
                                            detail, level='NOT_COMPLIANT')
+                    elif read_depth < 100:
+                        yield AuditFailure('extremely low read depth',
+                                           detail, level='ERROR')
             else:
                 if 'assembly' in file_to_check:
                     detail = 'Alignment file {} '.format(file_to_check['@id']) + \

--- a/src/encoded/audit/standards_data.py
+++ b/src/encoded/audit/standards_data.py
@@ -44,7 +44,7 @@ pipelines_with_read_depth = {
         },
         'broad': {
             'recommended': 45000000,
-            'minimal': 35000000,
+            'minimal': 40000000,
             'low': 5000000
         },
         'TF': {

--- a/src/encoded/audit/standards_data.py
+++ b/src/encoded/audit/standards_data.py
@@ -44,7 +44,7 @@ pipelines_with_read_depth = {
         },
         'broad': {
             'recommended': 45000000,
-            'minimal': 40000000,
+            'minimal': 35000000,
             'low': 5000000
         },
         'TF': {

--- a/src/encoded/audit/standards_data.py
+++ b/src/encoded/audit/standards_data.py
@@ -37,8 +37,21 @@ pipelines_with_read_depth = {
     'RNA-seq of long RNAs (single-end, unstranded)': 30000000,
     'RAMPAGE (paired-end, stranded)': 20000000,
     'ChIP-seq read mapping': {
-        'narrow': 20000000,
-        'broad': 45000000
+        'narrow': {
+            'recommended': 20000000,
+            'minimal': 10000000,
+            'low': 5000000
+        },
+        'broad': {
+            'recommended': 45000000,
+            'minimal': 35000000,
+            'low': 5000000
+        },
+        'TF': {
+            'recommended': 20000000,
+            'minimal': 10000000,
+            'low': 5000000
+        }
     },
     'Transcription factor ChIP-seq pipeline (modERN)': 3000000
     }


### PR DESCRIPTION
(1) the minimal threshold of 3M was moved to be 5M for everything except H3K9me3 where it was moved to be 100.
(2) the maximal insufficient threshold for broad marks was lowered from 40M to 35M
(3) the low read depth control audit that cold not be called (>20M but <45) moved into INTERNAL_ACTION