### PR TITLE
ENCD-3823,3864,3868 Filter out restricted files from batch download, refactor, and unit tests

### DIFF
--- a/src/encoded/batch_download.py
+++ b/src/encoded/batch_download.py
@@ -306,13 +306,21 @@ def batch_download(context, request):
     files = [metadata_link]
     exp_files_gen = filter_restricted_files(results)
     for exp_file in exp_files_gen:
-        if exp_file['file_type'] in param_list.get('files.file_type', []):
-            files.append(
-                '{host_url}{href}'.format(
-                    host_url=request.host_url,
-                    href=exp_file['href'],
+        if 'files.file_type' in param_list:
+            if exp_file['file_type'] in param_list.get('files.file_type', []):
+                files.append(
+                    '{host_url}{href}'.format(
+                        host_url=request.host_url,
+                        href=exp_file['href'],
+                    )
                 )
-            )
+        else:
+            files.append(
+                    '{host_url}{href}'.format(
+                        host_url=request.host_url,
+                        href=exp_file['href'],
+                    )
+                )
     return Response(
         content_type='text/plain',
         body='\n'.join(files),

--- a/src/encoded/batch_download.py
+++ b/src/encoded/batch_download.py
@@ -309,17 +309,23 @@ def batch_download(context, request):
         for exp in results['@graph']:
             for f in exp.get('files', []):
                 if f['file_type'] in param_list['files.file_type']:
+                    if 'restricted' in f and f['restricted'] == 'true':
+                        continue
+                    else:
+                        files.append('{host_url}{href}'.format(
+                            host_url=request.host_url,
+                            href=f['href']
+                        ))
+    else:
+        for exp in results['@graph']:
+            for f in exp.get('files', []):
+                if 'restricted' in f and f['restricted'] == 'true':
+                    continue
+                else:
                     files.append('{host_url}{href}'.format(
                         host_url=request.host_url,
                         href=f['href']
                     ))
-    else:
-        for exp in results['@graph']:
-            for f in exp.get('files', []):
-                files.append('{host_url}{href}'.format(
-                    host_url=request.host_url,
-                    href=f['href']
-                ))
     return Response(
         content_type='text/plain',
         body='\n'.join(files),

--- a/src/encoded/tests/test_batch_download.py
+++ b/src/encoded/tests/test_batch_download.py
@@ -1,8 +1,32 @@
 # Use workbook fixture from BDD tests (including elasticsearch)
 from .features.conftest import app_settings, app, workbook
+import json, pytest
+from ..batch_download import lookup_column_value, filter_restricted_files
 
+@pytest.fixture
+def lookup_column_value_item():
+    item = {'assay_term_name': 'ISO-seq',
+           'lab': {'title': 'John Stamatoyannopoulos, UW'},
+           'accession': 'ENCSR751ISO',
+           'assay_title': 'ISO-seq',
+           'award': {'project': 'Roadmap'},
+           'status': 'released',
+           '@id': '/experiments/ENCSR751ISO/',
+           '@type': ['Experiment', 'Dataset', 'Item'],
+        'biosample_term_name': 'midbrain'}
+    return item
 
-def test_report_download(testapp, workbook):
+@pytest.fixture
+def lookup_column_value_validate():
+    valid = {'assay_term_name' : 'ISO-seq',
+            'lab.title' : 'John Stamatoyannopoulos, UW',
+            'audit' : '',
+            'award.project' : 'Roadmap',
+            '@id' : '/experiments/ENCSR751ISO/',
+            'level.name' : ''}
+    return valid
+
+def test_batch_download_report_download(testapp, workbook):
     res = testapp.get('/report.tsv?type=Experiment&sort=accession')
     assert res.headers['content-type'] == 'text/tsv; charset=UTF-8'
     disposition = res.headers['content-disposition']
@@ -27,3 +51,23 @@ def test_report_download(testapp, workbook):
     #     b'', b'', b'', b'', b'', b'', b''
     # ]
     assert len(lines) == 47
+
+def test_batch_download_files_txt(testapp, workbook):
+    results = testapp.get('/batch_download/type%3DExperiment')
+    assert results.headers['Content-Type'] == 'text/plain; charset=UTF-8'
+    assert results.headers['Content-Disposition'] == 'attachment; filename="files.txt"'
+    lines = results.body.splitlines()
+    assert len(lines) > 0
+
+def test_batch_download_filter_restricted_files(testapp, workbook):
+    results = testapp.get('/search/?limit=all&field=files.href&field=files.file_type&field=files&type=Experiment')
+    assert results.headers['Content-Type'] == 'application/json; charset=UTF-8'
+    results = results.body.decode("utf-8")
+    results = json.loads(results)
+    files = filter_restricted_files(results)
+    for file in files:
+        assert file.get('restricted', 'false') == 'false'
+
+def test_batch_download_lookup_column_value(lookup_column_value_item, lookup_column_value_validate):
+    for path in lookup_column_value_validate.keys():
+        assert lookup_column_value_validate[path] == lookup_column_value(lookup_column_value_item, path)


### PR DESCRIPTION
The fix here is basically looking for 'restricted' key in the files and checking if its set to 'true'. If these two conditions are met, then skip adding this file to files.txt which eventually gets downloaded as part of batch download.

Demo URL: ec2-54-191-169-118.us-west-2.compute.amazonaws.com