### PR TITLE
ENCD-3882 Update DOI preferred resolver url

### DIFF
--- a/src/encoded/schemas/namespaces.json
+++ b/src/encoded/schemas/namespaces.json
@@ -15,7 +15,7 @@
     "UCSC-GB-hg19": "http://genome.cse.ucsc.edu/cgi-bin/hgTrackUi?db=hg19&g=",
     "PMID": "https://www.ncbi.nlm.nih.gov/pubmed/?term=",
     "PMCID": "https://www.ncbi.nlm.nih.gov/pmc/articles/",
-    "doi": "http://dx.doi.org/doi:",
+    "doi": "https://doi.org/doi:",
     "EFO": "http://www.ebi.ac.uk/efo/EFO_",
     "CL": "http://purl.obolibrary.org/obo/CL_",
     "UBERON": "http://purl.obolibrary.org/obo/UBERON_",

--- a/src/encoded/static/components/__tests__/dbxref-test.js
+++ b/src/encoded/static/components/__tests__/dbxref-test.js
@@ -499,8 +499,8 @@ describe('Test individual dbxref types', () => {
 
         it('has the correct links', () => {
             expect(dbxLinks.length).toBe(2);
-            expect(dbxLinks.at(0).prop('href')).toEqual('http://dx.doi.org/doi:10.1038%2Fnphys1170');
-            expect(dbxLinks.at(1).prop('href')).toEqual('http://dx.doi.org/doi:10.1006%2Fgeno.1998.5693');
+            expect(dbxLinks.at(0).prop('href')).toEqual('https://doi.org/doi:10.1038%2Fnphys1170');
+            expect(dbxLinks.at(1).prop('href')).toEqual('https://doi.org/doi:10.1006%2Fgeno.1998.5693');
         });
     });
 

--- a/src/encoded/static/components/dbxref.js
+++ b/src/encoded/static/components/dbxref.js
@@ -167,7 +167,7 @@ export const dbxrefPrefixMap = {
         pattern: 'https://www.ncbi.nlm.nih.gov/pmc/articles/{0}',
     },
     doi: {
-        pattern: 'http://dx.doi.org/doi:{0}',
+        pattern: 'https://doi.org/doi:{0}',
     },
     AR: {
         pattern: 'http://antibodyregistry.org/search.php?q={0}',


### PR DESCRIPTION
Same as https://github.com/ENCODE-DCC/snovault/pull/80, but affecting both static links and code, that generates new links. Greetings!