### PR TITLE
ENCD-3863 Eliminate repeated values in report TSV

### DIFF
--- a/src/encoded/batch_download.py
+++ b/src/encoded/batch_download.py
@@ -346,12 +346,11 @@ def lookup_column_value(value, path):
     # if we ended with an embedded object, show the @id
     if nodes and hasattr(nodes[0], '__contains__') and '@id' in nodes[0]:
         nodes = [node['@id'] for node in nodes]
-    seen = set()
     deduped_nodes = []
     for n in nodes:
         if isinstance(n, dict):
             n = str(n)
-        if n not in seen:
+        if n not in deduped_nodes:
             deduped_nodes.append(n)
     return u','.join(u'{}'.format(n) for n in deduped_nodes)
 


### PR DESCRIPTION
* The fix is basically adding the already seen values to the 'seen' set()

Demo: https://encd-3863-eliminate-repeated-values-in-report-tsv-155bb34cd-karthik.demo.encodedcc.org

(Note: This is a bug which got introduced while fixing ENCD-3473 Fix for unknown error in batch_download)