### PR TITLE
ENCD-3698 Add Institutional certifications to biosample

### DIFF
--- a/src/encoded/audit/biosample.py
+++ b/src/encoded/audit/biosample.py
@@ -197,6 +197,20 @@ def audit_biosample_part_of_consistency(value, system):
                            level='INTERNAL_ACTION')
         return
 
+
+def audit_biosample_nih_institutional_certification(value, system):
+    '''
+    Check if library from human biosample and ENCODE4 award has NIH consent identifier.
+    '''
+    if (value.get('award', {}).get('rfa') == 'ENCODE4'
+            and value.get('organism', {}).get('name') == 'human'
+            and not value.get('nih_institutional_certification')):
+        detail = ('Biosample {} is missing NIH institutional certification'
+                  ' required for human data'.format(value['@id']))
+        yield AuditFailure('missing nih_institutional_certification', detail, level='ERROR')
+
+
+
 # utility functions
 
 def is_part_of(term_id, part_of_term_id, ontology):
@@ -216,13 +230,15 @@ function_dispatcher = {
     'audit_bio_term': audit_biosample_term,
     'audit_culture_date': audit_biosample_culture_date,
     'audit_donor': audit_biosample_donor,
-    'audit_part_of': audit_biosample_part_of_consistency
+    'audit_part_of': audit_biosample_part_of_consistency,
+    'audit_nih_consent': audit_biosample_nih_institutional_certification,
 }
 
 @audit_checker('Biosample',
                frame=['award',
                       'donor',
                       'donor.mutated_gene',
+                      'organism',
                       'part_of'])
 def audit_biosample(value, system):
     for function_name in function_dispatcher.keys():

--- a/src/encoded/audit/biosample.py
+++ b/src/encoded/audit/biosample.py
@@ -203,7 +203,7 @@ def audit_biosample_nih_institutional_certification(value, system):
     Check if library from human biosample and ENCODE4 award has NIH consent identifier.
     '''
     if (value.get('award', {}).get('rfa') == 'ENCODE4'
-            and value.get('organism', {}).get('name') == 'human'
+            and value.get('organism') == '/organisms/human/'
             and not value.get('nih_institutional_certification')):
         detail = ('Biosample {} is missing NIH institutional certification'
                   ' required for human data'.format(value['@id']))
@@ -238,7 +238,6 @@ function_dispatcher = {
                frame=['award',
                       'donor',
                       'donor.mutated_gene',
-                      'organism',
                       'part_of'])
 def audit_biosample(value, system):
     for function_name in function_dispatcher.keys():

--- a/src/encoded/schemas/biosample.json
+++ b/src/encoded/schemas/biosample.json
@@ -830,6 +830,13 @@
             "type": "string",
             "description": "Health status of the model organism.",
             "comment": "model_organism_health_status is not valid for a human biosample."
+        },
+        "nih_institutional_certification": {
+            "type": "string",
+            "title": "NIH institutional certification",
+            "description": "Institutional certification given by the NIH for human biosamples.",
+            "comment": "Required for ENCODE4 human biosamples.",
+            "pattern": "^NIC[A-Z0-9]+$"
         }
     },
     "facets": {
@@ -1004,7 +1011,8 @@
         "references.title": 1.0,
         "award.pi.title": 1.0,
         "notes": 1.0,
-        "internal_tags": 1.0
+        "internal_tags": 1.0,
+        "nih_institutional_certification": 1.0
     },
     "changelog": "/profiles/changelogs/biosample.md"
 

--- a/src/encoded/schemas/changelogs/biosample.md
+++ b/src/encoded/schemas/changelogs/biosample.md
@@ -1,11 +1,14 @@
 ## Changelog for biosample.json
 
+
 ### Minor changes since schema version 19
 
 * *PMI* and *PMI_units* were added as new properties, with dependencies enforcing their interdependent use.
 * *PMI* and *PMI_units* are additionally restricted to only be used for tissue biosamples.
 * *culture_harvest_date* and *culture_start_date* no longer can be used for tissues (a mistake introduced recently and now corrected within the dependencies).
 * Sample property *preservation_method* with enums ["cryopreservation", "flash-freezing"] was added.
+* Add nih_consent property for storing biosample institutional certification.
+
 
 ### Schema version 19
 

--- a/src/encoded/schemas/changelogs/biosample.md
+++ b/src/encoded/schemas/changelogs/biosample.md
@@ -1,14 +1,12 @@
 ## Changelog for biosample.json
 
-
 ### Minor changes since schema version 19
 
 * *PMI* and *PMI_units* were added as new properties, with dependencies enforcing their interdependent use.
 * *PMI* and *PMI_units* are additionally restricted to only be used for tissue biosamples.
 * *culture_harvest_date* and *culture_start_date* no longer can be used for tissues (a mistake introduced recently and now corrected within the dependencies).
 * Sample property *preservation_method* with enums ["cryopreservation", "flash-freezing"] was added.
-* Add nih_consent property for storing biosample institutional certification.
-
+* Add nih_institutional_certification property for storing biosample institutional certification.
 
 ### Schema version 19
 

--- a/src/encoded/tests/datafixtures.py
+++ b/src/encoded/tests/datafixtures.py
@@ -879,3 +879,14 @@ def platform2(testapp):
         'term_name': 'HiSeq4000'
     }
     return testapp.post_json('/platform', item).json['@graph'][0]
+
+
+@pytest.fixture
+def encode4_award(testapp):
+    item = {
+        'name': 'encode4-award',
+        'rfa': 'ENCODE4',
+        'project': 'ENCODE',
+        'viewing_group': 'ENCODE4',
+    }
+    return testapp.post_json('/award', item).json['@graph'][0]

--- a/src/encoded/tests/test_audit_biosample.py
+++ b/src/encoded/tests/test_audit_biosample.py
@@ -216,3 +216,28 @@ def test_audit_biosample_part_of_consistency_ontology_part_of(testapp,
     for error_type in errors:
         errors_list.extend(errors[error_type])
     assert all(error['category'] != 'inconsistent biosample_term_id' for error in errors_list)
+
+
+def test_audit_library_without_nih_consent(testapp, biosample, encode4_award):
+    testapp.patch_json(biosample['@id'], {'award': encode4_award['@id']})
+    r = testapp.get(biosample['@id'] + '@@index-data')
+    audits = r.json['audit']
+    assert any(
+        [
+            detail['category'] == 'missing nih_institutional_certification'
+            for audit in audits.values() for detail in audit
+        ]
+    )
+
+
+def test_audit_library_with_nih_consent(testapp, biosample, encode4_award):
+    testapp.patch_json(biosample['@id'], {'award': encode4_award['@id'],
+                                          'nih_institutional_certification': 'NICABC123'})
+    r = testapp.get(biosample['@id'] + '@@index-data')
+    audits = r.json['audit']
+    assert all(
+        [
+            detail['category'] != 'missing nih_institutional_certification'
+            for audit in audits.values() for detail in audit
+        ]
+    )

--- a/src/encoded/tests/test_audit_biosample.py
+++ b/src/encoded/tests/test_audit_biosample.py
@@ -131,6 +131,18 @@ def test_audit_biosample_donor_organism(testapp, base_biosample, base_human_dono
     assert any(error['category'] == 'inconsistent organism' for error in errors_list)
 
 
+def test_audit_biosample_consistent_organism(testapp, base_biosample, base_human_donor):
+    testapp.patch_json(base_biosample['@id'], {'donor': base_human_donor['@id']})
+    r = testapp.get(base_biosample['@id'] + '@@index-data')
+    audits = r.json['audit']
+    assert all(
+        [
+            detail['category'] != 'inconsistent organism'
+            for audit in audits.values() for detail in audit
+        ]
+    )
+
+
 def test_audit_biosample_status(testapp, base_biosample, construct_genetic_modification):
     testapp.patch_json(base_biosample['@id'], {
         'status': 'released',


### PR DESCRIPTION
Adds nih_institutional_certification property to biosample and triggers audit if field missing for human ENCODE4 samples.