### PR TITLE
ENCD-3854 Fix report description column sort error

### DIFF
--- a/src/encoded/search.py
+++ b/src/encoded/search.py
@@ -138,10 +138,9 @@ def set_sort_order(request, search_term, types, doc_types, query, result):
     sort = OrderedDict()
     result_sort = OrderedDict()
 
-    # Prefer sort order specified in request, if any. Ignore if the sorted
-    # field is included in TEXT_FIELDS and thus can't be sorted.
+    # Prefer sort order specified in request, if any
     requested_sort = request.params.get('sort')
-    if requested_sort and requested_sort.replace('-', '', 1) not in TEXT_FIELDS:
+    if requested_sort:
         if requested_sort.startswith('-'):
             name = requested_sort[1:]
             order = 'desc'
@@ -149,10 +148,11 @@ def set_sort_order(request, search_term, types, doc_types, query, result):
             name = requested_sort
             order = 'asc'
         # TODO: unmapped type needs to be determined, not hard coded
-        sort['embedded.' + name] = result_sort[name] = {
-            'order': order,
-            'unmapped_type': 'keyword',
-        }
+        if name not in TEXT_FIELDS:
+            sort['embedded.' + name] = result_sort[name] = {
+                'order': order,
+                'unmapped_type': 'keyword',
+            }
 
     # Otherwise we use a default sort only when there's no text search to be  ranked
     if not sort and search_term == '*':

--- a/src/encoded/search.py
+++ b/src/encoded/search.py
@@ -6,6 +6,7 @@ from snovault import (
     TYPES,
 )
 from snovault.elasticsearch import ELASTIC_SEARCH
+from snovault.elasticsearch.create_mapping import TEXT_FIELDS
 from snovault.resource_views import collection_view_listing_db
 from elasticsearch.helpers import scan
 from pyramid.httpexceptions import HTTPBadRequest
@@ -147,10 +148,11 @@ def set_sort_order(request, search_term, types, doc_types, query, result):
             name = requested_sort
             order = 'asc'
         # TODO: unmapped type needs to be determined, not hard coded
-        sort['embedded.' + name] = result_sort[name] = {
-            'order': order,
-            'unmapped_type': 'keyword',
-        }
+        if name not in TEXT_FIELDS:
+            sort['embedded.' + name] = result_sort[name] = {
+                'order': order,
+                'unmapped_type': 'keyword',
+            }
 
     # Otherwise we use a default sort only when there's no text search to be  ranked
     if not sort and search_term == '*':
@@ -944,6 +946,7 @@ def report(context, request):
     res['download_tsv'] = request.route_path('report_download') + search_base
     res['title'] = 'Report'
     res['@type'] = ['Report']
+    res['non_sortable'] = TEXT_FIELDS
     return res
 
 

--- a/src/encoded/search.py
+++ b/src/encoded/search.py
@@ -138,9 +138,10 @@ def set_sort_order(request, search_term, types, doc_types, query, result):
     sort = OrderedDict()
     result_sort = OrderedDict()
 
-    # Prefer sort order specified in request, if any
+    # Prefer sort order specified in request, if any. Ignore if the sorted
+    # field is included in TEXT_FIELDS and thus can't be sorted.
     requested_sort = request.params.get('sort')
-    if requested_sort:
+    if requested_sort and requested_sort.replace('-', '', 1) not in TEXT_FIELDS:
         if requested_sort.startswith('-'):
             name = requested_sort[1:]
             order = 'desc'
@@ -148,11 +149,10 @@ def set_sort_order(request, search_term, types, doc_types, query, result):
             name = requested_sort
             order = 'asc'
         # TODO: unmapped type needs to be determined, not hard coded
-        if name not in TEXT_FIELDS:
-            sort['embedded.' + name] = result_sort[name] = {
-                'order': order,
-                'unmapped_type': 'keyword',
-            }
+        sort['embedded.' + name] = result_sort[name] = {
+            'order': order,
+            'unmapped_type': 'keyword',
+        }
 
     # Otherwise we use a default sort only when there's no text search to be  ranked
     if not sort and search_term == '*':

--- a/src/encoded/static/components/report.js
+++ b/src/encoded/static/components/report.js
@@ -222,11 +222,12 @@ class Table extends React.Component {
         const sort = this.getSort();
 
         const headers = columns.map((column, index) => {
-            let className = 'icon';
-            if (column.path === sort.column) {
-                className += sort.reversed ? ' icon-chevron-up' : ' icon-chevron-down';
+            let className;
+            const sortable = context.non_sortable.indexOf(column.path) === -1;
+            if (column.path === sort.column && sortable) {
+                className = `icon ${sort.reversed ? 'icon-chevron-up' : 'icon-chevron-down'}`;
             }
-            return <ColumnHeader key={index} setSort={this.setSort} column={column} className={className} />;
+            return <ColumnHeader key={index} setSort={this.setSort} sortable={sortable} column={column} className={className} />;
         });
 
         const data = this.extractData(context['@graph']).concat(this.extractData(this.props.more));
@@ -268,14 +269,16 @@ class ColumnHeader extends React.Component {
     }
 
     setSort() {
-        this.props.setSort(this.props.column.path);
+        if (this.props.sortable) {
+            this.props.setSort(this.props.column.path);
+        }
     }
 
     render() {
-        const { column, className } = this.props;
+        const { column, className, sortable } = this.props;
 
         return (
-            <th onClick={this.setSort}>
+            <th onClick={this.setSort} className={sortable ? null : 'non-sortable'}>
                 {column.title}&nbsp;<i className={className} />
             </th>
         );
@@ -284,8 +287,15 @@ class ColumnHeader extends React.Component {
 
 ColumnHeader.propTypes = {
     setSort: PropTypes.func, // Parent function to handle a click in a column header
-    column: PropTypes.object,
+    column: PropTypes.object.isRequired,
     className: PropTypes.string, // CSS class string for column title
+    sortable: PropTypes.bool, // True if column isn't sortable
+};
+
+ColumnHeader.defaultProps = {
+    setSort: null,
+    className: '',
+    sortable: true,
 };
 
 

--- a/src/encoded/static/scss/encoded/modules/_tables.scss
+++ b/src/encoded/static/scss/encoded/modules/_tables.scss
@@ -136,6 +136,12 @@ form.table-filter {
 
 .col-headers th:hover {
     cursor: pointer;
+    background-color: darken($tableHeadFootBackgroundColor, 5%);
+}
+
+.col-headers th.non-sortable:hover {
+    cursor: default;
+    background-color: $tableHeadFootBackgroundColor;
 }
 
 .tcell-sortable {


### PR DESCRIPTION
* This branch does not require any snovault modifications, but search.py now imports TEXT_FIELDS from snovault. This is a list of encodeD properties that are configured as text fields in Elasticsearch and thus can’t be sorted without causing the problem that prompted this ticket.
* `set_sort_order` uses TEXT_FIELDS to decide whether to include a property in the Elasticsearch query sorting property. `search` calls `set_sort_order`, and `report` calls `search` to do most of the grunt work. So even if one of the properties in TEXT_FIELDS gets specified for sorting in the query string, they won’t get sorted.
* `search` also passes the contents of TEXT_FIELDS up to the front end with a new `non_sortable` property of search results, which the front end’s report function reads to know whether to make the corresponding columns sortable or not.
* Also changed the CSS styles so that sortable column headers highlight in a slightly darker shade of gray while the mouse hovers over them. Non-sortable columns don’t highlight, and don’t include the sorting chevron.