### PR TITLE
ENCD-3841 Add collapsing sections on schema pages

### DIFF
--- a/src/encoded/static/components/schema.js
+++ b/src/encoded/static/components/schema.js
@@ -33,6 +33,9 @@ const excludedTerms = [
     'boost_values',
     'changelog',
     '@type',
+    'output_type_output_category',
+    'file_format_file_extension',
+    'sort_by',
 ];
 
 
@@ -244,6 +247,63 @@ TermDisplay.propTypes = {
 };
 
 
+class DisplayObjectSection extends React.PureComponent {
+    constructor() {
+        super();
+
+        // Set initial React component state.
+        this.state = {
+            sectionOpen: false, // True if the section has been opened for display
+        };
+
+        // Bind `this` to non-React methods.
+        this.handleDisclosureClick = this.handleDisclosureClick.bind(this);
+    }
+
+    handleDisclosureClick() {
+        // Click in the disclosure icon. Toggle the `sectionOpen` state to show or hide the list of
+        // child properties.
+        this.setState(prevState => ({ sectionOpen: !prevState.sectionOpen }));
+    }
+
+    render() {
+        const { term, schema } = this.props;
+
+        // Set aria values for accessibility.
+        const accordionId = `profile-display-values-${term}`;
+        const accordionLabel = `profile-value-item-${term}`;
+
+        return (
+            <div className={`profile-display__section${this.state.sectionOpen ? ' profile-display__section--open' : ''}`}>
+                <h3 className="profile-value__item" id={accordionLabel}>
+                    <button
+                        className="profile-value__disclosure-button"
+                        data-toggle="collapse"
+                        data-target={`#${accordionId}`}
+                        aria-controls={accordionId}
+                        aria-expanded={this.state.sectionOpen}
+                        onClick={this.handleDisclosureClick}
+                    >
+                        {collapseIcon(!this.state.sectionOpen)}
+                    </button>
+                    {titleMap[term] || term}
+                </h3>
+                {this.state.sectionOpen ?
+                    <div id={accordionId} aria-labelledby={accordionLabel} className="profile-display__values">
+                        <TermDisplay termSchema={schema[term]} />
+                    </div>
+                : null}
+            </div>
+        );
+    }
+}
+
+DisplayObjectSection.propTypes = {
+    term: PropTypes.string.isRequired, // Top-level property name in schema being displayed
+    schema: PropTypes.object.isRequired, // Entire Schema containing term being displayed
+};
+
+
 // Display an entire formatted schema.
 const DisplayObject = (props) => {
     const { schema } = props;
@@ -251,12 +311,7 @@ const DisplayObject = (props) => {
     return (
         <div className="profile-display">
             {schemaTerms.map(term =>
-                <div className="profile-display__section" key={term}>
-                    <h3>{titleMap[term] || term}</h3>
-                    <div className="profile-display__values">
-                        <TermDisplay termSchema={schema[term]} />
-                    </div>
-                </div>
+                <DisplayObjectSection key={term} term={term} schema={schema} />
             )}
         </div>
     );

--- a/src/encoded/static/scss/encoded/modules/_schema.scss
+++ b/src/encoded/static/scss/encoded/modules/_schema.scss
@@ -1,12 +1,13 @@
 .profile-display {
     @at-root #{&}__section {
         margin-top: 20px;
-        padding-top: 20px;
-        border-top: 1px solid #e0e0e0;
+        @at-root #{&}--open {
+            padding-bottom: 20px;
+            border-bottom: 1px solid #e0e0e0;
+        }
 
-        &:first-child {
-            margin-top: 0;
-            border-top: none;
+        &:last-child {
+            border-bottom: none;
         }
     }
 
@@ -17,7 +18,7 @@
     }
 
     @at-root #{&}__values {
-        margin-left: 10px;
+        margin-left: 25px;
     }
 }
 
@@ -27,7 +28,7 @@
     }
 
     @at-root #{&}__disclosure-button {
-        margin: 2px 0;
+        margin: 2px 5px 2px 0;
         padding: 0;
         font-size: 0; // Prevent gap between focus border and icon
         border: 0 none;

--- a/src/encoded/static/scss/style.scss
+++ b/src/encoded/static/scss/style.scss
@@ -104,6 +104,7 @@ $brand-info: #4F689E;
         "encoded/modules/pipeline",
         "encoded/modules/quality_metric",
         "encoded/modules/report",
+        "encoded/modules/schema",
         "encoded/modules/tooltip",
         "encoded/modules/badge",
         "encoded/modules/news",


### PR DESCRIPTION
Most of the change involves the new `<DisplayObjectSection>` component that replaces a loop inside `<DisplayObject>`. Now that each displayed section needs to keep its own state for being open or closed, it needed its own component to track that, and react to clicks in the new button.

I also added aria properties so that people using screen readers can better tell what they’re doing when opening and closing these sections. I should have added those to the open/closed state of the individual properties originally too.