### PR TITLE
ENCD-3891 Fix file test for duplicates in derived_from

### DIFF
--- a/src/encoded/tests/data/inserts/file.json
+++ b/src/encoded/tests/data/inserts/file.json
@@ -1278,7 +1278,7 @@
         "lab": "/labs/richard-myers/",
         "output_type": "alignments",
         "assembly": "hg19",
-        "derived_from": ["ENCFF431TKZ", "ENCFF504RKH", "ENCFF958GWJ", "ENCFF360FSI", "ENCFF019HBG", "ENCFF020HBG", "ENCFF021HBG", "ENCFF022HBG"],
+        "derived_from": ["ENCFF431TKZ", "ENCFF504RKH", "ENCFF958GWJ", "ENCFF360FSI", "ENCFF019HBG", "ENCFF022HBG"],
         "aliases": [],
         "step_run": "7c81414f-a9c0-44ed-87fb-2e2207733d3b"
     },


### PR DESCRIPTION
This updates one piece of test data so that the tests won't break once `encoded` is updated to a release of `snovault` that includes https://github.com/ENCODE-DCC/snovault/pull/85 (we can no longer have multiple references to the same object in a property marked with `uniqueItems: true`)