### PR TITLE
ENCD-3894 Move NIH cert audit to experiment

### DIFF
--- a/src/encoded/audit/biosample.py
+++ b/src/encoded/audit/biosample.py
@@ -198,19 +198,6 @@ def audit_biosample_part_of_consistency(value, system):
         return
 
 
-def audit_biosample_nih_institutional_certification(value, system):
-    '''
-    Check if library from human biosample and ENCODE4 award has NIH consent identifier.
-    '''
-    if (value.get('award', {}).get('rfa') == 'ENCODE4'
-            and value.get('organism') == '/organisms/human/'
-            and not value.get('nih_institutional_certification')):
-        detail = ('Biosample {} is missing NIH institutional certification'
-                  ' required for human data'.format(value['@id']))
-        yield AuditFailure('missing nih_institutional_certification', detail, level='ERROR')
-
-
-
 # utility functions
 
 def is_part_of(term_id, part_of_term_id, ontology):
@@ -230,8 +217,7 @@ function_dispatcher = {
     'audit_bio_term': audit_biosample_term,
     'audit_culture_date': audit_biosample_culture_date,
     'audit_donor': audit_biosample_donor,
-    'audit_part_of': audit_biosample_part_of_consistency,
-    'audit_nih_consent': audit_biosample_nih_institutional_certification,
+    'audit_part_of': audit_biosample_part_of_consistency
 }
 
 @audit_checker('Biosample',

--- a/src/encoded/audit/experiment.py
+++ b/src/encoded/audit/experiment.py
@@ -2913,14 +2913,14 @@ def audit_experiment_nih_institutional_certification(value, system, excluded_typ
     if value.get('award', {}).get('rfa') != 'ENCODE4':
         return
     # Build up list of human biosamples missing NIC used in experiment. 
-    human_biosamples_missing_hic = [
+    human_biosamples_missing_hic = {
         b['@id']
         for b in get_biosamples(value)
         if (b.get('organism') == '/organisms/human/'
-                and not b.get('nih_institutional_certification'))
-    ]
+            and not b.get('nih_institutional_certification'))
+    }
     # Yield AuditFailure for unique biosamples.
-    for b in set(human_biosamples_missing_hic):
+    for b in human_biosamples_missing_hic:
         detail = ('Experiment {} uses biosample {} missing NIH institutional'
                   ' certification required for human data'.format(value['@id'], b))
         yield AuditFailure('missing nih_institutional_certification', detail, level='ERROR')

--- a/src/encoded/tests/test_audit_biosample.py
+++ b/src/encoded/tests/test_audit_biosample.py
@@ -229,27 +229,3 @@ def test_audit_biosample_part_of_consistency_ontology_part_of(testapp,
         errors_list.extend(errors[error_type])
     assert all(error['category'] != 'inconsistent biosample_term_id' for error in errors_list)
 
-
-def test_audit_library_without_nih_consent(testapp, biosample, encode4_award):
-    testapp.patch_json(biosample['@id'], {'award': encode4_award['@id']})
-    r = testapp.get(biosample['@id'] + '@@index-data')
-    audits = r.json['audit']
-    assert any(
-        [
-            detail['category'] == 'missing nih_institutional_certification'
-            for audit in audits.values() for detail in audit
-        ]
-    )
-
-
-def test_audit_library_with_nih_consent(testapp, biosample, encode4_award):
-    testapp.patch_json(biosample['@id'], {'award': encode4_award['@id'],
-                                          'nih_institutional_certification': 'NICABC123'})
-    r = testapp.get(biosample['@id'] + '@@index-data')
-    audits = r.json['audit']
-    assert all(
-        [
-            detail['category'] != 'missing nih_institutional_certification'
-            for audit in audits.values() for detail in audit
-        ]
-    )


### PR DESCRIPTION
This moves nih_institutional_certification audit from biosample to experiment. Will trigger on any ENCODE4 experiment that is using biosample missing nih_institutional_certification field. 