### PR TITLE
ENCD-3840 Add link to linkFrom linkTo schema properties

### DIFF
--- a/src/encoded/static/components/schema.js
+++ b/src/encoded/static/components/schema.js
@@ -134,8 +134,8 @@ function collectLinks(prop) {
             // Simple linkTo or linkFrom property; adds its value to the array we're collecting.
             linksLists[key].push(key === 'linkFrom' ? prop[key].split('.')[0] : prop[key]);
         } else if (typeof prop[key] === 'object' && !Array.isArray(prop[key])) {
-            // The schema property key is not one of `nonlinkProps` and has a value that's an object.
-            // Look for linkTo properties within this object.
+            // The schema property is an object. Look for linkTo/LinkFrom properties within this
+            // object.
             const subLinksLists = collectLinks(prop[key]);
             linksLists.linkTo = linksLists.linkTo.concat(subLinksLists.linkTo);
             linksLists.linkFrom = linksLists.linkFrom.concat(subLinksLists.linkFrom);

--- a/src/encoded/static/components/schema.js
+++ b/src/encoded/static/components/schema.js
@@ -36,6 +36,7 @@ const excludedTerms = [
     'output_type_output_category',
     'file_format_file_extension',
     'sort_by',
+    'anyOf',
 ];
 
 
@@ -45,6 +46,10 @@ const simpleTypeDisplay = {
     boolean: item => <span>{item ? 'True' : 'False'}</span>,
     number: item => <span >{item}</span>,
 };
+
+
+// Keys in a schema for objects that should be searched for links to other schemas.
+const linkedTerms = ['properties'];
 
 
 /**
@@ -89,24 +94,135 @@ function createJsonDisplay(elementId, term) {
 
 
 /**
- * Convert the contents of the `id` field of a schema to a path we can use to link to the page to
- * add a new object of its type.
+ * Convert the contents of the `id` field of a schema to a schema name.
  *
  * @param {*} schemaId - `id` property from schema
  */
-function schemaIdToPath(schemaId) {
+function schemaIdToName(schemaId) {
     const pathMatch = schemaId.match(/\/profiles\/(.*).json/);
     return pathMatch && pathMatch.length ? pathMatch[1] : null;
 }
 
 
+/**
+ * Convert the schema id property value to a page URI.
+ *
+ * @param {string} schemaId - value of id property within a schema
+ */
+function schemaIdToPage(schemaId) {
+    return schemaId.slice(0, -5);
+}
+
+
+/**
+ * Collect any linkTo and linkFrom properties within the schema object in the `prop` object. Two
+ * arrays of these string properties get returned as an object with this format...
+ *
+ * {
+ *     linkTo - array of linkTo property strings
+ *     linkFrom - array of linkFrom property strings
+ * }
+ *
+ * @param {object} prop - Schema property containing its own terms.
+ */
+function collectLinks(prop) {
+    const propKeys = Object.keys(prop);
+    const linksLists = { linkTo: [], linkFrom: [] };
+
+    propKeys.forEach((key) => {
+        if (key === 'linkTo' || key === 'linkFrom') {
+            // Simple linkTo or linkFrom property; adds its value to the array we're collecting.
+            linksLists[key].push(key === 'linkFrom' ? prop[key].split('.')[0] : prop[key]);
+        } else if (typeof prop[key] === 'object' && !Array.isArray(prop[key])) {
+            // The schema property key is not one of `nonlinkProps` and has a value that's an object.
+            // Look for linkTo properties within this object.
+            const subLinksLists = collectLinks(prop[key]);
+            linksLists.linkTo = linksLists.linkTo.concat(subLinksLists.linkTo);
+            linksLists.linkFrom = linksLists.linkFrom.concat(subLinksLists.linkFrom);
+        }
+    });
+
+    return linksLists;
+}
+
+
+// Display links to the schemas specified by the array of schema object names given in
+// `schemaNames`. Any schema objects name without a corresponding schema get displayed as plain
+// text instead of a link.
+const SchemaTermLinks = (props) => {
+    const { schemaNames, profilesMap } = props;
+
+    return (
+        <span>
+            {schemaNames.map((link, i) => {
+                const schemaId = profilesMap[link];
+                if (schemaId) {
+                    return (
+                        <span key={link}>
+                            {i > 0 ? <span>, </span> : null}
+                            <a href={schemaIdToPage(schemaId)}>{link}</a>
+                        </span>
+                    );
+                }
+
+                // No corresponding schema, so just display the schema name as plain text.
+                return <span key={link}>{i > 0 ? <span>, </span> : null}{link}</span>;
+            })}
+        </span>
+    );
+};
+
+SchemaTermLinks.propTypes = {
+    schemaNames: PropTypes.array.isRequired, // Array of the names of schemas to link to
+    profilesMap: PropTypes.object.isRequired, // Map of schema object @type to corresponding schema ID
+};
+
+
+// Display linkFrom and linkTo property values as links to the respecive schema pages, given a
+// property in the schema that contains at least one linkTo and/or linkFrom.
+const SchemaTermLinksSection = (props) => {
+    const { schemaProp, profilesMap } = props;
+
+    // Collect all the linkTo and linkFrom @types from schemaProp.
+    const collectedLinks = collectLinks(schemaProp);
+
+    if (collectedLinks.linkTo.length || collectedLinks.linkFrom.length) {
+        return (
+            <div className="schema-term-links">
+                {collectedLinks.linkTo.length ?
+                    <div>
+                        <span className="schema-term-links__title">References: </span>
+                        <SchemaTermLinks schemaNames={collectedLinks.linkTo} profilesMap={profilesMap} />
+                    </div>
+                : null}
+                {collectedLinks.linkFrom.length ?
+                    <div>
+                        <span className="schema-term-links__title">Referenced by: </span>
+                        <SchemaTermLinks schemaNames={collectedLinks.linkFrom} profilesMap={profilesMap} />
+                    </div>
+                : null}
+            </div>
+        );
+    }
+
+    // No linkTo or linkFrom found in the property being displayed.
+    return null;
+};
+
+SchemaTermLinksSection.propTypes = {
+    schemaProp: PropTypes.object.isRequired, // Schema property from which to collect and display links
+    profilesMap: PropTypes.object.isRequired, // Map of schema object @type to corresponding schema ID
+};
+
+
 // Display JSON for one schema term.
 class SchemaTermJsonDisplay extends React.Component {
-    constructor() {
-        super();
+    constructor(props) {
+        super(props);
 
         // Initialize component properties.
         this.editor = null; // Tracks brace editor reference.
+        this.id = `profile-value-json-${props.term}`; // HTML ID of component to draw brace editor into
     }
 
     componentDidMount() {
@@ -114,7 +230,7 @@ class SchemaTermJsonDisplay extends React.Component {
         const { schemaValue, term } = this.props;
 
         // Create a read-only brace editor to display the formatted JSON.
-        createJsonDisplay(term, schemaValue[term]).then((editor) => {
+        createJsonDisplay(this.id, schemaValue[term]).then((editor) => {
             // The brace editor successfully created. Save the reference to the brace editor
             // instance so we can get rid of it when the JSON display is closed.
             this.editor = editor;
@@ -129,11 +245,9 @@ class SchemaTermJsonDisplay extends React.Component {
     }
 
     render() {
-        const { term } = this.props;
-
         return (
-            <div className="profile-value__json">
-                <div id={term} />
+            <div className="profile-value__json-content">
+                <div id={this.id} />
             </div>
         );
     }
@@ -167,7 +281,7 @@ class SchemaTermItemDisplay extends React.Component {
     }
 
     render() {
-        const { schemaValue, term } = this.props;
+        const { schemaValue, term, linkedTerm, profilesMap } = this.props;
 
         return (
             <div>
@@ -176,7 +290,10 @@ class SchemaTermItemDisplay extends React.Component {
                     <span> {term}</span>
                 </div>
                 {this.state.jsonOpen ?
-                    <SchemaTermJsonDisplay schemaValue={schemaValue} term={term} />
+                    <div>
+                        <SchemaTermJsonDisplay schemaValue={schemaValue} term={term} />
+                        {linkedTerm ? <SchemaTermLinksSection schemaProp={schemaValue[term]} profilesMap={profilesMap} /> : null}
+                    </div>
                 : null}
             </div>
         );
@@ -186,26 +303,35 @@ class SchemaTermItemDisplay extends React.Component {
 SchemaTermItemDisplay.propTypes = {
     schemaValue: PropTypes.object.isRequired, // Schema object to display
     term: PropTypes.string.isRequired, // Item within the schema object to display
+    linkedTerm: PropTypes.bool.isRequired, // True if property should be searched for linkTo/linkFrom
+    profilesMap: PropTypes.object.isRequired, // Map of schema object @type to corresponding schema ID
 };
 
 
 // Display all property terms of a schema object (usually dependencies and properties).
-const SchemaTermDisplay = props => (
-    <div>
-        {Object.keys(props.schemaValue).sort().map(key =>
-            <SchemaTermItemDisplay key={key} schemaValue={props.schemaValue} term={key} />
-        )}
-    </div>
-);
+const SchemaTermDisplay = (props) => {
+    const { schemaValue, linkedTerm, schemaName, profilesMap } = props;
+
+    return (
+        <div>
+            {Object.keys(props.schemaValue).sort().map(key =>
+                <SchemaTermItemDisplay key={`${schemaName}-${key}`} term={key} schemaValue={schemaValue} schemaName={schemaName} linkedTerm={linkedTerm} profilesMap={profilesMap} />
+            )}
+        </div>
+    );
+};
 
 SchemaTermDisplay.propTypes = {
-    schemaValue: PropTypes.object, // Object from schema to display
+    schemaValue: PropTypes.object.isRequired, // Object from schema to display
+    linkedTerm: PropTypes.bool.isRequired, // True if property should be searched for linkTo/linkFrom
+    schemaName: PropTypes.string.isRequired, // Name of the schema from the URL
+    profilesMap: PropTypes.object.isRequired, // Map of schema object @type to corresponding schema ID
 };
 
 
 // Display one term of the schema regardless of its value type.
 const TermDisplay = (props) => {
-    const { termSchema } = props;
+    const { termSchema, linkedTerm, schemaName, profilesMap } = props;
     const termType = typeof termSchema;
 
     // If the schema term value has a simple type (string, boolean, number), then just display
@@ -237,13 +363,16 @@ const TermDisplay = (props) => {
         }
 
         // The value's an object, so display the schema value itself.
-        return <SchemaTermDisplay schemaValue={termSchema} />;
+        return <SchemaTermDisplay schemaValue={termSchema} linkedTerm={linkedTerm} schemaName={schemaName} profilesMap={profilesMap} />;
     }
     return null;
 };
 
 TermDisplay.propTypes = {
     termSchema: PropTypes.any.isRequired, // Value for `term` in the schema
+    linkedTerm: PropTypes.bool.isRequired, // True if the schema term should be searched for linkTo/linkFrom
+    schemaName: PropTypes.string.isRequired, // Name of the schema from URL
+    profilesMap: PropTypes.object.isRequired, // Map of schema object @type to corresponding schema ID
 };
 
 
@@ -267,7 +396,7 @@ class DisplayObjectSection extends React.PureComponent {
     }
 
     render() {
-        const { term, schema } = this.props;
+        const { term, schema, schemaName, profilesMap } = this.props;
 
         // Set aria values for accessibility.
         const accordionId = `profile-display-values-${term}`;
@@ -290,7 +419,7 @@ class DisplayObjectSection extends React.PureComponent {
                 </h3>
                 {this.state.sectionOpen ?
                     <div id={accordionId} aria-labelledby={accordionLabel} className="profile-display__values">
-                        <TermDisplay termSchema={schema[term]} />
+                        <TermDisplay termSchema={schema[term]} linkedTerm={linkedTerms.indexOf(term) !== -1} schemaName={schemaName} profilesMap={profilesMap} />
                     </div>
                 : null}
             </div>
@@ -301,24 +430,28 @@ class DisplayObjectSection extends React.PureComponent {
 DisplayObjectSection.propTypes = {
     term: PropTypes.string.isRequired, // Top-level property name in schema being displayed
     schema: PropTypes.object.isRequired, // Entire Schema containing term being displayed
+    schemaName: PropTypes.string.isRequired, // Name of the schema from URL
+    profilesMap: PropTypes.object.isRequired, // Map of schema object @type to corresponding schema ID
 };
 
 
 // Display an entire formatted schema.
 const DisplayObject = (props) => {
-    const { schema } = props;
+    const { schema, schemaName, profilesMap } = props;
     const schemaTerms = Object.keys(schema).filter(term => excludedTerms.indexOf(term) === -1);
     return (
         <div className="profile-display">
             {schemaTerms.map(term =>
-                <DisplayObjectSection key={term} term={term} schema={schema} />
+                <DisplayObjectSection key={`${schemaName}-${term}`} term={term} schemaName={schemaName} profilesMap={profilesMap} schema={schema} />
             )}
         </div>
     );
 };
 
 DisplayObject.propTypes = {
-    schema: PropTypes.object.isRequired,
+    schema: PropTypes.object.isRequired, // Schema being displayed
+    schemaName: PropTypes.string.isRequired, // Name of the schema from URL
+    profilesMap: PropTypes.object, // Map of schema object @type to corresponding schema ID; required but provided by GET response
 };
 
 
@@ -388,29 +521,74 @@ ChangeLog.defaultProps = {
 };
 
 
-const SchemaPage = (props, reactContext) => {
-    const context = props.context;
-    const itemClass = globals.itemClass(context);
-    const title = context.title;
-    const changelog = context.changelog;
-    const loggedIn = !!(reactContext.session && reactContext.session['auth.userid']);
-
-    // Generate a link to add an object for the currently displayed schema.
-    const schemaPath = schemaIdToPath(context.id);
-
-    // Set up the "breadcrumbs" (sneer quotes because it's really just a link to /profiles/).
-    // If schemaPath happened to be null (which it realistically can't), <BreadCrumbs> would
-    // harmlessly display nothing.
-    const crumbs = [
-        { id: 'Profiles', uri: '/profiles/', wholeTip: 'All schemas' },
-        { id: schemaPath },
-    ];
-
+// Renders the panel that displays the schema given in the `schema` prop. Included in this
+// implementation is a GET request for /profiles-map/ which is a mapping of schema object name to
+// schema id. /profiles/ provides the same information but in a very large object not provided when
+// loading a single schema, while /profiles-map/ is a relatively small object.
+const SchemaPanel = (props, reactContext) => {
+    const { schema, schemaName } = props;
 
     // Determine whether we should display an "Add" button or not depending on the user's logged-in
     // state.
-    const decoration = loggedIn ? <a href={`/${schemaPath}/#!add`} className="btn btn-info profiles-add-obj__btn">Add</a> : null;
+    const loggedIn = !!(reactContext.session && reactContext.session['auth.userid']);
+    const decoration = loggedIn ? <a href={`/${schemaName}/#!add`} className="btn btn-info profiles-add-obj__btn">Add</a> : null;
     const decorationClasses = loggedIn ? 'profiles-add-obj' : '';
+
+    return (
+        <Panel>
+            <TabPanel
+                tabs={{ formatted: 'Formatted', raw: 'Raw' }}
+                decoration={decoration}
+                decorationClasses={decorationClasses}
+            >
+                <TabPanelPane key="formatted">
+                    <PanelBody>
+                        <FetchedData>
+                            <Param name="profilesMap" url="/profiles-map/" />
+                            <DisplayObject schema={schema} schemaName={schemaName} />
+                        </FetchedData>
+                    </PanelBody>
+                </TabPanelPane>
+                <TabPanelPane key="raw">
+                    <PanelBody>
+                        <DisplayRawObject schema={schema} />
+                    </PanelBody>
+                </TabPanelPane>
+            </TabPanel>
+        </Panel>
+    );
+};
+
+SchemaPanel.propTypes = {
+    schema: PropTypes.object.isRequired, // Schema to display
+    schemaName: PropTypes.string, // Schema name e.g. genetic_modification
+};
+
+SchemaPanel.defaultProps = {
+    profilesMap: {},
+};
+
+SchemaPanel.contextTypes = {
+    session: PropTypes.object,
+};
+
+
+// Displays a page for a single schema given in the `context` prop.
+const SchemaPage = (props) => {
+    const context = props.context;
+    const itemClass = globals.itemClass(context);
+    const title = context.title;
+
+    // The schema id is a path to the schema's JSON. Convert that to just the schema name.
+    const schemaName = schemaIdToName(context.id);
+
+    // Set up the "breadcrumbs" (sneer quotes because it's really just a link to /profiles/).
+    // If schemaName happened to be null (which it realistically can't), <BreadCrumbs> would
+    // harmlessly display nothing in the second element.
+    const crumbs = [
+        { id: 'Profiles', uri: '/profiles/', wholeTip: 'All schemas' },
+        { id: schemaName },
+    ];
 
     return (
         <div className={itemClass}>
@@ -421,32 +599,15 @@ const SchemaPage = (props, reactContext) => {
                 </div>
             </header>
             {typeof context.description === 'string' ? <p className="description">{context.description}</p> : null}
-            <Panel>
-                <TabPanel
-                    tabs={{ formatted: 'Formatted', raw: 'Raw' }}
-                    decoration={decoration}
-                    decorationClasses={decorationClasses}
-                >
-                    <TabPanelPane key="formatted">
-                        <PanelBody>
-                            <DisplayObject schema={context} />
-                        </PanelBody>
-                    </TabPanelPane>
-                    <TabPanelPane key="raw">
-                        <PanelBody>
-                            <DisplayRawObject schema={context} />
-                        </PanelBody>
-                    </TabPanelPane>
-                </TabPanel>
-            </Panel>
-            {changelog ?
+            <SchemaPanel schema={context} schemaName={schemaName} />
+            {context.changelog ?
                 <Panel>
                     <PanelHeading>
                         <h4>ChangeLog</h4>
                     </PanelHeading>
                     <PanelBody>
                         <FetchedData>
-                            <Param name="source" url={changelog} type="text" />
+                            <Param name="source" url={context.changelog} type="text" />
                             <ChangeLog />
                         </FetchedData>
                     </PanelBody>
@@ -457,39 +618,40 @@ const SchemaPage = (props, reactContext) => {
 };
 
 SchemaPage.propTypes = {
-    context: PropTypes.object.isRequired,
-};
-
-SchemaPage.contextTypes = {
-    session: PropTypes.object,
+    context: PropTypes.object.isRequired, // Schema to display
 };
 
 globals.contentViews.register(SchemaPage, 'JSONSchema');
 
 
-// Displays a page listing all schemas available in the system.
+// Displays a page listing all schemas available in the system, as well as buttons by each one to
+// add a new object of that type if you're logged in.
 const AllSchemasPage = (props, reactContext) => {
     const { context } = props;
     const loggedIn = !!(reactContext.session && reactContext.session['auth.userid']);
 
-    // Get a sorted list of all available schemas. Filter out those without any
-    // `identifyingProperties` because the user can't add objects of that type.
-    const schemaNames = Object.keys(context).sort().filter(schemaName => (
-        !!(context[schemaName].identifyingProperties && context[schemaName].identifyingProperties.length)
+    // Get a sorted list of all available schema object names (e.g. GeneticModification). Filter
+    // out those without any `identifyingProperties` because the user can't add objects of that
+    // type, nor display their schemas.
+    const objectNames = Object.keys(context).sort().filter(objectName => (
+        !!(context[objectName].identifyingProperties && context[objectName].identifyingProperties.length)
     ));
 
     return (
         <Panel>
             <PanelBody>
                 <div className="schema-list">
-                    {schemaNames.map((schemaName) => {
-                        const schemaId = context[schemaName].id;
-                        const schemaPath = schemaIdToPath(schemaId);
+                    {objectNames.map((objectName) => {
+                        // `objectName` is the @type of each objects e.g. GeneticModification
+                        // `schemaName` is the system name of the objects e.g. genetic_modification
+                        // `schemaPath` is the schema page path e.g. /profiles/genetic_modification
+                        const schemaName = schemaIdToName(context[objectName].id);
+                        const schemaPath = schemaIdToPage(context[objectName].id);
 
                         return (
-                            <div className="schema-list__item" key={schemaName}>
-                                {loggedIn ? <a className="btn btn-info btn-xs" href={`/${schemaPath}/#!add`}>Add</a> : null}
-                                <a href={schemaId} title={context[schemaName].description}>{schemaName}</a>
+                            <div className="schema-list__item" key={objectName}>
+                                {loggedIn ? <a className="btn btn-info btn-xs" href={`/${schemaName}/#!add`}>Add</a> : null}
+                                <a href={schemaPath} title={context[objectName].description}>{objectName}</a>
                             </div>
                         );
                     })}
@@ -500,7 +662,7 @@ const AllSchemasPage = (props, reactContext) => {
 };
 
 AllSchemasPage.propTypes = {
-    context: PropTypes.object.isRequired,
+    context: PropTypes.object.isRequired, // /profiles/ object
 };
 
 AllSchemasPage.contextTypes = {

--- a/src/encoded/static/scss/encoded/modules/_schema.scss
+++ b/src/encoded/static/scss/encoded/modules/_schema.scss
@@ -40,7 +40,7 @@
         }
     }
 
-    @at-root #{&}__json {
+    @at-root #{&}__json-content {
         padding: 10px;
         border: 1px solid #e0e0e0;
         background-color: #f3f2f3;
@@ -86,5 +86,13 @@
 
     @at-root #{&}__btn {
         height: 90%;
+    }
+}
+
+.schema-term-links {
+    margin: 2px 0 10px;
+
+    @at-root #{&}__title {
+        font-weight: bold;
     }
 }


### PR DESCRIPTION
This PR relies on SNO-26-json-extension.

The most key new function is `collectLinks` which digs into schema properties looking for linkTo/linkFrom properties at any embedded levels and making arrays of all those properties it could find of each kind. These then get displayed as links.

The other part (relying on SNO-26) involves doing a GET request on the new /profiles-map/ object through the <FetchedData>/<Param> components, which then gets used to convert whatever properties `collectLinks` found to the corresponding schema paths.