### PR TITLE
ENCD-3916 Fix for broken metadata queries

### DIFF
--- a/src/encoded/batch_download.py
+++ b/src/encoded/batch_download.py
@@ -241,7 +241,7 @@ def metadata_tsv(context, request):
     results = request.embed(path, as_user=True)
     rows = []
     for experiment_json in results['@graph']:
-        if experiment_json['files']:
+        if experiment_json.get('files', []):
             exp_data_row = []
             for column in header:
                 if not _tsv_mapping[column][0].startswith('files'):


### PR DESCRIPTION
- Issue: metadata_tsv route fails when experiment_json object doesn't have the 'files' key

- Fix: Default 'files' to an empty list when there is no 'files' key
