### PR TITLE
ENCD-3886 Update deploy machine instance types

### DIFF
--- a/checkfiles/deploy.py
+++ b/checkfiles/deploy.py
@@ -109,7 +109,7 @@ def main():
     parser.add_argument(
         '-n', '--name', type=hostname, help="Instance name")
     parser.add_argument(
-        '--image-id', default='ami-4b37d42b',
+        '--image-id', default='ami-8f78c2f7',
         help="ubuntu/images/hvm-ssd/ubuntu-wily-15.10-amd64-server-20160217.1")
     parser.add_argument(
         '--instance-type', default='c4.xlarge',

--- a/checkfiles/deploy.py
+++ b/checkfiles/deploy.py
@@ -109,11 +109,11 @@ def main():
     parser.add_argument(
         '-n', '--name', type=hostname, help="Instance name")
     parser.add_argument(
-        '--image-id', default='ami-8f78c2f7',
-        help="ubuntu/images/hvm-ssd/ubuntu-wily-15.10-amd64-server-20160217.1")
+        '--image-id', default='ami-2133bc59',
+        help="https://us-west-2.console.aws.amazon.com/ec2/home?region=us-west-2#LaunchInstanceWizard:ami=ami-2133bc59")
     parser.add_argument(
-        '--instance-type', default='c4.xlarge',
-        help="specify 'c4.8xlarge' if there are many files to check")
+        '--instance-type', default='c5.xlarge',
+        help="specify 'c5.9xlarge' if there are many files to check")
     parser.add_argument(
         '--profile-name', default=None, help="AWS creds profile")
     parser.add_argument(

--- a/src/encoded/commands/deploy.py
+++ b/src/encoded/commands/deploy.py
@@ -402,13 +402,13 @@ def main():
     parser.add_argument(
         '--test', action='store_const', default='demo', const='test', dest='role',
         help="Deploy to production AWS")
-    parser.add_argument(ami-8f78c2f7
-        '--image-id', default='ami-8f78c2f7',
-        help="ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20151015 or try ami-2133bc59")
     parser.add_argument(
-        '--instance-type', default='c4.4xlarge',
-        help="(defualts to c4.4xlarge for indexing) Switch to a smaller instance afterwards"
-        "(m4.xlarge or c4.xlarge)")
+        '--image-id', default='ami-2133bc59',
+        help="https://us-west-2.console.aws.amazon.com/ec2/home?region=us-west-2#LaunchInstanceWizard:ami=ami-2133bc59")
+    parser.add_argument(
+        '--instance-type', default='c5.9xlarge',
+        help="(defualts to c5.9xlarge for indexing) Switch to a smaller instance afterwards"
+        "(m5.xlarge or c5.xlarge).")
     parser.add_argument('--profile-name', default=None, help="AWS creds profile")
     parser.add_argument('--elasticsearch', default=None, help="Launch an Elasticsearch instance")
     parser.add_argument('--cluster-size', default=2, help="Elasticsearch cluster size")

--- a/src/encoded/commands/deploy.py
+++ b/src/encoded/commands/deploy.py
@@ -402,12 +402,12 @@ def main():
     parser.add_argument(
         '--test', action='store_const', default='demo', const='test', dest='role',
         help="Deploy to production AWS")
-    parser.add_argument(
-        '--image-id', default='ami-1c1eff2f',
-        help="ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20151015")
+    parser.add_argument(ami-8f78c2f7
+        '--image-id', default='ami-8f78c2f7',
+        help="ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20151015 or try ami-2133bc59")
     parser.add_argument(
         '--instance-type', default='c4.4xlarge',
-        help="(defualts toc4.4xlarge for indexing) Switch to a smaller instance afterwards"
+        help="(defualts to c4.4xlarge for indexing) Switch to a smaller instance afterwards"
         "(m4.xlarge or c4.xlarge)")
     parser.add_argument('--profile-name', default=None, help="AWS creds profile")
     parser.add_argument('--elasticsearch', default=None, help="Launch an Elasticsearch instance")


### PR DESCRIPTION
Changed default ami in deploy scripts to use c5 and m5 series.  Way faster (and cheaper!)