### PR TITLE
ENCD-3451 New summary page

### DIFF
--- a/src/encoded/static/components/__tests__/status-test.js
+++ b/src/encoded/static/components/__tests__/status-test.js
@@ -1,0 +1,26 @@
+import { getObjectStatuses } from '../statuslabel';
+
+
+describe('Statuses', () => {
+    describe('getObjectStatuses successful', () => {
+        test('has the proper number of statuses at each access level for Experiments', () => {
+            let statuses = getObjectStatuses('Experiment', 'external');
+            expect(statuses).toHaveLength(3);
+            statuses = getObjectStatuses('Experiment', 'consortium');
+            expect(statuses).toHaveLength(6);
+            statuses = getObjectStatuses('Experiment', 'admin');
+            expect(statuses).toHaveLength(8);
+            statuses = getObjectStatuses('Experiment');
+            expect(statuses).toHaveLength(8);
+        });
+    });
+
+    describe('getObjectStatuses failures', () => {
+        test('test failure conditions', () => {
+            let statuses = getObjectStatuses('Assay', 'public');
+            expect(statuses).toHaveLength(0);
+            statuses = getObjectStatuses('Experiment', 'faculty');
+            expect(statuses).toHaveLength(0);
+        });
+    });
+});

--- a/src/encoded/static/components/antibody.js
+++ b/src/encoded/static/components/antibody.js
@@ -12,7 +12,7 @@ import { DbxrefList } from './dbxref';
 import { DocumentsPanel, Document, DocumentPreview, CharacterizationDocuments } from './doc';
 import { RelatedItems } from './item';
 import { AlternateAccession } from './objectutils';
-import StatusLabel from './statuslabel';
+import { StatusLabel } from './statuslabel';
 
 
 const LotComponent = (props, reactContext) => {

--- a/src/encoded/static/components/app.js
+++ b/src/encoded/static/components/app.js
@@ -7,7 +7,6 @@ import url from 'url';
 import jsonScriptEscape from '../libs/jsonScriptEscape';
 import origin from '../libs/origin';
 import * as globals from './globals';
-import DataColors from './datacolors';
 import Navigation from './navigation';
 import Footer from './footer';
 import Home from './home';
@@ -22,6 +21,8 @@ const portal = {
             children: [
                 { id: 'assaymatrix', title: 'Matrix', url: '/matrix/?type=Experiment' },
                 { id: 'assaysearch', title: 'Search', url: '/search/?type=Experiment' },
+                { id: 'assaysummary', title: 'Summary', url: '/summary/?type=Experiment' },
+                { id: 'sep-mm-1' },
                 { id: 'region-search', title: 'Search by region', url: '/region-search/' },
                 { id: 'reference-epigenomes', title: 'Reference epigenomes', url: '/search/?type=ReferenceEpigenome' },
                 { id: 'publications', title: 'Publications', url: '/publications/' },
@@ -70,27 +71,6 @@ const portal = {
         },
     ],
 };
-
-
-// Keep lists of currently known project and biosample_type. As new project and biosample_type
-// enter the system, these lists must be updated. Used mostly to keep chart and matrix colors
-// consistent.
-const projectList = [
-    'ENCODE',
-    'Roadmap',
-    'modENCODE',
-    'modERN',
-    'GGR',
-];
-const biosampleTypeList = [
-    'cell line',
-    'tissue',
-    'primary cell',
-    'whole organisms',
-    'stem cell',
-    'in vitro differentiated cells',
-    'induced pluripotent stem cell line',
-];
 
 
 // See https://github.com/facebook/react/issues/2323 for an IE8 fix removed for Redmine #4755.
@@ -241,17 +221,11 @@ class App extends React.Component {
 
     // Data for child components to subscrie to.
     getChildContext() {
-        // Make `project` and `biosample_type` color mappings for downstream modules to use.
-        const projectColors = new DataColors(projectList);
-        const biosampleTypeColors = new DataColors(biosampleTypeList);
-
         return {
             listActionsFor: this.listActionsFor,
             currentResource: this.currentResource,
             location_href: this.state.href,
             portal,
-            projectColors,
-            biosampleTypeColors,
             fetch: this.fetch,
             navigate: this.navigate,
             adviseUnsavedChanges: this.adviseUnsavedChanges,

--- a/src/encoded/static/components/award.js
+++ b/src/encoded/static/components/award.js
@@ -1836,7 +1836,8 @@ export const ExperimentDate = (props) => {
         accumulatedDataSubmitted = createDataset(deduplicatedsubmitted);
 
         // Adjust the submitted counts by the released counts so we can stack the chart.
-        accumulatedDataSubmitted = accumulatedDataReleased.map((count, i) => Math.max((accumulatedDataSubmitted[i - 1] || 0) - count, 0));
+        // accumulatedDataSubmitted = accumulatedDataReleased.map((count, i) => Math.max((accumulatedDataSubmitted[i - 1] || 0) - count, 0));
+        accumulatedDataSubmitted = accumulatedDataReleased.map((count, i) => Math.max((accumulatedDataSubmitted[i] || 0) - count, 0));
     }
 
     return (

--- a/src/encoded/static/components/award.js
+++ b/src/encoded/static/components/award.js
@@ -1811,8 +1811,8 @@ export const ExperimentDate = (props) => {
         } else {
             const releasedIndex = sortedreleasedTerms.findIndex(item => item.doc_count);
             const submittedIndex = sortedsubmittedTerms.findIndex(item => item.doc_count);
-            const earliestReleased = sortedreleasedTerms[releasedIndex].key;
-            const earliestSubmitted = sortedsubmittedTerms[submittedIndex].key;
+            const earliestReleased = releasedIndex > -1 ? sortedreleasedTerms[releasedIndex].key : sortedreleasedTerms[sortedreleasedTerms.length - 1];
+            const earliestSubmitted = submittedIndex > -1 ? sortedsubmittedTerms[submittedIndex].key : sortedsubmittedTerms[sortedsubmittedTerms.length - 1];
             awardStartDate = earliestReleased < earliestSubmitted ? earliestReleased : earliestSubmitted;
         }
         deduplicatedreleased = fillDates(sortedreleasedTerms, deduplicatedreleased, awardStartDate);

--- a/src/encoded/static/components/award.js
+++ b/src/encoded/static/components/award.js
@@ -1821,7 +1821,7 @@ export const ExperimentDate = (props) => {
         accumulatedDataSubmitted = createDataset(deduplicatedsubmitted, accumulatorsubmitted, cumulativedatasetSubmitted);
 
         // Adjust the submitted counts by the released counts.
-        accumulatedDataSubmitted = accumulatedDataSubmitted.map((count, i) => count + accumulatedDataReleased[i]);
+        accumulatedDataSubmitted = accumulatedDataSubmitted.map((count, i) => Math.max(count - accumulatedDataReleased[i]));
     }
 
     return (
@@ -2032,6 +2032,9 @@ class CumulativeGraph extends React.Component {
                                 maxTicksLimit: 15, // sets maximum number of x-axis labels
                             },
                         }],
+                        yAxes: [{
+                            stacked: true,
+                        }],
                     },
                 },
                 data: {
@@ -2042,7 +2045,7 @@ class CumulativeGraph extends React.Component {
                         backgroundColor: '#604a7b',
                     },
                     {
-                        label: 'Submitted + Released',
+                        label: 'Submitted',
                         data: submitteddatavalue,
                         backgroundColor: '#ccc1da',
                     }],

--- a/src/encoded/static/components/award.js
+++ b/src/encoded/static/components/award.js
@@ -1821,7 +1821,7 @@ export const ExperimentDate = (props) => {
         accumulatedDataSubmitted = createDataset(deduplicatedsubmitted, accumulatorsubmitted, cumulativedatasetSubmitted);
 
         // Adjust the submitted counts by the released counts.
-        accumulatedDataSubmitted = accumulatedDataSubmitted.map((count, i) => Math.max(count - accumulatedDataSubmitted[i], 0));
+        accumulatedDataSubmitted = accumulatedDataSubmitted.map((count, i) => Math.max(count - accumulatedDataReleased[i], 0));
     }
 
     return (

--- a/src/encoded/static/components/award.js
+++ b/src/encoded/static/components/award.js
@@ -1824,7 +1824,7 @@ export const ExperimentDate = (props) => {
         accumulatedDataSubmitted = createDataset(deduplicatedsubmitted, accumulatorsubmitted, cumulativedatasetSubmitted);
 
         // Adjust the submitted counts by the released counts so we can stack the chart.
-        accumulatedDataSubmitted = accumulatedDataSubmitted.map((count, i) => Math.max(count - accumulatedDataReleased[i], 0));
+        accumulatedDataSubmitted = accumulatedDataReleased.map((count, i) => Math.max((accumulatedDataSubmitted[i - 1] || 0) - count, 0));
     }
 
     return (

--- a/src/encoded/static/components/award.js
+++ b/src/encoded/static/components/award.js
@@ -1794,6 +1794,7 @@ export const ExperimentDate = (props) => {
         const sortedreleasedTerms = sortTerms(releasedDates);
         const sortedsubmittedTerms = sortTerms(submittedDates);
 
+        // Trim to the earliest non-zero doc_count.
         // Add an object with the most current date to one of the arrays.
         if ((releasedDates && releasedDates.length) && (submittedDates && submittedDates.length)) {
             if (sortedreleasedTerms.length && moment(sortedsubmittedTerms[sortedsubmittedTerms.length - 1].key).isAfter(sortedreleasedTerms[sortedreleasedTerms.length - 1].key, 'date')) {
@@ -1808,8 +1809,10 @@ export const ExperimentDate = (props) => {
         if (award && award.start_date) {
             awardStartDate = moment(award.start_date, 'YYYY-MM-DD').format('YYYY-MM');
         } else {
-            const earliestReleased = sortedreleasedTerms[0].key;
-            const earliestSubmitted = sortedsubmittedTerms[0].key;
+            const releasedIndex = sortedreleasedTerms.findIndex(item => item.doc_count);
+            const submittedIndex = sortedsubmittedTerms.findIndex(item => item.doc_count);
+            const earliestReleased = sortedreleasedTerms[releasedIndex].key;
+            const earliestSubmitted = sortedsubmittedTerms[submittedIndex].key;
             awardStartDate = earliestReleased < earliestSubmitted ? earliestReleased : earliestSubmitted;
         }
         deduplicatedreleased = fillDates(sortedreleasedTerms, deduplicatedreleased, awardStartDate);
@@ -1820,7 +1823,7 @@ export const ExperimentDate = (props) => {
         accumulatedDataReleased = createDataset(deduplicatedreleased, accumulatorreleased, cumulativedatasetReleased);
         accumulatedDataSubmitted = createDataset(deduplicatedsubmitted, accumulatorsubmitted, cumulativedatasetSubmitted);
 
-        // Adjust the submitted counts by the released counts.
+        // Adjust the submitted counts by the released counts so we can stack the chart.
         accumulatedDataSubmitted = accumulatedDataSubmitted.map((count, i) => Math.max(count - accumulatedDataReleased[i], 0));
     }
 

--- a/src/encoded/static/components/award.js
+++ b/src/encoded/static/components/award.js
@@ -1834,6 +1834,9 @@ export const ExperimentDate = (props) => {
         date = deduplicatedreleased.map(dateTerm => moment(dateTerm.key, 'YYYY-MM').format('MMM YYYY'));
         accumulatedDataReleased = createDataset(deduplicatedreleased);
         accumulatedDataSubmitted = createDataset(deduplicatedsubmitted);
+
+        // Adjust the submitted counts by the released counts so we can stack the chart.
+        accumulatedDataSubmitted = accumulatedDataReleased.map((count, i) => Math.max((accumulatedDataSubmitted[i - 1] || 0) - count, 0));
     }
 
     return (
@@ -2043,6 +2046,9 @@ class CumulativeGraph extends React.Component {
                                 autoSkip: true,
                                 maxTicksLimit: 15, // sets maximum number of x-axis labels
                             },
+                        }],
+                        yAxes: [{
+                            stacked: true,
                         }],
                     },
                 },

--- a/src/encoded/static/components/award.js
+++ b/src/encoded/static/components/award.js
@@ -180,7 +180,7 @@ function createDoughnutChart(chartId, values, labels, colors, baseSearchUri, nav
 //             because this function can't access the navigation function.
  * @return {promise}
  */
-export function createBarChart(chartId, data, colors, replicateLabels, baseSearchUri, navigate) {
+export function createBarChart(chartId, data, colors, replicateLabels, legendTitle, baseSearchUri, navigate) {
     return new Promise((resolve) => {
         require.ensure(['chart.js'], (require) => {
             const Chart = require('chart.js');
@@ -252,6 +252,9 @@ export function createBarChart(chartId, data, colors, replicateLabels, baseSearc
                             dataColors.push(chartInstance.data.datasets[i].backgroundColor);
                         }
                         const text = [];
+                        if (legendTitle) {
+                            text.push(`<div class="legend-title">${legendTitle}</div>`);
+                        }
                         text.push('<ul>');
                         for (let i = 0; i < LegendLabels.length; i += 1) {
                             if (LegendLabels[i]) {
@@ -1078,7 +1081,7 @@ class StatusExperimentChart extends React.Component {
         const replicatelabels = ['unreplicated', 'isogenic', 'anisogenic'];
         const colors = replicatelabels.map((label, i) => statusColorList[i % statusColorList.length]);
 
-        createBarChart(chartId, data, colors, replicatelabels, `${this.props.linkUri}${this.props.award ? this.props.award.name : ''}`, (uri) => { this.context.navigate(uri); })
+        createBarChart(chartId, data, colors, replicatelabels, 'Replication', `${this.props.linkUri}${this.props.award ? this.props.award.name : ''}`, (uri) => { this.context.navigate(uri); })
             .then((chartInstance) => {
                 // Save the created chart instance.
                 this.chart = chartInstance;

--- a/src/encoded/static/components/award.js
+++ b/src/encoded/static/components/award.js
@@ -1821,7 +1821,7 @@ export const ExperimentDate = (props) => {
         accumulatedDataSubmitted = createDataset(deduplicatedsubmitted, accumulatorsubmitted, cumulativedatasetSubmitted);
 
         // Adjust the submitted counts by the released counts.
-        accumulatedDataSubmitted = accumulatedDataSubmitted.map((count, i) => Math.max(count - accumulatedDataReleased[i], 0));
+        accumulatedDataSubmitted = accumulatedDataSubmitted.map((count, i) => count + accumulatedDataReleased[i]);
     }
 
     return (
@@ -2032,20 +2032,17 @@ class CumulativeGraph extends React.Component {
                                 maxTicksLimit: 15, // sets maximum number of x-axis labels
                             },
                         }],
-                        yAxes: [{
-                            stacked: true,
-                        }],
                     },
                 },
                 data: {
                     labels: monthReleased,
                     datasets: [{
-                        label: 'Date Released',
+                        label: 'Released',
                         data: releaseddatavalue,
                         backgroundColor: '#604a7b',
                     },
                     {
-                        label: 'Date Submitted',
+                        label: 'Submitted + Released',
                         data: submitteddatavalue,
                         backgroundColor: '#ccc1da',
                     }],

--- a/src/encoded/static/components/award.js
+++ b/src/encoded/static/components/award.js
@@ -2055,14 +2055,14 @@ class CumulativeGraph extends React.Component {
                 data: {
                     labels: monthReleased,
                     datasets: [{
-                        label: 'Released',
-                        data: releaseddatavalue,
-                        backgroundColor: '#538235',
-                    },
-                    {
                         label: 'Submitted',
                         data: submitteddatavalue,
                         backgroundColor: '#a9d18e',
+                    },
+                    {
+                        label: 'Released',
+                        data: releaseddatavalue,
+                        backgroundColor: '#538235',
                     }],
                 },
             });

--- a/src/encoded/static/components/award.js
+++ b/src/encoded/static/components/award.js
@@ -1819,6 +1819,9 @@ export const ExperimentDate = (props) => {
         date = Object.keys(deduplicatedreleased).map(term => term);
         accumulatedDataReleased = createDataset(deduplicatedreleased, accumulatorreleased, cumulativedatasetReleased);
         accumulatedDataSubmitted = createDataset(deduplicatedsubmitted, accumulatorsubmitted, cumulativedatasetSubmitted);
+
+        // Adjust the submitted counts by the released counts.
+        accumulatedDataSubmitted = accumulatedDataSubmitted.map((count, i) => Math.max(count - accumulatedDataSubmitted[i], 0));
     }
 
     return (

--- a/src/encoded/static/components/award.js
+++ b/src/encoded/static/components/award.js
@@ -1078,7 +1078,7 @@ class StatusExperimentChart extends React.Component {
         const replicatelabels = ['unreplicated', 'isogenic', 'anisogenic'];
         const colors = replicatelabels.map((label, i) => statusColorList[i % statusColorList.length]);
 
-        createBarChart(chartId, data, colors, replicatelabels, `${this.props.linkUri}${this.award ? this.props.award.name : ''}`, (uri) => { this.context.navigate(uri); })
+        createBarChart(chartId, data, colors, replicatelabels, `${this.props.linkUri}${this.props.award ? this.props.award.name : ''}`, (uri) => { this.context.navigate(uri); })
             .then((chartInstance) => {
                 // Save the created chart instance.
                 this.chart = chartInstance;

--- a/src/encoded/static/components/award.js
+++ b/src/encoded/static/components/award.js
@@ -1821,7 +1821,7 @@ export const ExperimentDate = (props) => {
         accumulatedDataSubmitted = createDataset(deduplicatedsubmitted, accumulatorsubmitted, cumulativedatasetSubmitted);
 
         // Adjust the submitted counts by the released counts.
-        accumulatedDataSubmitted = accumulatedDataSubmitted.map((count, i) => Math.max(count - accumulatedDataReleased[i]));
+        accumulatedDataSubmitted = accumulatedDataSubmitted.map((count, i) => Math.max(count - accumulatedDataReleased[i], 0));
     }
 
     return (

--- a/src/encoded/static/components/award.js
+++ b/src/encoded/static/components/award.js
@@ -1834,9 +1834,6 @@ export const ExperimentDate = (props) => {
         date = deduplicatedreleased.map(dateTerm => moment(dateTerm.key, 'YYYY-MM').format('MMM YYYY'));
         accumulatedDataReleased = createDataset(deduplicatedreleased);
         accumulatedDataSubmitted = createDataset(deduplicatedsubmitted);
-
-        // Adjust the submitted counts by the released counts so we can stack the chart.
-        accumulatedDataSubmitted = accumulatedDataReleased.map((count, i) => Math.max((accumulatedDataSubmitted[i - 1] || 0) - count, 0));
     }
 
     return (
@@ -2047,9 +2044,6 @@ class CumulativeGraph extends React.Component {
                                 maxTicksLimit: 15, // sets maximum number of x-axis labels
                             },
                         }],
-                        yAxes: [{
-                            stacked: true,
-                        }],
                     },
                 },
                 data: {
@@ -2057,12 +2051,12 @@ class CumulativeGraph extends React.Component {
                     datasets: [{
                         label: 'Released',
                         data: releaseddatavalue,
-                        backgroundColor: '#604a7b',
+                        backgroundColor: '#538235',
                     },
                     {
                         label: 'Submitted',
                         data: submitteddatavalue,
-                        backgroundColor: '#ccc1da',
+                        backgroundColor: '#a9d18e',
                     }],
                 },
             });

--- a/src/encoded/static/components/award.js
+++ b/src/encoded/static/components/award.js
@@ -1701,7 +1701,7 @@ const fillDates = (sortedDateTerms, startDate) => {
     // The new array limits go between `startDate` and the current date.
     const startDateMoment = moment(startDate, 'YYYY-MM');
     const endDateMoment = moment();
-    const monthCount = endDateMoment.diff(startDateMoment, 'months');
+    const monthCount = endDateMoment.diff(startDateMoment, 'months') + 1;
 
     // For every possible month, generate a new array entry, filling in the doc_count with
     // matching data from `sortedDateTerms`, or 0 if `sortedDateTerms` has no matching month.

--- a/src/encoded/static/components/award.js
+++ b/src/encoded/static/components/award.js
@@ -1688,6 +1688,18 @@ ExperimentDateRenderer.defaultProps = {
 };
 
 
+const fillDates2 = (sortedDates, startDate) => {
+    const startDateMoment = moment(startDate, 'YYYY-MM');
+    const endDateMoment = moment();
+    const monthCount = endDateMoment.diff(startDateMoment, 'months');
+    const filledDateArray = [{ key: startDateMoment.format('YYYY-MM'), doc_count: 0 }];
+    for (let i = 0; i < monthCount; i += 1) {
+        filledDateArray.push({ key: startDateMoment.add(1, 'month').format('YYYY-MM'), doc_count: 0 });
+    }
+    console.log('MonthCount: %s:%o', startDate, filledDateArray);
+};
+
+
 // Overall component to render the cumulative line chart
 export const ExperimentDate = (props) => {
     const { experiments, award, panelCss, panelHeadingCss } = props;
@@ -1794,7 +1806,6 @@ export const ExperimentDate = (props) => {
         const sortedreleasedTerms = sortTerms(releasedDates);
         const sortedsubmittedTerms = sortTerms(submittedDates);
 
-        // Trim to the earliest non-zero doc_count.
         // Add an object with the most current date to one of the arrays.
         if ((releasedDates && releasedDates.length) && (submittedDates && submittedDates.length)) {
             if (sortedreleasedTerms.length && moment(sortedsubmittedTerms[sortedsubmittedTerms.length - 1].key).isAfter(sortedreleasedTerms[sortedreleasedTerms.length - 1].key, 'date')) {
@@ -1815,11 +1826,12 @@ export const ExperimentDate = (props) => {
             const earliestSubmitted = submittedIndex > -1 ? sortedsubmittedTerms[submittedIndex].key : sortedsubmittedTerms[sortedsubmittedTerms.length - 1];
             awardStartDate = earliestReleased < earliestSubmitted ? earliestReleased : earliestSubmitted;
         }
+        fillDates2(sortedsubmittedTerms, awardStartDate);
         deduplicatedreleased = fillDates(sortedreleasedTerms, deduplicatedreleased, awardStartDate);
         deduplicatedsubmitted = fillDates(sortedsubmittedTerms, deduplicatedsubmitted, awardStartDate);
 
         // Create an array of dates.
-        date = Object.keys(deduplicatedreleased).map(term => term);
+        date = Object.keys(deduplicatedreleased);
         accumulatedDataReleased = createDataset(deduplicatedreleased, accumulatorreleased, cumulativedatasetReleased);
         accumulatedDataSubmitted = createDataset(deduplicatedsubmitted, accumulatorsubmitted, cumulativedatasetSubmitted);
 

--- a/src/encoded/static/components/biosample.js
+++ b/src/encoded/static/components/biosample.js
@@ -12,7 +12,7 @@ import { RelatedItems } from './item';
 import { Breadcrumbs } from './navigation';
 import { singleTreatment, treatmentDisplay, PanelLookup, AlternateAccession } from './objectutils';
 import pubReferenceList from './reference';
-import StatusLabel from './statuslabel';
+import { StatusLabel } from './statuslabel';
 import { BiosampleSummaryString, CollectBiosampleDocs, BiosampleTable } from './typeutils';
 
 

--- a/src/encoded/static/components/dataset.js
+++ b/src/encoded/static/components/dataset.js
@@ -9,7 +9,7 @@ import { Breadcrumbs } from './navigation';
 import { DbxrefList } from './dbxref';
 import { FetchedItems } from './fetched';
 import { auditDecor } from './audit';
-import StatusLabel from './statuslabel';
+import { StatusLabel } from './statuslabel';
 import pubReferenceList from './reference';
 import { donorDiversity, publicDataset, AlternateAccession } from './objectutils';
 import { softwareVersionList } from './software';

--- a/src/encoded/static/components/donor.js
+++ b/src/encoded/static/components/donor.js
@@ -15,7 +15,7 @@ import { requestObjects, AlternateAccession } from './objectutils';
 import pubReferenceList from './reference';
 import { PickerActions } from './search';
 import { SortTablePanel, SortTable } from './sorttable';
-import StatusLabel from './statuslabel';
+import { StatusLabel } from './statuslabel';
 import { BiosampleTable } from './typeutils';
 
 

--- a/src/encoded/static/components/experiment.js
+++ b/src/encoded/static/components/experiment.js
@@ -15,7 +15,7 @@ import { Breadcrumbs } from './navigation';
 import { singleTreatment, AlternateAccession } from './objectutils';
 import pubReferenceList from './reference';
 import { SortTablePanel, SortTable } from './sorttable';
-import StatusLabel from './statuslabel';
+import { StatusLabel } from './statuslabel';
 import { BiosampleSummaryString, BiosampleOrganismNames, CollectBiosampleDocs, AwardRef } from './typeutils';
 
 

--- a/src/encoded/static/components/file.js
+++ b/src/encoded/static/components/file.js
@@ -13,7 +13,7 @@ import { ProjectBadge } from './image';
 import { QualityMetricsPanel } from './quality_metric';
 import { PickerActions } from './search';
 import { SortTablePanel, SortTable } from './sorttable';
-import StatusLabel from './statuslabel';
+import { StatusLabel } from './statuslabel';
 
 
 // Columns to display in Deriving/Derived From file tables

--- a/src/encoded/static/components/genetic_modification.js
+++ b/src/encoded/static/components/genetic_modification.js
@@ -13,7 +13,7 @@ import { Breadcrumbs } from './navigation';
 import { singleTreatment } from './objectutils';
 import { PickerActions } from './search';
 import { SortTablePanel, SortTable } from './sorttable';
-import StatusLabel from './statuslabel';
+import { StatusLabel } from './statuslabel';
 import { BiosampleTable, DonorTable } from './typeutils';
 
 

--- a/src/encoded/static/components/globals.js
+++ b/src/encoded/static/components/globals.js
@@ -1,6 +1,7 @@
 import _ from 'underscore';
 import ga from 'google-analytics';
 import Registry from '../libs/registry';
+import DataColors from './datacolors';
 
 // Item pages
 export const contentViews = new Registry();
@@ -282,3 +283,37 @@ export const dbxrefPrefixMap = {
     FlyBase: 'http://flybase.org/cgi-bin/quicksearch_solr.cgi?caller=quicksearch&tab=basic_tab&data_class=FBgn&species=Dmel&search_type=all&context=',
     WormBase: 'http://www.wormbase.org/species/c_elegans/strain/',
 };
+
+
+// Keep lists of currently known project and biosample_type. As new project and biosample_type
+// enter the system, these lists must be updated. Used mostly to keep chart and matrix colors
+// consistent.
+export const projectList = [
+    'ENCODE',
+    'Roadmap',
+    'modENCODE',
+    'modERN',
+    'GGR',
+];
+
+export const biosampleTypeList = [
+    'cell line',
+    'tissue',
+    'primary cell',
+    'whole organisms',
+    'stem cell',
+    'in vitro differentiated cells',
+    'induced pluripotent stem cell line',
+];
+
+export const replicateTypeList = [
+    'unreplicated',
+    'isogenic',
+    'anisogenic',
+];
+
+
+// Make `project` and `biosample_type` color mappings for downstream modules to use.
+export const projectColors = new DataColors(projectList);
+export const biosampleTypeColors = new DataColors(biosampleTypeList);
+export const replicateTypeColors = new DataColors(replicateTypeList);

--- a/src/encoded/static/components/home.js
+++ b/src/encoded/static/components/home.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import _ from 'underscore';
 import moment from 'moment';
 import { FetchedData, FetchedItems, Param } from './fetched';
+import * as globals from './globals';
 import { Panel, PanelBody } from '../libs/bootstrap/panel';
 
 
@@ -379,7 +380,7 @@ class HomepageChart extends React.Component {
             const Chart = require('chart.js');
 
             // for each item, set doc count, add to total doc count, add proper label, and assign color.
-            const colors = this.context.projectColors.colorList(facetData.map(term => term.key), { shade: 10 });
+            const colors = globals.projectColors.colorList(facetData.map(term => term.key), { shade: 10 });
             const data = [];
             const labels = [];
 
@@ -462,7 +463,7 @@ class HomepageChart extends React.Component {
     // Update existing chart with new data.
     updateChart(Chart, facetData) {
         // for each item, set doc count, add to total doc count, add proper label, and assign color.
-        const colors = this.context.projectColors.colorList(facetData.map(term => term.key), { shade: 10 });
+        const colors = globals.projectColors.colorList(facetData.map(term => term.key), { shade: 10 });
         const data = [];
         const labels = [];
 
@@ -571,7 +572,7 @@ class HomepageChart2 extends React.Component {
         // require.
         require.ensure(['chart.js'], (require) => {
             const Chart = require('chart.js');
-            const colors = this.context.biosampleTypeColors.colorList(facetData.map(term => term.key), { shade: 10 });
+            const colors = globals.biosampleTypeColors.colorList(facetData.map(term => term.key), { shade: 10 });
             const data = [];
             const labels = [];
 
@@ -657,7 +658,7 @@ class HomepageChart2 extends React.Component {
 
     updateChart(Chart, facetData) {
         // for each item, set doc count, add to total doc count, add proper label, and assign color.
-        const colors = this.context.biosampleTypeColors.colorList(facetData.map(term => term.key), { shade: 10 });
+        const colors = globals.biosampleTypeColors.colorList(facetData.map(term => term.key), { shade: 10 });
         const data = [];
         const labels = [];
 

--- a/src/encoded/static/components/index.js
+++ b/src/encoded/static/components/index.js
@@ -34,6 +34,7 @@ require('./inputs');
 require('./blocks');
 require('./user');
 require('./schema');
+require('./summary');
 require('./region_search');
 require('./auditmatrix');
 

--- a/src/encoded/static/components/matrix.js
+++ b/src/encoded/static/components/matrix.js
@@ -184,7 +184,7 @@ class Matrix extends React.Component {
             };
 
             // Make an array of colors corresponding to the ordering of biosample_type
-            const biosampleTypeColors = this.context.biosampleTypeColors.colorList(yGroups.map(yGroup => yGroup.key));
+            const biosampleTypeColors = globals.biosampleTypeColors.colorList(yGroups.map(yGroup => yGroup.key));
 
             return (
                 <div>

--- a/src/encoded/static/components/pipeline.js
+++ b/src/encoded/static/components/pipeline.js
@@ -11,7 +11,7 @@ import { Breadcrumbs } from './navigation';
 import { PanelLookup } from './objectutils';
 import { PickerActions } from './search';
 import { softwareVersionList } from './software';
-import StatusLabel from './statuslabel';
+import { StatusLabel } from './statuslabel';
 
 
 const stepNodePrefix = 'step'; // Prefix for step node IDs

--- a/src/encoded/static/components/search.js
+++ b/src/encoded/static/components/search.js
@@ -1047,7 +1047,7 @@ TextFilter.propTypes = {
 // Displays the entire list of facets. It contains a number of <Facet> cmoponents.
 export class FacetList extends React.Component {
     render() {
-        const { context, facets, filters, mode, orientation, hideTextFilter } = this.props;
+        const { context, facets, filters, mode, orientation, hideTextFilter, addClasses } = this.props;
 
         // Get "normal" facets, meaning non-audit facets.
         const normalFacets = facets.filter(facet => facet.field.substring(0, 6) !== 'audit.');
@@ -1092,7 +1092,7 @@ export class FacetList extends React.Component {
         const negationFilters = filters.filter(filter => filter.field.charAt(filter.field.length - 1) === '!');
 
         return (
-            <div className="box facets">
+            <div className={`box facets${addClasses ? ` ${addClasses}` : ''}`}>
                 <div className={`orientation${this.props.orientation === 'horizontal' ? ' horizontal' : ''}`}>
                     {clearButton ?
                         <div className="clear-filters-control">
@@ -1131,10 +1131,12 @@ FacetList.propTypes = {
     mode: PropTypes.string,
     orientation: PropTypes.string,
     hideTextFilter: PropTypes.bool,
+    addClasses: PropTypes.string, // CSS classes to use if the default isn't needed.
 };
 
 FacetList.defaultProps = {
     orientation: 'vertical',
+    addClasses: '',
 };
 
 FacetList.contextTypes = {

--- a/src/encoded/static/components/software.js
+++ b/src/encoded/static/components/software.js
@@ -6,7 +6,7 @@ import * as globals from './globals';
 import { Breadcrumbs } from './navigation';
 import pubReferenceList from './reference';
 import { PickerActions } from './search';
-import StatusLabel from './statuslabel';
+import { StatusLabel } from './statuslabel';
 import { auditDecor } from './audit';
 
 

--- a/src/encoded/static/components/statuslabel.js
+++ b/src/encoded/static/components/statuslabel.js
@@ -2,7 +2,61 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import * as globals from './globals';
 
-const StatusLabel = (props) => {
+
+// objectStatuses holds all possible statuses for each kind of object at the different logged-in
+// levels. These must be kept in sync with statuses defined in each object's schema. Each top-level
+// property has a name matching the @type of each kind of object. Within that property are objects of
+// arrays; each array defining the statuses available at each logged-in level represented by that
+// object.
+const objectStatuses = {
+    Experiment: {
+        external: [
+            'released',
+            'archived',
+            'revoked',
+        ],
+        consortium: [
+            'proposed',
+            'started',
+            'submitted',
+        ],
+        admin: [
+            'deleted',
+            'replaced',
+        ],
+    },
+};
+
+
+// Defines the order of the viewing access of the different logged-in states, and has to match the
+// order of arrays in each @type property in `objectStatuses`.
+const objectStatusLevelOrder = ['external', 'consortium', 'admin'];
+
+
+/**
+ * Given an object @id and login level, get an array of all possible statuses for that object at
+ * that login level.
+ *
+ * @param {string} objectType - Retrieve possible statuses for this @type.
+ * @param {string} level - Level of statuses to get (external, consortium, admin). If nothing is
+ *         passed in this parameter, then 'admin' is assumed.
+ * @return (array) - Returns array of possible statuses for the given object and access level.
+ */
+export function getObjectStatuses(objectType, level = 'admin') {
+    const maxLevelIndex = objectStatusLevelOrder.indexOf(level);
+    const objectStatusGroups = objectStatuses[objectType];
+    if (maxLevelIndex !== -1 && objectStatusGroups) {
+        let statuses = [];
+        for (let levelIndex = 0; levelIndex <= maxLevelIndex; levelIndex += 1) {
+            statuses = statuses.concat(objectStatusGroups[objectStatusLevelOrder[levelIndex]]);
+        }
+        return statuses;
+    }
+    return [];
+}
+
+
+export const StatusLabel = (props) => {
     const { status, title, buttonLabel, fileStatus } = props;
 
     // Handle file statuses speficially.
@@ -59,5 +113,3 @@ StatusLabel.defaultProps = {
     buttonLabel: '',
     fileStatus: false,
 };
-
-export default StatusLabel;

--- a/src/encoded/static/components/summary.js
+++ b/src/encoded/static/components/summary.js
@@ -138,7 +138,7 @@ class SummaryStatusChart extends React.Component {
         // Generate colors to use for each replicate type.
         const colors = globals.replicateTypeColors.colorList(globals.replicateTypeList);
 
-        createBarChart(this.chartId, data, colors, globals.replicateTypeList, this.props.linkUri, (uri) => { this.context.navigate(uri); })
+        createBarChart(this.chartId, data, colors, globals.replicateTypeList, 'Replication', this.props.linkUri, (uri) => { this.context.navigate(uri); })
             .then((chartInstance) => {
                 // Save the created chart instance.
                 this.chart = chartInstance;

--- a/src/encoded/static/components/summary.js
+++ b/src/encoded/static/components/summary.js
@@ -1,0 +1,447 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import queryString from 'query-string';
+import _ from 'underscore';
+import url from 'url';
+import { Panel, PanelBody } from '../libs/bootstrap/panel';
+import { LabChart, CategoryChart, ExperimentDate, createBarChart } from './award';
+import * as globals from './globals';
+import { FacetList } from './search';
+import { getObjectStatuses } from './statuslabel';
+
+
+// Get an array of all possible experiment statuses.
+const experimentStatuses = getObjectStatuses('Experiment');
+
+
+// Render the title pane.
+const SummaryTitle = (props) => {
+    const { context } = props;
+
+    let clearButton;
+    const searchQuery = url.parse(context['@id']).search;
+    if (searchQuery) {
+        // If we have a 'type' query string term along with others terms, we need a Clear Filters
+        // button.
+        const terms = queryString.parse(searchQuery);
+        const nonPersistentTerms = _(Object.keys(terms)).any(term => term !== 'type');
+        clearButton = nonPersistentTerms && terms.type;
+    }
+
+    return (
+        <div className="summary-header__title">
+            <h1>{context.title}</h1>
+            {clearButton ?
+                <div className="clear-filters-control--summary">
+                    <a href={context.clear_filters}>Clear filters <i className="icon icon-times-circle" /></a>
+                </div>
+            : null}
+        </div>
+    );
+};
+
+SummaryTitle.propTypes = {
+    context: PropTypes.object.isRequired, // Summary search result object
+};
+
+
+/**
+ * Generate an array of data from one facet bucket for displaying in a chart, with one array entry
+ * per experiment status. The order of the entries in the resulting array correspond to the order
+ * of the statuses in `labels`.
+ *
+ * @param {array} buckets - Buckets for one facet returned in summary search results.
+ * @param {array} labels - Experiment status labels.
+ * @return {array} - Data extracted from buckets with an order of values corresponding to `labels`.
+ */
+function generateStatusData(buckets, labels) {
+    // Fill the array to the proper length with zeroes to start with. Actual non-zero data will
+    // overwrite the appropriate entries.
+    const statusData = Array.from({ length: experimentStatuses.length }, (() => 0));
+
+    // Convert statusData to a form createBarChart understands.
+    if (buckets && buckets.length) {
+        buckets.forEach((bucketItem) => {
+            const statusIndex = labels.indexOf(bucketItem.key);
+            if (statusIndex !== -1) {
+                statusData[statusIndex] = bucketItem.doc_count;
+            }
+        });
+    }
+    return statusData;
+}
+
+
+// Column graph of experiment statuses.
+class SummaryStatusChart extends React.Component {
+    constructor() {
+        super();
+        this.createChart = this.createChart.bind(this);
+    }
+
+    componentDidMount() {
+        if (this.props.totalStatusData) {
+            this.createChart();
+        }
+    }
+
+    componentDidUpdate() {
+        const { chart, props } = this;
+        const { statusData } = props;
+
+        if (chart) {
+            const replicateTypeColors = globals.replicateTypeColors.colorList(globals.replicateTypeList);
+
+            // For each replicate type, extract the data for each status to assign to the existing
+            // chart's dataset.
+            const datasets = [];
+            globals.replicateTypeList.forEach((replicateType, replicateTypeIndex) => {
+                const facetData = statusData.find(facet => facet.key === replicateType);
+                if (facetData) {
+                    // Get an array of replicate data per status from the facet data.
+                    const data = generateStatusData(facetData.status.buckets, experimentStatuses);
+
+                    datasets.push({
+                        backgroundColor: replicateTypeColors[replicateTypeIndex],
+                        data,
+                        label: replicateType,
+                    });
+                }
+            });
+
+            // Update the chart data, then force a redraw of the chart and legend.
+            chart.data.datasets = datasets;
+            chart.update();
+            document.getElementById(`${this.chartId}-legend`).innerHTML = chart.generateLegend();
+        }
+    }
+
+    createChart() {
+        const { statusData } = this.props;
+
+        // Initialize data object to pass to createBarChart.
+        const data = {
+            anisogenicDataset: null,
+            isogenicDataset: null,
+            unreplicatedDataset: null,
+            labels: experimentStatuses,
+        };
+
+        // Convert statusData to a form createBarChart understands.
+        let facetData = statusData.find(facet => facet.key === 'anisogenic');
+        data.anisogenicDataset = facetData ? generateStatusData(facetData.status.buckets, data.labels) : [];
+        facetData = statusData.find(facet => facet.key === 'isogenic');
+        data.isogenicDataset = facetData ? generateStatusData(facetData.status.buckets, data.labels) : [];
+        facetData = statusData.find(facet => facet.key === 'unreplicated');
+        data.unreplicatedDataset = facetData ? generateStatusData(facetData.status.buckets, data.labels) : [];
+
+        // Generate colors to use for each replicate type.
+        const colors = globals.replicateTypeColors.colorList(globals.replicateTypeList);
+
+        createBarChart(this.chartId, data, colors, globals.replicateTypeList, this.props.linkUri, (uri) => { this.context.navigate(uri); })
+            .then((chartInstance) => {
+                // Save the created chart instance.
+                this.chart = chartInstance;
+            });
+    }
+
+    render() {
+        const { totalStatusData } = this.props;
+
+        // Calculate a (hopefully) unique ID to put on the DOM elements.
+        this.chartId = 'status-chart-experiments';
+
+        return (
+            <div className="award-charts__chart">
+                <div className="award-charts__title">
+                    Status
+                </div>
+                {totalStatusData ?
+                    <div className="award-charts__visual">
+                        <div id={this.chartId} className="award-charts__canvas">
+                            <canvas id={`${this.chartId}-chart`} />
+                        </div>
+                        <div id={`${this.chartId}-legend`} className="award-charts__legend" />
+                    </div>
+                :
+                    <div className="chart-no-data" style={{ height: this.wrapperHeight }}>No data to display</div>
+                }
+            </div>
+        );
+    }
+}
+
+SummaryStatusChart.propTypes = {
+    statusData: PropTypes.array.isRequired, // Experiment status data from /summary/ search results
+    totalStatusData: PropTypes.number.isRequired, // Number of items in statusData
+    linkUri: PropTypes.string.isRequired, // URI of base link for each bar to link to
+};
+
+SummaryStatusChart.contextTypes = {
+    navigate: PropTypes.func,
+};
+
+
+// Render the horizontal facets.
+class SummaryHorzFacets extends React.Component {
+    constructor() {
+        super();
+
+        // Bind `this` to non-React methods
+        this.onFilter = this.onFilter.bind(this);
+    }
+
+    onFilter(e) {
+        const search = e.currentTarget.getAttribute('href');
+        this.context.navigate(search);
+        e.stopPropagation();
+        e.preventDefault();
+    }
+
+    render() {
+        const { context } = this.props;
+        const { location_href } = this.context;
+        const allFacets = context.facets;
+
+        // Get the array of facet field values to display in the horizontal facet area.
+        const horzFacetFields = context.summary.x.facets;
+
+        // Extract the horizontal facets from the list of all facets. We use the array of horizontal
+        // facet field values of facets that should appear in the horizontal facets.
+        const horzFacets = allFacets.filter(facet => horzFacetFields.indexOf(facet.field) >= 0);
+
+        // Calculate the searchBase, which is the current search query string fragment that can have
+        // terms added to it.`
+        const searchBase = `${url.parse(location_href).search}&` || '?';
+
+        return (
+            <div className="summary-header__facets-horizontal">
+                <FacetList
+                    facets={horzFacets}
+                    filters={context.filters}
+                    orientation="horizontal"
+                    searchBase={searchBase}
+                    onFilter={this.onFilter}
+                    addClasses="summary-facets"
+                />
+            </div>
+        );
+    }
+}
+
+SummaryHorzFacets.propTypes = {
+    context: PropTypes.object.isRequired, // Summary search result object
+};
+
+SummaryHorzFacets.contextTypes = {
+    location_href: PropTypes.string, // Current URL
+    navigate: PropTypes.func, // encoded navigation
+};
+
+
+// Render the vertical facets.
+class SummaryVertFacets extends React.Component {
+    constructor() {
+        super();
+
+        // Bind `this` to non-React methods.
+        this.onFilter = this.onFilter.bind(this);
+    }
+
+    onFilter(e) {
+        const search = e.currentTarget.getAttribute('href');
+        this.context.navigate(search);
+        e.stopPropagation();
+        e.preventDefault();
+    }
+
+    render() {
+        const { context } = this.props;
+
+        // Get the array of facet field values to display in the horizontal facet area.
+        const vertFacetFields = context.summary.y.facets;
+
+        // Extract the horizontal facets from the list of all facets. We use the array of horizontal
+        // facet field values of facets that should appear in the horizontal facets.
+        const vertFacets = context.facets.filter(facet => vertFacetFields.indexOf(facet.field) >= 0);
+
+        // Calculate the searchBase, which is the current search query string fragment that can have
+        // terms added to it.`
+        const searchBase = `${url.parse(this.context.location_href).search}&` || '?';
+
+        return (
+            <div className="summary-content__facets-vertical">
+                <FacetList
+                    facets={vertFacets}
+                    filters={context.filters}
+                    searchBase={searchBase}
+                    onFilter={this.onFilter}
+                    addClasses="summary-facets"
+                />
+            </div>
+        );
+    }
+}
+
+SummaryVertFacets.propTypes = {
+    context: PropTypes.object.isRequired, // Summary search result object
+};
+
+SummaryVertFacets.contextTypes = {
+    location_href: PropTypes.string, // Current URL
+    navigate: PropTypes.func, // encoded navigation
+};
+
+
+// Update all charts to resize themselves on print.
+const printHandler = () => {
+    Object.keys(window.Chart.instances).forEach((id) => {
+        window.Chart.instances[id].resize();
+    });
+};
+
+
+// Render the data for the summary in the main panel. Note that we use the charting components from
+// awards.js for labs and categories, but not for the status chart. That's because the data gets
+// retrieved so differently -- through multiple search requests in awards.js, but in its own
+// property with this summary page. Might be good for a refactor later to share common code.
+class SummaryData extends React.Component {
+    constructor() {
+        super();
+        this.mediaQueryInfo = null;
+    }
+
+    componentDidMount() {
+        if (window.matchMedia) {
+            this.mediaQueryInfo = window.matchMedia('print');
+            this.mediaQueryInfo.addListener(printHandler);
+        }
+
+        // In case matchMedia doesn't work (e.g. FF and IE).
+        window.onbeforeprint = printHandler;
+        window.onafterprint = printHandler;
+    }
+
+    componentWillUnmount() {
+        if (this.mediaQueryInfo) {
+            this.mediaQueryInfo.removeListener(printHandler);
+            this.mediaQueryInfo = null;
+        }
+    }
+
+    render() {
+        const { context } = this.props;
+
+        // Find the labs and assay facets in the search results.
+        const labFacet = context.facets.find(facet => facet.field === 'lab.title');
+        let labs = labFacet ? labFacet.terms : null;
+        const assayFacet = context.facets.find(facet => facet.field === 'assay_title');
+        let assays = assayFacet ? assayFacet.terms : null;
+
+        // Filter the assay list if any assay facets have been selected so that the assay graph will be
+        // filtered accordingly. Find assay_title filters. Same applies to the lab filters.
+        if (context.filters && context.filters.length) {
+            const assayTitleFilters = context.filters.filter(filter => filter.field === 'assay_title');
+            if (assayTitleFilters.length) {
+                const assayTitleFilterTerms = assayTitleFilters.map(filter => filter.term);
+                assays = assays.filter(assayItem => assayTitleFilterTerms.indexOf(assayItem.key) !== -1);
+            }
+            const labFilters = context.filters.filter(filter => filter.field === 'lab.title');
+            if (labFilters.length) {
+                const labFilterTerms = labFilters.map(filter => filter.term);
+                labs = labs.filter(labItem => labFilterTerms.indexOf(labItem.key) !== -1);
+            }
+        }
+
+        // Get the status data with a process completely different from the others because it comes
+        // in its own property in the /summary/ context. Start by getting the name of the property
+        // that contains the status data, as well as the number of items within it.
+        const statusProp = context.summary.summary_grouping[0];
+        const statusSection = context.summary[statusProp];
+        const statusDataCount = statusSection.doc_count;
+        const statusData = statusSection[statusProp].buckets;
+
+        // Collect selected facet terms to add to the base linkUri.
+        let searchQuery = '';
+        if (context.filters && context.filters.length) {
+            searchQuery = context.filters.reduce((queryAcc, filter) => `${queryAcc}&${filter.field}=${globals.encodedURIComponent(filter.term)}`, '');
+        }
+        const linkUri = `/matrix/?type=Experiment${searchQuery}`;
+
+        return (
+            <div className="summary-content__data">
+                <div className="summary-content__snapshot">
+                    {labs ? <LabChart labs={labs} linkUri={linkUri} ident="experiments" /> : null}
+                    {assays ? <CategoryChart categoryData={assays} categoryFacet="assay_title" title="Assay" linkUri={linkUri} ident="assay" /> : null}
+                    {statusDataCount ? <SummaryStatusChart statusData={statusData} totalStatusData={statusDataCount} linkUri={linkUri} ident="status" /> : null}
+                </div>
+                <div className="summary-content__statistics">
+                    <ExperimentDate experiments={context.facets} panelCss="summary-content__panel" panelHeadingCss="summary-content__panel-heading" />
+                </div>
+            </div>
+        );
+    }
+}
+
+SummaryData.propTypes = {
+    context: PropTypes.object.isRequired, // Summary search result object
+};
+
+
+// Render the title panel and the horizontal facets.
+const SummaryHeader = (props) => {
+    const { context } = props;
+
+    return (
+        <div className="summary-header">
+            <SummaryTitle context={context} />
+            <SummaryHorzFacets context={context} />
+        </div>
+    );
+};
+
+SummaryHeader.propTypes = {
+    context: PropTypes.object.isRequired, // Summary search result object
+};
+
+
+// Render the vertical facets and the summary contents.
+const SummaryContent = (props) => {
+    const { context } = props;
+
+    return (
+        <div className="summary-content">
+            <SummaryVertFacets context={context} />
+            <SummaryData context={context} />
+        </div>
+    );
+};
+
+SummaryContent.propTypes = {
+    context: PropTypes.object.isRequired, // Summary search result object
+};
+
+
+// Render the entire summary page based on summary search results.
+const Summary = (props) => {
+    const { context } = props;
+    const itemClass = globals.itemClass(context, 'view-item');
+
+    if (context.summary.doc_count) {
+        return (
+            <Panel addClasses={itemClass}>
+                <PanelBody>
+                    <SummaryHeader context={context} />
+                    <SummaryContent context={context} />
+                </PanelBody>
+            </Panel>
+        );
+    }
+    return <h4>No results found</h4>;
+};
+
+Summary.propTypes = {
+    context: PropTypes.object.isRequired, // Summary search result object
+};
+
+globals.contentViews.register(Summary, 'Summary');

--- a/src/encoded/static/scss/encoded/_base.scss
+++ b/src/encoded/static/scss/encoded/_base.scss
@@ -14,6 +14,7 @@ $tableHeadFootBackgroundColor: #f5f5f5;
 $std-href-color:               #428bca;
 
 $mobile-font-factor:           1.2; // Amount text increases size on mobile
+$print-font-factor:            0.95; // Amount text decreases size when printing
 
 
 // Pass value with CSS units and get just the value back
@@ -51,6 +52,10 @@ html {
 
     @media screen and (min-width: $screen-sm-min) {
         font-size: $font-size-base;
+    }
+
+    @media print {
+        font-size: $font-size-base * $print-font-factor;
     }
 }
 

--- a/src/encoded/static/scss/encoded/_layout.scss
+++ b/src/encoded/static/scss/encoded/_layout.scss
@@ -4,6 +4,12 @@
     min-height: 100%;
 }
 
+@media print {
+    .container {
+        width: 100%;
+    }
+}
+
 .homepage-main-box {
 	min-height: 400px;
 	background: url('/static/img/encode-bg-gray.png') no-repeat center;

--- a/src/encoded/static/scss/encoded/_state.scss
+++ b/src/encoded/static/scss/encoded/_state.scss
@@ -2,7 +2,7 @@
 #content {
     padding-top: 0;
     
-    @media (min-width: $screen-md-min) {
+    @media screen and (min-width: $screen-md-min) {
         padding-top: 75px;
     }
 }
@@ -63,5 +63,11 @@
             padding-left: 10px;
             padding-right: 10px;
         }
+    }
+}
+
+#page-footer {
+    @media print {
+        display: none;
     }
 }

--- a/src/encoded/static/scss/encoded/modules/_award.scss
+++ b/src/encoded/static/scss/encoded/modules/_award.scss
@@ -153,3 +153,9 @@
 
 }
 
+.legend-title {
+    margin-bottom: 5px;
+    text-align: center;
+    color: #808080;
+    font-size: 1.1rem;
+}

--- a/src/encoded/static/scss/encoded/modules/_award.scss
+++ b/src/encoded/static/scss/encoded/modules/_award.scss
@@ -11,6 +11,12 @@
             width: 33.3333%;
         }
 
+        @media print {
+            break-after: page;
+            page-break-after: always;
+            margin: 0 auto;
+        }
+
         .title {
             font-size: 1.2rem;
         }
@@ -21,6 +27,12 @@
         position: relative;
         height: 180px;
 
+        @media print {
+            width: 100%;
+            height: auto;
+            margin: 0 auto;
+        }
+
         canvas {
             display: block;
             width: 0;
@@ -29,12 +41,15 @@
     }
 
     @at-root #{&}__legend {
-        margin: 50px auto;
+        margin: 20px auto 50px;
         width: 100%;
 
         @media screen and (min-width: $screen-md-min) {
-            margin: 20px auto;
             width: 80%;
+        }
+
+        @media print {
+            width: 70%;
         }
 
         ul {

--- a/src/encoded/static/scss/encoded/modules/_facet.scss
+++ b/src/encoded/static/scss/encoded/modules/_facet.scss
@@ -33,6 +33,12 @@
             }
         }
     }
+
+    &.summary-facets {
+        padding: 0;
+        border: none;
+        border-radius: 0;
+    }
 }
 
 .sm-no-padding {
@@ -44,6 +50,16 @@
     margin-bottom: 5px;
     text-align: right;
     font-size: 0.9rem;
+
+    @at-root #{&}--summary {
+        margin-top: -30px;
+        margin-bottom: 30px;
+        text-align: left;
+
+        @media print {
+            display: none;
+        }
+    }
 }
 
 .clear-filters-control-matrix {

--- a/src/encoded/static/scss/encoded/modules/_navbar.scss
+++ b/src/encoded/static/scss/encoded/modules/_navbar.scss
@@ -4,6 +4,10 @@
     border-bottom: 0px solid #4e7294;
     background: #0a253d;
 
+    @media print {
+        display: none;
+    }
+
     .navbar-brand {
         margin-left: -15px;
         color: #fff;

--- a/src/encoded/static/scss/encoded/modules/_panels.scss
+++ b/src/encoded/static/scss/encoded/modules/_panels.scss
@@ -8,6 +8,10 @@
     padding: 15px 20px;
     overflow: visible;
 
+    @media print {
+        border: none;
+    }
+
     &.panel-default {
         padding: 0;
 

--- a/src/encoded/static/scss/encoded/modules/_summary.scss
+++ b/src/encoded/static/scss/encoded/modules/_summary.scss
@@ -21,7 +21,11 @@
 
 // Contains the vertical facets and the charts.
 .summary-content {
-    display: flex;
+    display: block;
+
+    @media screen and (min-width: $screen-md-min) {
+        display: flex;
+    }
 
     @media print {
         display: block;
@@ -29,7 +33,9 @@
     }
 
     @at-root #{&}__facets-vertical {
-        flex: 0 0 20%;
+        @media screen and (min-width: $screen-md-min) {
+            flex: 0 0 20%;
+        }
 
         @media print {
             display: none;
@@ -38,8 +44,10 @@
 
     // Contains all the charts.
     @at-root #{&}__data {
-        flex: 0 1 80%;
-        min-width: 0; // https://github.com/chartjs/Chart.js/issues/4156#issuecomment-345773111
+        @media screen and (min-width: $screen-md-min) {
+            flex: 0 1 80%;
+            min-width: 0; // https://github.com/chartjs/Chart.js/issues/4156#issuecomment-345773111
+        }
 
         @media print {
             display: block;
@@ -49,11 +57,27 @@
 
     // Contains side-by-side charts.
     @at-root #{&}__snapshot {
-        display: flex;
+        display: block;
+
+        @media screen and (min-width: $screen-sm-min) {
+            display: flex;
+            flex-wrap: wrap;
+        }
+
+        @media screen and (min-width: $screen-md-min) {
+            flex-wrap: nowrap;
+        }
 
         & .award-charts__chart {
-            flex: 0 0 33.33%;
-            width: 33.33%;
+            @media screen and (min-width: $screen-sm-min) {
+                flex: 0 0 50%;
+                width: 50%;
+            }
+
+            @media screen and (min-width: $screen-md-min) {
+                flex: 0 0 33.33%;
+                width: 33.33%;
+            }
         }
     }
 

--- a/src/encoded/static/scss/encoded/modules/_summary.scss
+++ b/src/encoded/static/scss/encoded/modules/_summary.scss
@@ -1,0 +1,94 @@
+// Contains the summary title and horizontal facets
+.summary-header {
+    h1 {
+        margin-top: 0;
+        margin-bottom: 30px;
+    }
+
+    @at-root #{&}__facets-horizontal {
+        @media print {
+            display: none;
+        }
+    }
+
+    @at-root #{&}__title {
+        h1 {
+            margin-top: 0;
+            font-size: 1.7rem;
+        }
+    }
+}
+
+// Contains the vertical facets and the charts.
+.summary-content {
+    display: flex;
+
+    @media print {
+        display: block;
+        padding: 20px;
+    }
+
+    @at-root #{&}__facets-vertical {
+        flex: 0 0 20%;
+
+        @media print {
+            display: none;
+        }
+    }
+
+    // Contains all the charts.
+    @at-root #{&}__data {
+        flex: 0 1 80%;
+        min-width: 0; // https://github.com/chartjs/Chart.js/issues/4156#issuecomment-345773111
+
+        @media print {
+            display: block;
+            width: 100%;
+        }
+    }
+
+    // Contains side-by-side charts.
+    @at-root #{&}__snapshot {
+        display: flex;
+
+        & .award-charts__chart {
+            flex: 0 0 33.33%;
+            width: 33.33%;
+        }
+    }
+
+    // Contains a full-width chart.
+    @at-root #{&}__statistics {
+        display: block;     
+
+        @media print {
+            width: 100%;
+
+            canvas {
+                display: block;
+            }
+        }
+    }
+
+    @at-root #{&}__panel {
+        border: none;
+        page-break-inside: avoid;
+    }
+}
+
+.panel.panel-default > .panel-heading.summary-content__panel-heading {
+    background-color: transparent;
+    border-bottom: none;
+
+    h4 {
+        text-align: center;
+        font-weight: normal;
+        color: #808080;
+    }
+}
+
+.chartjs-size-monitor {
+    @media print {
+        display: none;
+    }
+}

--- a/src/encoded/static/scss/style.scss
+++ b/src/encoded/static/scss/style.scss
@@ -96,6 +96,7 @@ $brand-info: #4F689E;
         "encoded/modules/tables",
         "encoded/modules/facet",
         "encoded/modules/search",
+        "encoded/modules/summary",
         "encoded/modules/genome_browser",
         "encoded/modules/characterizations",
         "encoded/modules/audits",

--- a/src/encoded/types/experiment.py
+++ b/src/encoded/types/experiment.py
@@ -426,6 +426,8 @@ class Experiment(Dataset,
                 'biosample_type',
                 'organ_slims',
                 'award.project',
+                'award.rfa',
+                'status',
                 'assembly',
                 'internal_status',
                 'audit_category', # Added for auditmatrix

--- a/src/encoded/types/experiment.py
+++ b/src/encoded/types/experiment.py
@@ -440,11 +440,13 @@ class Experiment(Dataset,
                 'assay_slims',
                 'target.investigated_as',
                 'month_released',
+                'date_submitted',
                 'files.file_type',
             ],
             'group_by': 'assay_title',
             'label': 'Assay',
         },
+        'summary_grouping': ['replication_type', 'status'],
     }
 
 


### PR DESCRIPTION
* Removed the project and biosample chart colors out of the App context and into globals because they’re static and made more sense in globals than carried around in React, especially now that we have replicate chart colors in addition to the existing ones
* Tried to use awards.js charting functions and components the summer interns wrote as much as possible, which meant modifying them to fit a more general case. These charting functions should really be moved to a new file since they’re no longer specific to awards, but we’ll worry about that in another ticket as the charting code needs a lot of refactoring to reduce duplication.
* I included some embryonic code in statuslabels.js so that any front-end code can get consistent statuses for each kind of object and at different login levels, only defining the statuses for Experiment for now, as the only client is the summary page. After I wrote this, I found out Keenan was reworking statuses, so I think this has promise, but I’ll need to see what comes out of his efforts before really continuing with this in ENCD-3629.
* One back-end change to handle the /summary/ route. Only ?type=Experiment gives results. Most of this is just a simpler variant of the matrix code, as it doesn’t retrieve the `hits` data — only facet data.