### PR TITLE
ENCD-3870-publication-status-mixin

### DIFF
--- a/src/encoded/schemas/publication.json
+++ b/src/encoded/schemas/publication.json
@@ -65,16 +65,6 @@
             "description": "The journal of the publication.",
             "type": "string"
         },
-        "status": {
-            "title": "Status",
-            "type": "string",
-            "default": "in progress",
-            "enum" : [
-                "deleted",
-                "in progress",
-                "released"
-            ]
-        },
         "identifiers": {
             "title": "Identifiers",
             "description": "The identifiers that reference data found in the object.",

--- a/src/encoded/schemas/publication.json
+++ b/src/encoded/schemas/publication.json
@@ -11,7 +11,8 @@
         { "$ref": "mixins.json#/schema_version" },
         { "$ref": "mixins.json#/uuid" },
         { "$ref": "mixins.json#/submitted" },
-        { "$ref": "mixins.json#/attribution" }
+        { "$ref": "mixins.json#/attribution" },
+        { "$ref": "mixins.json#/standard_status"}
     ],
     "properties": {
         "schema_version": {

--- a/src/encoded/schemas/publication.json
+++ b/src/encoded/schemas/publication.json
@@ -8,11 +8,11 @@
     "identifyingProperties": ["uuid", "title"],
     "additionalProperties": false,
     "mixinProperties": [
-        { "$ref": "mixins.json#/schema_version" },
-        { "$ref": "mixins.json#/uuid" },
-        { "$ref": "mixins.json#/submitted" },
-        { "$ref": "mixins.json#/attribution" },
-        { "$ref": "mixins.json#/standard_status"}
+        {"$ref": "mixins.json#/schema_version"},
+        {"$ref": "mixins.json#/uuid"},
+        {"$ref": "mixins.json#/submitted"},
+        {"$ref": "mixins.json#/attribution"},
+        {"$ref": "mixins.json#/standard_status"}
     ],
     "properties": {
         "schema_version": {

--- a/src/encoded/tests/test_schema_publication.py
+++ b/src/encoded/tests/test_schema_publication.py
@@ -1,0 +1,28 @@
+import pytest
+
+
+@pytest.mark.parametrize(
+    'status',
+    [
+        'released',
+        'in progress',
+        'deleted'
+    ]
+)
+def test_publication_valid_statuses(status, testapp, publication):
+    testapp.patch_json(publication['@id'], {'status': status})
+    res = testapp.get(publication['@id'] + '@@embedded').json
+    assert res['status'] == status
+
+
+@pytest.mark.parametrize(
+    'status',
+    [
+        'archived',
+        'revoked',
+        'replaced'
+    ]
+)
+def test_publication_invalid_statuses(status, testapp, publication):
+    with pytest.raises(Exception):
+        testapp.patch_json(publication['@id'], {'status': status})


### PR DESCRIPTION
Makes publication use standard_status mixin. 