### PR TITLE
[FIX] ENCD-3868 Failing test_batch_download_lookup_column_value

### DIFF
--- a/src/encoded/tests/test_batch_download.py
+++ b/src/encoded/tests/test_batch_download.py
@@ -44,7 +44,7 @@ def lookup_column_value_validate():
         'award.project': 'Roadmap',
         '@id': '/experiments/ENCSR751ISO/',
         'level.name': '',
-        '@type': ['Experiment', 'Dataset', 'Item']
+        '@type': 'Experiment,Dataset,Item'
     }
     return valid
 


### PR DESCRIPTION
**Issue:** lookup_column_value() returns a string. The validation data returned by the validation fixture for validating a list should be a concatenated string of the objects contained in the list. But, the validation fixture returns a list for validation. 

**Fix:** Change the validation fixture to return a concatenated string of the objects contained in the list for validating a list.