### PR TITLE
[3RD] ENCD-3934 fix plate location in library

### DIFF
--- a/src/encoded/tests/data/inserts/library.json
+++ b/src/encoded/tests/data/inserts/library.json
@@ -747,9 +747,9 @@
                 "barcode": "ABCDEFG1"
             },
             {
-                "barcode": "ABC2EFG12",
+                "barcode": "ABCDEFG12",
                 "plate_id": "plate_1",
-                "plate_location": "5:3"
+                "plate_location": "A11"
             }
         ],
         "nucleic_acid_term_name": "DNA",


### PR DESCRIPTION
branch is slightly misnamed but it's not the barcode that was failing the REGEX but the plate location