### PR TITLE
ENCD-3620 Update deploy options for region search

### DIFF
--- a/cloud-config-cluster.yml
+++ b/cloud-config-cluster.yml
@@ -208,9 +208,9 @@ runcmd:
 - if test "%(REGION_INDEX)s" = "False"
 - then
 -    sudo -u encoded cp /srv/encoded/etc/encoded-apache.conf /srv/encoded/etc/encoded-apache.conf.original
--    sudo -u encoded grep -v encoded\-regionindexer /srv/encoded/etc/encoded-apache.conf.original | grep -v _region > /srv/encoded/etc/work/encoded-apache.conf
+-    sudo -u encoded sh -c "grep -v encoded\-regionindexer /srv/encoded/etc/encoded-apache.conf.original | grep -v _region > /srv/encoded/etc/encoded-apache.conf"
 -    sudo -u encoded cp /srv/encoded/base.ini /srv/encoded/base.ini.original
--    sudo -u encoded sed 's/vis_indexer, region_indexer/vis_indexer/' /srv/encoded/base.ini.original > /srv/encoded/base.ini
+-    sudo -u encoded sh -c "sed 's/vis_indexer, region_indexer/vis_indexer/' /srv/encoded/base.ini.original > /srv/encoded/base.ini"
 - fi
 - ln -s /srv/encoded/etc/encoded-apache.conf /etc/apache2/sites-available/encoded.conf
 - ln -s /srv/encoded/etc/logging-apache.conf /etc/apache2/conf-available/logging.conf

--- a/cloud-config-cluster.yml
+++ b/cloud-config-cluster.yml
@@ -205,6 +205,13 @@ runcmd:
 - sudo -u encoded sh -c 'cat /dev/urandom | head -c 256 | base64 > session-secret.b64'
 - sudo -u encoded bin/create-mapping production.ini --app-name app
 - sudo -u encoded bin/index-annotations production.ini --app-name app
+- if test "%(REGION_INDEX)s" = "False"
+- then
+-    sudo -u encoded cp /srv/encoded/etc/encoded-apache.conf /srv/encoded/etc/encoded-apache.conf.original
+-    sudo -u encoded grep -v encoded\-regionindexer /srv/encoded/etc/encoded-apache.conf.original | grep -v _region > /srv/encoded/etc/work/encoded-apache.conf
+-    sudo -u encoded cp /srv/encoded/base.ini /srv/encoded/base.ini.original
+-    sudo -u encoded sed 's/vis_indexer, region_indexer/vis_indexer/' /srv/encoded/base.ini.original > /srv/encoded/base.ini
+- fi
 - ln -s /srv/encoded/etc/encoded-apache.conf /etc/apache2/sites-available/encoded.conf
 - ln -s /srv/encoded/etc/logging-apache.conf /etc/apache2/conf-available/logging.conf
 - a2enmod headers
@@ -293,7 +300,7 @@ write_files:
   content: |
     #!/bin/bash
     name=$1
-    
+
     if [[ -n "$name" ]]; then
         echo "cluster.name: $name" >> /etc/elasticsearch/elasticsearch.yml
     else

--- a/cloud-config.yml
+++ b/cloud-config.yml
@@ -207,9 +207,9 @@ runcmd:
 - if test "%(REGION_INDEX)s" = "False"
 - then
 -    sudo -u encoded cp /srv/encoded/etc/encoded-apache.conf /srv/encoded/etc/encoded-apache.conf.original
--    sudo -u encoded grep -v encoded\-regionindexer /srv/encoded/etc/encoded-apache.conf.original | grep -v _region > /srv/encoded/etc/work/encoded-apache.conf
+-    sudo -u encoded sh -c "grep -v encoded\-regionindexer /srv/encoded/etc/encoded-apache.conf.original | grep -v _region > /srv/encoded/etc/encoded-apache.conf"
 -    sudo -u encoded cp /srv/encoded/base.ini /srv/encoded/base.ini.original
--    sudo -u encoded sed 's/vis_indexer, region_indexer/vis_indexer/' /srv/encoded/base.ini.original > /srv/encoded/base.ini
+-    sudo -u encoded sh -c "sed 's/vis_indexer, region_indexer/vis_indexer/' /srv/encoded/base.ini.original > /srv/encoded/base.ini"
 - fi
 - ln -s /srv/encoded/etc/encoded-apache.conf /etc/apache2/sites-available/encoded.conf
 - ln -s /srv/encoded/etc/logging-apache.conf /etc/apache2/conf-available/logging.conf

--- a/cloud-config.yml
+++ b/cloud-config.yml
@@ -204,6 +204,13 @@ runcmd:
 - sudo -u encoded sh -c 'cat /dev/urandom | head -c 256 | base64 > session-secret.b64'
 - sudo -u encoded bin/create-mapping production.ini --app-name app
 - sudo -u encoded bin/index-annotations production.ini --app-name app
+- if test "%(REGION_INDEX)s" = "False"
+- then
+-    sudo -u encoded cp /srv/encoded/etc/encoded-apache.conf /srv/encoded/etc/encoded-apache.conf.original
+-    sudo -u encoded grep -v encoded\-regionindexer /srv/encoded/etc/encoded-apache.conf.original | grep -v _region > /srv/encoded/etc/work/encoded-apache.conf
+-    sudo -u encoded cp /srv/encoded/base.ini /srv/encoded/base.ini.original
+-    sudo -u encoded sed 's/vis_indexer, region_indexer/vis_indexer/' /srv/encoded/base.ini.original > /srv/encoded/base.ini
+- fi
 - ln -s /srv/encoded/etc/encoded-apache.conf /etc/apache2/sites-available/encoded.conf
 - ln -s /srv/encoded/etc/logging-apache.conf /etc/apache2/conf-available/logging.conf
 - a2enmod headers

--- a/src/encoded/region_indexer.py
+++ b/src/encoded/region_indexer.py
@@ -284,6 +284,8 @@ def regionindexer_state_show(request):
     encoded_INDEX = request.registry.settings['snovault.elasticsearch.index']
     regions_es    = request.registry[SNP_SEARCH_ES]
     state = RegionIndexerState(encoded_es,encoded_INDEX)  # Consider putting this in regions es instead of encoded es
+    if not state.get():  # region_indexer is off by default in unclustered demos
+        return "%s is not in service." % (state.state_id)
 
     # requesting reindex
     reindex = request.params.get("reindex")


### PR DESCRIPTION
Defaults unclustered demos to no region-index.  Optionally allows region-index to included/excluded.  Also optionally allows setting volume size to something other than the default of 200gb.