### PR TITLE
[2ND] ENCD-3935 Remove duplicated code in dependency of experiment schema

### DIFF
--- a/src/encoded/schemas/experiment.json
+++ b/src/encoded/schemas/experiment.json
@@ -72,18 +72,6 @@
                     "properties": {
                         "biosample_type": {
                             "enum" : [
-                                "single cell"
-                            ]
-                        },
-                        "biosample_term_id":{
-                            "pattern": "^(CL|EFO|UBERON|NTR):[0-9]{2,8}$"
-                        }
-                    }
-                },
-                { 
-                    "properties": {
-                        "biosample_type": {
-                            "enum" : [
                                 "tissue",
                                 "whole organisms"
                             ]


### PR DESCRIPTION
Due to the code duplication, dependencies didn't work and single cell was not possible for specification in experiment biosample_type