### PR TITLE
ENCD-3973 Redo how GM characterization documents get displayed

### DIFF
--- a/src/encoded/static/components/biosample.js
+++ b/src/encoded/static/components/biosample.js
@@ -5,7 +5,7 @@ import { auditDecor } from './audit';
 import { ExperimentTable } from './dataset';
 import { DbxrefList } from './dbxref';
 import { Document, DocumentsPanel, DocumentPreview, DocumentFile, CharacterizationDocuments } from './doc';
-import { GeneticModificationSummary } from './genetic_modification';
+import GeneticModificationSummary from './genetic_modification';
 import * as globals from './globals';
 import { ProjectBadge } from './image';
 import { RelatedItems } from './item';

--- a/src/encoded/static/components/donor.js
+++ b/src/encoded/static/components/donor.js
@@ -7,7 +7,7 @@ import { auditDecor } from './audit';
 import { ExperimentTable } from './dataset';
 import { DbxrefList } from './dbxref';
 import { DocumentsPanel, DocumentsSubpanels } from './doc';
-import { GeneticModificationSummary } from './genetic_modification';
+import GeneticModificationSummary from './genetic_modification';
 import * as globals from './globals';
 import { RelatedItems } from './item';
 import { Breadcrumbs } from './navigation';

--- a/src/encoded/static/components/genetic_modification.js
+++ b/src/encoded/static/components/genetic_modification.js
@@ -10,7 +10,7 @@ import * as globals from './globals';
 import { ProjectBadge } from './image';
 import { RelatedItems } from './item';
 import { Breadcrumbs } from './navigation';
-import { singleTreatment } from './objectutils';
+import { singleTreatment, requestSearch } from './objectutils';
 import { PickerActions } from './search';
 import { SortTablePanel, SortTable } from './sorttable';
 import { StatusLabel } from './statuslabel';
@@ -316,190 +316,229 @@ Attribution.propTypes = {
 };
 
 
-const DocumentsRenderer = (props) => {
-    let characterizations = [];
-
-    // Get the document objects and convert to an object keyed by their @id for easy searching in
-    // the next step.
-    const modCharDocs = props.modCharDocs ? props.modCharDocs['@graph'] : [];
-    const modCharDocsKeyed = {};
-    modCharDocs.forEach((doc) => {
-        modCharDocsKeyed[doc['@id']] = doc;
-    });
-
-    // Now go through the GM characterizations and replace any document @ids with the actual
-    // document objects. This allows us to pass the characterizations array to `DocumentsPanel`
-    // in a way it expects, with embedded documents that GM objects do not have.
-    if (props.characterizations && props.characterizations.length) {
-        // Clone the characterizations array so we don't mutate the original characterization objects
-        // which causes problems if other props change which could happen if the user logs in while
-        // viewing this page.
-        characterizations = props.characterizations.map(characterization => Object.assign({}, characterization));
-
-        // Now replace the characterization document array @ids with the actual document objects we
-        // got from the GET request for documents.
-        characterizations.forEach((characterization) => {
-            if (characterization.documents && characterization.documents.length) {
-                // We cloned the characterizations array, but each still refers to the original
-                // characterizations.documents @id array that we're overwriting. Copy its reference
-                // and then overwrite `characterization.documents` to prepare it to receive actual
-                // document objects.
-                const charDocs = characterization.documents;
-                characterization.documents = [];
-
-                // For each document in the current GM characterization, find its full object in
-                // `modDocs` and copy that full object into the characterization document,
-                // replacing the document's @id. Then delete the corresponding document in
-                // `modDocs`.
-                for (let i = 0; i < charDocs.length; i += 1) {
-                    characterization.documents[i] = modCharDocsKeyed[charDocs[i]];
-                }
-            }
+// Render a panel containing GM document panels and GM characterization panels associated with a
+// GM object.
+const DocumentsRenderer = ({ characterizations, modificationDocuments, characterizationDocuments }) => {
+    // Don't need to check for characterizationDocuments.length because these only get displyed
+    // within characterization panels.
+    if (characterizations.length || modificationDocuments.length) {
+        // Make a mapping of characterization document @ids to characterization documents
+        // to make searching in the next step easier.
+        const characterizationDocumentMap = {};
+        characterizationDocuments.forEach((document) => {
+            characterizationDocumentMap[document['@id']] = document;
         });
+
+        // Need to replace the `documents` array of @ids in each characterization with an array of
+        // corresponding document objects. We can't touch the GM object's characterizations so we
+        // make a copy of each and modify that instead.
+        const characterizationsCopy = characterizations.map((characterization) => {
+            const copy = Object.assign({}, characterization);
+            copy.documents = _.compact(characterization.documents.map(documentAtId => characterizationDocumentMap[documentAtId]));
+            return copy;
+        });
+
+        return (
+            <DocumentsPanel
+                documentSpecs={[
+                    { label: 'Characterization', documents: characterizationsCopy },
+                    { label: 'Modification document', documents: modificationDocuments },
+                ]}
+            />
+        );
     }
-
-    // Now filter out any characterization documents out of modDocs.
-    const modDocs = modCharDocs.filter(doc => props.charDocs.indexOf(doc['@id']) === -1);
-
-    return (
-        <DocumentsPanel
-            documentSpecs={[
-                { label: 'Characterizations', documents: characterizations },
-                { label: 'Modification', documents: modDocs },
-            ]}
-        />
-    );
+    return null;
 };
 
 DocumentsRenderer.propTypes = {
-    modCharDocs: PropTypes.object, // GM document search results containing GM docs and GM characterization docs
     characterizations: PropTypes.array.isRequired, // GM characterizations
-    charDocs: PropTypes.array.isRequired, // Array of @ids of docs belonging to all GM characterizations
-};
-
-DocumentsRenderer.defaultProps = {
-    modCharDocs: null,
+    characterizationDocuments: PropTypes.array.isRequired, // GM characterization documents for all given characterizations
+    modificationDocuments: PropTypes.array.isRequired, // GM documents
 };
 
 
 // Render the entire GeneticModification page. This is called by the back end as a result of an
 // attempt to render an object with an @type of GeneticModification.
-export const GeneticModificationComponent = (props, reactContext) => {
-    const { context } = props;
-    const itemClass = globals.itemClass(context, 'view-detail key-value');
-
-    // Configure breadcrumbs for the page.
-    const crumbs = [
-        { id: 'Genetic Modifications' },
-        { id: context.target && context.target.label, query: `target.label=${context.target && context.target.label}`, tip: context.target && context.target.label },
-        { id: context.modification_type, query: `modification_type=${context.modification_type}`, tip: context.modification_type },
-    ];
-
-    // Collect and combine document @ids, including from genetic modification
-    // characterization document @ids. Later we'll do a GET request on these @ids to show these
-    // documents along with the embedded characterizations.
-    let modDocs = context.documents && context.documents.length ? context.documents : [];
-    let charDocs = [];
-    if (context.characterizations && context.characterizations.length) {
-        context.characterizations.forEach((characterization) => {
-            if (characterization.documents && characterization.documents.length) {
-                charDocs = charDocs.concat(characterization.documents);
-            }
-        });
+class GeneticModificationComponent extends React.Component {
+    constructor() {
+        super();
+        this.state = {
+            modificationDocuments: [], // GM document search results
+            characterizationDocuments: [], // GM characterization document search results
+        };
+        this.requestDocuments = this.requestDocuments.bind(this);
+        this.geneticModificationComponentChanged = this.geneticModificationComponentChanged.bind(this);
     }
-    modDocs = _.uniq(modDocs.concat(charDocs));
 
-    // Convert the array of document @ids into a query string that we can do a GET request on.
-    const modDocsQuery = modDocs.length ? modDocs.reduce((acc, document) => `${acc}&${globals.encodedURIComponent(`@id=${document}`)}`, '') : null;
+    componentDidMount() {
+        this.requestDocuments();
+    }
 
-    return (
-        <div className={globals.itemClass(context, 'view-item')}>
-            <header className="row">
-                <div className="col-sm-12">
-                    <Breadcrumbs root="/search/?type=GeneticModification" crumbs={crumbs} />
-                    <h2>{context.accession}</h2>
-                    <div className="status-line">
-                        <div className="characterization-status-labels">
-                            <StatusLabel title="Status" status={context.status} />
+    componentDidUpdate() {
+        this.requestDocuments();
+    }
+
+    requestDocuments() {
+        const { context } = this.props;
+
+        // Collect all GM characterization document @ids.
+        const characterizationDocumentAtIds = [];
+        if (context.characterizations && context.characterizations.length) {
+            context.characterizations.forEach((characterization) => {
+                if (characterization.documents && characterization.documents.length) {
+                    characterizationDocumentAtIds.push(...characterization.documents);
+                }
+            });
+        }
+
+        // Collect GM document @ids and combine with characterization document @ids so we can do
+        // one GET request for both.
+        const modificationCharacterizationDocumentsAtIds = _.uniq((context.documents && context.documents.length ? context.documents : []).concat(characterizationDocumentAtIds));
+
+        // Convert the array of document @ids into a query string and do the GET request for their
+        // objects.
+        const modificationCharacterizationDocumentsQuery = modificationCharacterizationDocumentsAtIds.length ? modificationCharacterizationDocumentsAtIds.reduce((acc, document) => `${acc}&${globals.encodedURIComponent(`@id=${document}`)}`, '') : null;
+        requestSearch(`type=Document${modificationCharacterizationDocumentsQuery}`).then(
+            (results) => {
+                // `results` is the search results object, or {} if it 404ed.
+                const modificationDocuments = [];
+                const characterizationDocuments = [];
+                if (results['@graph'] && results['@graph'].length) {
+                    // Split the results into arrays of modification and characterization
+                    // document objects.
+                    results['@graph'].forEach((document) => {
+                        if (characterizationDocumentAtIds.indexOf(document['@id']) > -1) {
+                            characterizationDocuments.push(document);
+                        } else {
+                            modificationDocuments.push(document);
+                        }
+                    });
+                }
+
+                // If the resulting documents are different from what we have in state, then
+                // update the state.
+                if (this.geneticModificationComponentChanged(modificationDocuments, characterizationDocuments)) {
+                    this.setState({ modificationDocuments, characterizationDocuments });
+                }
+            }
+        );
+    }
+
+    // Compare the given modificationDocuments and characterizationDocuments arrays with what's
+    // currently in state, returning true if they're different.
+    geneticModificationComponentChanged(modificationDocuments, characterizationDocuments) {
+        if (modificationDocuments.length !== this.state.modificationDocuments.length ||
+            characterizationDocuments.length !== this.state.characterizationDocuments.length) {
+            return true;
+        }
+        if (modificationDocuments.some((document, i) => document['@id'] !== this.state.modificationDocuments[i]['@id'])) {
+            return true;
+        }
+        if (characterizationDocuments.some((document, i) => document['@id'] !== this.state.characterizationDocuments[i]['@id'])) {
+            return true;
+        }
+        return false;
+    }
+
+    render() {
+        const { context } = this.props;
+        const itemClass = globals.itemClass(context, 'view-detail key-value');
+
+        // Configure breadcrumbs for the page.
+        const crumbs = [
+            { id: 'Genetic Modifications' },
+            { id: context.target && context.target.label, query: `target.label=${context.target && context.target.label}`, tip: context.target && context.target.label },
+            { id: context.modification_type, query: `modification_type=${context.modification_type}`, tip: context.modification_type },
+        ];
+
+        return (
+            <div className={globals.itemClass(context, 'view-item')}>
+                <header className="row">
+                    <div className="col-sm-12">
+                        <Breadcrumbs root="/search/?type=GeneticModification" crumbs={crumbs} />
+                        <h2>{context.accession}</h2>
+                        <div className="status-line">
+                            <div className="characterization-status-labels">
+                                <StatusLabel title="Status" status={context.status} />
+                            </div>
+                            {this.props.auditIndicators(context.audit, 'genetic-modification-audit', { session: this.context.session })}
                         </div>
-                        {props.auditIndicators(context.audit, 'genetic-modification-audit', { session: reactContext.session })}
                     </div>
-                </div>
-            </header>
-            {props.auditDetail(context.audit, 'genetic-modification-audit', { session: reactContext.session, except: context['@id'] })}
-            <Panel addClasses="data-display">
-                <PanelBody addClasses="panel-body-with-header">
-                    <div className="flexrow">
-                        <div className="flexcol-sm-6">
-                            <div className="flexcol-heading experiment-heading"><h4>Summary</h4></div>
-                            <dl className={itemClass}>
-                                {context.description ?
-                                    <div data-test="description">
-                                        <dt>Description</dt>
-                                        <dd>{context.description}</dd>
-                                    </div>
-                                : null}
+                </header>
+                {this.props.auditDetail(context.audit, 'genetic-modification-audit', { session: this.context.session, except: context['@id'] })}
+                <Panel addClasses="data-display">
+                    <PanelBody addClasses="panel-body-with-header">
+                        <div className="flexrow">
+                            <div className="flexcol-sm-6">
+                                <div className="flexcol-heading experiment-heading"><h4>Summary</h4></div>
+                                <dl className={itemClass}>
+                                    {context.description ?
+                                        <div data-test="description">
+                                            <dt>Description</dt>
+                                            <dd>{context.description}</dd>
+                                        </div>
+                                    : null}
 
-                                <div data-test="type">
-                                    <dt>Type</dt>
-                                    <dd>{context.category}</dd>
-                                </div>
-
-                                {context.introduced_sequence ?
                                     <div data-test="type">
-                                        <dt>Introduced sequence</dt>
-                                        <dd>{context.introduced_sequence ? <span>{context.introduced_sequence}</span> : null}</dd>
+                                        <dt>Type</dt>
+                                        <dd>{context.category}</dd>
                                     </div>
-                                : null}
 
-                                {context.zygosity ?
-                                    <div data-test="zygosity">
-                                        <dt>Zygosity</dt>
-                                        <dd>{context.zygosity}</dd>
+                                    {context.introduced_sequence ?
+                                        <div data-test="type">
+                                            <dt>Introduced sequence</dt>
+                                            <dd>{context.introduced_sequence ? <span>{context.introduced_sequence}</span> : null}</dd>
+                                        </div>
+                                    : null}
+
+                                    {context.zygosity ?
+                                        <div data-test="zygosity">
+                                            <dt>Zygosity</dt>
+                                            <dd>{context.zygosity}</dd>
+                                        </div>
+                                    : null}
+
+                                    <IntroducedTags geneticModification={context} />
+
+                                    <div data-test="purpose">
+                                        <dt>Purpose</dt>
+                                        <dd>{context.purpose}</dd>
                                     </div>
-                                : null}
+                                </dl>
 
-                                <IntroducedTags geneticModification={context} />
+                                <ModificationSite geneticModification={context} />
 
-                                <div data-test="purpose">
-                                    <dt>Purpose</dt>
-                                    <dd>{context.purpose}</dd>
-                                </div>
-                            </dl>
+                                <ModificationMethod geneticModification={context} />
+                            </div>
 
-                            <ModificationSite geneticModification={context} />
-
-                            <ModificationMethod geneticModification={context} />
+                            <div className="flexcol-sm-6">
+                                <Attribution geneticModification={context} />
+                            </div>
                         </div>
+                    </PanelBody>
+                </Panel>
 
-                        <div className="flexcol-sm-6">
-                            <Attribution geneticModification={context} />
-                        </div>
-                    </div>
-                </PanelBody>
-            </Panel>
+                <DocumentsRenderer
+                    characterizations={context.characterizations || []}
+                    modificationDocuments={this.state.modificationDocuments}
+                    characterizationDocuments={this.state.characterizationDocuments}
+                />
 
-            {modDocsQuery || (context.characterizations && context.characterizations.length) ?
-                <FetchedData>
-                    {modDocsQuery ? <Param name="modCharDocs" url={`/search/?type=Document${modDocsQuery}`} /> : null}
-                    <DocumentsRenderer characterizations={context.characterizations} charDocs={charDocs} />
-                </FetchedData>
-            : null}
+                <RelatedItems
+                    title="Donors using this genetic modification"
+                    url={`/search/?type=Donor&genetic_modifications.uuid=${context.uuid}`}
+                    Component={DonorTable}
+                />
 
-            <RelatedItems
-                title="Donors using this genetic modification"
-                url={`/search/?type=Donor&genetic_modifications.uuid=${context.uuid}`}
-                Component={DonorTable}
-            />
-
-            <RelatedItems
-                title="Biosamples using this genetic modification"
-                url={`/search/?type=Biosample&genetic_modifications.uuid=${context.uuid}`}
-                Component={BiosampleTable}
-            />
-        </div>
-    );
-};
+                <RelatedItems
+                    title="Biosamples using this genetic modification"
+                    url={`/search/?type=Biosample&genetic_modifications.uuid=${context.uuid}`}
+                    Component={BiosampleTable}
+                />
+            </div>
+        );
+    }
+}
 
 GeneticModificationComponent.propTypes = {
     context: PropTypes.object.isRequired, // GM object being displayed
@@ -556,7 +595,7 @@ globals.listingViews.register(Listing, 'GeneticModification');
 
 
 // Display a table of genetic modifications.
-export const GeneticModificationSummary = (props) => {
+const GeneticModificationSummary = (props) => {
     const { geneticModifications } = props;
 
     return (
@@ -588,6 +627,8 @@ GeneticModificationSummary.columns = {
     },
 };
 
+export default GeneticModificationSummary;
+
 
 // The next few components override parts of the standard documents panel for genetic modification
 // characterizations. GM characterizations are attachments and not actual document objects, so the
@@ -598,12 +639,17 @@ const EXCERPT_LENGTH = 80; // Maximum number of characters in an excerpt
 
 const CharacterizationHeader = props => (
     <div className="document__header">
-        {props.doc.characterization_method}
+        {props.doc.characterization_method} {props.label ? <span>{props.label}</span> : null}
     </div>
 );
 
 CharacterizationHeader.propTypes = {
     doc: PropTypes.object.isRequired, // Characterization object to render
+    label: PropTypes.string, // Extra label to add to document type in header
+};
+
+CharacterizationHeader.defaultProps = {
+    label: '',
 };
 
 


### PR DESCRIPTION
The basic cause of this problem is that I had expected DocumentRender to be called even if the GM/characterization document search 404ed, but it doesn’t.  So if the GM had no documents of its own, and none of the GM characterizations had documents, then no GM characterizations would appear. If even one document existed, then they would all appear. All the local test data either had no characterizations or some with documents, so it always checked out.

To fix this, instead of using `<FetchedData>` to retrieve the documents, I use `requestSearch` which does a search GET request for document objects that’s promise based, then sets a couple of states with the results of the GET request which causes the document panels to update with the results along with the embedded characterizations.