### PR TITLE
ENCD-3216 Hide antibody characterizations via user access level

### DIFF
--- a/src/encoded/static/components/__tests__/status-test.js
+++ b/src/encoded/static/components/__tests__/status-test.js
@@ -8,9 +8,14 @@ describe('Statuses', () => {
             expect(statuses).toHaveLength(3);
             statuses = getObjectStatuses('Experiment', 'consortium');
             expect(statuses).toHaveLength(6);
-            statuses = getObjectStatuses('Experiment', 'admin');
+            statuses = getObjectStatuses('Experiment', 'administrator');
             expect(statuses).toHaveLength(8);
             statuses = getObjectStatuses('Experiment');
+            expect(statuses).toHaveLength(8);
+
+            statuses = getObjectStatuses('AntibodyCharacterization', 'external');
+            expect(statuses).toHaveLength(5);
+            statuses = getObjectStatuses('AntibodyCharacterization');
             expect(statuses).toHaveLength(8);
         });
     });

--- a/src/encoded/static/components/antibody.js
+++ b/src/encoded/static/components/antibody.js
@@ -12,14 +12,17 @@ import { DbxrefList } from './dbxref';
 import { DocumentsPanel, Document, DocumentPreview, CharacterizationDocuments } from './doc';
 import { RelatedItems } from './item';
 import { AlternateAccession } from './objectutils';
-import { StatusLabel } from './statuslabel';
+import { StatusLabel, getObjectStatuses, sessionToAccessLevel } from './statuslabel';
 
 
 const LotComponent = (props, reactContext) => {
     const context = props.context;
 
-    // Sort characterization arrays
-    const characterizations = _(context.characterizations).sortBy(characterization => (
+    // Sort characterization arrays, filtering for the current logged-in and administrative status.
+    const accessLevel = sessionToAccessLevel(reactContext.session, reactContext.session_properties);
+    const viewableStatuses = getObjectStatuses('AntibodyCharacterization', accessLevel);
+    let characterizations = context.characterizations.filter(characterization => viewableStatuses.indexOf(characterization.status) !== -1);
+    characterizations = _(characterizations).sortBy(characterization => (
         [characterization.target.label, characterization.target.organism.name]
     ));
 
@@ -227,6 +230,7 @@ LotComponent.propTypes = {
 
 LotComponent.contextTypes = {
     session: PropTypes.object, // Login session information
+    session_properties: PropTypes.object, // Logged-in user information
 };
 
 const Lot = auditDecor(LotComponent);

--- a/src/encoded/static/components/statuslabel.js
+++ b/src/encoded/static/components/statuslabel.js
@@ -8,47 +8,79 @@ import * as globals from './globals';
 // property has a name matching the @type of each kind of object. Within that property are objects of
 // arrays; each array defining the statuses available at each logged-in level represented by that
 // object.
+
+const datasetObjectStatuses = {
+    external: [
+        'released',
+        'archived',
+        'revoked',
+    ],
+    consortium: [
+        'proposed',
+        'started',
+        'submitted',
+    ],
+    administrator: [
+        'deleted',
+        'replaced',
+    ],
+};
+
 const objectStatuses = {
-    Experiment: {
+    AntibodyCharacterization: {
         external: [
-            'released',
-            'archived',
-            'revoked',
+            'compliant',
+            'exempt from standards',
+            'not compliant',
+            'not reviewed',
+            'not submitted for review by lab',
         ],
         consortium: [
-            'proposed',
-            'started',
-            'submitted',
+            'in progress',
+            'pending dcc review',
         ],
-        admin: [
+        administrator: [
             'deleted',
-            'replaced',
         ],
     },
+    Experiment: datasetObjectStatuses,
 };
 
 
-// Defines the order of the viewing access of the different logged-in states, and has to match the
-// order of arrays in each @type property in `objectStatuses`.
-const objectStatusLevelOrder = ['external', 'consortium', 'admin'];
+// Defines the order of the viewing access of the different logged-in states.
+const objectStatusLevels = ['external', 'consortium', 'administrator'];
 
 
 /**
- * Given an object @id and login level, get an array of all possible statuses for that object at
+ * Maps the current session information from the <App> React context to an access level from the
+ * objectStatusLevels array.
+ *
+ * @param {object} session - From encoded session context
+ * @param {object} sessionProperties - From encoded session_properties context
+ */
+export const sessionToAccessLevel = (session, sessionProperties) => {
+    const loggedIn = !!(session && session['auth.userid']);
+    const administrativeUser = loggedIn && !!(sessionProperties && sessionProperties.admin);
+    return loggedIn ? (administrativeUser ? 'administrator' : 'consortium') : 'external';
+};
+
+
+/**
+ * Given an object @type and login level, get an array of all possible statuses for that object at
  * that login level.
  *
  * @param {string} objectType - Retrieve possible statuses for this @type.
- * @param {string} level - Level of statuses to get (external, consortium, admin). If nothing is
- *         passed in this parameter, then 'admin' is assumed.
+ * @param {string} accessLevel - Level of statuses to get (external, consortium, administrator).
+ *         If nothing is passed in this parameter, then 'administrator' is assumed.
  * @return (array) - Returns array of possible statuses for the given object and access level.
  */
-export function getObjectStatuses(objectType, level = 'admin') {
-    const maxLevelIndex = objectStatusLevelOrder.indexOf(level);
+export function getObjectStatuses(objectType, accessLevel = 'administrator') {
+    const maximumLevelIndex = objectStatusLevels.indexOf(accessLevel);
     const objectStatusGroups = objectStatuses[objectType];
-    if (maxLevelIndex !== -1 && objectStatusGroups) {
+    if (maximumLevelIndex !== -1 && objectStatusGroups) {
         let statuses = [];
-        for (let levelIndex = 0; levelIndex <= maxLevelIndex; levelIndex += 1) {
-            statuses = statuses.concat(objectStatusGroups[objectStatusLevelOrder[levelIndex]]);
+        for (let levelIndex = 0; levelIndex <= maximumLevelIndex; levelIndex += 1) {
+            statuses = statuses.concat(objectStatusGroups[objectStatusLevels[levelIndex]]);
         }
         return statuses;
     }


### PR DESCRIPTION
The core of this change is to filter AntibodyLot.characterizations (embedded on antibody pages) by status based on your current logged-in and admin states, and I extend my past half-hearted attempt at status revision which now seems necessary to provide in some form in ENCD-3629.

You can still see unreleased antibody characterizations in the JSON, but for now the team feels this is acceptable until and unless we figure out something better than a front-end-only change.

Where this Jest test will go eventually, I don’t know. Probably it’ll just be a kind of random sample of types, or just these two.