### PR TITLE
ENCD-4010 fixing a typo in the samtools flagstat quality metric

### DIFF
--- a/src/encoded/schemas/samtools_flagstats_quality_metric.json
+++ b/src/encoded/schemas/samtools_flagstats_quality_metric.json
@@ -62,7 +62,7 @@
             "description": "flagstats: mapped - percent"
         },
         "mapped_qc_failed": {
-            "title": "% reads mapped failing QC",
+            "title": "# reads mapped failing QC",
             "type": "number",
             "description": "flagstats: mapped - qc failed"
         },


### PR DESCRIPTION
replacing "%" with "#"