### PR TITLE
ENCD-3867 Display proper replicate_type string

### DIFF
--- a/src/encoded/static/components/experiment.js
+++ b/src/encoded/static/components/experiment.js
@@ -801,7 +801,7 @@ const replicateTableColumns = {
     },
 };
 
-// Display the table of replicates
+// Display the table of replicates.
 const ReplicateTable = (props) => {
     let tableTitle;
     const { condensedReplicates, replicationType } = props;
@@ -810,12 +810,9 @@ const ReplicateTable = (props) => {
     if (replicationType === 'anisogenic') {
         tableTitle = 'Anisogenic replicates';
         replicateTableColumns.biological_replicate_number.title = 'Anisogenic replicate';
-    } else if (replicationType === 'isogenic') {
+    } else {
         tableTitle = 'Isogenic replicates';
         replicateTableColumns.biological_replicate_number.title = 'Isogenic replicate';
-    } else {
-        tableTitle = 'Replicates';
-        replicateTableColumns.biological_replicate_number.title = 'Biological replicate';
     }
 
     return (

--- a/src/encoded/static/components/filegallery.js
+++ b/src/encoded/static/components/filegallery.js
@@ -50,7 +50,7 @@ function fileAccessionSort(a, b) {
 
 // Calculate a string representation of the given replication_type.
 const replicationDisplay = replicationType => (
-    replicationType === 'unreplicated' ? 'Replicate' : `${`${replicationType.charAt(0).toUpperCase()}${replicationType.slice(1)}`} replicate`
+    `${replicationType === 'anisogenic' ? 'Anisogenic' : 'Isogenic'} replicate`
 );
 
 


### PR DESCRIPTION
The largest change involves removing the `anisogenic` boolean that I had been passing around before, and instead just using `context.replication_type` to determine what to display in table column headers. I added a function that takes `replication_type` and returns a string appropriate for table headers.