### PR TITLE
ENCD-3957 Add biosample accession to report columns

### DIFF
--- a/src/encoded/schemas/experiment.json
+++ b/src/encoded/schemas/experiment.json
@@ -433,6 +433,9 @@
         "status": {
             "title": "Status"
         },
+        "replicates.library.biosample.accession": {
+            "title": "Biosample accession"
+        },
         "replicates.biological_replicate_number": {
             "title": "Biological replicate"
         },

--- a/src/encoded/tests/test_batch_download.py
+++ b/src/encoded/tests/test_batch_download.py
@@ -58,9 +58,9 @@ def test_batch_download_report_download(testapp, workbook):
     assert lines[1].split(b'\t') == [
         b'ID', b'Accession', b'Assay Type', b'Assay Nickname', b'Target label',
         b'Target gene', b'Biosample summary', b'Biosample', b'Description', b'Lab',
-        b'Project', b'Status', b'Biological replicate', b'Technical replicate',
-        b'Linked Antibody', b'Species', b'Life stage', b'Age', b'Age Units',
-        b'Treatment', b'Term ID', b'Concentration', b'Concentration units',
+        b'Project', b'Status', b'Biosample accession', b'Biological replicate',
+        b'Technical replicate', b'Linked Antibody', b'Species', b'Life stage', b'Age',
+        b'Age Units', b'Treatment', b'Term ID', b'Concentration', b'Concentration units',
         b'Duration', b'Duration units', b'Synchronization',
         b'Post-synchronization time', b'Post-synchronization time units',
         b'Replicates',


### PR DESCRIPTION
Just adds the new column to experiment.json so it appears on type=Experiment report pages, and adjusted the corresponding test to expect this new column.