### PR TITLE
ENCD-4045 Add privacy link to footer

### DIFF
--- a/src/encoded/static/components/app.js
+++ b/src/encoded/static/components/app.js
@@ -543,7 +543,8 @@ class App extends React.Component {
         const nativeEvent = event.nativeEvent;
 
         // SVG anchor elements have tagName == 'a' while HTML anchor elements have tagName == 'A'
-        while (target && (target.tagName.toLowerCase() !== 'a' || target.getAttribute('data-href'))) {
+        const tagName = target && (target.tagName.toLowerCase());
+        while (target && ((tagName !== 'a' && tagName !== 'button') || target.getAttribute('data-href'))) {
             target = target.parentElement;
         }
         if (!target) {
@@ -803,6 +804,7 @@ class App extends React.Component {
         return request;
     }
 
+    /* eslint-disable class-methods-use-this */
     fallbackNavigate(href, fragment, options) {
         // Navigate using window.location
         if (options.replace) {
@@ -815,6 +817,7 @@ class App extends React.Component {
             }
         }
     }
+    /* eslint-enable class-methods-use-this */
 
     receiveContextResponse(data) {
         // title currently ignored by browsers

--- a/src/encoded/static/components/footer.js
+++ b/src/encoded/static/components/footer.js
@@ -3,51 +3,47 @@ import PropTypes from 'prop-types';
 
 
 // Reworking the data triggers to use buttons doesn't seem worth it to avoid an eslint warning.
-/* eslint-disable jsx-a11y/anchor-is-valid, react/prefer-stateless-function */
-export default class Footer extends React.Component {
-    render() {
-        const session = this.context.session;
-        const disabled = !session;
-        let userActionRender;
+const Footer = ({ version }, reactContext) => {
+    const session = reactContext.session;
+    let userActionRender;
 
-        if (!(session && session['auth.userid'])) {
-            userActionRender = <a href="#" data-trigger="login" disabled={disabled}>Submitter sign-in</a>;
-        } else {
-            userActionRender = <a href="#" data-trigger="logout">Submitter sign out</a>;
-        }
-        return (
-            <footer id="page-footer">
+    if (!(session && session['auth.userid'])) {
+        userActionRender = <button data-trigger="login">Submitter sign-in</button>;
+    } else {
+        userActionRender = <button data-trigger="logout">Submitter sign out</button>;
+    }
+    return (
+        <footer id="page-footer">
+            <div className="container">
+                <div className="row">
+                    <div className="app-version">{version}</div>
+                </div>
+            </div>
+            <div className="page-footer">
                 <div className="container">
                     <div className="row">
-                        <div className="app-version">{this.props.version}</div>
-                    </div>
-                </div>
-                <div className="page-footer">
-                    <div className="container">
-                        <div className="row">
-                            <div className="col-sm-6 col-sm-push-6">
-                                <ul className="footer-links">
-                                    <li><a href="mailto:encode-help@lists.stanford.edu">Contact</a></li>
-                                    <li><a href="http://www.stanford.edu/site/terms.html">Terms of Use</a></li>
-                                    <li id="user-actions-footer">{userActionRender}</li>
-                                </ul>
-                                <p className="copy-notice">&copy;{new Date().getFullYear()} Stanford University.</p>
-                            </div>
+                        <div className="col-sm-6 col-sm-push-6">
+                            <ul className="footer-links">
+                                <li><a href="https://www.stanford.edu/site/privacy/">Privacy</a></li>
+                                <li><a href="mailto:encode-help@lists.stanford.edu">Contact</a></li>
+                                <li><a href="http://www.stanford.edu/site/terms.html">Terms of Use</a></li>
+                                <li id="user-actions-footer">{userActionRender}</li>
+                            </ul>
+                            <p className="copy-notice">&copy;{new Date().getFullYear()} Stanford University.</p>
+                        </div>
 
-                            <div className="col-sm-6 col-sm-pull-6">
-                                <ul className="footer-logos">
-                                    <li><a href="/"><img src="/static/img/encode-logo-small-2x.png" alt="ENCODE" id="encode-logo" height="45px" width="78px" /></a></li>
-                                    <li><a href="http://www.stanford.edu"><img src="/static/img/su-logo-white-2x.png" alt="Stanford University" id="su-logo" width="105px" height="49px" /></a></li>
-                                </ul>
-                            </div>
+                        <div className="col-sm-6 col-sm-pull-6">
+                            <ul className="footer-logos">
+                                <li><a href="/"><img src="/static/img/encode-logo-small-2x.png" alt="ENCODE" id="encode-logo" height="45px" width="78px" /></a></li>
+                                <li><a href="http://www.stanford.edu"><img src="/static/img/su-logo-white-2x.png" alt="Stanford University" id="su-logo" width="105px" height="49px" /></a></li>
+                            </ul>
                         </div>
                     </div>
                 </div>
-            </footer>
-        );
-    }
-}
-/* eslint-enable jsx-a11y/anchor-is-valid, react/prefer-stateless-function */
+            </div>
+        </footer>
+    );
+};
 
 Footer.contextTypes = {
     session: PropTypes.object,
@@ -60,3 +56,5 @@ Footer.propTypes = {
 Footer.defaultProps = {
     version: '',
 };
+
+export default Footer;

--- a/src/encoded/static/scss/encoded/_layout.scss
+++ b/src/encoded/static/scss/encoded/_layout.scss
@@ -37,13 +37,14 @@
 	background-color: #a4afb8; // for IE8
 	background-color: $footerBackground; // overwrite previous line for CSS3 browsers
 	//height: $footerHeight;
-	text-shadow: 0 1px rgba(0, 0, 0, 0.3);
 	//line-height: 0;
 	text-align: center;
 	overflow: hidden;
-	a { 
+	a, button { 
 		color: rgb(255, 255, 255); 
-		font-weight: bold;
+        font-weight: bold;
+        text-shadow: 0 1px rgba(0, 0, 0, 0.3);
+        border: none;
 	}
 	ul {
 	    list-style: none;
@@ -64,18 +65,18 @@
         }
     }
 
-    a {
+    a, button {
         display: block;
         margin: 0 0 8px;
         padding: 10px 15px;
         background-color: darken($footerBackground, 0.1%);
         border-radius: 3px;
     }
-    a:hover { 
+    a:hover, button:hover { 
         text-decoration: none; 
         background-color: darken($footerBackground, 6%);   
     }
-    a:active {
+    a:active button:active {
         background-color: darken($footerBackground, 15%);
     }
 }

--- a/src/encoded/static/scss/encoded/_state.scss
+++ b/src/encoded/static/scss/encoded/_state.scss
@@ -43,17 +43,17 @@
             padding-left: 10px;
             padding-right: 10px;
         }
-        a {
+        a, button {
             display: inline;
             margin: 0;
             padding: 0;
             background-color: transparent;   
         }
-        a:hover { 
+        a:hover, button:hover { 
             text-decoration: underline;
             background-color: transparent; 
         }
-        a:active { background-color: transparent; }
+        a:active, button:active { background-color: transparent; }
     }
     
     .footer-logos {


### PR DESCRIPTION
In addition to adding the new link in the footer in footer.js, I also took this chance to enable the two disabled eslint rules for the `<Footer>` component as I was modifying that component for this ticket. That meant converting the component to a pure function and converting the two anchors to buttons. That meant adding “button” to the relevant CSS rules and changing the login/logout code to account for both buttons and anchors instead of just anchors.

Also I must have missed the `fallbackNavigate` method when I converted to the new eslint version, and it showed up red-marked. As this ticket doesn’t cover that method and fixing it isn’t a trivial change, I disabled that eslint rule for that method.