### PR TITLE
ENCD-4045 Add privacy link to footer

### DIFF
--- a/src/encoded/static/components/footer.js
+++ b/src/encoded/static/components/footer.js
@@ -2,52 +2,50 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 
-// Reworking the data triggers to use buttons doesn't seem worth it to avoid an eslint warning.
-/* eslint-disable jsx-a11y/anchor-is-valid, react/prefer-stateless-function */
-export default class Footer extends React.Component {
-    render() {
-        const session = this.context.session;
-        const disabled = !session;
-        let userActionRender;
+/* eslint-disable jsx-a11y/anchor-is-valid */
+const Footer = ({ version }, reactContext) => {
+    const session = reactContext.session;
+    const disabled = !session;
+    let userActionRender;
 
-        if (!(session && session['auth.userid'])) {
-            userActionRender = <a href="#" data-trigger="login" disabled={disabled}>Submitter sign-in</a>;
-        } else {
-            userActionRender = <a href="#" data-trigger="logout">Submitter sign out</a>;
-        }
-        return (
-            <footer id="page-footer">
+    if (!(session && session['auth.userid'])) {
+        userActionRender = <a href="#" data-trigger="login" disabled={disabled}>Submitter sign-in</a>;
+    } else {
+        userActionRender = <a href="#" data-trigger="logout">Submitter sign out</a>;
+    }
+    return (
+        <footer id="page-footer">
+            <div className="container">
+                <div className="row">
+                    <div className="app-version">{version}</div>
+                </div>
+            </div>
+            <div className="page-footer">
                 <div className="container">
                     <div className="row">
-                        <div className="app-version">{this.props.version}</div>
-                    </div>
-                </div>
-                <div className="page-footer">
-                    <div className="container">
-                        <div className="row">
-                            <div className="col-sm-6 col-sm-push-6">
-                                <ul className="footer-links">
-                                    <li><a href="mailto:encode-help@lists.stanford.edu">Contact</a></li>
-                                    <li><a href="http://www.stanford.edu/site/terms.html">Terms of Use</a></li>
-                                    <li id="user-actions-footer">{userActionRender}</li>
-                                </ul>
-                                <p className="copy-notice">&copy;{new Date().getFullYear()} Stanford University.</p>
-                            </div>
+                        <div className="col-sm-6 col-sm-push-6">
+                            <ul className="footer-links">
+                                <li><a href="https://www.stanford.edu/site/privacy/">Privacy</a></li>
+                                <li><a href="mailto:encode-help@lists.stanford.edu">Contact</a></li>
+                                <li><a href="http://www.stanford.edu/site/terms.html">Terms of Use</a></li>
+                                <li id="user-actions-footer">{userActionRender}</li>
+                            </ul>
+                            <p className="copy-notice">&copy;{new Date().getFullYear()} Stanford University.</p>
+                        </div>
 
-                            <div className="col-sm-6 col-sm-pull-6">
-                                <ul className="footer-logos">
-                                    <li><a href="/"><img src="/static/img/encode-logo-small-2x.png" alt="ENCODE" id="encode-logo" height="45px" width="78px" /></a></li>
-                                    <li><a href="http://www.stanford.edu"><img src="/static/img/su-logo-white-2x.png" alt="Stanford University" id="su-logo" width="105px" height="49px" /></a></li>
-                                </ul>
-                            </div>
+                        <div className="col-sm-6 col-sm-pull-6">
+                            <ul className="footer-logos">
+                                <li><a href="/"><img src="/static/img/encode-logo-small-2x.png" alt="ENCODE" id="encode-logo" height="45px" width="78px" /></a></li>
+                                <li><a href="http://www.stanford.edu"><img src="/static/img/su-logo-white-2x.png" alt="Stanford University" id="su-logo" width="105px" height="49px" /></a></li>
+                            </ul>
                         </div>
                     </div>
                 </div>
-            </footer>
-        );
-    }
-}
-/* eslint-enable jsx-a11y/anchor-is-valid, react/prefer-stateless-function */
+            </div>
+        </footer>
+    );
+};
+/* eslint-enable jsx-a11y/anchor-is-valid */
 
 Footer.contextTypes = {
     session: PropTypes.object,
@@ -60,3 +58,5 @@ Footer.propTypes = {
 Footer.defaultProps = {
     version: '',
 };
+
+export default Footer;


### PR DESCRIPTION
Added the link for privacy in the footer, and not including the auth0 update which will happen in another branch. I did change the `<Footer>` component to get rid of one eslint exception, but I kept the other exception because it would involve a fair amount of small changes here and there — easy for a release but a bit much for a hot fix.