### PR TITLE
added hypen for long words

### DIFF
--- a/src/encoded/static/scss/encoded/modules/_key-value-display.scss
+++ b/src/encoded/static/scss/encoded/modules/_key-value-display.scss
@@ -23,6 +23,9 @@ dl.key-value, dl.key-value-doc {
         width: auto;
         word-wrap: break-word;
         word-break: break-word;
+        -webkit-hyphens: auto;
+        -ms-hyphens: auto;
+        hyphens: auto;
     }
 
     dt {


### PR DESCRIPTION
Firefox and other browsers have slight differences. For example, Firefox adds an extra dash if the word breaks on a dash while Chrome does not. But essentially, all evergreen browsers and IE11 should be the same. 