### PR TITLE
ENCD-4058-expanding-matrix-creates-unaligned-headers-on-the-x-axis

### DIFF
--- a/src/encoded/static/components/matrix.js
+++ b/src/encoded/static/components/matrix.js
@@ -234,7 +234,7 @@ class Matrix extends React.Component {
                                                 </tr>
                                             : null}
                                             <tr style={{ borderBottom: 'solid 1px #ddd' }}>
-                                                <th style={{ textAlign: 'center', width: 200 }}>
+                                                <th style={{ textAlign: 'center', 'min-width': 200 }}>
                                                     <h3>
                                                         {matrix.doc_count} results
                                                     </h3>


### PR DESCRIPTION
This is a bit tricky. I gave the th in this fix a "min-width" so that it does not wrap to an unacceptable width as can occur if given merely a "width"-style. I am not sure why the style is inline rather than through a css-class (in multiple places). However, I believe that is a discussion behold the scope of this bug. 