### PR TITLE
ENCD-4077 Cast deploy volmne size to int

### DIFF
--- a/docs/region-search-viz-cache.rst
+++ b/docs/region-search-viz-cache.rst
@@ -16,77 +16,64 @@ b) files that created those peaks (bed)
 c) experments with facets ("aggegrations" in ES lingo) that those files belong to (via a secondary query on list of files).
 
 This search functionality is in src/encode/region_search.py and is relatively compact and straightforward.
-The process by which the BED files get into Elasticsearch is handled by the fileindexer system.
+The process by which the BED files get into Elasticsearch is handled by the "region indexer" system.
+
+
+Automatic Region Indexing
+-----------------------
+
+The "peaks" which are essentially intervals in a BED file are kept in a separate index per chromosome (including scaffolds).   In the apache config there is a seperate indexing listener:
+
+.. code::
+    # regionindexer. Configure first to avoid catchall '/'
+    WSGIDaemonProcess encoded-regionindexer user=encoded group=encoded processes=1 threads=1 display-name=encoded-regionindexer
+    WSGIScriptAlias /_regionindexer /srv/encoded/parts/production-regionindexer/wsgi process-group=encoded-indexer application-group=%{GLOBAL}
+
+Which is an instance of snovault.elasticsearch.indexer with path=index_region.   As a "follow up" indexer (see indexer.rst) the region_indexer never queries postgres and relies entirely on encodeD objects in elasticsearch.  The listener wakes every 60 seconds when idle and queries es for uuids staged by the primary encodeD indexer (/snovault/meta/staged_for_region_indexer) as having just been indexed. These uuids are filtered down to datasets that are likely to contain bed files to be added to the region indexer.  Each dataset is then verified to be of interest and its list of files is filtered down to candidate files to be added.  If a candidate file is NOT already resident in the regions index it is then added. The file are accessed via io.BytesIO() on the file download URL, and each peak (line of BED file) is indexed as {file-uuid, start, stop}.  The region indexes consist of one index per chromosome (e.g. 'chrx') (or scaffold), document type is the assembly (e.g. 'hg19') and key is the file's uuid.  A small amount of file specific information is then added to the "resident_regionsets" index.
+
+Analogous to the primary (encodeD metadata) indexer, the indexing state is stored in the Elasticsearch object snovault/meta/region_indexer.  Unlike the primary indexer, work of the region indexer is not multi-threaded, using only 1 process.
+
+Full indexing takes ~4 hours on ~5000 files.  Currently region indexes are only used for "region search" functionality described above.  However "Regulome DB" files are going to be added to the region indexes.
+
 
 TrackHub generation
 -----------------------
 
-UCSC trackhubs are large blocks ASCII/YAML that we provide a URL for.  The UCSC genome browser URL uses @@hub and /batch_hub/ endpoints as callbacks to generate 3 "files": hub.txt, genomes.txt and trackDb.txt.  The code for these views/endpoints is in visualization.py.
+UCSC trackhubs are large blocks of ASCII text that we provide a URL for.  The UCSC genome browser URL uses @@hub and /batch_hub/ endpoints as callbacks to generate 3 "files": hub.txt, genomes.txt and trackDb.txt.  The code for these views/endpoints is in visualization.py and vis_defines.py.
 
 The big output is the trackDb.txt which contains all the information to display each file (with metadata) at a browser that consumes it.
 The hub.txt lists the genomes available (genomes.txt) and genomes.txt are just "pointers" to the correct trackDb.txt per assembly (genome).
 
-Each visualizable ENCSR (Experiment or Dataset that contains one or more output files that are browser compliant, i.e., bigBed or bigWig) has the information for it's trackDb cached in Elasticsearch independent of the encodeD application.
+Ensembl should support the UCSC hub formatting and our hubs have worked in the past.  However, recently our hubs were failing at Ensembl, possibly due to a bug at their site.
 
-The "acc_composites" aka "viz_blobs" are stored in a separate ES index called vis_composites as JSON, keyed on ENCSRxxx_assembly.
-When a trackHub or other visualization query comes it, it's looked for by accession in the cache, otherwise it is created (there is a ?regenvis parameter to force recalculation).   
+Each visualizable ENCSR (Experiment or Dataset that contains one or more output files that are browser compliant, i.e., bigBed or bigWig) has the information for it's trackDb cached in Elasticsearch independent of the encodeD application.  While this would not be necessary if trackhubs only contained one or two experiments, batch_hubs can contain as many a 100 experiments and can only be efficiently generated if much of the reformatting for visualization is already cached.
 
-You can see the JSON with: 
-.. code::
-   
-    https://www.encodeproject.org/experiments/ENCSR778UBR/@@hub/hg38/jsonout/trackDb.txt
+The "vis_datasets" aka "vis_blobs" are stored in a separate ES index called vis_cache as JSON, keyed on ENCSRxxx_assembly.
+When a trackHub or other visualization query comes it, it's looked for by accession in the cache, otherwise it is created.  For batch_hubs, if at least one vis_blob is found in the cache then any missing ones will not be regenerated. It is possible to force the (re)creation of vis_blobs for any hub request by adding 'regen' to the trackDb request (e.g. ../trackDb.regen.txt).
 
-The individual acc_composites get remodeled (JSON transformed) to put into a batch hub or they can be exported as IHEC JSON with another query parameter "ihecjson".
-
-
-Automatic Peak Indexing
------------------------
-
-The "peaks" which is essentially an interval in a BED file are kept in a separate index per chromosome (including scaffolds).   In the apache config there is a seperate indexing listener:
-
-.. code::
-    #fileindexer. Configure first to avoid catchall '/'
-    WSGIDaemonProcess encoded-fileindexer user=encoded group=encoded processes=1 threads=1 display-name=encoded-fileindexer
-    WSGIScriptAlias /_fileindexer /srv/encoded/parts/production-fileindexer/wsgi process-group=encoded-indexer application-group=%{GLOBAL}
-
-Which is an instance of encoded.commands.es_file_index_listener (snovault.elasticsearch.indexer with path=index_file).   The listener polls postgres every 60 seconds for new transactions and responds to the API /_fileindexer/ with status.   It POSTs to the /index_file endpoint (defined in encoded.peak_indexer), in a parallel manner to the primary snovault ES indexer.  It is not multi-threaded, just using 1 process.
-
-Analogous to the metadata indexer, the indexing status is contained in the Elasticsearch object snovault/meta/peak_indexing - this object is read/written by fileindexer listener.
-
-The peak indexer (/index_file) compares the list of all invalidated uuids to all BED file uuids and UNION is passed to the BED file parser, the files are accessed via io.BytesIO() on the file download URL, and each peak (line of BED file) is indexed as {file-uuid, start, stop}.  
-
+You can see the raw JSON used to generate the trackDb.txt by requesting json instead of text (e.g. ../trackDb.json).  Further, since batch_hubs are reorganized from a list of vis_blobs to a set of assay based composites, the json for the vis_blobs themselves can be seen by requesting 'vis_blob.json'. (For single experiment hubs, trackDb.json and vis_blob.json are identical requests.)  Finally any trackDb.txt request can be transfomed to the IHEC JSON equivalent by requesting ihec.json.  (Note that IHEC JSON is an unreleased feature so far and the contents need to be verified by IHEC).
 
 
 Viz Caching and Priming
 -----------------------
 
-The caching of visualization JSON is linked to the fileindexer.  Generally, when the peak_indexer is done, it raises a semaphore with the list of UUIDs which is subscribed to by visualization.prime_vis_es_cache().   This triggers when main indexer is free (because the trackHub JSON depends on having up-to-date metadata in Elasticsearch).
+The caching of visualization JSON is handled by a "follow up" indexer (see indexer.rst), just as region indexing described above.  In the apache config there is a seperate indexing listener:
 
-So, when a (clustered) instance is started, all objects are new and each dataset will get passed to visualize.prime_viz_es_cache().  NOte that it short-circuits waiting for the file_indexer to finish if there are more than 100 files invalidated.
+.. code::
+    # visindexer. Configure first to avoid catchall '/'
+    WSGIDaemonProcess encoded-visindexer user=encoded group=encoded processes=1 threads=1 display-name=encoded-visindexer
+    WSGIScriptAlias /_visindexer /srv/encoded/parts/production-visindexer/wsgi process-group=encoded-indexer application-group=%{GLOBAL}
 
-Due to quirks in how the peak indexer functions, this will get triggered whenever a dataset is invalidated (even if none of the files or peak files changed) and will re-cache the visualization JSON for those experiments.
+The listener wakes every 60 seconds when idle and queries es for uuids staged by the primary encodeD indexer (/snovault/meta/staged_for_vis_indexer) as having just been indexed. These uuids are filtered down to datasets that are likely to be visualizable.  The embedded object is retrieved for each likely dataset and reformatted to one or more vis_blobs (one for each relevant assembly) which is then added to the on index named "vis_cache".  To support IHEC JSON, each dataset may require one or more additional queries of encodeD metadata from elasticsearch.
 
-The whole indexing takes around 100ms per Dataset.
+Analogous to the primary (encodeD metadata) indexer, the indexing state is stored in the Elasticsearch object snovault/meta/vis_indexer.  Unlike the primary indexer, work of the vis indexer uses only 1 process.
+
+The whole indexing of all visualizable datasets takes ~30 minutes for ~25K of vis_blobs.
+
 
 Differences between clustered and non-clustered deployments
 -----------------------------------------------------------
 
-To conserver resources on unclustered demo machines (Postgres/Pyramid/ES all on the same machine), the fileindexer is turned off.   Region-search is redirected to a "permanent" machine (configured as region_search_instance in buildout.cfg and gets copied to snp_search.server in production.ini (development.ini, for local instances us localhost:9200 although they have no ability to index files or do region search because they have no BED files.  
+Currently the region indexes are contained in the same elasticsearch instance as encodeD metadata, for all flavors of the encodeD application including local.  In the future it is expected that unclustered demo's will not have region indexes, and under some circumstances the region indexes will be migrated to their own instance of elasticsearch.  It is not anticipated that the vis_cache index will ever be separated from the encodeD elasticsearch instance, nor will it be turned off in unclustered demos.
 
-The machine specified in region_search_instance is a stable elasticsearch-only machine that gets new data from various unclustered demos.  Port 9200 is used (default elasticsearch), and should be accessible to IP addresses in the correct range (*.instance.encodedcc.org)
-
-Demos generally do not get files posted to them (BED or otherewise), so it's rare for new peaks to get reindexed.  When a new demo is created it checks the region-search-test machine and updates it with newly invalidated BED files (DB transactions since the xmin property of snovault/meta/peak_indexing (because it's snp_search.server is set to the common one).
-
-This is overridden by the following line in cloud-config-cluster.yml:
-.. code::
-    - sudo -u encoded LANG=en_US.UTF-8 bin/buildout -c %(ROLE)s.cfg production-ini:region_search_instance=localhost:9200
-
-Since this is only used when a clustered instance is built, the default region-search ES instance will be the one in production.ini
-This is set in encoded.__init__() as config.registry['snp_search'], a Elasticsearch connnection object (aka registry[SNP_SEARCH_ES])
-
-In the clustered case, each master has it's own peak_indexer process and it's own snovault/meta/peak_indexing so it will re-index everything from scratch.
-
-Because of the (current) interaction between the visualization caching and the file indexer, if you need to reset the vis cache on an unclustered demo machine, you will have to:
-.. code::
-    > curl -XDELETE localhost:9200/snovault/meta/peak_indexing ON the current demo region search machine.
 

--- a/docs/region-search-viz-cache.rst
+++ b/docs/region-search-viz-cache.rst
@@ -3,7 +3,7 @@ Region Search and Viz Cache
 ===============================
 
 Region-Search
-------------
+-------------
 
 encodeD has a feature to search through a sub-set of result files "tracks" by genomic coordinate.
 This is accessble from the URL region-search/ (in production: https://www.encodeproject.org/region-search).
@@ -12,12 +12,21 @@ Region search takes a variety of inputs, all of which must be tranformed into ge
 
 This region is intersected with the region-search index in elasticsearch (ES) to return a list of:
 a) peaks that intersect
-b) files that created those peaks (bed)
+b) file uuids that define those peaks and a small object containing minimal file details including dataset uuid
 c) experments with facets ("aggegrations" in ES lingo) that those files belong to (via a secondary query on list of files).
 
-This search functionality is in src/encode/region_search.py and is relatively compact and straightforward.
+This region_search API is in src/encode/region_search.py, which calls into region_atlas.py which encapsulates access to the region_index.
 The process by which the BED files get into Elasticsearch is handled by the "region indexer" system.
 
+
+Regulome-Search
+---------------
+
+Access to the RegulomeDB feature is through the URL regulome-search/ (in production: https://www.encodeproject.org/regulome-search).
+This is near identical to region-search and is served by the same function defined in region_search.py.
+The set of files that are indexed for regulome and region_search are not identical but are overlapping.
+Regulome is primarily focuses on SNPs and calculates a 'regulome score' for each single-base position.
+Most of the subtle differences between region and regulome are defined in the two classes RegionAtlas and RegulomeAtlas found in region_atlas.py.
 
 Automatic Region Indexing
 -----------------------
@@ -29,44 +38,79 @@ The "peaks" which are essentially intervals in a BED file are kept in a separate
     WSGIDaemonProcess encoded-regionindexer user=encoded group=encoded processes=1 threads=1 display-name=encoded-regionindexer
     WSGIScriptAlias /_regionindexer /srv/encoded/parts/production-regionindexer/wsgi process-group=encoded-indexer application-group=%{GLOBAL}
 
-Which is an instance of snovault.elasticsearch.indexer with path=index_region.   As a "follow up" indexer (see indexer.rst) the region_indexer never queries postgres and relies entirely on encodeD objects in elasticsearch.  The listener wakes every 60 seconds when idle and queries es for uuids staged by the primary encodeD indexer (/snovault/meta/staged_for_region_indexer) as having just been indexed. These uuids are filtered down to datasets that are likely to contain bed files to be added to the region indexer.  Each dataset is then verified to be of interest and its list of files is filtered down to candidate files to be added.  If a candidate file is NOT already resident in the regions index it is then added. The file are accessed via io.BytesIO() on the file download URL, and each peak (line of BED file) is indexed as {file-uuid, start, stop}.  The region indexes consist of one index per chromosome (e.g. 'chrx') (or scaffold), document type is the assembly (e.g. 'hg19') and key is the file's uuid.  A small amount of file specific information is then added to the "resident_regionsets" index.
+Which is an instance of snovault.elasticsearch.indexer with path=index_region.
+As a "follow up" indexer (see indexer.rst) the region_indexer never queries postgres and relies entirely on encodeD objects in elasticsearch.
+The listener wakes every 60 seconds when idle and queries es for uuids staged by the primary encodeD indexer (/snovault/meta/staged_for_region_indexer) as having just been indexed.
+These uuids are filtered down to datasets that are likely to contain bed files to be added to the region indexes.
+Each dataset is then verified to be of interest and its list of files is filtered down to candidate files to be added.
+If a candidate file is NOT already resident in the regions index it is then added.
+Most files are accessed via io.BytesIO() on the file download URL, and each peak (line of BED file) is indexed as {file-uuid, start, stop}.
+(Large files can be downloaded to the server as a temp file and then gunzip read line by line to accomplish the same thing as the in-memory byte-stream does.)
+The region indexes consist of one index per chromosome (e.g. 'chrx') (or scaffold), document type is the assembly (e.g. 'hg19') and key is the file's uuid.
+A single document contains all the positions for that assembly/chromosome found in the file.  Positions are a "nested" array (in ES terminology).
+A small amount of file specific information is then added to the "resident_regionsets" index, including whether the file was indexed for region search, regulome, or both.
 
-Analogous to the primary (encodeD metadata) indexer, the indexing state is stored in the Elasticsearch object snovault/meta/region_indexer.  Unlike the primary indexer, work of the region indexer is not multi-threaded, using only 1 process.
+In addition to the peak positions, the region_indexer also holds dbSNP variants in a slightly different arrangement.
+There is a need to look up SNPs not only by position but also by rsid.  To do this requires a separate document per SNP, keyed on rsid.
+Unlike peaks, which have chromosome based indexes, SNPs have assembly based indexes and chromosome based document types.
+A small amount of information for each the entire SNP file is added to the "resident_regionsets" index, just like for peak files.
+A primary reason of the resident_regionsets index index is to avoid reindexing a file once it has been added to the index.
+This is especially important for SNP files which contain more than 60 million SNPs each and take a *very long time* to index.
 
-Full indexing takes ~4 hours on ~5000 files.  Currently region indexes are only used for "region search" functionality described above.  However "Regulome DB" files are going to be added to the region indexes.
+Analogous to the primary (encodeD metadata) indexer, the indexing state is stored in the Elasticsearch object snovault/meta/region_indexer.
+Unlike the primary indexer, work of the region indexer is not multi-threaded, using only 1 process.
+
+Full indexing takes ~4 hours on ~6000 region search files.
+This expands to ~8 hours with regulome and dbSNP files.
 
 
 TrackHub generation
 -----------------------
 
-UCSC trackhubs are large blocks of ASCII text that we provide a URL for.  The UCSC genome browser URL uses @@hub and /batch_hub/ endpoints as callbacks to generate 3 "files": hub.txt, genomes.txt and trackDb.txt.  The code for these views/endpoints is in visualization.py and vis_defines.py.
+UCSC trackhubs are large blocks of ASCII text that we provide a URL for.
+The UCSC genome browser URL uses @@hub and /batch_hub/ endpoints as callbacks to generate 3 "files": hub.txt, genomes.txt and trackDb.txt.
+The code for these views/endpoints is in visualization.py and vis_defines.py.
 
 The big output is the trackDb.txt which contains all the information to display each file (with metadata) at a browser that consumes it.
-The hub.txt lists the genomes available (genomes.txt) and genomes.txt are just "pointers" to the correct trackDb.txt per assembly (genome).
+The hub.txt lists the genomes available and genomes.txt are just "pointers" to the correct trackDb.txt per assembly (genome).
 
-Ensembl should support the UCSC hub formatting and our hubs have worked in the past.  However, recently our hubs were failing at Ensembl, possibly due to a bug at their site.
+Ensembl should support the UCSC hub formatting and our hubs have worked in the past.
+However, recently our hubs were failing at Ensembl, possibly due to a bug at their site.
 
-Each visualizable ENCSR (Experiment or Dataset that contains one or more output files that are browser compliant, i.e., bigBed or bigWig) has the information for it's trackDb cached in Elasticsearch independent of the encodeD application.  While this would not be necessary if trackhubs only contained one or two experiments, batch_hubs can contain as many a 100 experiments and can only be efficiently generated if much of the reformatting for visualization is already cached.
+Each visualizable ENCSR (Experiment or Dataset that contains one or more output files that are browser compliant, i.e., bigBed or bigWig) has the information for it's trackDb cached in Elasticsearch independent of the encodeD application.
+While this would not be necessary if trackhubs only contained one or two experiments, batch_hubs can contain as many a 100 experiments and can only be efficiently generated if much of the reformatting for visualization is already cached.
 
 The "vis_datasets" aka "vis_blobs" are stored in a separate ES index called vis_cache as JSON, keyed on ENCSRxxx_assembly.
-When a trackHub or other visualization query comes it, it's looked for by accession in the cache, otherwise it is created.  For batch_hubs, if at least one vis_blob is found in the cache then any missing ones will not be regenerated. It is possible to force the (re)creation of vis_blobs for any hub request by adding 'regen' to the trackDb request (e.g. ../trackDb.regen.txt).
+When a trackHub or other visualization query comes in, it's looked for by accession in the cache, otherwise it is created (and added to the vis_cache index).
+For batch_hubs, if at least one vis_blob is found in the cache then any missing ones will not be regenerated.
+It is possible to force the (re)creation of vis_blobs for any hub request by adding 'regen' to the trackDb request (e.g. ../trackDb.regen.txt).
 
-You can see the raw JSON used to generate the trackDb.txt by requesting json instead of text (e.g. ../trackDb.json).  Further, since batch_hubs are reorganized from a list of vis_blobs to a set of assay based composites, the json for the vis_blobs themselves can be seen by requesting 'vis_blob.json'. (For single experiment hubs, trackDb.json and vis_blob.json are identical requests.)  Finally any trackDb.txt request can be transfomed to the IHEC JSON equivalent by requesting ihec.json.  (Note that IHEC JSON is an unreleased feature so far and the contents need to be verified by IHEC).
+You can see the raw JSON used to generate the trackDb.txt by requesting json instead of text (e.g. ../trackDb.json).
+Further, since batch_hubs are reorganized from a list of vis_blobs to a set of assay based composites, the json for the vis_blobs themselves can be seen by requesting 'vis_blob.json'.
+(For single experiment hubs, trackDb.json and vis_blob.json are identical requests.)
+Finally any trackDb.txt request can be transfomed to the IHEC JSON equivalent by requesting ihec.json.
+(Note that IHEC JSON is an unreleased feature so far and the contents need to be verified by IHEC).
 
 
 Viz Caching and Priming
 -----------------------
 
-The caching of visualization JSON is handled by a "follow up" indexer (see indexer.rst), just as region indexing described above.  In the apache config there is a seperate indexing listener:
+The caching of visualization JSON is handled by a "follow up" indexer (see indexer.rst), just as region indexing, described above.
+In the apache config there is a seperate indexing listener:
 
 .. code::
     # visindexer. Configure first to avoid catchall '/'
     WSGIDaemonProcess encoded-visindexer user=encoded group=encoded processes=1 threads=1 display-name=encoded-visindexer
     WSGIScriptAlias /_visindexer /srv/encoded/parts/production-visindexer/wsgi process-group=encoded-indexer application-group=%{GLOBAL}
 
-The listener wakes every 60 seconds when idle and queries es for uuids staged by the primary encodeD indexer (/snovault/meta/staged_for_vis_indexer) as having just been indexed. These uuids are filtered down to datasets that are likely to be visualizable.  The embedded object is retrieved for each likely dataset and reformatted to one or more vis_blobs (one for each relevant assembly) which is then added to the on index named "vis_cache".  To support IHEC JSON, each dataset may require one or more additional queries of encodeD metadata from elasticsearch.
+The listener wakes every 60 seconds when idle and queries es for uuids staged by the primary encodeD indexer (/snovault/meta/staged_for_vis_indexer) as having just been indexed.
+As a follow up indexer, the vis caching does not query postgres and gets all information from the primary indexes in elasticsearch.
+These uuids are filtered down to datasets that are likely to be visualizable.
+The embedded object is retrieved for each likely dataset and reformatted to one or more vis_blobs (one for each relevant assembly) which is then added to the one index named "vis_cache".
+To support IHEC JSON, each dataset may require one or more additional queries of encodeD metadata from elasticsearch.
 
-Analogous to the primary (encodeD metadata) indexer, the indexing state is stored in the Elasticsearch object snovault/meta/vis_indexer.  Unlike the primary indexer, work of the vis indexer uses only 1 process.
+Analogous to the primary (encodeD metadata) indexer, the indexing state is stored in the Elasticsearch object snovault/meta/vis_indexer.
+Unlike the primary indexer, work of the vis indexer uses only 1 process.
 
 The whole indexing of all visualizable datasets takes ~30 minutes for ~25K of vis_blobs.
 
@@ -74,6 +118,12 @@ The whole indexing of all visualizable datasets takes ~30 minutes for ~25K of vi
 Differences between clustered and non-clustered deployments
 -----------------------------------------------------------
 
-Currently the region indexes are contained in the same elasticsearch instance as encodeD metadata, for all flavors of the encodeD application including local.  In the future it is expected that unclustered demo's will not have region indexes, and under some circumstances the region indexes will be migrated to their own instance of elasticsearch.  It is not anticipated that the vis_cache index will ever be separated from the encodeD elasticsearch instance, nor will it be turned off in unclustered demos.
+Currently the region indexes are contained in the same elasticsearch instance as encodeD metadata, for all flavors of the encodeD application including local.
+By default, unclustered demo's will not have region indexes, while clustered deployments will.
+(This arrangement can be overridden using deploy.py option: --set-region-index-to 'True' or 'False'.)
+It is possible in the future (as in the past) that the region indexes will be separated from the primary indexes.
+This would be desirable because the region indexes could grow to be massive, take a very long time to index and have very low turnover.
+The region indexes may not change at all between releases of the encodeD portal, so recreating them each release would be of little value.
+It is not anticipated that the vis_cache index will ever be separated from the encodeD elasticsearch instance, nor will it be turned off in unclustered demos.
 
 

--- a/src/encoded/batch_download.py
+++ b/src/encoded/batch_download.py
@@ -17,7 +17,6 @@ import io
 import json
 import time  # DEBUG: timing
 import datetime
-import zlib
 from .region_atlas import RegulomeAtlas
 
 import logging
@@ -60,7 +59,8 @@ _tsv_mapping = OrderedDict([
     ('Library strand specific', ['replicates.library.strand_specificity']),
     ('Experiment date released', ['date_released']),
     ('Project', ['award.project']),
-    ('RBNS protein concentration', ['files.replicate.rbns_protein_concentration', 'files.replicate.rbns_protein_concentration_units']),
+    ('RBNS protein concentration', ['files.replicate.rbns_protein_concentration',
+                                    'files.replicate.rbns_protein_concentration_units']),
     ('Library fragmentation method', ['files.replicate.library.fragmentation_method']),
     ('Library size range', ['files.replicate.library.size_range']),
     ('Biological replicate(s)', ['files.biological_replicates']),
@@ -105,6 +105,7 @@ def get_file_uuids(result_dict):
             file_uuids.append(file['uuid'])
     return list(set(file_uuids))
 
+
 def get_biosample_accessions(file_json, experiment_json):
     bio_reps = None
     for f in experiment_json['files']:
@@ -112,15 +113,16 @@ def get_biosample_accessions(file_json, experiment_json):
             bio_reps = f.get('biological_replicates')
     accessions = set()
     for replicate in experiment_json.get('replicates', []):
-        if bio_reps and replicate.get('biological_replicate_number',0) not in bio_reps:
+        if bio_reps and replicate.get('biological_replicate_number', 0) not in bio_reps:
             continue
         try:
             accession = replicate['library']['biosample']['accession']
             if accession:
                 accessions.add(accession)
-        except:
+        except Exception:
             pass
     return ', '.join(list(accessions))
+
 
 def get_regulome_evidence_links(request, assembly, chrom, start, end):
     regulome_link = '{host_url}/regulome_download/regulome_evidence_{assembly}_{chrom}_{start}_{end}'.format(
@@ -132,6 +134,7 @@ def get_regulome_evidence_links(request, assembly, chrom, start, end):
     )
     return [regulome_link + '.bed', regulome_link + '.json']
 
+
 def get_peak_metadata_links(request, assembly, chrom, start, end):
     page = request.path.split('/')[1]
     if page.startswith('regulome'):
@@ -141,7 +144,7 @@ def get_peak_metadata_links(request, assembly, chrom, start, end):
         search_params = request.matchdict['search_params']
     else:
         search_params = request.query_string
-    #if regulome:
+    # if regulome:
     #    search_params += '&regulome=1'
 
     peak_metadata_tsv_link = '{host_url}/peak_metadata/{search_params}/peak_metadata.tsv'.format(
@@ -153,6 +156,7 @@ def get_peak_metadata_links(request, assembly, chrom, start, end):
         search_params=search_params
     )
     return [peak_metadata_tsv_link, peak_metadata_json_link]
+
 
 def make_cell(header_column, row, exp_data_row):
     temp = []
@@ -193,17 +197,17 @@ def make_audit_cell(header_column, experiment_json, file_json):
 
 @view_config(route_name='peak_metadata', request_method='GET')
 def peak_metadata(context, request):
-    # TODO: make regulome version using atlas.scored_snps
     param_list = parse_qs(request.matchdict['search_params'])
-    regulome = param_list.pop('regulome',None)
+    regulome = param_list.pop('regulome', None)
     target_page = 'region-search'
     if regulome:
         target_page = 'regulome-search'
 
     param_list['field'] = []
-    header = ['assay_term_name', 'coordinates', 'target.label', 'biosample.accession', 'file.accession', 'experiment.accession']
+    header = ['assay_term_name', 'coordinates', 'target.label', 'biosample.accession',
+              'file.accession', 'experiment.accession']
     param_list['limit'] = ['all']
-    path = '/{}/?{}&{}'.format(target_page,urlencode(param_list, True),'referrer=peak_metadata')
+    path = '/{}/?{}&{}'.format(target_page, urlencode(param_list, True), 'referrer=peak_metadata')
     results = request.embed(path, as_user=True)
     uuids_in_results = get_file_uuids(results)
     rows = []
@@ -214,15 +218,17 @@ def peak_metadata(context, request):
             experiment_json = request.embed(file_json['dataset'])
             for hit in row['inner_hits']['positions']['hits']['hits']:
                 data_row = []
-                coordinates = '{}:{}-{}'.format(row['_index'], hit['_source']['start'], hit['_source']['end'])
+                coordinates = '{}:{}-{}'.format(row['_index'], hit['_source']['start'],
+                                                hit['_source']['end'])
                 file_accession = file_json['accession']
                 experiment_accession = experiment_json['accession']
-                assay_name = experiment_json.get('assay_term_name','')
+                assay_name = experiment_json.get('assay_term_name', '')
                 if assay_name == '' and regulome:
-                    assay_name = experiment_json.get('annotation_type','')
-                target_name = experiment_json.get('target', {}).get('label','') # not all experiments have targets
+                    assay_name = experiment_json.get('annotation_type', '')
+                target_name = experiment_json.get('target', {}).get('label', '')
                 biosample_accession = get_biosample_accessions(file_json, experiment_json)
-                data_row.extend([assay_name, coordinates, target_name, biosample_accession, file_accession, experiment_accession])
+                data_row.extend([assay_name, coordinates, target_name, biosample_accession,
+                                 file_accession, experiment_accession])
                 rows.append(data_row)
                 if assay_name not in json_doc:
                     json_doc[assay_name] = []
@@ -250,6 +256,7 @@ def peak_metadata(context, request):
         content_disposition='attachment;filename="%s"' % 'peak_metadata.tsv'
     )
 
+
 @view_config(route_name='regulome_download', request_method='GET')
 def regulome_download(context, request):
     begin = time.time()  # DEBUG: timing
@@ -262,7 +269,7 @@ def regulome_download(context, request):
         chrom = page_parts[3]
         start = int(page_parts[4])
         end = int(page_parts[5])
-    except:
+    except Exception:
         log.error('Could not parse: ' + request.url)
         return None
     if assembly is None or chrom is None or start == 0 or end == 0:
@@ -282,15 +289,17 @@ def regulome_download(context, request):
             count += 1
             coordinates = '{}:{}-{}'.format(snp['chrom'], snp['start'], snp['end'])
             if format_json:
-                formatted_snp = json.dumps({snp.get('rsid', coordinates): snp},sort_keys=True)[1:-1] + ','
+                formatted_snp = json.dumps({snp.get('rsid', coordinates): snp},
+                                           sort_keys=True)[1:-1] + ','
             else:
-                score = snp.get('score','')
-                num_score = atlas.numeric_score(score)           # - 1 because bed format is 'half open'
-                formatted_snp = "%s\t%d\t%d\t%s\t%d\t%s" % (snp['chrom'], snp['start'] - 1, snp['end'], \
-                                                  snp.get('rsid',coordinates), num_score, score)
+                score = snp.get('score', '')
+                num_score = atlas.numeric_score(score)    # - 1 because bed format is 'half open'
+                formatted_snp = "%s\t%d\t%d\t%s\t%d\t%s" % \
+                                (snp['chrom'], snp['start'] - 1, snp['end'],
+                                 snp.get('rsid', coordinates), num_score, score)
                 case = atlas.make_a_case(snp)
                 for category in atlas.evidence_categories():  # in order
-                    formatted_snp += '\t%s' % case.get(category,'')
+                    formatted_snp += '\t%s' % case.get(category, '')
             yield bytes(formatted_snp + '\n', 'utf-8')
         took = '%.3f' % (time.time() - begin)    # DEBUG: timing
         if format_json:
@@ -305,11 +314,13 @@ def regulome_download(context, request):
             header = '\t'.join(['#chrom', 'start', 'end', 'num_score']) + '\n'  # bedGraph
         yield bytes(header, 'utf-8')
         count = 0
-        for (sig_start, sig_end, sig_score) in atlas.iter_scored_signal(assembly, chrom, start, end):
+        for (sig_start, sig_end, sig_score) in atlas.iter_scored_signal(assembly, chrom,
+                                                                        start, end):
             count += 1
             if format_json:
-                sig_json = {'chrom': chrom, 'start': sig_start, 'end': sig_end, 'num_score': sig_score}
-                formatted_sig = json.dumps(sig_json,sort_keys=True)[1:-1] + ','
+                sig_json = {'chrom': chrom, 'start': sig_start, 'end': sig_end,
+                            'num_score': sig_score}
+                formatted_sig = json.dumps(sig_json, sort_keys=True)[1:-1] + ','
             else:                                          # - 1 because bed format is 'half open'
                 formatted_sig = "%s\t%d\t%d\t%d" % (chrom, sig_start - 1, sig_end, sig_score)
             yield bytes(formatted_sig + '\n', 'utf-8')
@@ -323,7 +334,7 @@ def regulome_download(context, request):
 
     # Stream response using chunked encoding.
     if format_json:
-        request.response.content_type = 'text/plain' # ?? 'application/json'
+        request.response.content_type = 'text/plain'   # ?? 'application/json'
         request.response.content_disposition = 'attachment;filename="%s.json"' % (file_root)
     else:
         request.response.content_type = 'text/tsv'
@@ -507,9 +518,9 @@ def report_download(context, request):
     type = type.replace("'", '')
 
     def format_header(seq):
-        newheader="%s\t%s%s?%s\r\n" % (currenttime, request.host_url, '/report/', request.query_string)
+        newheader = "%s\t%s%s?%s\r\n" % (currenttime, request.host_url, '/report/',
+                                         request.query_string)
         return(bytes(newheader, 'utf-8'))
-
 
     # Work around Excel bug; can't open single column TSV with 'ID' header
     if len(columns) == 1 and '@id' in columns:
@@ -526,6 +537,9 @@ def report_download(context, request):
 
     # Stream response using chunked encoding.
     request.response.content_type = 'text/tsv'
-    request.response.content_disposition = 'attachment;filename="%s"' % '%(doctype)s Report %(yyyy)s/%(mm)s/%(dd)s.tsv' % {'yyyy': currenttime.year, 'mm': currenttime.month, 'dd': currenttime.day, 'doctype': type} #change file name
+    request.response.content_disposition = 'attachment;filename="%s"' % \
+                                           '%(doctype)s Report %(yyyy)s/%(mm)s/%(dd)s.tsv' % \
+                                           {'yyyy': currenttime.year, 'mm': currenttime.month,
+                                            'dd': currenttime.day, 'doctype': type}
     request.response.app_iter = generate_rows()
     return request.response

--- a/src/encoded/commands/deploy.py
+++ b/src/encoded/commands/deploy.py
@@ -213,7 +213,7 @@ def _get_bdm(main_args):
         {
             'DeviceName': '/dev/sda1',
             'Ebs': {
-                'VolumeSize': main_args.volume_size,
+                'VolumeSize': int(main_args.volume_size),
                 'VolumeType': 'gp2',
                 'DeleteOnTermination': True
             }

--- a/src/encoded/commands/generate_scored_snps.py
+++ b/src/encoded/commands/generate_scored_snps.py
@@ -1,0 +1,131 @@
+from pyramid.paster import get_app
+from elasticsearch import RequestError
+import logging
+import json
+import time  # DEBUG: timing
+from ..region_indexer import (
+    SUPPORTED_CHROMOSOMES,
+    REGULOME_SUPPORTED_ASSEMBLIES
+)
+from ..region_atlas import (
+    RegulomeAtlas
+)
+
+from snovault.elasticsearch.interfaces import (
+    ELASTIC_SEARCH,
+    SNP_SEARCH_ES
+)
+
+
+EPILOG = __doc__
+
+log = logging.getLogger(__name__)
+
+
+def run(app, format_json=False, chosen_assembly=None, chosen_chrom=None, signal=False):
+    if chosen_assembly is not None and chosen_assembly.lower() == 'all':
+        chosen_assembly=None
+    if chosen_chrom is not None and chosen_chrom.lower() == 'all':
+        chosen_chrom=None
+
+    atlas = RegulomeAtlas(app.registry[SNP_SEARCH_ES])
+
+    for assmebly in REGULOME_SUPPORTED_ASSEMBLIES:
+        if chosen_assembly is not None and assembly != chosen_assembly:
+            continue
+        count = 0
+        chrom_count = 0
+        bed_file_name = 'regulome_SNPs_%s.bed' % assembly
+        print("Starting to generate %s", bed_file_name)
+        begin = time.time()  # DEBUG: timing
+        bed_file = open(bed_file_name, 'a')
+        if format_json:
+            header = '{\n'
+        else:
+            if signal:
+                columns = ['#chrom', 'start', 'end', 'num_score']  # bedGraph
+            else:
+                columns = ['#chrom', 'start', 'end', 'rsid', 'num_score', 'score']  # bed 5 +
+                columns.extend(atlas.evidence_categories())
+            header = '\t'.join(columns) + '\n'
+        bed_file.write(header)
+        for chrom in SUPPORTED_CHROMOSOMES:
+            if chosen_chrom is not None and chrom != chosen_chrom:
+                continue
+            count_by_chrom = 0
+            start = 0
+            end = 200000000 # chrom_length ??
+            # Alternative: call path regulome_evidence/regulomeDB_{assembly}_{chrom}_0_{end}.bed
+            #              then append all chrom files into bed_file (grep -v $# to remove comments)
+            if signal:
+                for (pos_start, pos_end, pos_score) in atlas.iter_scored_signal(assembly, chrom, start, end):
+                    count += 1
+                    count_by_chrom += 1
+                    (pos_start, pos_end, pos_score) = pos
+                    if format_json:
+                        pos_json = {'chrom': chrom, 'start': pos_start, 'end': pos_end, 'num_score': pos_score}
+                        formatted_pos = json.dumps(pos_json,sort_keys=True)[1:-1] + ','
+                    else:                                     # - 1 because bed format is 'half open'
+                        formatted_pos = "%s\t%d\t%d\t%d" % (chrom, pos_start - 1, pos_end, pos_score)
+                    bed_file.write(formatted_pos + '\n')
+                    if (count % 1000000) == 0:  # Make some noise every 10 minutes
+                        print("%d", count)
+            else:
+                for pos in atlas.iter_scored_snps(assembly, chrom, start, end):
+                    count += 1
+                    count_by_chrom += 1
+                    coordinates = '{}:{}-{}'.format(chrom, pos['start'], pos['end'])
+                    if format_json:
+                        formatted_pos = json.dumps({pos.get('rsid', coordinates): pos},sort_keys=True)[1:-1] + ','
+                    else:
+                        score = pos.get('score','')
+                        num_score = atlas.numeric_score(score)     # - 1 because bed format is 'half open'
+                        formatted_pos = "%s\t%d\t%d\t%s\t%d\t%s" % (chrom, pos['start'] - 1, pos['end'], \
+                                                        pos.get('rsid',coordinates), num_score, score)
+                        case = atlas.make_a_case(pos)
+                        for category in atlas.evidence_categories():  # in order
+                            formatted_pos += '\t%s' % case.get(category,'')
+                    bed_file.write(formatted_pos + '\n')
+                    if (count % 1000000) == 0:  # Make some noise every 10 minutes
+                        print("%d", count)
+
+            if format_json:
+                bed_file.write('"%s_count": %d,\n' % (chrom, count_by_chrom))
+            print("wrote %d SNPs for %s to %s", count_by_chrom, chrom, bed_file_name)
+            if count_by_chrom > 0:
+                chrom_count += 1
+        took = '%.3f' % (time.time() - begin)    # DEBUG: timing
+        if format_json:
+            bed_file.write('"took": %s,\n"chrom_count": %d,\n"count": %d\n}\n' % (took, chrom_count, count))
+        else:
+            yield bytes('# took: %s, count: %d\n' % (took, count), 'utf-8')
+        bed_file.close()
+        print("wrote %d SNPs to %s", count, bed_file_name)
+    print("Done (finally)")
+
+def main():
+    import argparse
+    parser = argparse.ArgumentParser(
+        description="Generate scored SNPs from regulome_search", epilog=EPILOG,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    # sudo -u encoded bin/generate-scored-snps production.ini --assembly hg19 --chrom chr22
+    parser.add_argument('config_uri', help="path to configfile")
+    parser.add_argument('--app-name', help="Pyramid app name in configfile", default='app', required=False)
+    parser.add_argument('--assembly', help="Select 'hg19' or 'GRCh38'.", default=None, required=False)
+    parser.add_argument('--chrom',    help="Limit file to a single chromosome.", default=None, required=False)
+    parser.add_argument('--signal',   help="Output bedGraph format for bigWig signal.", action='store_true', required=False)
+    parser.add_argument('--json',     help="Output JSON instead of default bed.", action='store_true', required=False)
+    args = parser.parse_args()
+
+    logging.basicConfig()
+    app = get_app(args.config_uri, args.app_name)
+
+    # Loading app will have configured from config file. Reconfigure here:
+    logging.getLogger('encoded').setLevel(logging.DEBUG)
+
+    return run(app, args.json, args.assembly, args.chrom, args.signal)
+
+
+if __name__ == '__main__':
+    main()

--- a/src/encoded/commands/generate_scored_snps.py
+++ b/src/encoded/commands/generate_scored_snps.py
@@ -1,5 +1,4 @@
 from pyramid.paster import get_app
-from elasticsearch import RequestError
 import logging
 import json
 import time  # DEBUG: timing
@@ -12,7 +11,6 @@ from ..region_atlas import (
 )
 
 from snovault.elasticsearch.interfaces import (
-    ELASTIC_SEARCH,
     SNP_SEARCH_ES
 )
 
@@ -22,20 +20,18 @@ EPILOG = __doc__
 log = logging.getLogger(__name__)
 
 
-def run(app, format_json=False, chosen_assembly=None, chosen_chrom=None, signal=False):
-    if chosen_assembly is not None and chosen_assembly.lower() == 'all':
-        chosen_assembly=None
-    if chosen_chrom is not None and chosen_chrom.lower() == 'all':
-        chosen_chrom=None
+def run(app, format_json=False, chosen_assembly='GRCh38', chosen_chrom='all', signal=False):
 
     atlas = RegulomeAtlas(app.registry[SNP_SEARCH_ES])
 
-    for assmebly in REGULOME_SUPPORTED_ASSEMBLIES:
-        if chosen_assembly is not None and assembly != chosen_assembly:
+    for assembly in REGULOME_SUPPORTED_ASSEMBLIES:
+        if assembly != chosen_assembly and chosen_assembly.lower() != 'all':
             continue
         count = 0
         chrom_count = 0
         bed_file_name = 'regulome_SNPs_%s.bed' % assembly
+        if signal:
+            bed_file_name = 'regulome_signal_%s.bedGraph' % assembly
         print("Starting to generate %s", bed_file_name)
         begin = time.time()  # DEBUG: timing
         bed_file = open(bed_file_name, 'a')
@@ -50,23 +46,29 @@ def run(app, format_json=False, chosen_assembly=None, chosen_chrom=None, signal=
             header = '\t'.join(columns) + '\n'
         bed_file.write(header)
         for chrom in SUPPORTED_CHROMOSOMES:
-            if chosen_chrom is not None and chrom != chosen_chrom:
+            if chrom != chosen_chrom and chosen_chrom.lower() != 'all':
                 continue
             count_by_chrom = 0
             start = 0
-            end = 200000000 # chrom_length ??
-            # Alternative: call path regulome_evidence/regulomeDB_{assembly}_{chrom}_0_{end}.bed
-            #              then append all chrom files into bed_file (grep -v $# to remove comments)
+            end = 200000000   # chrom.sizes ?? (e.g. /files/GRCh38_EBV.chrom.sizes/)
+            # Not really necessary to have an accurate end, just don't stop too soon.
+
+            # NOTE: Alternative to calling atlas directly:
+            #       call path regulome_download/regulome_evidence_{assembly}_{chrom}_0_{end}.bed
+            #       then append all chrom files into bed_file (grep -v $# to remove comments)
             if signal:
-                for (pos_start, pos_end, pos_score) in atlas.iter_scored_signal(assembly, chrom, start, end):
+                for (pos_start, pos_end, pos_score) in atlas.iter_scored_signal(assembly, chrom,
+                                                                                start, end):
                     count += 1
                     count_by_chrom += 1
-                    (pos_start, pos_end, pos_score) = pos
                     if format_json:
-                        pos_json = {'chrom': chrom, 'start': pos_start, 'end': pos_end, 'num_score': pos_score}
-                        formatted_pos = json.dumps(pos_json,sort_keys=True)[1:-1] + ','
-                    else:                                     # - 1 because bed format is 'half open'
-                        formatted_pos = "%s\t%d\t%d\t%d" % (chrom, pos_start - 1, pos_end, pos_score)
+                        pos_json = {'chrom': chrom, 'start': pos_start, 'end': pos_end,
+                                    'num_score': pos_score}
+                        formatted_pos = json.dumps(pos_json, sort_keys=True)[1:-1] + ','
+                    else:
+                        formatted_pos = "%s\t%d\t%d\t%d" % \
+                                        (chrom, pos_start - 1, pos_end, pos_score)
+                        #                                 - 1 because bed format is 'half open'
                     bed_file.write(formatted_pos + '\n')
                     if (count % 1000000) == 0:  # Make some noise every 10 minutes
                         print("%d", count)
@@ -76,15 +78,18 @@ def run(app, format_json=False, chosen_assembly=None, chosen_chrom=None, signal=
                     count_by_chrom += 1
                     coordinates = '{}:{}-{}'.format(chrom, pos['start'], pos['end'])
                     if format_json:
-                        formatted_pos = json.dumps({pos.get('rsid', coordinates): pos},sort_keys=True)[1:-1] + ','
+                        formatted_pos = json.dumps({pos.get('rsid', coordinates): pos},
+                                                   sort_keys=True)[1:-1] + ','
                     else:
-                        score = pos.get('score','')
-                        num_score = atlas.numeric_score(score)     # - 1 because bed format is 'half open'
-                        formatted_pos = "%s\t%d\t%d\t%s\t%d\t%s" % (chrom, pos['start'] - 1, pos['end'], \
-                                                        pos.get('rsid',coordinates), num_score, score)
+                        score = pos.get('score', '')
+                        num_score = atlas.numeric_score(score)
+                        formatted_pos = "%s\t%d\t%d\t%s\t%d\t%s" % \
+                                        (chrom, pos['start'] - 1, pos['end'],
+                                         pos.get('rsid', coordinates), num_score, score)
+                        #                                    - 1 because bed format is 'half open'
                         case = atlas.make_a_case(pos)
                         for category in atlas.evidence_categories():  # in order
-                            formatted_pos += '\t%s' % case.get(category,'')
+                            formatted_pos += '\t%s' % case.get(category, '')
                     bed_file.write(formatted_pos + '\n')
                     if (count % 1000000) == 0:  # Make some noise every 10 minutes
                         print("%d", count)
@@ -96,12 +101,14 @@ def run(app, format_json=False, chosen_assembly=None, chosen_chrom=None, signal=
                 chrom_count += 1
         took = '%.3f' % (time.time() - begin)    # DEBUG: timing
         if format_json:
-            bed_file.write('"took": %s,\n"chrom_count": %d,\n"count": %d\n}\n' % (took, chrom_count, count))
+            bed_file.write('"took": %s,\n"chrom_count": %d,\n"count": %d\n}\n' %
+                           (took, chrom_count, count))
         else:
             yield bytes('# took: %s, count: %d\n' % (took, count), 'utf-8')
         bed_file.close()
         print("wrote %d SNPs to %s", count, bed_file_name)
     print("Done (finally)")
+
 
 def main():
     import argparse
@@ -111,11 +118,16 @@ def main():
     )
     # sudo -u encoded bin/generate-scored-snps production.ini --assembly hg19 --chrom chr22
     parser.add_argument('config_uri', help="path to configfile")
-    parser.add_argument('--app-name', help="Pyramid app name in configfile", default='app', required=False)
-    parser.add_argument('--assembly', help="Select 'hg19' or 'GRCh38'.", default=None, required=False)
-    parser.add_argument('--chrom',    help="Limit file to a single chromosome.", default=None, required=False)
-    parser.add_argument('--signal',   help="Output bedGraph format for bigWig signal.", action='store_true', required=False)
-    parser.add_argument('--json',     help="Output JSON instead of default bed.", action='store_true', required=False)
+    parser.add_argument('--app-name', help="Pyramid app name in configfile", default='app',
+                        required=False)
+    parser.add_argument('--assembly', help="Select 'hg19' or 'GRCh38'. Default: 'GRCh38'.",
+                        default='GRCh38', required=False)
+    parser.add_argument('--chrom', help="Limit file to a single chromosome. Default: 'all'",
+                        default='all', required=False)
+    parser.add_argument('--signal', help="Output bedGraph format for bigWig signal.",
+                        action='store_true', required=False)
+    parser.add_argument('--json', help="Output JSON instead of default bed.",
+                        action='store_true', required=False)
     args = parser.parse_args()
 
     logging.basicConfig()

--- a/src/encoded/region_atlas.py
+++ b/src/encoded/region_atlas.py
@@ -507,7 +507,7 @@ class RegulomeAtlas(RegionAtlas):
                                         region_end = base
                                         continue
                                     if region_score > 0:  # end previous region?
-                                        yield (region_start - 1, region_end, region_score)
+                                        yield (region_start, region_end, region_score)
                                     # start new region
                                     region_score = num_score
                                     region_start = base
@@ -515,12 +515,12 @@ class RegulomeAtlas(RegionAtlas):
                                     continue
             # if we are here this base had no score
             if region_score > 0:  # end previous region?
-                yield (region_start - 1, region_end, region_score)
+                yield (region_start, region_end, region_score)
                 region_score = 0
                 last_uuids = base_uuids  # zero score so don't try these uuids again!
 
         if region_score > 0:  # end previous region?
-            yield (region_start - 1, region_end, region_score)
+            yield (region_start, region_end, region_score)
 
     def nearby_snps(self, assembly, chrom, pos, rsid=None, max_snps=10, scores=False):
         '''Return SNPs nearby to the chosen SNP.'''

--- a/src/encoded/region_atlas.py
+++ b/src/encoded/region_atlas.py
@@ -1,0 +1,592 @@
+import logging
+import json
+from elasticsearch.exceptions import (
+    NotFoundError
+)
+from .region_indexer import (
+    snp_index_key,
+    RESIDENT_REGIONSET_KEY,
+    FOR_REGION_SEARCH,
+    FOR_REGULOME_DB,
+    FOR_MULTIPLE_USES,
+    ENCODED_ALLOWED_STATUSES,
+    ENCODED_DATASET_TYPES,
+    REGULOME_ALLOWED_STATUSES,
+    REGULOME_DATASET_TYPES
+)
+
+log = logging.getLogger(__name__)
+
+# ##################################
+# RegionAtlas and RegulomeAtlas classes encapsulate the methods
+# for querying regions and SNPs from the region_index.
+# ##################################
+
+# when iterating scored snps or bases, chunk calls to index for efficiency
+# NOTE: failures seen when chunking is too large
+REGDB_SCORE_CHUNK_SIZE = 30000
+
+# RegulomeDB scores for bigWig (bedGraph) are converted to numeric and can be converted back
+REGDB_STR_SCORES = ['1a','1b','1c','1d','1e','1f','2a','2b','2c','3a','3b','4','5','6']
+REGDB_NUM_SCORES = [1000, 950, 900, 850, 800, 750, 600, 550, 500, 450, 400,300,200,100]
+
+#def includeme(config):
+#    config.scan(__name__)
+#    registry = config.registry
+#    registry['region'+INDEXER] = RegionIndexer(registry)
+
+class RegionAtlas(object):
+    '''Methods for getting stuff out of the region_index.'''
+
+    def __init__(self, region_es):
+        self.region_es = region_es
+        self.expected_use=FOR_REGION_SEARCH
+
+    def type(self):
+        return 'region search'
+
+    def allowed_statuses(self):
+        return ENCODED_ALLOWED_STATUSES
+
+    def set_type(self):
+        return ENCODED_DATASET_TYPES
+
+    def set_indices(self):
+        indices = [ set_type.lower() for set_type in ENCODED_DATASET_TYPES ]
+        return indices
+
+    def snp(self, assembly, rsid):
+        '''Return single SNP by rsid and assembly'''
+        try:
+            res = self.region_es.get(index=snp_index_key(assembly), doc_type='_all', id=rsid)
+        except Exception:
+            return None
+
+        return res['_source']
+
+    def _range_query(self, start, end, snps=False, with_inner_hits=False):
+        '''private: return peak query'''
+        # get all peaks that overlap requested region:
+        #     peak.start <= requested.end and peak.end >= requested.start
+        prefix = 'positions.'
+        if snps:
+            prefix = ''
+
+        range_clause = {
+            'bool': {
+                'must': [
+                    {'range': {prefix + 'start': {'lte': end  }}},
+                    {'range': {prefix + 'end':   {'gte': start}}}
+                ]
+            }
+        }
+        if snps:
+            filter = {'bool': {'should': [ range_clause ]}}
+        else:
+            filter = {
+                'nested': {
+                    'path': 'positions',
+                    'query': {
+                        'bool': {'should': [ range_clause ]}
+                    }
+                }
+            }
+
+        query = {
+            'query': {
+                'bool': {
+                    'filter': filter
+                }
+            },
+            '_source': snps,  # True is snps, False if regions
+        }
+        # special SLOW query will return inner_hits positions
+        if with_inner_hits:
+            query['query']['bool']['filter']['nested']['inner_hits'] = {'size': 99999}
+        return query
+
+    def find_snps(self, assembly, chrom, start, end):
+        '''Return all SNPs in a region.'''
+        range_query = self._range_query(start, end, snps=True)
+
+        try:
+            results = self.region_es.search(index=snp_index_key(assembly), doc_type=chrom,
+                                            _source=True, body=range_query, size=99999)
+        except NotFoundError:
+            return []
+        except Exception as e:
+            return []  # TODO: andle errors?
+        #log.warn('Find SNPS in %s:%d-%d found %d', chrom, start, end, len(results['hits']['hits']))
+
+        return [ hit['_source'] for hit in results['hits']['hits'] ]
+
+    #def snp_suggest(self, assembly, text):
+    # Using suggest with 60M of rsids leads to es crashing during SNP indexing
+
+    def find_peaks(self, assembly, chrom, start, end, peaks_too=False):
+        '''Return all peaks in a region.  NOTE: peaks are not filtered by use.'''
+        range_query = self._range_query(start, end, False, peaks_too)
+
+        try:
+            results = self.region_es.search(index=chrom.lower(), doc_type=assembly, _source=False,
+                                        body=range_query, size=99999)
+        except NotFoundError:
+            return None
+        except Exception as e:
+            return None
+
+        return list(results['hits']['hits'])
+
+    def _resident_details(self, uuids, use=None):
+        '''private: returns resident details filtered by use.'''
+        if use is None:
+            use = self.expected_use
+        use_types = [FOR_MULTIPLE_USES, use]
+        try:
+            id_query = {"query": {"ids": {"values": uuids}}}
+            res = self.region_es.search(index=RESIDENT_REGIONSET_KEY, body=id_query, doc_type=use_types, size=99999)
+        except Exception:
+            return None
+
+        details = {}
+        hits = res.get("hits", {}).get("hits", [])
+        for hit in hits:
+            details[hit["_id"]] = hit["_source"]
+
+        return details
+
+    def _filter_peaks_by_use(self, peaks, use=None):
+        '''private: returns peaks and resident details, both filtered by use'''
+        uuids = list(set([ peak['_id'] for peak in peaks ]))
+        details = self._resident_details(uuids, use)
+        if not details:
+            return ([], details)
+        filtered_peaks = []
+        while peaks:
+            peak = peaks.pop(0)
+            uuid = peak['_id']
+            if uuid in details:
+                filtered_peaks.append(peak)
+        return (filtered_peaks, details)
+
+    def find_peaks_filtered(self, assembly, chrom, start, end, peaks_too=False, use=None):
+        '''Return peaks in a region and resident details, both filtered by use'''
+        peaks = self.find_peaks(assembly, chrom, start, end, peaks_too=peaks_too)
+        if not peaks:
+            return (peaks, None)
+        return self._filter_peaks_by_use(peaks, use=use)
+
+    def _peak_uuids_in_overlap(self, peaks, chrom, start, end=None):
+        '''private: returns set of only the uuids for peaks that overlap a given location'''
+        if end is None:
+            end = start
+
+        overlap = set()
+        for peak in peaks:
+            for hit in peak['inner_hits']['positions']['hits']['hits']:
+                if chrom == peak['_index'] and start <= hit['_source']['end'] and end >= hit['_source']['start']:
+                    overlap.add(peak['_id'])
+                    break
+
+        return overlap
+
+    def _filter_details(self, details, uuids=None, peaks=None):
+        '''private: returns only the details that match the uuids'''
+        if uuids is None:
+            assert(peaks is not None)
+            uuids = list(set([ peak['_id'] for peak in peaks ]))
+        filtered = {}
+        for uuid in uuids:
+            if uuid in details:  # region peaks may not be in regulome only details
+                filtered[uuid] = details[uuid]
+        return filtered
+
+    def details_breakdown(self, details, uuids=None):
+        '''Return dataset and file dicts from resident details dicts.'''
+        if not details:
+            return (None, None)
+        file_dets = {}
+        dataset_dets = {}
+        if uuids is None:
+            uuids = details.keys()
+        for uuid in uuids:
+            if uuid not in details:
+                continue
+            afile = details[uuid]['file']
+            file_dets[afile['@id']] = afile
+            dataset = details[uuid]['dataset']
+            dataset_dets[dataset['@id']] = dataset
+        return (dataset_dets, file_dets)
+
+
+class RegulomeAtlas(RegionAtlas):
+    '''Methods for getting stuff out of the region_index.'''
+
+    def __init__(self, region_es):
+        super(RegulomeAtlas, self).__init__(region_es)
+        self.expected_use=FOR_REGULOME_DB
+
+    def type(self):
+        return 'regulome'
+
+    def allowed_statuses(self):
+        return REGULOME_ALLOWED_STATUSES
+
+    def set_type(self):
+        return ['Dataset']
+
+    def set_indices(self):
+        indices = [ set_type.lower() for set_type in REGULOME_DATASET_TYPES ]
+        return indices
+
+    #def snp_suggest(self, assembly, text):
+    # Using suggest with 60M of rsids leads to es crashing during SNP indexing
+
+    def evidence_categories(self):
+        '''Returns a list of regulome evidence categories'''
+        # TODO: Fix ategories to be collection_types!!!
+        return ['eQTL', 'ChIP', 'DNase', 'PWM', 'Footprint', 'PWM_matched', 'Footprint_matched']
+
+    def _score_category(self, dataset):
+        '''private: returns one of the categories of evidence that are needed for scoring.'''
+        # score categories are slighly different from regulome categories
+        collection_type = dataset.get('collection_type')  # resident_regionset dataset
+        if collection_type == 'ChIP-seq':
+            return 'ChIP'
+        if collection_type in ['DNase-seq', 'FAIRE-seq']:  # TODO: confirm FAIRE is lumped in
+            return 'DNase'                                 #       aka Chromatin_Structure
+        if collection_type == 'transcription factor motifs':
+            return 'PWM'
+        if collection_type == 'representative DNase hypersensitivity sites':
+             return 'Footprint'
+        if collection_type in ['eQTLs','dsQTLs']:
+            return 'eQTL'
+        return None
+
+    def _regulome_category(self, score_category=None, dataset=None):
+        '''private: returns one of the categories used to present evidence in a bed file.'''
+        # regulome category 'Motifs' contains score categories 'PWM' and 'Footprint'
+        if score_category is None:
+            if dataset is None:
+                return '???'
+            score_category = self._score_category(dataset)
+        if score_category == 'ChIP':
+            return 'Protein_Binding'
+        if score_category == 'DNase':
+            return 'Chromatin_Structure'
+        if score_category in ['PWM', 'Footprint']:
+            return 'Motifs'
+        if score_category == 'eQTL':
+            return 'Single_Nucleotides'
+        return '???'
+
+    def regulome_evidence(self, datasets):
+        '''Returns evidence for scoring: datasets in a characterized dict'''
+        evidence = {}
+        targets = {'ChIP': [], 'PWM': [], 'Footprint': []}
+        for dataset in datasets.values():
+            character = self._score_category(dataset)
+            if character is None:
+                continue
+            if character not in evidence:
+                evidence[character] = []
+            evidence[character].append(dataset)
+            target = dataset.get('target')
+            if target and character in ['ChIP', 'PWM', 'Footprint']:
+                if isinstance(target, str):
+                    targets[character].append(target)
+                elif isinstance(target, list):  # rare but PWM targets might be list
+                    for targ in target:
+                        targets[character].append(targ)
+
+        # Targets... For each ChIP target, there could be a PWM and/or Footprint to match
+        for target in targets['ChIP']:
+            if target in targets['PWM']:
+                if 'PWM_matched' not in evidence:
+                    evidence['PWM_matched'] = []
+                evidence['PWM_matched'].append(target)
+            if target in targets['Footprint']:
+                if 'Footprint_matched' not in evidence:
+                    evidence['Footprint_matched'] = []
+                evidence['Footprint_matched'].append(target)
+
+        return evidence
+
+    def _write_a_brief(self, category, snp_evidence):
+        '''private: given evidence for a category make a string that summarizes it'''
+        snp_evidence_category = snp_evidence[category]
+
+        # What do we want the brief to look like?
+        # Regulome: Chromatin_Structure|DNase-seq|Chorion|, Chromatin_Structure|DNase-seq|Adultcd4th1|, Protein_Binding|ChIP-seq|E2F1|MCF-7|, ...
+        # Us: Chromatin_Structure:DNase-seq:|ENCSR...|Chorion|,|ENCSR...|Adultcd4th1| (tab) Protein_Binding/ChIP-seq:|ENCSR...|E2F1|MCF-7|,|ENCSR...|SP4|H1-hESC|
+        brief = ''
+        cur_score_category = ''
+        cur_regdb_category = ''
+        for dataset in snp_evidence_category:
+            new_score_category = self._score_category(dataset)
+            if cur_score_category != new_score_category:
+                cur_score_category = new_score_category
+                new_regdb_category = self._regulome_category(cur_score_category)
+                if cur_regdb_category != new_regdb_category:
+                    cur_regdb_category = new_regdb_category
+                    if brief != '':  # 'PWM' and 'Footprint' are both 'Motif'
+                        brief += ';'
+                    brief += '%s:' % cur_regdb_category
+                brief += '%s:|' % cur_score_category
+            try:
+                brief += dataset.get('@id', '').split('/')[-2] + '|'  # accession is buried in @id
+            except:
+                brief += '|'
+            target = dataset.get('target')
+            if target:
+                if isinstance(target, list):
+                    target = '/'.join(target)
+                brief += target.replace(' ', '') + '|'
+            biosample = dataset.get('biosample_term_name',dataset.get('biosample_summary'))
+            if biosample:
+                brief += biosample.replace(' ', '') + '|'
+            brief += ','
+        return brief[:-1] # remove last comma
+
+    def make_a_case(self, snp):
+        '''Convert evidence json to list of evidence strings for bed batch downloads.'''
+        case = {}
+        if 'evidence' in snp:
+            for category in snp['evidence'].keys():
+                if category.endswith('_matched'):
+                    case[category] = ','.join(snp['evidence'][category])
+                else:
+                    case[category] = self._write_a_brief(category, snp['evidence'])
+        return case
+
+    def _score(self, charactization):
+        '''private: returns regulome score from characterization set'''
+        if 'eQTL' in charactization:
+            if 'ChIP' in charactization:
+                if 'DNase':
+                    if 'PWM_matched' in charactization and 'Footprint_matched' in charactization:
+                        return '1a'
+                    if 'PWM' in charactization and 'Footprint' in charactization:
+                        return '1b'
+                    if 'PWM_matched' in charactization:
+                        return '1c'
+                    if 'PWM' in charactization:
+                        return '1d'
+                elif 'PWM_matched' in charactization:
+                    return '1e'
+                return '1f'
+            if 'DNase' in charactization:
+                return '1f'
+        if 'ChIP' in charactization:
+            if 'DNase':
+                if 'PWM_matched' in charactization and 'Footprint_matched' in charactization:
+                    return '2a'
+                if 'PWM' in charactization and 'Footprint' in charactization:
+                    return '2b'
+                if 'PWM_matched' in charactization:
+                    return '2c'
+                if 'PWM' in charactization:
+                    return '3a'
+            elif 'PWM_matched' in charactization:
+                return '3b'
+            if 'DNase' in charactization:
+                return '4'
+            return '5'
+        if 'DNase' in charactization:
+            return '5'
+        if 'PWM' in charactization or 'Footprint' in charactization or 'eQTL' in charactization:
+            return '6'
+
+        return None  # "Found: " + str(characterize)
+
+
+    def regulome_score(self, datasets, evidence=None):
+        '''Calculate RegulomeDB score based upon hits and voodoo'''
+        if not evidence:
+            evidence = self.regulome_evidence(datasets)
+            if not evidence:
+                return None
+        return self._score(set(evidence.keys()))
+
+    def _snp_window(self, snps, window, center_pos=None):
+        '''Reduce a list of snps to a set number of snps centered around position'''
+        if len(snps) <= window:
+            return snps
+
+        # find ix of pos NOTE: luckily these are sorted on start!
+        ix = 0
+        for snp in snps:
+            if snp['start'] >= center_pos:
+                break
+            ix += 1
+
+        first_ix = int(ix - (window / 2))
+        if first_ix > 0:
+            snps = snps[first_ix:]
+        return snps[:window]
+
+    def _scored_snps(self, assembly, chrom, start, end, window=-1, center_pos=None):
+        '''For a region, yields all SNPs with scores'''
+        snps = self.find_snps(assembly, chrom, start, end)
+        if not snps:
+            return
+        if window > 0:
+            snps = self._snp_window(snps, window, center_pos)
+
+        start = snps[0]['start']  # SNPs must be in location order!
+        end = snps[-1]['end']                                        # MUST do SLOW peaks_too
+        (peaks, details) = self.find_peaks_filtered(assembly, chrom, start, end, peaks_too=True)
+        if not peaks or not details:
+            for snp in snps:
+                snp['score'] = None
+                yield snp
+                return
+
+        last_uuids = {}
+        last_snp = {}
+        for snp in snps:
+            snp['score'] = None  # default
+            snp['assembly'] = assembly
+            snp_uuids = self._peak_uuids_in_overlap(peaks, snp['chrom'], snp['start'])
+            if snp_uuids:
+                if snp_uuids == last_uuids:  # good chance evidence hasn't changed
+                    if last_snp:
+                        snp['score'] = last_snp['score']
+                        if 'evidence' in last_snp:
+                            snp['evidence'] = last_snp['evidence']
+                    yield snp
+                    continue
+                else:
+                    last_uuids = snp_uuids
+                    snp_details = self._filter_details(details, uuids=list(snp_uuids))
+                    if snp_details:
+                        (snp_datasets, snp_files) = self.details_breakdown(snp_details)
+                        if snp_datasets:
+                            snp_evidence = self.regulome_evidence(snp_datasets)
+                            if snp_evidence:
+                                snp['score'] = self.regulome_score(snp_datasets, snp_evidence)
+                                snp['evidence'] = snp_evidence
+                                #snp['datasets'] = snp_datasets
+                                #snp['files'] = snp_files
+                                last_snp = snp
+                                yield snp
+                                continue
+            # if we are here this snp had no score
+            last_snp = {}
+            yield snp
+
+    def _scored_regions(self, assembly, chrom, start, end):
+        '''For a region, yields sub-regions (start, end, score) of contiguous numeric score > 0'''
+        (peaks, details) = self.find_peaks_filtered(assembly, chrom, start, end, peaks_too=True)
+        if not peaks or not details:
+            return
+
+        last_uuids = set()
+        region_start = 0
+        region_end = 0
+        region_score = 0
+        num_score = 0
+        for base in range(start, end):
+            base_uuids = self._peak_uuids_in_overlap(peaks, chrom, base)
+            if base_uuids:
+                if base_uuids == last_uuids:
+                    region_end = base  # extend region
+                    continue
+                else:
+                    last_uuids = base_uuids
+                    base_details = self._filter_details(details, uuids=list(base_uuids))
+                    if base_details:
+                        (base_datasets, base_files) = self.details_breakdown(base_details)
+                        if base_datasets:
+                            base_evidence = self.regulome_evidence(base_datasets)
+                            if base_evidence:
+                                score = self.regulome_score(base_datasets, base_evidence)
+                                if score:
+                                    num_score = self.numeric_score(score)
+                                    if num_score == region_score:
+                                        region_end = base
+                                        continue
+                                    if region_score > 0:  # end previous region?
+                                        yield (region_start - 1, region_end, region_score)
+                                    # start new region
+                                    region_score = num_score
+                                    region_start = base
+                                    region_end = base
+                                    continue
+            # if we are here this base had no score
+            if region_score > 0:  # end previous region?
+                yield (region_start - 1, region_end, region_score)
+                region_score = 0
+                last_uuids = base_uuids  # zero score so don't try these uuids again!
+
+        if region_score > 0:  # end previous region?
+            yield (region_start - 1, region_end, region_score)
+
+    def nearby_snps(self, assembly, chrom, pos, rsid=None, max_snps=10, scores=False):
+        '''Return SNPs nearby to the chosen SNP.'''
+        if rsid:
+            max_snps += 1
+
+        range_start = pos - 800
+        range_end = pos + 800
+        if range_start < 0:
+            range_end += 0 - range_start
+            range_start = 0
+
+        if scores:
+            snps = self._scored_snps(assembly, chrom, range_start, range_end, max_snps, pos)
+            for snp in snps:
+                snp.pop('evidence', None)  # don't need this much detail
+        else:
+            snps = self.find_snps(assembly, chrom, range_start, range_end)
+            snps = self._snp_window(snps, max_snps, pos)
+
+        return snps
+
+    def iter_scored_snps(self, assembly, chrom, start, end, base_level=False):
+        '''For a region, iteratively yields all SNPs with scores.'''
+        if end < start:
+            return
+        chunk_size = REGDB_SCORE_CHUNK_SIZE
+        chunk_start = start
+        while chunk_start <= end:
+            chunk_end = chunk_start + chunk_size
+            if chunk_end > end:
+                chunk_end = end
+            yield from self._scored_snps(assembly, chrom, chunk_start, chunk_end)
+            chunk_start += chunk_size
+
+    def iter_scored_signal(self, assembly, chrom, start, end):
+        '''For a region, iteratively yields all bedGraph styled regions of contiguous numeric score.'''
+        if end < start:
+            return
+        chunk_size = REGDB_SCORE_CHUNK_SIZE
+        chunk_start = start
+        while chunk_start <= end:
+            chunk_end = chunk_start + chunk_size
+            if chunk_end > end:
+                chunk_end = end
+            yield from self._scored_regions(assembly, chrom, chunk_start, chunk_end)
+            chunk_start += chunk_size
+
+    def live_score(self, assembly, chrom, pos):
+        '''Returns score knowing single position and nothing more.'''
+        (peaks, details) = self.find_peaks_filtered(assembly, chrom, pos, pos)
+        if not peaks or not details:
+            return None
+        (datasets, files) = self.details_breakdown(details)
+        return self.regulome_score(datasets)
+
+    def numeric_score(self, alpha_score):
+        '''converst str score to numeric representation (for bedGraph)'''
+        try:
+            return REGDB_NUM_SCORES[REGDB_STR_SCORES.index(alpha_score)]
+        except:
+            return 0
+
+    def str_score(self, int_score):
+        '''converst numeric representation of score to standard string score'''
+        try:
+            return REGDB_STR_SCORES[REGDB_NUM_SCORES.index(int_score)]
+        except:
+            return ''

--- a/src/encoded/region_indexer.py
+++ b/src/encoded/region_indexer.py
@@ -9,10 +9,14 @@ import requests
 import os
 from pyramid.view import view_config
 from sqlalchemy.sql import text
+from shutil import copyfileobj
 from elasticsearch.exceptions import (
     NotFoundError
 )
-from elasticsearch.helpers import scan
+from elasticsearch.helpers import (
+    scan,
+    bulk
+)
 from snovault import DBSESSION, COLLECTIONS
 #from snovault.storage import (
 #    TransactionRecord,
@@ -22,8 +26,7 @@ from snovault.elasticsearch.indexer import (
 )
 from snovault.elasticsearch.indexer_state import (
     SEARCH_MAX,
-    IndexerState,
-    all_uuids
+    IndexerState
 )
 
 from snovault.elasticsearch.interfaces import (
@@ -34,25 +37,42 @@ from snovault.elasticsearch.interfaces import (
 
 log = logging.getLogger(__name__)
 
-
+# ##################################
 # Region indexer 2.0
 # What it does:
 # 1) get list of uuids of primary indexer and filter down to datasets covered
 # 2) walk through uuid list querying encoded for each doc[embedded]
 #    3) Walk through embedded files
-#       4) If file passes required tests (e.g. bed, released, DNase narrowpeak) AND not in regions_es, put in regions_es
-#       5) If file does not pass tests                                          AND     IN regions_es, remove from regions_es
+#       4) If file passes required tests (e.g. bed, released, ...) AND not in regions_es, put in regions_es
+#       5) If file does not pass tests                             AND     IN regions_es, remove from regions_es
 # TODO:
-# *) Build similar path for regulome files
-# - regulomeDb versions of ENCODED_ALLOWED_FILE_FORMATS, ENCODED_ALLOWED_STATUSES, add_encoded_to_regions_es()
+# Add snp 'suggest' to regulome-search (not real useful)
+# Add score to snp indexing (takes a LONG time to calculate them all)
+# Add nearby snps (with scores) to regulome-search, and means to select them!
+#     only after scores are in index
+# Update resident doc, even when file is already resident.
+# ##################################
 
-# Species and references being indexed
-SUPPORTED_ASSEMBLIES = ['hg19', 'mm10', 'mm9', 'GRCh38']
 
-ENCODED_ALLOWED_FILE_FORMATS = ['bed']
-ENCODED_ALLOWED_STATUSES = ['released']
+# TEMPORARY: limit SNPs to major chroms
+SUPPORTED_CHROMOSOMES = [
+    'chr1',  'chr2',  'chr3',  'chr4',  'chr5',  'chr6',  'chr7',  'chr8',  'chr9',  'chr10',
+    'chr11', 'chr12', 'chr13', 'chr14', 'chr15', 'chr16', 'chr17', 'chr18', 'chr19', 'chr20',
+    'chr21', 'chr22', 'chrX',  'chrY']  # chroms are lower case
+
+ALLOWED_FILE_FORMATS = ['bed']
 RESIDENT_REGIONSET_KEY = 'resident_regionsets'  # in regions_es, keeps track of what datsets are resident in one place
 
+FOR_REGION_SEARCH = 'region_search'
+#FOR_REGULOME_DB = 'RegulomeDB'
+#FOR_MULTIPLE_USES = 'multiple'  # Only used for residence doc_type to aid accounting
+# TODO: requires deleting indexes and then full reindexing
+FOR_REGULOME_DB = 'regulomedb'
+FOR_MULTIPLE_USES = 'region_regulomedb'  # doc_type = region*  or *regulomedb
+
+ENCODED_SUPPORTED_ASSEMBLIES = ['hg19', 'mm10', 'mm9', 'GRCh38']
+ENCODED_ALLOWED_STATUSES = ['released']
+ENCODED_DATASET_TYPES = ['Experiment']
 ENCODED_REGION_REQUIREMENTS = {
     'ChIP-seq': {
         'output_type': ['optimal idr thresholded peaks'],
@@ -68,6 +88,59 @@ ENCODED_REGION_REQUIREMENTS = {
     }
 }
 
+REGULOME_SUPPORTED_ASSEMBLIES = ['hg19', 'GRCh38']
+REGULOME_ALLOWED_STATUSES = ['released', 'archived', 'in progress']  # in progress NOT for files: permission
+REGULOME_DATASET_TYPES   = ['Experiment', 'Annotation', 'Reference']
+REGULOME_COLLECTION_TYPES = ['assay_term_name', 'annotation_type', 'reference_type']
+# NOTE: regDB requirements keyed on "collection_type": assay_term_name or else annotation_type
+REGULOME_REGION_REQUIREMENTS = {
+    'ChIP-seq': {
+        'output_type': ['optimal idr thresholded peaks'],
+        'file_format': ['bed']
+    },
+    'DNase-seq': {
+        'file_type': ['bed narrowPeak'],
+        'file_format': ['bed']
+    },
+    'FAIRE-seq': {
+        'file_type': ['bed narrowPeak'],
+        'file_format': ['bed']
+    },
+    'chromatin state': {
+        'file_format': ['bed']
+    },
+    'transcription factor motifs': {  # AKA PWMs
+        'output_type': ['motif model'],
+        'file_format': ['bed']
+    },
+    'representative DNase hypersensitivity sites': {  # AKA Footprints
+        'file_format': ['bed']
+    },
+    'eQTLs': {
+        'file_format': ['bed']
+    },
+    'dsQTLs': {
+        'file_format': ['bed']
+    },
+    'index': {  # TODO: reference of variant calls doesn't yet exist.  'index' is temporary
+        'output_type': ['variant calls'],
+        'file_format': ['bed']
+    }
+}
+# Less than ideal way to recognize the SNP files by submitted_file_name
+# SNP_DATASET_UUID = 'ff8dff4e-1de5-446b-8a13-bb6243bc64aa'  # works on demo, but...
+SNP_FILES = [
+    's3://regulomedb/snp141/snp141_hg19.bed.gz',
+    's3://regulomedb/snp141/snp141_GRCh38.bed.gz'
+]
+# scores for bigWig (bedGraph) are converted to numeric and can be converted back
+SNP_STR_SCORES = ['1a','1b','1c','1d','1e','1f','2a','2b','2c','3a','3b','4','5','6']
+SNP_NUM_SCORES = [1000, 950, 900, 850, 800, 750, 600, 550, 500, 450, 400,300,200,100]
+
+# If files are too large then they will be copied locally and read
+MAX_IN_MEMORY_FILE_SIZE = (700 * 1024 * 1024)  # most files will be below this and index faster
+TEMPORARY_REGIONS_FILE = '/tmp/region_temp.bed.gz'
+
 # On local instance, these are the only files that can be downloaded and regionalizable.  Currently only one is!
 TESTABLE_FILES = ['ENCFF002COS']  # '/static/test/peak_indexer/ENCFF002COS.bed.gz']
                                   # '/static/test/peak_indexer/ENCFF296FFD.tsv',     # tsv's some day?
@@ -81,15 +154,8 @@ def includeme(config):
     registry = config.registry
     registry['region'+INDEXER] = RegionIndexer(registry)
 
-def tsvreader(file):
-    reader = csv.reader(file, delimiter='\t')
-    for row in reader:
-        yield row
-
-# Mapping should be generated dynamically for each assembly type
-
-
-def get_mapping(assembly_name='hg19'):
+# Region mapping: index: chr*, doc_type: assembly, _id=uuid
+def get_chrom_index_mapping(assembly_name='hg19'):
     return {
         assembly_name: {
             '_all': {
@@ -117,34 +183,193 @@ def get_mapping(assembly_name='hg19'):
         }
     }
 
+# Files are also put in the resident: index: RESIDENT_REGIONSET_KEY, doc_type: use_type, _id=uuid
+def get_resident_mapping(use_type=FOR_MULTIPLE_USES):
+    return {use_type: {"enabled": False}}
+    # True map: IF we ever want to query by anything other than uuid...
+    # return {
+    #     use_type: {
+    #         '_all':    {'enabled': False},
+    #         '_source': {'enabled': True},
+    #         'properties': {
+    #             'uuid':   {'type': 'keyword'},  # same as _id and file['uuid']
+    #             'uses':   {'type': 'keyword'},  # e.g FOR_REGULOME_DB
+    #             'chroms': {'type': 'keyword'},  # Used to remove from 'chr*' indices
+    #             'snps':   {'type': 'boolean'},  # If present, then this is a file of SNPs
+    #             'index':  {'type': 'keyword'},  # If present, the 1 index for this 1 SNP file
+    #             'file': {
+    #                 'properties': {
+    #                     'uuid':     {'type': 'keyword'},  # Yes, redundant
+    #                     '@id':      {'type': 'keyword'},
+    #                     'assembly': {'type': 'keyword'},
+    #                 }
+    #             },
+    #             'dataset': {
+    #                 'properties': {
+    #                     'uuid':            {'type': 'keyword'},
+    #                     '@id':             {'type': 'keyword'},
+    #                     'assay_term_name': {'type': 'keyword'},  # \
+    #                     'annotation_type': {'type': 'keyword'},  # - only one of these three will appear
+    #                     'reference_type':  {'type': 'keyword'},  # /
+    #                     'collection_type': {'type': 'keyword'},  # assay or else annotation
+    #                     'target':          {'type': 'keyword'},  # could be array (e.g. PWM targets)
+    #                     'dataset_type':    {'type': 'keyword'}   # 1st @type of *_PRIORITIZED_TYPES
+    #                 }
+    #             }
+    #         }
+    #     }
+    # }
+
+# SNP mapping index: snp141_hg19, doc_type: chr*, _id=rsid
+def get_snp_index_mapping(chrom='chr1'):
+    return {
+        chrom: {
+            '_all': {
+                'enabled': False
+            },
+            '_source': {
+                'enabled': True
+            },
+            'properties': {
+                'rsid': {
+                    'type': 'keyword'
+                },
+                'chrom': {
+                    'type': 'keyword'
+                },
+                'start': {
+                    'type': 'long'
+                },
+                'end': {
+                    'type': 'long'
+                }
+            }
+        }
+    }
+# This results in too much stress on elasticsearch: it crashes doring indexing of 60M rsids
+#                'suggest' : {
+#                    'type' : 'completion'
+#                },
+
+SNP_INDEX_PREFIX = 'snp141_'
+def snp_index_key(assembly):
+    return SNP_INDEX_PREFIX + assembly.lower()
+
 
 def index_settings():
     return {
         'index': {
-            'number_of_shards': 1,
+            'number_of_shards': 2,
             'max_result_window': 99999
         }
     }
 
 
-#def all_regionable_dataset_uuids(registry):
-#    # NOTE: this old method needs postgres.  Avoid using postgres
-#    return list(all_uuids(registry, types=["experiment"]))
-
-
 def encoded_regionable_datasets(request, restrict_to_assays=[]):
     '''return list of all dataset uuids eligible for regions'''
-
-    encoded_es = request.registry[ELASTIC_SEARCH]
-    encoded_INDEX = request.registry.settings['snovault.elasticsearch.index']
-
     # basics... only want uuids of experiments that are released
-    query = '/search/?type=Experiment&field=uuid&status=released&limit=all'
+    query = '/search/?type=Experiment&field=uuid&limit=all'
+    for status in ENCODED_ALLOWED_STATUSES:
+        query += '&status=' + status
     # Restrict to just these assays
     for assay in restrict_to_assays:
         query += '&assay_title=' + assay
     results = request.embed(query)['@graph']
     return [ result['uuid'] for result in results ]
+
+def regulome_regionable_datasets(request):
+    query = '/search/?type=Dataset&field=uuid&limit=all'
+    query += '&internal_tags=RegulomeDB'
+    for status in REGULOME_ALLOWED_STATUSES:
+        query += '&status=' + status
+    results = request.embed(query)['@graph']
+    return [ result['uuid'] for result in results ]
+
+def regulome_collection_type(dataset):
+    for prop in REGULOME_COLLECTION_TYPES:
+        if prop in dataset:
+            return dataset[prop]
+    return None
+
+
+class RemoteReader(object):
+    # Tools for reading remote files
+
+    def __init__(self, test_instance=False):
+        self.temp_file = TEMPORARY_REGIONS_FILE
+        self.max_memory = MAX_IN_MEMORY_FILE_SIZE
+        self.test_instance = test_instance
+
+    def readable_file(self, request, afile):
+        '''returns either an in memory file or a temp file'''
+
+        # Special case local instance so that tests can work...
+        if self.test_instance:
+            href = 'http://www.encodeproject.org' + afile['href']  # test files are read from production
+        else:
+            href = request.host_url + afile['href']
+
+        # TODO: support for remote access for big files (could do bam and vcf as well)
+        #if afile.get('file_format') in ['bigBed', 'bigWig']:
+        #    return href
+        #assert(afile.get('file_format') == 'bed')
+
+        # Note: this reads the file into an in-memory byte stream.  If files get too large,
+        # We could replace this with writing a temp file, then reading it via gzip and tsvreader.
+        urllib3.disable_warnings()
+        http = urllib3.PoolManager()
+
+        # use afile.get(file_size) to decide between in mem file or temp file
+        file_to_read = None
+        if afile.get('file_size', 0) > self.max_memory:
+            with http.request('GET',href, preload_content=False) as r, open(self.temp_file, 'wb') as out_file:
+                copyfileobj(r, out_file)
+            file_to_read = self.temp_file
+            log.warn('Wrote %s to %s', href, file_to_read)
+        else:
+            r = http.request('GET', href)
+            if r.status != 200:
+                log.warn("File (%s or %s) not found" % (afile['@id'], href))
+                return False
+            file_in_mem = io.BytesIO()
+            file_in_mem.write(r.data)
+            file_in_mem.seek(0)
+            file_to_read = file_in_mem
+        r.release_conn()
+
+        return file_to_read
+
+    def tsv(self, file_handle):
+        reader = csv.reader(file_handle, delimiter='\t')
+        for row in reader:
+            yield row
+
+    def region(self, row):
+        '''Read a region from an in memory row and returns chrom and document to index.'''
+        chrom, start, end = row[0], int(row[1]), int(row[2])
+        return (chrom, {'start': start + 1, 'end': end})  # bed loc 'half-open', but we will close it
+
+    def snp(self, row):
+        '''Read a SNP from an in memory row and returns chrom and document to index.'''
+        chrom, start, end, rsid = row[0], int(row[1]), int(row[2]), row[3]
+        return (chrom, {'rsid': rsid, 'chrom': chrom, 'start': start + 1, 'end': end})  # bed loc 'half-open'
+
+    # TODO: support bigBeds
+    #def bb_region(self, row):
+    #    '''Read a region from a bigBed file read with "pyBigWig" and returns document to index.'''
+    #    start, end = int(row[0]), int(row[1])
+    #    return {'start': start + 1, 'end': end}  # bed loc 'half-open', but we will close it
+
+    # TODO: support bigBeds
+    #def bb_snp(self, row):
+    #    '''Read a SNP from a bigBed file read with "pyBigWig"  and returns document to index.'''
+    #    start, end = int(row[0]), int(row[1])
+    #    extras = row[3].split('\t')
+    #    rsid = extras[0]
+    #    num_score = int(extras[1])
+    #    score = extras[2]
+    #    start, end, rsid = row[0], int(row[0]), int(row[2]), row[3]
+    #    return {'rsid': rsid, 'chrom': chrom, 'start': start + 1, 'end': end, 'num_score': num_score, 'score': score}
 
 
 class RegionIndexerState(IndexerState):
@@ -165,10 +390,16 @@ class RegionIndexerState(IndexerState):
     def file_dropped(self, uuid):
         self.list_extend(self.files_added_set, [uuid])
 
+    def all_indexable_uuids_set(self, request):
+        '''returns set of uuids. allowing intersections.'''
+        assays = list(ENCODED_REGION_REQUIREMENTS.keys())
+        uuids = set(encoded_regionable_datasets(request, assays))
+        uuids |= set(regulome_regionable_datasets(request))
+        return uuids  # Uses elasticsearch query
+
     def all_indexable_uuids(self, request):
         '''returns list of uuids pertinant to this indexer.'''
-        assays = list(ENCODED_REGION_REQUIREMENTS.keys())
-        return encoded_regionable_datasets(request, assays)  # Uses elasticsearch query
+        return list(self.all_indexable_uuids_set(request))
 
     def priority_cycle(self, request):
         '''Initial startup, reindex, or interupted prior cycle can all lead to a priority cycle.
@@ -214,11 +445,6 @@ class RegionIndexerState(IndexerState):
                 return (uuids, True)
             if status == "restart":  # Restart is fine... just do the uuids over again
                 return (uuids, False)
-                #log.info('%s skipping this restart' % (self.state_id))
-                #state = self.get()
-                #state['status'] = "interrupted"
-                #self.put(state)
-                #return ([], False)
         assert(uuids == [])
 
         # Normal case, look for uuids staged by primary indexer
@@ -238,8 +464,7 @@ class RegionIndexerState(IndexerState):
         if len(uuids) > 500:  # some arbitrary cutoff.
             # There is an efficiency trade off examining many non-dataset uuids
             # # vs. the cost of eliminating those uuids from the list ahead of time.
-            assays = list(ENCODED_REGION_REQUIREMENTS.keys())
-            uuids = list(set(encoded_regionable_datasets(request, assays)).intersection(uuids))
+            uuids = list(self.all_indexable_uuids_set(request).intersection(uuids))
             uuid_count = len(uuids)
 
         return (list(set(uuids)),False)  # Only unique uuids
@@ -269,6 +494,29 @@ class RegionIndexerState(IndexerState):
         self.put(state)
 
         return state
+
+    def counts(self, region_es, assemblies=None):
+        '''returns counts (region files, regulome files, snp files and all files)'''
+        counts = {'all_files': 0}
+        for use in [FOR_REGION_SEARCH, FOR_REGULOME_DB, FOR_MULTIPLE_USES]:
+            try:
+                counts[use] = region_es.count(index=RESIDENT_REGIONSET_KEY, doc_type=use).get('count',0)
+            except:
+                counts[use] = 0
+            counts['all_files'] += counts[use]
+        counts[FOR_REGION_SEARCH] += counts[FOR_MULTIPLE_USES]
+        counts[FOR_REGULOME_DB] += counts[FOR_MULTIPLE_USES]
+        counts.pop(FOR_MULTIPLE_USES, None)
+
+        if assemblies:
+            counts['SNPs'] = {}
+            for assembly in assemblies:
+                try:
+                    counts['SNPs'][assembly] = region_es.count(index=snp_index_key(assembly)).get('count',0)
+                except:
+                    counts['SNPs'][assembly] = 0
+
+        return counts
 
     def display(self, uuids=None):
         display = super(RegionIndexerState, self).display(uuids=uuids)
@@ -300,16 +548,17 @@ def regionindexer_state_show(request):
         notices = state.set_notices(request.host_url, who, bot_token, request.params.get("which"))
         if notices is not None:
             return notices
+    # Note: if reindex=all then maybe we should delete the entire region_index
+    # On the otherhand, that should probably be left for extreme cases done by hand
+    # curl -XDELETE http://localhost:9201/resident_datasets/
+    # curl -XDELETE http://localhost:9201/chr*/
 
     display = state.display(uuids=request.params.get("uuids"))
-
-    try:
-        count = regions_es.count(index=RESIDENT_REGIONSET_KEY, doc_type='default').get('count',0)
-        if count:
-            display['files_in_index'] = count
-    except:
-        display['files_in_index'] = 'Not Found'
-        pass
+    counts = state.counts(regions_es, REGULOME_SUPPORTED_ASSEMBLIES)
+    display['files_for_region_search'] = counts.get(FOR_REGION_SEARCH,0)
+    display['files_for_regulomedb'] = counts.get(FOR_REGULOME_DB,0)
+    display['files_in_index'] = counts.get('all_files',0)
+    display['snps_in_index'] = counts.get('SNPs',0)
 
     if not request.registry.settings.get('testing',False):  # NOTE: _indexer not working on local instances
         try:
@@ -343,16 +592,6 @@ def index_regions(request):
 
     (uuids, force) = state.get_one_cycle(request)
 
-    # Note: if reindex=all_uuids then maybe we should delete the entire index
-    # On the otherhand, that should probably be left for extreme cases done by hand
-    # curl -XDELETE http://region-search-test-v5.instance.encodedcc.org:9200/resident_datasets/
-    #if force == 'all':  # Unfortunately force is a simple boolean
-    #    try:
-    #        r = indexer.regions_es.indices.delete(index='chr*')  # Note region_es and encoded_es may be the same!
-    #        r = indexer.regions_es.indices.delete(index=self.residents_index)
-    #    except:
-    #        pass
-
     uuid_count = len(uuids)
     if uuid_count > 0 and not dry_run:
         log.info("Region indexer started on %d uuid(s)" % uuid_count)
@@ -361,13 +600,10 @@ def index_regions(request):
         errors = indexer.update_objects(request, uuids, force)
         result = state.finish_cycle(result, errors)
         if result['indexed'] == 0:
-            log.info("Region indexer added %d file(s) from %d dataset uuids" % (result['indexed'], uuid_count))
-
-        # cycle_took: "2:31:55.543311" reindex all with force (2017-10-16ish)
+            log.warn("Region indexer added %d file(s) from %d dataset uuids" % (result['indexed'], uuid_count))
 
     state.send_notices()
     return result
-
 
 class RegionIndexer(Indexer):
     def __init__(self, registry):
@@ -378,10 +614,7 @@ class RegionIndexer(Indexer):
         self.residents_index = RESIDENT_REGIONSET_KEY
         self.state = RegionIndexerState(self.encoded_es,self.encoded_INDEX)  # WARNING, race condition is avoided because there is only one worker
         self.test_instance = registry.settings.get('testing',False)
-
-    def get_from_es(request, comp_id):
-        '''Returns composite json blob from elastic-search, or None if not found.'''
-        return None
+        self.reader = RemoteReader(self.test_instance)
 
     def update_object(self, request, dataset_uuid, force):
         request.datastore = 'elasticsearch'  # Let's be explicit
@@ -395,92 +628,234 @@ class RegionIndexer(Indexer):
             return
 
         # TODO: add case where files are never dropped (when demos share test server this might be necessary)
-        if not self.encoded_candidate_dataset(dataset):
+        dataset_region_uses = self.candidate_dataset(dataset)
+        if not dataset_region_uses:
             return  # Note that if a dataset is no longer a candidate but it had files in regions es, they won't get removed.
-        #log.debug("dataset is a candidate: %s", dataset['accession'])
-
-        assay_term_name = dataset.get('assay_term_name')
-        if assay_term_name is None:
-            return
+        #log.warn("dataset is a candidate: %s", dataset['accession'])  # DEBUG
 
         files = dataset.get('files',[])
         for afile in files:
-            if afile.get('file_format') not in ENCODED_ALLOWED_FILE_FORMATS:
+            # files may not be embedded
+            if isinstance(afile, str):
+                file_id = afile
+                try:
+                    afile = request.embed(file_id, as_user=True)
+                except:
+                    log.warn("file is not found for: %s",file_id)
+                    continue
+
+            if afile.get('file_format') not in ALLOWED_FILE_FORMATS:
                 continue  # Note: if file_format changed to not allowed but file already in regions es, it doesn't get removed.
 
             file_uuid = afile['uuid']
 
-            if self.encoded_candidate_file(afile, assay_term_name):
+            file_doc = self.candidate_file(request, afile, dataset, dataset_region_uses)
+            if file_doc:
 
+                #log.warn("file is a candidate: %s", afile['accession'])  # DEBUG
                 using = ""
                 if force:
                     using = "with FORCE"
-                    #log.debug("file is a candidate: %s %s", afile['accession'], using)
                     self.remove_from_regions_es(file_uuid)  # remove all regions first
                 else:
-                    #log.debug("file is a candidate: %s", afile['accession'])
                     if self.in_regions_es(file_uuid):
+                        # TODO: update residence doc but not file!
                         continue
 
-                if self.add_encoded_file_to_regions_es(request, assay_term_name, afile):
+                if self.add_file_to_regions_es(request, afile, file_doc):
                     log.info("added file: %s %s %s", dataset['accession'], afile['href'], using)
                     self.state.file_added(file_uuid)
 
             else:
                 if self.remove_from_regions_es(file_uuid):
-                    log.info("dropped file: %s %s %s", dataset['accession'], afile['@id'], using)
+                    log.warn("dropped file: %s %s", dataset['accession'], afile['@id'])
                     self.state.file_dropped(file_uuid)
 
+        try:
+            self.regions_es.indices.flush_synced(index='chr*')
+            self.regions_es.indices.flush_synced(index=SNP_INDEX_PREFIX+'*')
+            self.regions_es.indices.flush_synced(index=self.residents_index)
+        except:
+            pass
         # TODO: gather and return errors
 
+    def check_embedded_targets(self, request, dataset):
+        '''Make sure taget or targets is embedded.'''
+        # Not all datasets will have a target but if they do it must be embeeded
+        target = dataset.get('target')
+        if target is not None:
+            if not isinstance(target, str):
+                return target
+            else:
+                try:
+                    return request.embed(target, as_user=True)
+                except:
+                    log.warn("Target is not found for: %s", dataset['@id'])
+                    return None
+        else:
+            targets = dataset.get('targets',[])
+            if len(targets) > 0:
+                if isinstance(targets[0], dict):
+                    return targets
+                target_objects = []
+                for targ in targets:
+                    if isinstance(targets[0], str):
+                        try:
+                            target_objects.append(request.embed(targ, as_user=True))
+                        except:
+                            log.warn("Target %s is not found for: %s" % (targ, dataset['@id']))
+                return target_objects
 
-    def encoded_candidate_file(self, afile, assay_term_name):
-        '''returns True if an encoded file should be in regions es'''
-        if afile.get('status', 'imagined') not in ENCODED_ALLOWED_STATUSES:
-            return False
+        return None
+
+    def candidate_dataset(self, dataset):
+        '''returns None, or a list of uses which may include region search and/or regulome.'''
+        if 'Experiment' not in dataset['@type'] and 'FileSet' not in dataset['@type']:
+            return None
+
+        if len(dataset.get('files',[])) == 0:  # TODO: files array may be empty (released dataset with archived files)
+            return None
+
+        dataset_uses = []
+        assay = dataset.get('assay_term_name')
+        if assay is not None and assay in list(ENCODED_REGION_REQUIREMENTS.keys()):
+            dataset_uses.append(FOR_REGION_SEARCH)
+        if 'RegulomeDB' in dataset.get('internal_tags',[]):
+            collection_type = regulome_collection_type(dataset)
+            if collection_type is not None and \
+                collection_type in list(REGULOME_REGION_REQUIREMENTS.keys()):
+                dataset_uses.append(FOR_REGULOME_DB)
+
+        return dataset_uses
+
+    def metadata_doc(self, afile, dataset, assembly, uses):
+        '''returns file and dataset metadata document'''
+        meta_doc = {
+            'uuid': str(afile['uuid']),
+            'uses': uses,
+            'file': {
+                'uuid': str(afile['uuid']),
+                '@id': afile['@id'],
+                'assembly': assembly
+            },
+            'dataset': {
+                'uuid': str(dataset['uuid']),  # TODO: dataset may be file_set and file's dataset is different!!!!
+                '@id': dataset['@id']
+            }
+        }
+
+        # collection_type may be the first of these that are actually found
+        for prop in REGULOME_COLLECTION_TYPES:
+            prop_value = dataset.get(prop)
+            if prop_value:
+                meta_doc['dataset'][prop] = prop_value
+                if 'collection_type' not in meta_doc['dataset']:
+                    meta_doc['dataset']['collection_type'] = prop_value
+        target = dataset.get('target',{})
+        if target:  # overloaded target with potential list of target objects
+            if isinstance(target, dict):
+                target = [ target ]
+            if isinstance(target, list):
+                target_labels = []
+                for targ in target:
+                    label = targ.get('label')
+                    if label:
+                        target_labels.append(label)
+                if len(target_labels) > 0:
+                    meta_doc['dataset']['target'] = target_labels
+        biosample = dataset.get('biosample_term_name')  # TODO: tighten the screws
+        if biosample:
+            meta_doc['dataset']['biosample_term_name'] = biosample
+
+        for dataset_type in REGULOME_DATASET_TYPES:  # prioritized
+            if dataset_type in dataset['@type']:
+                meta_doc['dataset_type'] = dataset_type
+                break
+        if afile['submitted_file_name'] in SNP_FILES:
+            meta_doc['snps'] = True
+        #log.error(json.dumps(meta_doc))
+        return meta_doc
+
+    def candidate_file(self, request, afile, dataset, dataset_uses):
+        '''returns None or a document with file details to save in the residence index'''
         if afile.get('href') is None:
-            return False
-
-        assembly = afile.get('assembly','unknown')
-        if assembly == 'mm10-minimal':        # Treat mm10-minimal as mm10
-            assembly = 'mm10'
-        if assembly not in SUPPORTED_ASSEMBLIES:
-            return False
-
-        required = ENCODED_REGION_REQUIREMENTS.get(assay_term_name,{})
-        if not required:
-            return False
-
-        for prop in list(required.keys()):
-            val = afile.get(prop)
-            if val is None:
-                return False
-            if val not in required[prop]:
-                return False
+            return None
+        if afile['file_format'] not in ALLOWED_FILE_FORMATS:
+            return None
 
         if self.test_instance:
             if afile['accession'] not in TESTABLE_FILES:
-                return False
+                return None
 
-        return True
+        file_status = afile.get('status', 'imagined')
+        assembly = afile.get('assembly','unknown')
+        if assembly == 'mm10-minimal':        # Treat mm10-minimal as mm10
+            assembly = 'mm10'
 
-    def encoded_candidate_dataset(self, dataset):
-        '''returns True if an encoded dataset may have files that should be in regions es'''
-        if 'Experiment' not in dataset['@type']:  # Only experiments?
-            return False
+        # dataset passed in can be file's dataset OR file_set, with each file pointing elsewhere
+        if isinstance(afile['dataset'],dict) and afile['dataset']['@id'] != dataset['@id']:
+            dataset = afile['dataset']
+        elif isinstance(afile['dataset'],str) and afile['dataset'] != dataset['@id']:
+            try:
+                dataset = request.embed(afile['dataset'], as_user=True)
+            except:
+                log.warn("dataset is not found for uuid: %s",dataset_uuid)
+                return None
+        target = self.check_embedded_targets(request, dataset)
+        if target is not None:
+            dataset['target'] = target
 
-        if dataset.get('assay_term_name','unknown') not in list(ENCODED_REGION_REQUIREMENTS.keys()):
-            return False
+        assay_term_name = dataset.get('assay_term_name')
 
-        if len(dataset.get('files',[])) == 0:
-            return False
-        return True
+        file_uses = []
+        if FOR_REGION_SEARCH in dataset_uses:  # encoded datasets must have encoded files
+            if assay_term_name is not None and \
+                file_status in ENCODED_ALLOWED_STATUSES and \
+                assembly in ENCODED_SUPPORTED_ASSEMBLIES:
+                required_properties = ENCODED_REGION_REQUIREMENTS.get(assay_term_name,{})
+                if required_properties:
+                    failed = False
+                    for prop in list(required_properties.keys()):
+                        val = afile.get(prop)
+                        if val is None:
+                            failed = True
+                            break
+                        if val not in required_properties[prop]:
+                            failed = True
+                            break
+                    if not failed:
+                        file_uses.append(FOR_REGION_SEARCH)
 
-    def in_regions_es(self, id):
+        if FOR_REGULOME_DB in dataset_uses:  # regulome datasets must have regulome files
+            if file_status in REGULOME_ALLOWED_STATUSES and assembly in REGULOME_SUPPORTED_ASSEMBLIES:
+                collection_type = regulome_collection_type(dataset)
+                if collection_type is not None:
+                    required_properties = REGULOME_REGION_REQUIREMENTS[collection_type]
+                    if required_properties:
+                        failed = False
+                        for prop in list(required_properties.keys()):
+                            val = afile.get(prop)
+                            if val is None:
+                                failed = True
+                                break
+                            if val not in required_properties[prop]:
+                                failed = True
+                                break
+                        if not failed:
+                            file_uses.append(FOR_REGULOME_DB)
+
+        if not file_uses:
+            return None
+
+        return self.metadata_doc(afile, dataset, assembly, file_uses)
+
+    def in_regions_es(self, id, use_type=None):
         '''returns True if an id is in regions es'''
-        #return False # DEBUG
         try:
-            doc = self.regions_es.get(index=self.residents_index, doc_type='default', id=str(id)).get('_source',{})
+            if use_type is not None:
+                doc = self.regions_es.get(index=self.residents_index, doc_type=use_type, id=str(id)).get('_source',{})
+            else:
+                doc = self.regions_es.get(index=self.residents_index, id=str(id)).get('_source',{})
             if doc:
                 return True
         except NotFoundError:
@@ -494,144 +869,195 @@ class RegionIndexer(Indexer):
 
     def remove_from_regions_es(self, id):
         '''Removes all traces of an id (usually uuid) from region search elasticsearch index.'''
-        #return True # DEBUG
         try:
-            doc = self.regions_es.get(index=self.residents_index, doc_type='default', id=str(id)).get('_source',{})
+            result = self.regions_es.get(index=self.residents_index, id=str(id))
+            doc = result.get('_source',{})
+            use_type = result.get('_type',FOR_MULTIPLE_USES)
             if not doc:
+                log.warn("Trying to drop file: %s  NOT FOUND", id)
                 return False
         except:
             return False  # Not an error: remove may be called without looking first
 
-        for chrom in doc['chroms']:
+        if 'index' in doc:
             try:
-                self.regions_es.delete(index=chrom, doc_type=doc['assembly'], id=str(uuid))
+                self.regions_es.delete(index=doc['index'])
             except:
-                #log.error("Region indexer failed to remove %s regions of %s" % (chrom,id))
+                log.error("Region indexer failed to delete %s index" % (doc['index']))  #, exc_info=True)
                 return False # Will try next full cycle
+        else:
+            for chrom in doc['chroms']:  # Could just try index='chr*'
+                try:
+                    self.regions_es.delete(index=chrom.lower(), doc_type=doc['assembly'], id=str(id))
+                except:
+                    #log.error("Region indexer failed to remove %s regions of %s" % (chrom, id))  #, exc_info=True)
+                    #return False # Will try next full cycle
+                    pass
 
         try:
-            self.regions_es.delete(index=self.residents_index, doc_type='default', id=str(uuid))
+            self.regions_es.delete(index=self.residents_index, doc_type=use_type, id=str(id))
         except:
-            log.error("Region indexer failed to remove %s from %s" % (id, self.residents_index))
+            log.error("Region indexer failed to remove %s from %s" % (id, self.residents_index))  #, exc_info=True)
             return False # Will try next full cycle
 
         return True
 
+    def add_to_residence(self, file_doc):
+        '''Adds a file into residence index.'''
+        uuid = file_doc['uuid']
 
-    def add_to_regions_es(self, id, assembly, assay_term_name, regions, source='encoded'):
-        '''Given regions from some source (most likely encoded file) loads the data into region search es'''
-        #return True # DEBUG
-        for key in regions:
-            doc = {
-                'uuid': str(id),
-                'positions': regions[key]
-            }
-            # Could be a chrom never seen before!
-            if not self.regions_es.indices.exists(key):
-                self.regions_es.indices.create(index=key, body=index_settings())
+        # Only splitting on doc_type=use in order to easily count them
+        use_type = FOR_MULTIPLE_USES
+        if len(file_doc['uses']) == 1:
+            use_type = file_doc['uses'][0]
 
-            if not self.regions_es.indices.exists_type(index=key, doc_type=assembly):
-                self.regions_es.indices.put_mapping(index=key, doc_type=assembly, body=get_mapping(assembly))
-
-            self.regions_es.index(index=key, doc_type=assembly, body=doc, id=str(id))
-
-        # Now add dataset to residency list
-        doc = {
-            'uuid': str(id),
-            'source': source,
-            'assay_term_name': assay_term_name,
-            'assembly': assembly,
-            'chroms': list(regions.keys())
-        }
         # Make sure there is an index set up to handle whether uuids are resident
         if not self.regions_es.indices.exists(self.residents_index):
             self.regions_es.indices.create(index=self.residents_index, body=index_settings())
 
-        if not self.regions_es.indices.exists_type(index=self.residents_index, doc_type='default'):
-            mapping = {'default': {"enabled": False}}
-            self.regions_es.indices.put_mapping(index=self.residents_index, doc_type='default', body=mapping)
+        if not self.regions_es.indices.exists_type(index=self.residents_index, doc_type=use_type):
+            mapping = get_resident_mapping(use_type)
+            self.regions_es.indices.put_mapping(index=self.residents_index, doc_type=use_type, body=mapping)
 
-        self.regions_es.index(index=self.residents_index, doc_type='default', body=doc, id=str(id))
+        self.regions_es.index(index=self.residents_index, doc_type=use_type, body=file_doc, id=str(uuid))
         return True
 
-    def add_encoded_file_to_regions_es(self, request, assay_term_name, afile):
+    def index_regions(self, assembly, regions, file_doc, chroms):
+        '''Given regions from some source (most likely encoded file) loads the data into region search es'''
+        uuid = file_doc['uuid']
+
+        if chroms is None:
+            chroms = list(regions.keys())
+        for chrom in list(regions.keys()):
+            if len(regions[chrom]) == 0:
+                continue
+            doc = {
+                'uuid': uuid,
+                'positions': regions[chrom]
+            }
+            chrom_lc = chrom.lower()
+            # Could be a chrom never seen before!
+            if not self.regions_es.indices.exists(chrom_lc):
+                self.regions_es.indices.create(index=chrom_lc, body=index_settings())
+
+            if not self.regions_es.indices.exists_type(index=chrom_lc, doc_type=assembly):
+                mapping = get_chrom_index_mapping(assembly)
+                self.regions_es.indices.put_mapping(index=chrom_lc, doc_type=assembly, body=mapping)
+
+            self.regions_es.index(index=chrom_lc, doc_type=assembly, body=doc, id=uuid)
+            file_doc['chroms'].append(chrom)
+
+        return True
+
+    def snps_bulk_iterator(self, snp_index, chrom, snps_for_chrom):
+        '''Given SNPs yields snps packaged for bulk indexing'''
+        for snp in snps_for_chrom:
+            yield {'_index': snp_index, '_type': chrom, '_id': snp['rsid'], '_source': snp}
+
+    def index_snps(self, assembly, snps, file_doc, chroms=None):
+        '''Given SNPs from file loads the data into region search es'''
+        snp_index = snp_index_key(assembly)
+        file_doc['index'] = snp_index
+
+        if not self.regions_es.indices.exists(snp_index):
+            self.regions_es.indices.create(index=snp_index, body=index_settings())
+
+        if chroms is None:
+            chroms = list(snps.keys())
+        for chrom in chroms:
+            if len(snps[chrom]) == 0:
+                continue
+            if not self.regions_es.indices.exists_type(index=snp_index, doc_type=chrom):
+                mapping = get_snp_index_mapping(chrom)
+                self.regions_es.indices.put_mapping(index=snp_index, doc_type=chrom, body=mapping)
+            # indexing in bulk 500K snps at a time...
+            bulk(self.regions_es, self.snps_bulk_iterator(snp_index, chrom, snps[chrom]), chunk_size=500000)
+            file_doc['chroms'].append(chrom)
+
+            try:  # likely millions per chrom, so
+                self.regions_es.indices.flush_synced(index=snp_index)
+            except:
+                pass
+            log.warn('Added %s/%s %d docs', snp_index, chrom, len(snps[chrom]))
+
+        return True
+
+    def add_file_to_regions_es(self, request, afile, file_doc, snp=False):
         '''Given an encoded file object, reads the file to create regions data then loads that into region search es.'''
-        #return True # DEBUG
 
-        assembly = afile.get('assembly','unknown')
-        if assembly == 'mm10-minimal':        # Treat mm10-minimal as mm10
-            assembly = 'mm10'
-        if assembly not in SUPPORTED_ASSEMBLIES:
+        assembly = file_doc['file']['assembly']
+        snp_set = file_doc.get('snps', False)
+        ################ TEMPORARY  because snps take so long!
+        #if snp_set:
+        #    file_doc['chroms'] = SUPPORTED_CHROMOSOMES
+        #    file_doc['index'] = snp_index_key(assembly)
+        #    return self.add_to_residence(file_doc)
+        ################ TEMPORARY
+        big_file = (afile.get('file_size', 0) > MAX_IN_MEMORY_FILE_SIZE)
+        file_doc['chroms'] = []
+
+        readable_file = self.reader.readable_file(request, afile)
+        if not readable_file:
             return False
-
-        # Special case local instace so that tests can work...
-        if self.test_instance:
-            #if request.host_url == 'http://localhost':
-            # assume we are running in dev-servers
-            #href = request.host_url + ':8000' + afile['submitted_file_name']
-            href = 'http://www.encodeproject.org' + afile['href']
-        else:
-            href = request.host_url + afile['href']
-
-        ### Works with localhost:8000
-        # NOTE: Using requests instead of http.request which works locally and doesn't require gzip.open
-        #r = requests.get(href)
-        #if not r or r.status_code != 200:
-        #    log.warn("File (%s or %s) not found" % (afile.get('accession', id), href))
-        #    return False
-        #file_in_mem = io.StringIO()
-        #file_in_mem.write(r.text)
-        #file_in_mem.seek(0)
-        #
-        #file_data = {}
-        #if afile['file_format'] == 'bed':
-        #    for row in tsvreader(file_in_mem):
-        #        chrom, start, end = row[0].lower(), int(row[1]), int(row[2])
-        #        if isinstance(start, int) and isinstance(end, int):
-        #            if chrom in file_data:
-        #                file_data[chrom].append({
-        #                    'start': start + 1,
-        #                    'end': end + 1
-        #                })
-        #            else:
-        #                file_data[chrom] = [{'start': start + 1, 'end': end + 1}]
-        #        else:
-        #            log.warn('positions are not integers, will not index file')
-        ##else:  Other file types?
-
-        ### Works with http://www.encodeproject.org
-        # Note: this reads the file into an in-memory byte stream.  If files get too large,
-        # We could replace this with writing a temp file, then reading it via gzip and tsvreader.
-        urllib3.disable_warnings()
-        http = urllib3.PoolManager()
-        r = http.request('GET', href)
-        if r.status != 200:
-            log.warn("File (%s or %s) not found" % (afile.get('accession', id), href))
-            return False
-        file_in_mem = io.BytesIO()
-        file_in_mem.write(r.data)
-        file_in_mem.seek(0)
-        r.release_conn()
 
         file_data = {}
-        if afile['file_format'] == 'bed':
+        chroms = []
+        if afile['file_format'] == 'bed':  #else:  TODO: bigBeds? Other file types?
             # NOTE: requests doesn't require gzip but http.request does.
-            with gzip.open(file_in_mem, mode='rt') as file:  # localhost:8000 would not require localhost
-                for row in tsvreader(file):
-                    chrom, start, end = row[0].lower(), int(row[1]), int(row[2])
-                    if isinstance(start, int) and isinstance(end, int):
-                        if chrom in file_data:
-                            file_data[chrom].append({
-                                'start': start + 1,
-                                'end': end + 1
-                            })
+            with gzip.open(readable_file, mode='rt') as file_handle:  # localhost:8000 would not require localhost
+                for row in self.reader.tsv(file_handle):
+                    if row[0].startswith('#'):
+                        continue
+                    try:
+                        if snp_set:
+                            (chrom, doc) = self.reader.snp(row)
                         else:
-                            file_data[chrom] = [{'start': start + 1, 'end': end + 1}]
-                    else:
-                        log.warn('positions are not integers, will not index file')
-        #else:  Other file types?
+                            (chrom, doc) = self.reader.region(row)
+                    except:
+                        log.error('%s - failure to parse row %s:%s:%s, skipping row', \
+                                                        afile['href'], row[0], row[1], row[2])
+                        continue
+                    if snp_set and chrom not in SUPPORTED_CHROMOSOMES:
+                        continue   # TEMPORARY: limit SNPs to major chroms
+                    if chrom not in file_data:
+                        # 1 chrom at a time saves memory (but assumes the files are in chrom order!)
+                        if big_file and file_data and len(chroms) > 0:
+                            if snp_set:
+                                self.index_snps(assembly, file_data, file_doc, list(file_data.keys()))
+                            else:
+                                self.index_regions(assembly, file_data, file_doc, list(file_data.keys()))
+                            file_data = {}  # Don't hold onto data already indexed
+                        file_data[chrom] = []
+                        chroms.append(chrom)
+                    file_data[chrom].append(doc)
+        # TODO: Handle bigBeds...
+        #elif afile['file_format'] == 'bedBed':  # Use pyBigWig?
+        #    import pyBigWig  # https://github.com/deeptools/pyBigWig
+        #    with pyBigWig.open(readable_file) as bb:  # reader.readable_file must return remote url for bb files
+        #        chroms = bb.chroms()
+        #        for chrom in chroms.keys():  # should sort
+        #            for row in bb.entries(chrom, 0, chroms[chrom], withString=snp_set):
+        #                try:
+        #                    if snp_set:
+        #                        doc = self.reader.bb_snp(row)
+        #                    else:
+        #                        doc = self.reader.bb_region(row)
+        #                except:
+        #                    log.error('%s - failure to parse row %s:%s:%s, skipping row', \
+        #                                                    afile['href'], chrom, row[0], row[1])
+        # Could redesign with reader class, so this function is entirely ignorant of bed v. bigBed
+        # However, probably not worth as much as just abstracting the file_data building/indexing
 
-        if file_data:
-            return self.add_to_regions_es(afile['uuid'], assembly, assay_term_name, file_data, 'encoded')
+        if len(chroms) == 0 or not file_data:
+            return False
 
-        return False
+        # Note that if indexing by chrom (snp_set or big_file) then file_data will only have one chrom
+        if snp_set:
+            self.index_snps(assembly, file_data, file_doc, list(file_data.keys()))
+        else:
+            self.index_regions(assembly, file_data, file_doc, list(file_data.keys()))
+
+        if big_file and file_doc['chroms'] != chroms:
+            log.error('%s chromosomes %s indexed out of order!', file_doc['file']['@id'],
+                                                        ('SNPs' if snp_set else 'regions') )
+        return self.add_to_residence(file_doc)

--- a/src/encoded/region_indexer.py
+++ b/src/encoded/region_indexer.py
@@ -3,24 +3,16 @@ import io
 import gzip
 import csv
 import logging
-import collections
 import json
 import requests
-import os
 from pyramid.view import view_config
-from sqlalchemy.sql import text
 from shutil import copyfileobj
 from elasticsearch.exceptions import (
     NotFoundError
 )
 from elasticsearch.helpers import (
-    scan,
     bulk
 )
-from snovault import DBSESSION, COLLECTIONS
-#from snovault.storage import (
-#    TransactionRecord,
-#)
 from snovault.elasticsearch.indexer import (
     Indexer
 )
@@ -43,32 +35,30 @@ log = logging.getLogger(__name__)
 # 1) get list of uuids of primary indexer and filter down to datasets covered
 # 2) walk through uuid list querying encoded for each doc[embedded]
 #    3) Walk through embedded files
-#       4) If file passes required tests (e.g. bed, released, ...) AND not in regions_es, put in regions_es
-#       5) If file does not pass tests                             AND     IN regions_es, remove from regions_es
+#       4) If file passes required tests (e.g. bed, released, ...)
+#          AND not in regions_es, put in regions_es
+#       5) If file does not pass tests
+#          AND     IN regions_es, remove from regions_es
 # TODO:
-# Add snp 'suggest' to regulome-search (not real useful)
 # Add score to snp indexing (takes a LONG time to calculate them all)
 # Add nearby snps (with scores) to regulome-search, and means to select them!
 #     only after scores are in index
 # Update resident doc, even when file is already resident.
 # ##################################
+REGION_INDEXER_SHARDS = 2
 
 
 # TEMPORARY: limit SNPs to major chroms
 SUPPORTED_CHROMOSOMES = [
-    'chr1',  'chr2',  'chr3',  'chr4',  'chr5',  'chr6',  'chr7',  'chr8',  'chr9',  'chr10',
+    'chr1', 'chr2', 'chr3', 'chr4', 'chr5', 'chr6', 'chr7', 'chr8', 'chr9', 'chr10',
     'chr11', 'chr12', 'chr13', 'chr14', 'chr15', 'chr16', 'chr17', 'chr18', 'chr19', 'chr20',
-    'chr21', 'chr22', 'chrX',  'chrY']  # chroms are lower case
+    'chr21', 'chr22', 'chrX', 'chrY']  # chroms are lower case
 
 ALLOWED_FILE_FORMATS = ['bed']
-RESIDENT_REGIONSET_KEY = 'resident_regionsets'  # in regions_es, keeps track of what datsets are resident in one place
-
+RESIDENT_REGIONSET_KEY = 'resident_regionsets'  # keeps track of what datsets are resident
 FOR_REGION_SEARCH = 'region_search'
-#FOR_REGULOME_DB = 'RegulomeDB'
-#FOR_MULTIPLE_USES = 'multiple'  # Only used for residence doc_type to aid accounting
-# TODO: requires deleting indexes and then full reindexing
 FOR_REGULOME_DB = 'regulomedb'
-FOR_MULTIPLE_USES = 'region_regulomedb'  # doc_type = region*  or *regulomedb
+FOR_DUAL_USE = 'region_regulomedb'  # doc_type = region*  or *regulomedb
 
 ENCODED_SUPPORTED_ASSEMBLIES = ['hg19', 'mm10', 'mm9', 'GRCh38']
 ENCODED_ALLOWED_STATUSES = ['released']
@@ -89,8 +79,8 @@ ENCODED_REGION_REQUIREMENTS = {
 }
 
 REGULOME_SUPPORTED_ASSEMBLIES = ['hg19', 'GRCh38']
-REGULOME_ALLOWED_STATUSES = ['released', 'archived', 'in progress']  # in progress NOT for files: permission
-REGULOME_DATASET_TYPES   = ['Experiment', 'Annotation', 'Reference']
+REGULOME_ALLOWED_STATUSES = ['released', 'archived', 'in progress']  # no 'in progress' permission!
+REGULOME_DATASET_TYPES = ['Experiment', 'Annotation', 'Reference']
 REGULOME_COLLECTION_TYPES = ['assay_term_name', 'annotation_type', 'reference_type']
 # NOTE: regDB requirements keyed on "collection_type": assay_term_name or else annotation_type
 REGULOME_REGION_REQUIREMENTS = {
@@ -133,18 +123,18 @@ SNP_FILES = [
     's3://regulomedb/snp141/snp141_hg19.bed.gz',
     's3://regulomedb/snp141/snp141_GRCh38.bed.gz'
 ]
-# scores for bigWig (bedGraph) are converted to numeric and can be converted back
-SNP_STR_SCORES = ['1a','1b','1c','1d','1e','1f','2a','2b','2c','3a','3b','4','5','6']
-SNP_NUM_SCORES = [1000, 950, 900, 850, 800, 750, 600, 550, 500, 450, 400,300,200,100]
+SNP_INDEX_PREFIX = 'snp141_'
 
 # If files are too large then they will be copied locally and read
 MAX_IN_MEMORY_FILE_SIZE = (700 * 1024 * 1024)  # most files will be below this and index faster
 TEMPORARY_REGIONS_FILE = '/tmp/region_temp.bed.gz'
 
-# On local instance, these are the only files that can be downloaded and regionalizable.  Currently only one is!
-TESTABLE_FILES = ['ENCFF002COS']  # '/static/test/peak_indexer/ENCFF002COS.bed.gz']
-                                  # '/static/test/peak_indexer/ENCFF296FFD.tsv',     # tsv's some day?
-                                  # '/static/test/peak_indexer/ENCFF000PAR.bed.gz']
+# On local instance, these are the only files that can be downloaded and regionalizable.
+# '/static/test/peak_indexer/ENCFF002COS.bed.gz']
+# '/static/test/peak_indexer/ENCFF296FFD.tsv',     # tsv's some day?
+# '/static/test/peak_indexer/ENCFF000PAR.bed.gz']
+# Currently only one is!
+TESTABLE_FILES = ['ENCFF002COS']
 
 
 def includeme(config):
@@ -152,7 +142,8 @@ def includeme(config):
     config.scan(__name__)
     config.add_route('_regionindexer_state', '/_regionindexer_state')
     registry = config.registry
-    registry['region'+INDEXER] = RegionIndexer(registry)
+    registry['region' + INDEXER] = RegionIndexer(registry)
+
 
 # Region mapping: index: chr*, doc_type: assembly, _id=uuid
 def get_chrom_index_mapping(assembly_name='hg19'):
@@ -166,7 +157,7 @@ def get_chrom_index_mapping(assembly_name='hg19'):
             },
             'properties': {
                 'uuid': {
-                    'type': 'keyword' # WARNING: to add local files this must be 'type': 'string'
+                    'type': 'keyword'  # WARNING: to add local files this must be 'type': 'string'
                 },
                 'positions': {
                     'type': 'nested',
@@ -183,8 +174,9 @@ def get_chrom_index_mapping(assembly_name='hg19'):
         }
     }
 
+
 # Files are also put in the resident: index: RESIDENT_REGIONSET_KEY, doc_type: use_type, _id=uuid
-def get_resident_mapping(use_type=FOR_MULTIPLE_USES):
+def get_resident_mapping(use_type=FOR_DUAL_USE):
     return {use_type: {"enabled": False}}
     # True map: IF we ever want to query by anything other than uuid...
     # return {
@@ -209,16 +201,17 @@ def get_resident_mapping(use_type=FOR_MULTIPLE_USES):
     #                     'uuid':            {'type': 'keyword'},
     #                     '@id':             {'type': 'keyword'},
     #                     'assay_term_name': {'type': 'keyword'},  # \
-    #                     'annotation_type': {'type': 'keyword'},  # - only one of these three will appear
+    #                     'annotation_type': {'type': 'keyword'},  # - only one will appear
     #                     'reference_type':  {'type': 'keyword'},  # /
     #                     'collection_type': {'type': 'keyword'},  # assay or else annotation
-    #                     'target':          {'type': 'keyword'},  # could be array (e.g. PWM targets)
-    #                     'dataset_type':    {'type': 'keyword'}   # 1st @type of *_PRIORITIZED_TYPES
+    #                     'target':          {'type': 'keyword'},  # could be array (PWM targets)
+    #                     'dataset_type':    {'type': 'keyword'}   # 1st of *_PRIORITIZED_TYPES
     #                 }
     #             }
     #         }
     #     }
     # }
+
 
 # SNP mapping index: snp141_hg19, doc_type: chr*, _id=rsid
 def get_snp_index_mapping(chrom='chr1'):
@@ -251,7 +244,7 @@ def get_snp_index_mapping(chrom='chr1'):
 #                    'type' : 'completion'
 #                },
 
-SNP_INDEX_PREFIX = 'snp141_'
+
 def snp_index_key(assembly):
     return SNP_INDEX_PREFIX + assembly.lower()
 
@@ -259,8 +252,8 @@ def snp_index_key(assembly):
 def index_settings():
     return {
         'index': {
-            'number_of_shards': 2,
-            'max_result_window': 99999
+            'number_of_shards': REGION_INDEXER_SHARDS,
+            'max_result_window': SEARCH_MAX
         }
     }
 
@@ -275,7 +268,8 @@ def encoded_regionable_datasets(request, restrict_to_assays=[]):
     for assay in restrict_to_assays:
         query += '&assay_title=' + assay
     results = request.embed(query)['@graph']
-    return [ result['uuid'] for result in results ]
+    return [result['uuid'] for result in results]
+
 
 def regulome_regionable_datasets(request):
     query = '/search/?type=Dataset&field=uuid&limit=all'
@@ -283,7 +277,8 @@ def regulome_regionable_datasets(request):
     for status in REGULOME_ALLOWED_STATUSES:
         query += '&status=' + status
     results = request.embed(query)['@graph']
-    return [ result['uuid'] for result in results ]
+    return [result['uuid'] for result in results]
+
 
 def regulome_collection_type(dataset):
     for prop in REGULOME_COLLECTION_TYPES:
@@ -305,14 +300,14 @@ class RemoteReader(object):
 
         # Special case local instance so that tests can work...
         if self.test_instance:
-            href = 'http://www.encodeproject.org' + afile['href']  # test files are read from production
+            href = 'http://www.encodeproject.org' + afile['href']  # test files read from production
         else:
             href = request.host_url + afile['href']
 
         # TODO: support for remote access for big files (could do bam and vcf as well)
-        #if afile.get('file_format') in ['bigBed', 'bigWig']:
-        #    return href
-        #assert(afile.get('file_format') == 'bed')
+        # if afile.get('file_format') in ['bigBed', 'bigWig']:
+        #     return href
+        # assert(afile.get('file_format') == 'bed')
 
         # Note: this reads the file into an in-memory byte stream.  If files get too large,
         # We could replace this with writing a temp file, then reading it via gzip and tsvreader.
@@ -322,7 +317,8 @@ class RemoteReader(object):
         # use afile.get(file_size) to decide between in mem file or temp file
         file_to_read = None
         if afile.get('file_size', 0) > self.max_memory:
-            with http.request('GET',href, preload_content=False) as r, open(self.temp_file, 'wb') as out_file:
+            with http.request('GET', href, preload_content=False) \
+                    as r, open(self.temp_file, 'wb') as out_file:
                 copyfileobj(r, out_file)
             file_to_read = self.temp_file
             log.warn('Wrote %s to %s', href, file_to_read)
@@ -347,42 +343,44 @@ class RemoteReader(object):
     def region(self, row):
         '''Read a region from an in memory row and returns chrom and document to index.'''
         chrom, start, end = row[0], int(row[1]), int(row[2])
-        return (chrom, {'start': start + 1, 'end': end})  # bed loc 'half-open', but we will close it
+        return (chrom, {'start': start + 1, 'end': end})  # bed loc 'half-open', but we close it !
 
     def snp(self, row):
         '''Read a SNP from an in memory row and returns chrom and document to index.'''
         chrom, start, end, rsid = row[0], int(row[1]), int(row[2]), row[3]
-        return (chrom, {'rsid': rsid, 'chrom': chrom, 'start': start + 1, 'end': end})  # bed loc 'half-open'
+        return (chrom, {'rsid': rsid, 'chrom': chrom, 'start': start + 1, 'end': end})
 
     # TODO: support bigBeds
-    #def bb_region(self, row):
-    #    '''Read a region from a bigBed file read with "pyBigWig" and returns document to index.'''
-    #    start, end = int(row[0]), int(row[1])
-    #    return {'start': start + 1, 'end': end}  # bed loc 'half-open', but we will close it
+    # def bb_region(self, row):
+    #     '''Read a region from a bigBed file read with "pyBigWig" and returns document to index.'''
+    #     start, end = int(row[0]), int(row[1])
+    #     return {'start': start + 1, 'end': end}  # bed loc 'half-open', but we will close it
 
     # TODO: support bigBeds
-    #def bb_snp(self, row):
-    #    '''Read a SNP from a bigBed file read with "pyBigWig"  and returns document to index.'''
-    #    start, end = int(row[0]), int(row[1])
-    #    extras = row[3].split('\t')
-    #    rsid = extras[0]
-    #    num_score = int(extras[1])
-    #    score = extras[2]
-    #    start, end, rsid = row[0], int(row[0]), int(row[2]), row[3]
-    #    return {'rsid': rsid, 'chrom': chrom, 'start': start + 1, 'end': end, 'num_score': num_score, 'score': score}
+    # def bb_snp(self, row):
+    #     '''Read a SNP from a bigBed file read with "pyBigWig"  and returns document to index.'''
+    #     start, end = int(row[0]), int(row[1])
+    #     extras = row[3].split('\t')
+    #     rsid = extras[0]
+    #     num_score = int(extras[1])
+    #     score = extras[2]
+    #     start, end, rsid = row[0], int(row[0]), int(row[2]), row[3]
+    #     return {'rsid': rsid, 'chrom': chrom, 'start': start + 1, 'end': end,
+    #             'num_score': num_score, 'score': score}
 
 
 class RegionIndexerState(IndexerState):
-    # Accepts handoff of uuids from primary indexer. Keeps track of uuids and region_indexer state by cycle.
+    # Accepts handoff of uuids from primary indexer. Keeps track of uuids and state by cycle.
     def __init__(self, es, key):
-        super(RegionIndexerState, self).__init__(es,key, title='region')
-        self.files_added_set    = self.title + '_files_added'
-        self.files_dropped_set  = self.title + '_files_dropped'
-        self.success_set        = self.files_added_set
-        self.cleanup_last_cycle.extend([self.files_added_set,self.files_dropped_set])  # Clean up at beginning of next cycle
+        super(RegionIndexerState, self).__init__(es, key, title='region')
+        self.files_added_set = self.title + '_files_added'
+        self.files_dropped_set = self.title + '_files_dropped'
+        self.success_set = self.files_added_set
+        # Clean these at beginning of next cycle:
+        self.cleanup_last_cycle.extend([self.files_added_set, self.files_dropped_set])
         # DO NOT INHERIT! These keys are for passing on to other indexers
-        self.followup_prep_list = None                        # No followup to a following indexer
-        self.staged_cycles_list = None                        # Will take all of primary self.staged_for_regions_list
+        self.followup_prep_list = None  # No followup to a following indexer
+        self.staged_cycles_list = None  # Will take all of primary self.staged_for_regions_list
 
     def file_added(self, uuid):
         self.list_extend(self.files_added_set, [uuid])
@@ -411,11 +409,12 @@ class RegionIndexerState(IndexerState):
             state = self.get()
             state['status'] = 'uninitialized'
             self.put(state)
-            return ("uninitialized", [])  # primary indexer will know what to do and region indexer should do nothing yet
+            return ("uninitialized", [])
+            # primary indexer will know what to do and region indexer should do nothing yet
 
         # Is a full indexing underway
         primary_state = self.get_obj("primary_indexer")
-        if primary_state.get('cycle_count',0) > SEARCH_MAX:
+        if primary_state.get('cycle_count', 0) > SEARCH_MAX:
             return ("uninitialized", [])
 
         # Rare call for reindexing...
@@ -451,7 +450,7 @@ class RegionIndexerState(IndexerState):
         staged_list = self.get_list(self.staged_for_regions_list)
         if not staged_list or staged_list == []:
             return ([], False)            # Nothing to do!
-        self.delete_objs([self.staged_for_regions_list])  # TODO: tighten this by adding a locking semaphore
+        self.delete_objs([self.staged_for_regions_list])  # TODO: tighten with locking semaphore
 
         # we don't need no stinking xmins... just take the whole set of uuids
         uuids = []
@@ -465,27 +464,27 @@ class RegionIndexerState(IndexerState):
             # There is an efficiency trade off examining many non-dataset uuids
             # # vs. the cost of eliminating those uuids from the list ahead of time.
             uuids = list(self.all_indexable_uuids_set(request).intersection(uuids))
-            uuid_count = len(uuids)
 
-        return (list(set(uuids)),False)  # Only unique uuids
+        return (list(set(uuids)), False)  # Only unique uuids
 
     def finish_cycle(self, state, errors=None):
         '''Every indexing cycle must be properly closed.'''
 
-        if errors:  # By handling here, we avoid overhead and concurrency issues of uuid-level accounting
+        if errors:  # By handling here, we avoid overhead/concurrency issues of uuid-level accting
             self.add_errors(errors)
 
         # cycle-level accounting so todo => done => last in this function
-        #self.rename_objs(self.todo_set, self.done_set)
-        #done_count = self.get_count(self.todo_set)
-        cycle_count = state.pop('cycle_count', None)
+        # self.rename_objs(self.todo_set, self.done_set)
+        # done_count = self.get_count(self.todo_set)
+        state.pop('cycle_count', None)
         self.rename_objs(self.todo_set, self.last_set)
 
         added = self.get_count(self.files_added_set)
         dropped = self.get_count(self.files_dropped_set)
         state['indexed'] = added + dropped
 
-        #self.rename_objs(self.done_set, self.last_set)   # cycle-level accounting so todo => done => last in this function
+        # self.rename_objs(self.done_set, self.last_set)
+        # cycle-level accounting so todo => done => last in this function
         self.delete_objs(self.cleanup_this_cycle)
         state['status'] = 'done'
         state['cycles'] = state.get('cycles', 0) + 1
@@ -498,22 +497,24 @@ class RegionIndexerState(IndexerState):
     def counts(self, region_es, assemblies=None):
         '''returns counts (region files, regulome files, snp files and all files)'''
         counts = {'all_files': 0}
-        for use in [FOR_REGION_SEARCH, FOR_REGULOME_DB, FOR_MULTIPLE_USES]:
+        for use in [FOR_REGION_SEARCH, FOR_REGULOME_DB, FOR_DUAL_USE]:
             try:
-                counts[use] = region_es.count(index=RESIDENT_REGIONSET_KEY, doc_type=use).get('count',0)
-            except:
+                counts[use] = region_es.count(index=RESIDENT_REGIONSET_KEY,
+                                              doc_type=use).get('count', 0)
+            except Exception:
                 counts[use] = 0
             counts['all_files'] += counts[use]
-        counts[FOR_REGION_SEARCH] += counts[FOR_MULTIPLE_USES]
-        counts[FOR_REGULOME_DB] += counts[FOR_MULTIPLE_USES]
-        counts.pop(FOR_MULTIPLE_USES, None)
+        counts[FOR_REGION_SEARCH] += counts[FOR_DUAL_USE]
+        counts[FOR_REGULOME_DB] += counts[FOR_DUAL_USE]
+        counts.pop(FOR_DUAL_USE, None)
 
         if assemblies:
             counts['SNPs'] = {}
             for assembly in assemblies:
                 try:
-                    counts['SNPs'][assembly] = region_es.count(index=snp_index_key(assembly)).get('count',0)
-                except:
+                    counts['SNPs'][assembly] = \
+                        region_es.count(index=snp_index_key(assembly)).get('count', 0)
+                except Exception:
                     counts['SNPs'][assembly] = 0
 
         return counts
@@ -530,8 +531,8 @@ class RegionIndexerState(IndexerState):
 def regionindexer_state_show(request):
     encoded_es = request.registry[ELASTIC_SEARCH]
     encoded_INDEX = request.registry.settings['snovault.elasticsearch.index']
-    regions_es    = request.registry[SNP_SEARCH_ES]
-    state = RegionIndexerState(encoded_es,encoded_INDEX)  # Consider putting this in regions es instead of encoded es
+    regions_es = request.registry[SNP_SEARCH_ES]
+    state = RegionIndexerState(encoded_es, encoded_INDEX)
     if not state.get():
         return "%s is not in service." % (state.state_id)
     # requesting reindex
@@ -555,17 +556,17 @@ def regionindexer_state_show(request):
 
     display = state.display(uuids=request.params.get("uuids"))
     counts = state.counts(regions_es, REGULOME_SUPPORTED_ASSEMBLIES)
-    display['files_for_region_search'] = counts.get(FOR_REGION_SEARCH,0)
-    display['files_for_regulomedb'] = counts.get(FOR_REGULOME_DB,0)
-    display['files_in_index'] = counts.get('all_files',0)
-    display['snps_in_index'] = counts.get('SNPs',0)
+    display['files_for_region_search'] = counts.get(FOR_REGION_SEARCH, 0)
+    display['files_for_regulomedb'] = counts.get(FOR_REGULOME_DB, 0)
+    display['files_in_index'] = counts.get('all_files', 0)
+    display['snps_in_index'] = counts.get('SNPs', 0)
 
-    if not request.registry.settings.get('testing',False):  # NOTE: _indexer not working on local instances
+    if not request.registry.settings.get('testing', False):  # NOTE: _indexer not working on local
         try:
             r = requests.get(request.host_url + '/_regionindexer')
             display['listener'] = json.loads(r.text)
             display['status'] = display['listener']['status']
-        except:
+        except Exception:
             log.error('Error getting /_regionindexer', exc_info=True)
 
     # always return raw json
@@ -582,12 +583,11 @@ def index_regions(request):
     encoded_INDEX = request.registry.settings['snovault.elasticsearch.index']
     request.datastore = 'elasticsearch'  # Let's be explicit
     dry_run = request.json.get('dry_run', False)
-    indexer = request.registry['region'+INDEXER]
+    indexer = request.registry['region' + INDEXER]
     uuids = []
 
-
     # keeping track of state
-    state = RegionIndexerState(encoded_es,encoded_INDEX)
+    state = RegionIndexerState(encoded_es, encoded_INDEX)
     result = state.get_initial_state()
 
     (uuids, force) = state.get_one_cycle(request)
@@ -600,20 +600,23 @@ def index_regions(request):
         errors = indexer.update_objects(request, uuids, force)
         result = state.finish_cycle(result, errors)
         if result['indexed'] == 0:
-            log.warn("Region indexer added %d file(s) from %d dataset uuids" % (result['indexed'], uuid_count))
+            log.warn("Region indexer added %d file(s) from %d dataset uuids",
+                     (result['indexed'], uuid_count))
 
     state.send_notices()
     return result
 
+
 class RegionIndexer(Indexer):
     def __init__(self, registry):
         super(RegionIndexer, self).__init__(registry)
-        self.encoded_es    = registry[ELASTIC_SEARCH]    # yes this is self.es but we want clarity
-        self.encoded_INDEX = registry.settings['snovault.elasticsearch.index']  # yes this is self.index, but clarity
-        self.regions_es    = registry[SNP_SEARCH_ES]
+        self.encoded_es = registry[ELASTIC_SEARCH]    # yes this is self.es but we want clarity
+        self.encoded_INDEX = registry.settings['snovault.elasticsearch.index']
+        self.regions_es = registry[SNP_SEARCH_ES]
         self.residents_index = RESIDENT_REGIONSET_KEY
-        self.state = RegionIndexerState(self.encoded_es,self.encoded_INDEX)  # WARNING, race condition is avoided because there is only one worker
-        self.test_instance = registry.settings.get('testing',False)
+        # WARNING: updating 'state' could lead to race conditions if more than 1 worker
+        self.state = RegionIndexerState(self.encoded_es, self.encoded_INDEX)
+        self.test_instance = registry.settings.get('testing', False)
         self.reader = RemoteReader(self.test_instance)
 
     def update_object(self, request, dataset_uuid, force):
@@ -622,37 +625,34 @@ class RegionIndexer(Indexer):
         try:
             # less efficient than going to es directly but keeps methods in one place
             dataset = request.embed(str(dataset_uuid), as_user=True)
-        except:
-            log.warn("dataset is not found for uuid: %s",dataset_uuid)
+        except Exception:
+            log.warn("dataset is not found for uuid: %s", dataset_uuid)
             # Not an error if it wasn't found.
             return
 
-        # TODO: add case where files are never dropped (when demos share test server this might be necessary)
         dataset_region_uses = self.candidate_dataset(dataset)
         if not dataset_region_uses:
-            return  # Note that if a dataset is no longer a candidate but it had files in regions es, they won't get removed.
-        #log.warn("dataset is a candidate: %s", dataset['accession'])  # DEBUG
+            return  # Note if dataset is NO LONGER a candidate its files won't get removed.
 
-        files = dataset.get('files',[])
+        files = dataset.get('files', [])
         for afile in files:
             # files may not be embedded
             if isinstance(afile, str):
                 file_id = afile
                 try:
                     afile = request.embed(file_id, as_user=True)
-                except:
-                    log.warn("file is not found for: %s",file_id)
+                except Exception:
+                    log.warn("file is not found for: %s", file_id)
                     continue
 
             if afile.get('file_format') not in ALLOWED_FILE_FORMATS:
-                continue  # Note: if file_format changed to not allowed but file already in regions es, it doesn't get removed.
+                continue  # Note: if file_format changed, it doesn't get removed from region index.
 
             file_uuid = afile['uuid']
 
             file_doc = self.candidate_file(request, afile, dataset, dataset_region_uses)
             if file_doc:
 
-                #log.warn("file is a candidate: %s", afile['accession'])  # DEBUG
                 using = ""
                 if force:
                     using = "with FORCE"
@@ -673,9 +673,9 @@ class RegionIndexer(Indexer):
 
         try:
             self.regions_es.indices.flush_synced(index='chr*')
-            self.regions_es.indices.flush_synced(index=SNP_INDEX_PREFIX+'*')
+            self.regions_es.indices.flush_synced(index=SNP_INDEX_PREFIX + '*')
             self.regions_es.indices.flush_synced(index=self.residents_index)
-        except:
+        except Exception:
             pass
         # TODO: gather and return errors
 
@@ -689,11 +689,11 @@ class RegionIndexer(Indexer):
             else:
                 try:
                     return request.embed(target, as_user=True)
-                except:
+                except Exception:
                     log.warn("Target is not found for: %s", dataset['@id'])
                     return None
         else:
-            targets = dataset.get('targets',[])
+            targets = dataset.get('targets', [])
             if len(targets) > 0:
                 if isinstance(targets[0], dict):
                     return targets
@@ -702,7 +702,7 @@ class RegionIndexer(Indexer):
                     if isinstance(targets[0], str):
                         try:
                             target_objects.append(request.embed(targ, as_user=True))
-                        except:
+                        except Exception:
                             log.warn("Target %s is not found for: %s" % (targ, dataset['@id']))
                 return target_objects
 
@@ -713,17 +713,17 @@ class RegionIndexer(Indexer):
         if 'Experiment' not in dataset['@type'] and 'FileSet' not in dataset['@type']:
             return None
 
-        if len(dataset.get('files',[])) == 0:  # TODO: files array may be empty (released dataset with archived files)
+        if len(dataset.get('files', [])) == 0:
             return None
 
         dataset_uses = []
         assay = dataset.get('assay_term_name')
         if assay is not None and assay in list(ENCODED_REGION_REQUIREMENTS.keys()):
             dataset_uses.append(FOR_REGION_SEARCH)
-        if 'RegulomeDB' in dataset.get('internal_tags',[]):
+        if 'RegulomeDB' in dataset.get('internal_tags', []):
             collection_type = regulome_collection_type(dataset)
             if collection_type is not None and \
-                collection_type in list(REGULOME_REGION_REQUIREMENTS.keys()):
+               collection_type in list(REGULOME_REGION_REQUIREMENTS.keys()):
                 dataset_uses.append(FOR_REGULOME_DB)
 
         return dataset_uses
@@ -739,7 +739,7 @@ class RegionIndexer(Indexer):
                 'assembly': assembly
             },
             'dataset': {
-                'uuid': str(dataset['uuid']),  # TODO: dataset may be file_set and file's dataset is different!!!!
+                'uuid': str(dataset['uuid']),
                 '@id': dataset['@id']
             }
         }
@@ -751,10 +751,10 @@ class RegionIndexer(Indexer):
                 meta_doc['dataset'][prop] = prop_value
                 if 'collection_type' not in meta_doc['dataset']:
                     meta_doc['dataset']['collection_type'] = prop_value
-        target = dataset.get('target',{})
+        target = dataset.get('target', {})
         if target:  # overloaded target with potential list of target objects
             if isinstance(target, dict):
-                target = [ target ]
+                target = [target]
             if isinstance(target, list):
                 target_labels = []
                 for targ in target:
@@ -763,7 +763,7 @@ class RegionIndexer(Indexer):
                         target_labels.append(label)
                 if len(target_labels) > 0:
                     meta_doc['dataset']['target'] = target_labels
-        biosample = dataset.get('biosample_term_name')  # TODO: tighten the screws
+        biosample = dataset.get('biosample_term_name')
         if biosample:
             meta_doc['dataset']['biosample_term_name'] = biosample
 
@@ -773,7 +773,6 @@ class RegionIndexer(Indexer):
                 break
         if afile['submitted_file_name'] in SNP_FILES:
             meta_doc['snps'] = True
-        #log.error(json.dumps(meta_doc))
         return meta_doc
 
     def candidate_file(self, request, afile, dataset, dataset_uses):
@@ -788,18 +787,18 @@ class RegionIndexer(Indexer):
                 return None
 
         file_status = afile.get('status', 'imagined')
-        assembly = afile.get('assembly','unknown')
+        assembly = afile.get('assembly', 'unknown')
         if assembly == 'mm10-minimal':        # Treat mm10-minimal as mm10
             assembly = 'mm10'
 
         # dataset passed in can be file's dataset OR file_set, with each file pointing elsewhere
-        if isinstance(afile['dataset'],dict) and afile['dataset']['@id'] != dataset['@id']:
+        if isinstance(afile['dataset'], dict) and afile['dataset']['@id'] != dataset['@id']:
             dataset = afile['dataset']
-        elif isinstance(afile['dataset'],str) and afile['dataset'] != dataset['@id']:
+        elif isinstance(afile['dataset'], str) and afile['dataset'] != dataset['@id']:
             try:
                 dataset = request.embed(afile['dataset'], as_user=True)
-            except:
-                log.warn("dataset is not found for uuid: %s",dataset_uuid)
+            except Exception:
+                log.warn("dataset is not found: %s", afile['dataset'])
                 return None
         target = self.check_embedded_targets(request, dataset)
         if target is not None:
@@ -810,9 +809,9 @@ class RegionIndexer(Indexer):
         file_uses = []
         if FOR_REGION_SEARCH in dataset_uses:  # encoded datasets must have encoded files
             if assay_term_name is not None and \
-                file_status in ENCODED_ALLOWED_STATUSES and \
-                assembly in ENCODED_SUPPORTED_ASSEMBLIES:
-                required_properties = ENCODED_REGION_REQUIREMENTS.get(assay_term_name,{})
+               file_status in ENCODED_ALLOWED_STATUSES and \
+               assembly in ENCODED_SUPPORTED_ASSEMBLIES:
+                required_properties = ENCODED_REGION_REQUIREMENTS.get(assay_term_name, {})
                 if required_properties:
                     failed = False
                     for prop in list(required_properties.keys()):
@@ -827,7 +826,8 @@ class RegionIndexer(Indexer):
                         file_uses.append(FOR_REGION_SEARCH)
 
         if FOR_REGULOME_DB in dataset_uses:  # regulome datasets must have regulome files
-            if file_status in REGULOME_ALLOWED_STATUSES and assembly in REGULOME_SUPPORTED_ASSEMBLIES:
+            if file_status in REGULOME_ALLOWED_STATUSES \
+               and assembly in REGULOME_SUPPORTED_ASSEMBLIES:
                 collection_type = regulome_collection_type(dataset)
                 if collection_type is not None:
                     required_properties = REGULOME_REGION_REQUIREMENTS[collection_type]
@@ -853,52 +853,52 @@ class RegionIndexer(Indexer):
         '''returns True if an id is in regions es'''
         try:
             if use_type is not None:
-                doc = self.regions_es.get(index=self.residents_index, doc_type=use_type, id=str(id)).get('_source',{})
+                doc = self.regions_es.get(index=self.residents_index, doc_type=use_type,
+                                          id=str(id)).get('_source', {})
             else:
-                doc = self.regions_es.get(index=self.residents_index, id=str(id)).get('_source',{})
+                doc = self.regions_es.get(index=self.residents_index, id=str(id)).get('_source', {})
             if doc:
                 return True
         except NotFoundError:
             return False
-        except:
-            #raise
+        except Exception:
             pass
 
         return False
-
 
     def remove_from_regions_es(self, id):
         '''Removes all traces of an id (usually uuid) from region search elasticsearch index.'''
         try:
             result = self.regions_es.get(index=self.residents_index, id=str(id))
-            doc = result.get('_source',{})
-            use_type = result.get('_type',FOR_MULTIPLE_USES)
+            doc = result.get('_source', {})
+            use_type = result.get('_type', FOR_DUAL_USE)
             if not doc:
                 log.warn("Trying to drop file: %s  NOT FOUND", id)
                 return False
-        except:
+        except Exception:
             return False  # Not an error: remove may be called without looking first
 
         if 'index' in doc:
             try:
                 self.regions_es.delete(index=doc['index'])
-            except:
-                log.error("Region indexer failed to delete %s index" % (doc['index']))  #, exc_info=True)
-                return False # Will try next full cycle
+            except Exception:
+                log.error("Region indexer failed to delete %s index" % (doc['index']))
+                return False   # Will try next full cycle
         else:
             for chrom in doc['chroms']:  # Could just try index='chr*'
                 try:
-                    self.regions_es.delete(index=chrom.lower(), doc_type=doc['assembly'], id=str(id))
-                except:
-                    #log.error("Region indexer failed to remove %s regions of %s" % (chrom, id))  #, exc_info=True)
-                    #return False # Will try next full cycle
+                    self.regions_es.delete(index=chrom.lower(), doc_type=doc['assembly'],
+                                           id=str(id))
+                except Exception:
+                    # log.error("Region indexer failed to remove %s regions of %s" % (chrom, id))
+                    # return False # Will try next full cycle
                     pass
 
         try:
             self.regions_es.delete(index=self.residents_index, doc_type=use_type, id=str(id))
-        except:
-            log.error("Region indexer failed to remove %s from %s" % (id, self.residents_index))  #, exc_info=True)
-            return False # Will try next full cycle
+        except Exception:
+            log.error("Region indexer failed to remove %s from %s" % (id, self.residents_index))
+            return False  # Will try next full cycle
 
         return True
 
@@ -907,7 +907,7 @@ class RegionIndexer(Indexer):
         uuid = file_doc['uuid']
 
         # Only splitting on doc_type=use in order to easily count them
-        use_type = FOR_MULTIPLE_USES
+        use_type = FOR_DUAL_USE
         if len(file_doc['uses']) == 1:
             use_type = file_doc['uses'][0]
 
@@ -917,13 +917,16 @@ class RegionIndexer(Indexer):
 
         if not self.regions_es.indices.exists_type(index=self.residents_index, doc_type=use_type):
             mapping = get_resident_mapping(use_type)
-            self.regions_es.indices.put_mapping(index=self.residents_index, doc_type=use_type, body=mapping)
+            self.regions_es.indices.put_mapping(index=self.residents_index, doc_type=use_type,
+                                                body=mapping)
 
-        self.regions_es.index(index=self.residents_index, doc_type=use_type, body=file_doc, id=str(uuid))
+        self.regions_es.index(index=self.residents_index, doc_type=use_type, body=file_doc,
+                              id=str(uuid))
         return True
 
     def index_regions(self, assembly, regions, file_doc, chroms):
-        '''Given regions from some source (most likely encoded file) loads the data into region search es'''
+        '''Given regions from some source (most likely encoded file)
+           loads the data into region search es'''
         uuid = file_doc['uuid']
 
         if chroms is None:
@@ -971,28 +974,30 @@ class RegionIndexer(Indexer):
                 mapping = get_snp_index_mapping(chrom)
                 self.regions_es.indices.put_mapping(index=snp_index, doc_type=chrom, body=mapping)
             # indexing in bulk 500K snps at a time...
-            bulk(self.regions_es, self.snps_bulk_iterator(snp_index, chrom, snps[chrom]), chunk_size=500000)
+            bulk(self.regions_es,
+                 self.snps_bulk_iterator(snp_index, chrom, snps[chrom]), chunk_size=500000)
             file_doc['chroms'].append(chrom)
 
             try:  # likely millions per chrom, so
                 self.regions_es.indices.flush_synced(index=snp_index)
-            except:
+            except Exception:
                 pass
             log.warn('Added %s/%s %d docs', snp_index, chrom, len(snps[chrom]))
 
         return True
 
     def add_file_to_regions_es(self, request, afile, file_doc, snp=False):
-        '''Given an encoded file object, reads the file to create regions data then loads that into region search es.'''
+        '''Given an encoded file object, reads the file to create regions data
+           then loads that into region search es.'''
 
         assembly = file_doc['file']['assembly']
         snp_set = file_doc.get('snps', False)
-        ################ TEMPORARY  because snps take so long!
-        #if snp_set:
-        #    file_doc['chroms'] = SUPPORTED_CHROMOSOMES
-        #    file_doc['index'] = snp_index_key(assembly)
-        #    return self.add_to_residence(file_doc)
-        ################ TEMPORARY
+        # ############### TEMPORARY  because snps take so long!
+        # if snp_set:
+        #     file_doc['chroms'] = SUPPORTED_CHROMOSOMES
+        #     file_doc['index'] = snp_index_key(assembly)
+        #     return self.add_to_residence(file_doc)
+        # ############### TEMPORARY
         big_file = (afile.get('file_size', 0) > MAX_IN_MEMORY_FILE_SIZE)
         file_doc['chroms'] = []
 
@@ -1002,9 +1007,9 @@ class RegionIndexer(Indexer):
 
         file_data = {}
         chroms = []
-        if afile['file_format'] == 'bed':  #else:  TODO: bigBeds? Other file types?
+        if afile['file_format'] == 'bed':
             # NOTE: requests doesn't require gzip but http.request does.
-            with gzip.open(readable_file, mode='rt') as file_handle:  # localhost:8000 would not require localhost
+            with gzip.open(readable_file, mode='rt') as file_handle:
                 for row in self.reader.tsv(file_handle):
                     if row[0].startswith('#'):
                         continue
@@ -1013,9 +1018,9 @@ class RegionIndexer(Indexer):
                             (chrom, doc) = self.reader.snp(row)
                         else:
                             (chrom, doc) = self.reader.region(row)
-                    except:
-                        log.error('%s - failure to parse row %s:%s:%s, skipping row', \
-                                                        afile['href'], row[0], row[1], row[2])
+                    except Exception:
+                        log.error('%s - failure to parse row %s:%s:%s, skipping row',
+                                  afile['href'], row[0], row[1], row[2])
                         continue
                     if snp_set and chrom not in SUPPORTED_CHROMOSOMES:
                         continue   # TEMPORARY: limit SNPs to major chroms
@@ -1023,17 +1028,20 @@ class RegionIndexer(Indexer):
                         # 1 chrom at a time saves memory (but assumes the files are in chrom order!)
                         if big_file and file_data and len(chroms) > 0:
                             if snp_set:
-                                self.index_snps(assembly, file_data, file_doc, list(file_data.keys()))
+                                self.index_snps(assembly, file_data, file_doc,
+                                                list(file_data.keys()))
                             else:
-                                self.index_regions(assembly, file_data, file_doc, list(file_data.keys()))
+                                self.index_regions(assembly, file_data, file_doc,
+                                                   list(file_data.keys()))
                             file_data = {}  # Don't hold onto data already indexed
                         file_data[chrom] = []
                         chroms.append(chrom)
                     file_data[chrom].append(doc)
         # TODO: Handle bigBeds...
-        #elif afile['file_format'] == 'bedBed':  # Use pyBigWig?
+        # elif afile['file_format'] == 'bedBed':  # Use pyBigWig?
         #    import pyBigWig  # https://github.com/deeptools/pyBigWig
-        #    with pyBigWig.open(readable_file) as bb:  # reader.readable_file must return remote url for bb files
+        #    with pyBigWig.open(readable_file) as bb:
+        #              # reader.readable_file must return remote url for bb files
         #        chroms = bb.chroms()
         #        for chrom in chroms.keys():  # should sort
         #            for row in bb.entries(chrom, 0, chroms[chrom], withString=snp_set):
@@ -1042,7 +1050,7 @@ class RegionIndexer(Indexer):
         #                        doc = self.reader.bb_snp(row)
         #                    else:
         #                        doc = self.reader.bb_region(row)
-        #                except:
+        #                except Exception:
         #                    log.error('%s - failure to parse row %s:%s:%s, skipping row', \
         #                                                    afile['href'], chrom, row[0], row[1])
         # Could redesign with reader class, so this function is entirely ignorant of bed v. bigBed
@@ -1051,7 +1059,7 @@ class RegionIndexer(Indexer):
         if len(chroms) == 0 or not file_data:
             return False
 
-        # Note that if indexing by chrom (snp_set or big_file) then file_data will only have one chrom
+        # Note if indexing by chrom (snp_set or big_file) then file_data will only have one chrom
         if snp_set:
             self.index_snps(assembly, file_data, file_doc, list(file_data.keys()))
         else:
@@ -1059,5 +1067,5 @@ class RegionIndexer(Indexer):
 
         if big_file and file_doc['chroms'] != chroms:
             log.error('%s chromosomes %s indexed out of order!', file_doc['file']['@id'],
-                                                        ('SNPs' if snp_set else 'regions') )
+                      ('SNPs' if snp_set else 'regions'))
         return self.add_to_residence(file_doc)

--- a/src/encoded/region_search.py
+++ b/src/encoded/region_search.py
@@ -1,7 +1,14 @@
 from pyramid.view import view_config
+from pyramid.compat import bytes_
 from snovault import TYPES
-from snovault.elasticsearch.interfaces import ELASTIC_SEARCH
+from snovault.elasticsearch.interfaces import (
+    ELASTIC_SEARCH,
+    SNP_SEARCH_ES
+)
 from snovault.elasticsearch.indexer import MAX_CLAUSES_FOR_ES
+from elasticsearch.exceptions import (
+    NotFoundError
+)
 from pyramid.security import effective_principals
 from .search import (
     format_results,
@@ -12,18 +19,28 @@ from .search import (
     search_result_actions
 )
 from .batch_download import get_peak_metadata_links
+from .region_atlas import (
+    RegionAtlas,
+    RegulomeAtlas
+)
+from .vis_defines import (
+    vis_format_url,
+    ASSEMBLY_TO_UCSC_ID
+)
 from collections import OrderedDict
 import requests
 from urllib.parse import urlencode
 
 import logging
 import re
-
+import json
+import time
 
 log = logging.getLogger(__name__)
 
 
 _ENSEMBL_URL = 'http://rest.ensembl.org/'
+_ENSEMBL_URL_GRCH37 = 'http://grch37.rest.ensembl.org/'
 
 _REGION_FIELDS = [
     'embedded.files.uuid',
@@ -37,6 +54,20 @@ _REGION_FIELDS = [
 
 _FACETS = [
     ('assay_term_name', {'title': 'Assay'}),
+    ('biosample_term_name', {'title': 'Biosample term'}),
+    ('target.label', {'title': 'Target'}),
+    ('replicates.library.biosample.donor.organism.scientific_name', {
+        'title': 'Organism'
+    }),
+    ('organ_slims', {'title': 'Organ'}),
+    ('assembly', {'title': 'Genome assembly'}),
+    ('files.file_type', {'title': 'Available data'})
+]
+
+_REGULOME_FACETS = [
+    ('assay_term_name', {'title': 'Assay'}),
+    ('annotation_type', {'title': 'Annotation type'}),
+    ('status', {'title': 'Status'}),
     ('biosample_term_name', {'title': 'Biosample term'}),
     ('target.label', {'title': 'Target'}),
     ('replicates.library.biosample.donor.organism.scientific_name', {
@@ -64,79 +95,40 @@ _GENOME_TO_ALIAS = {
 
 def includeme(config):
     config.add_route('region-search', '/region-search{slash:/?}')
+    config.add_route('regulome-search', '/regulome-search{slash:/?}')
     config.add_route('suggest', '/suggest{slash:/?}')
+    config.add_route('jbrest', '/jbrest/snp141/{assembly}/{cmd}/{chrom}{slash:/?}')
     config.scan(__name__)
 
 
-def get_bool_query(start, end):
-    must_clause = {
-        'bool': {
-            'must': [
-                {
-                    'range': {
-                        'positions.start': {
-                            'lte': start,
-                        }
-                    }
-                },
-                {
-                    'range': {
-                        'positions.end': {
-                            'gte': end,
-                        }
-                    }
-                }
-            ]
-        }
-    }
-    return must_clause
+def region_get_hits(atlas, assembly, chrom, start, end, peaks_too=False):
+    '''Returns a list of file uuids AND dataset paths for chromosome location'''
+
+    all_hits = {}  #{ 'dataset_paths': [], 'files': {}, 'datasets': {}, 'peaks': [], 'message': ''}
+
+    (peaks, peak_details) = atlas.find_peaks_filtered(_GENOME_TO_ALIAS[assembly], chrom, start, end, peaks_too)
+    if not peaks:
+        return {'message': 'No hits found in this location'}
+    if peak_details is None:
+        return {'message': 'Error during peak filtering'}
+    if not peak_details:
+        return {'message': 'No %s sources found' % atlas.type()}
+
+    all_hits['peak_count'] = len(peaks)
+    if peaks_too:
+        all_hits['peaks'] = peaks  # For "download_elements", contains 'inner_hits' with positions
+    # NOTE: peak['inner_hits']['positions']['hits']['hits'] may exist with uuids but to same file
 
 
+    (all_hits['datasets'], all_hits['files']) = atlas.details_breakdown(peak_details)
+    all_hits['dataset_paths'] = list(all_hits['datasets'].keys())
+    all_hits['file_count'] = len(all_hits['files'].keys())
+    all_hits['dataset_count'] = len(all_hits['datasets'].keys())
 
-def get_peak_query(start, end, with_inner_hits=False, within_peaks=False):
-    """
-    return peak query
-    """
-    query = {
-        'query': {
-            'bool': {
-                'filter': {
-                    'nested': {
-                        'path': 'positions',
-                        'query': {
-                            'bool': {
-                                'should': []
-                            }
-                        }
-                    }
-                }
-             }
-         },
-        '_source': False,
-    }
-    search_ranges = {
-        'peaks_inside_range': {
-            'start': start,
-            'end': end
-        },
-        'range_inside_peaks': {
-            'start': end,
-            'end': start
-        },
-        'peaks_overlap_start_range': {
-            'start': start,
-            'end': start
-        },
-        'peaks_overlap_end_range': {
-            'start': end,
-            'end': end
-        }
-    }
-    for key, value in search_ranges.items():
-        query['query']['bool']['filter']['nested']['query']['bool']['should'].append(get_bool_query(value['start'], value['end']))
-    if with_inner_hits:
-        query['query']['bool']['filter']['nested']['inner_hits'] = {'size': 99999}
-    return query
+    all_hits['message'] = '%d peaks in %d files belonging to %s datasets in this region' % \
+                (all_hits['peak_count'], all_hits['file_count'], all_hits['dataset_count'])
+
+    return all_hits
 
 
 def sanitize_coordinates(term):
@@ -178,7 +170,7 @@ def get_annotation_coordinates(es, id, assembly):
             return (chromosome, start, end)
 
 def assembly_mapper(location, species, input_assembly, output_assembly):
-    # All others
+    # maps location on GRCh38 to hg19 for example
     new_url = _ENSEMBL_URL + 'map/' + species + '/' \
         + input_assembly + '/' + location + '/' + output_assembly \
         + '/?content-type=application/json'
@@ -196,10 +188,18 @@ def assembly_mapper(location, species, input_assembly, output_assembly):
         return(chromosome, start, end)
 
 
-def get_rsid_coordinates(id, assembly):
-    species = _GENOME_TO_SPECIES[assembly]
+def get_rsid_coordinates(id, assembly, atlas=None):
+    if atlas and assembly in ['GRCh38','hg19','GRCh37']:
+        snp = atlas.snp(_GENOME_TO_ALIAS[assembly], id)
+        if snp:
+            return (snp['chrom'], snp.get('start',''), snp.get('end',''))
+
+    species = _GENOME_TO_SPECIES.get(assembly, 'homo_sapiens')
+    ensembl_url = _ENSEMBL_URL
+    if assembly == 'GRCh37':
+        ensembl_url = _ENSEMBL_URL_GRCH37
     url = '{ensembl}variation/{species}/{id}?content-type=application/json'.format(
-        ensembl=_ENSEMBL_URL,
+        ensembl=ensembl_url,
         species=species,
         id=id
     )
@@ -212,7 +212,7 @@ def get_rsid_coordinates(id, assembly):
             return('', '', '')
         for mapping in response['mappings']:
             if 'PATCH' not in mapping['location']:
-                location = mapping['location']
+                #location = mapping['location']
                 if mapping['assembly_name'] == assembly:
                     chromosome, start, end = re.split(':|-', mapping['location'])
                     return('chr' + chromosome, start, end)
@@ -224,7 +224,7 @@ def get_rsid_coordinates(id, assembly):
 
 
 def get_ensemblid_coordinates(id, assembly):
-    species = _GENOME_TO_SPECIES[assembly]
+    species = _GENOME_TO_SPECIES.get(assembly, 'homo_sapiens')
     url = '{ensembl}lookup/id/{id}?content-type=application/json'.format(
         ensembl=_ENSEMBL_URL,
         id=id
@@ -255,28 +255,62 @@ def format_position(position, resolution):
     end = int(end) + resolution
     return '{}:{}-{}'.format(chromosome, start, end)
 
+def update_viusalize(result, assembly, dataset_paths, file_statuses):
+    '''Restrict visualize to assembly and add Quick View if possible.'''
+    # TODO: figure out why arxhived files are failing in biodaliance
+    vis = result.get('visualize_batch')
+    if vis is None:
+        vis = {}
+    assembly = _GENOME_TO_ALIAS[assembly]
+    vis_assembly = vis.pop(assembly, None)
+    if vis_assembly is None:
+        vis_assembly = {}
+    datasets = ''
+    count = 0
+    for path in dataset_paths:
+        datasets += '&dataset=' + path
+        count += 1
+        if count > 25:    # NOTE: only first 25 datasets
+            break
+    if count >= 1:
+        datasets = datasets[9:]  # first '&dataset=' will be redundant in vis_format_url
+        pos = result.get('coordinates')
+        quickview_url = vis_format_url("quickview", datasets, assembly, pos, file_statuses)
+        if quickview_url is not None:
+            vis_assembly['Quick View'] = quickview_url
+    if not vis_assembly:
+        return None
+    return { assembly: vis_assembly }
+
+
+@view_config(route_name='regulome-search', request_method='GET', permission='search')
 @view_config(route_name='region-search', request_method='GET', permission='search')
 def region_search(context, request):
     """
     Search files by region.
     """
+    begin = time.time()  # DEBUG: timing
     types = request.registry[TYPES]
+    page = request.path.split('/')[1]
+    regulome = page.startswith('regulome')
     result = {
-        '@id': '/region-search/' + ('?' + request.query_string.split('&referrer')[0] if request.query_string else ''),
+        '@id': '/' + page + '/' + ('?' + request.query_string.split('&referrer')[0] if request.query_string else ''),
         '@type': ['region-search'],
-        'title': 'Search by region',
+        'title': ('Regulome search' if regulome else 'Region search'),
         'facets': [],
         '@graph': [],
         'columns': OrderedDict(),
         'notification': '',
-        'filters': []
+        'filters': [],
+        'timing': []  # DEBUG: timing
     }
     principals = effective_principals(request)
     es = request.registry[ELASTIC_SEARCH]
-    snp_es = request.registry['snp_search']
+    if regulome:
+        atlas = RegulomeAtlas(request.registry[SNP_SEARCH_ES])
+    else:
+        atlas = RegionAtlas(request.registry[SNP_SEARCH_ES])
     region = request.params.get('region', '*')
-    region_inside_peak_status = False
-
 
     # handling limit
     size = request.params.get('limit', 25)
@@ -295,6 +329,9 @@ def region_search(context, request):
     annotation = request.params.get('annotation', '*')
     chromosome, start, end = ('', '', '')
 
+    result['timing'].append({'preamble': (time.time() - begin)})    # DEBUG: timing
+    begin = time.time()                                             # DEBUG: timing
+    rsid=None
     if annotation != '*':
         if annotation.lower().startswith('ens'):
             chromosome, start, end = get_ensemblid_coordinates(annotation, assembly)
@@ -304,8 +341,8 @@ def region_search(context, request):
         region = region.lower()
         if region.startswith('rs'):
             sanitized_region = sanitize_rsid(region)
-            chromosome, start, end = get_rsid_coordinates(sanitized_region, assembly)
-            region_inside_peak_status = True
+            chromosome, start, end = get_rsid_coordinates(sanitized_region, assembly, atlas)
+            rsid = sanitized_region
         elif region.startswith('ens'):
             chromosome, start, end = get_ensemblid_coordinates(region, assembly)
         elif region.startswith('chr'):
@@ -320,65 +357,140 @@ def region_search(context, request):
         result['coordinates'] = '{chr}:{start}-{end}'.format(
             chr=chromosome, start=start, end=end
         )
+    result['timing'].append({'get_coords': (time.time() - begin)})  # DEBUG: timing
+    begin = time.time()                                             # DEBUG: timing
 
     # Search for peaks for the coordinates we got
-    try:
-        # including inner hits is very slow
-        # figure out how to distinguish browser requests from .embed method requests
-        if 'peak_metadata' in request.query_string:
-            peak_query = get_peak_query(start, end, with_inner_hits=True, within_peaks=region_inside_peak_status)
-        else:
-            peak_query = get_peak_query(start, end, within_peaks=region_inside_peak_status)
-        peak_results = snp_es.search(body=peak_query,
-                                     index=chromosome.lower(),
-                                     doc_type=_GENOME_TO_ALIAS[assembly],
-                                     size=99999)
-    except Exception:
-        result['notification'] = 'Error during search'
+    peaks_too = ('peak_metadata' in request.query_string)
+    all_hits = region_get_hits(atlas, assembly, chromosome, start, end,
+                                                peaks_too=peaks_too)
+    result['timing'].append({'peaks': (time.time() - begin)})       # DEBUG: timing
+    begin = time.time()                                             # DEBUG: timing
+    result['notification'] = all_hits['message']
+    if all_hits.get('dataset_count',0) == 0:
         return result
-    file_uuids = []
-    for hit in peak_results['hits']['hits']:
-        if hit['_id'] not in file_uuids:
-            file_uuids.append(hit['_id'])
-    file_uuids = list(set(file_uuids))
-    result['notification'] = 'No results found'
 
 
     # if more than one peak found return the experiments with those peak files
-    uuid_count = len(file_uuids)
-    if uuid_count > MAX_CLAUSES_FOR_ES:
-        log.error("REGION_SEARCH WARNING: region with %d file_uuids is being restricted to %d" % \
-                                                            (uuid_count, MAX_CLAUSES_FOR_ES))
-        file_uuids = file_uuids[:MAX_CLAUSES_FOR_ES]
-        uuid_count = len(file_uuids)
+    dataset_count = all_hits['dataset_count']
+    if dataset_count > MAX_CLAUSES_FOR_ES:
+        log.error("REGION_SEARCH WARNING: region covered by %d datasets is being restricted to %d" % \
+                                                            (dataset_count, MAX_CLAUSES_FOR_ES))
+        all_hits['dataset_paths'] = all_hits['dataset_paths'][:MAX_CLAUSES_FOR_ES]
+        dataset_count = len(all_hits['dataset_paths'])
 
-    if uuid_count:
-        query = get_filtered_query('', [], set(), principals, ['Experiment'])
+    if dataset_count:
+
+        set_type = ['Experiment']
+        set_indices = atlas.set_indices()
+        allowed_status = atlas.allowed_statuses()
+        facets = _FACETS
+        if regulome:
+            facets = _REGULOME_FACETS
+
+        query = get_filtered_query('Dataset', [], set(), principals, atlas.set_type())
         del query['query']
-        query['post_filter']['bool']['must'].append({
-            'terms': {
-                'embedded.files.uuid': file_uuids
-            }
-        })
+        query['post_filter']['bool']['must'].append({'terms': {'embedded.@id': all_hits['dataset_paths']}})
+        query['post_filter']['bool']['must'].append({'terms': {'embedded.status': allowed_status}})
+
         used_filters = set_filters(request, query, result)
-        used_filters['files.uuid'] = file_uuids
-        query['aggs'] = set_facets(_FACETS, used_filters, principals, ['Experiment'])
+        used_filters['@id'] = all_hits['dataset_paths']
+        used_filters['status'] = allowed_status  # TODO: force regulome to show this facet
+        query['aggs'] = set_facets(facets, used_filters, principals, ['Dataset'])
         schemas = (types[item_type].schema for item_type in ['Experiment'])
         es_results = es.search(
-            body=query, index='experiment', doc_type='experiment', size=size, request_timeout=60
+            body=query, index=set_indices, doc_type=set_indices, size=size, request_timeout=60
         )
         result['@graph'] = list(format_results(request, es_results['hits']['hits']))
         result['total'] = total = es_results['hits']['total']
-        result['facets'] = format_facets(es_results, _FACETS, used_filters, schemas, total, principals)
-        result['peaks'] = list(peak_results['hits']['hits'])
-        result['download_elements'] = get_peak_metadata_links(request)
+        result['facets'] = format_facets(es_results, facets, used_filters, schemas, total, principals)
+        if len(result['@graph']) < dataset_count:  # paths should be the chosen few
+            all_hits['dataset_paths'] = [ dataset['@id'] for dataset in result['@graph'] ]
+
+        if peaks_too:
+            result['peaks'] = all_hits['peaks']
+        result['download_elements'] = get_peak_metadata_links(request, result['assembly'], chromosome, start, end)
         if result['total'] > 0:
-            result['notification'] = 'Success'
+            result['notification'] = 'Success: ' + result['notification']
             position_for_browser = format_position(result['coordinates'], 200)
             result.update(search_result_actions(request, ['Experiment'], es_results, position=position_for_browser))
+        result.pop('batch_download', None)  # not desired for region OR regulome
+
+        result['timing'].append({'datasets': (time.time() - begin)})  # DEBUG: timing
+        begin = time.time()                                           # DEBUG: timing
+        vis = update_viusalize(result, assembly, all_hits['dataset_paths'], allowed_status)
+        if vis is not None:
+            result['visualize_batch'] = vis
+        result['timing'].append({'visualize': (time.time() - begin)})  # DEBUG: timing
+        begin = time.time()                                            # DEBUG: timing
+
+        if regulome:
+            # score regulome SNPs or point locations
+            if (rsid is not None or (int(end) - int(start)) <= 1):
+                result['nearby_snps'] = atlas.nearby_snps(result['assembly'], chromosome, int(start), rsid)
+                result['timing'].append({'nearby_snps': (time.time() - begin)})  # DEBUG: timing
+                begin = time.time()                                              # DEBUG: timing
+                # NOTE: Needs all hits rather than 'released' or set reduced by facet selection
+                regdb_score = atlas.regulome_score(all_hits['datasets'])
+                if regdb_score:
+                    result['regulome_score'] = regdb_score
+            result['timing'].append({'scoring': (time.time() - begin)})  # DEBUG: timing
+        else:  # not regulome then clean up message
+            if result['notification'].startswith('Success'):
+                result['notification']= 'Success'
 
     return result
 
+#@view_config(route_name='jbrest', request_method='GET', permission='search')
+
+@view_config(route_name='jbrest')
+def jbrest(context, request):
+    '''Limited JBrowse REST API support for select region sets'''
+    # This allows including SNPs in biodalliance straight from es index and without bigBeds
+    #    jbQuery: 'type=HTMLFeatures'
+    #    jbURI: .../jbrest/snp141/hg19/features/chr19?start=234&end=5678
+    # or jbURI: .../jbrest/snp141/GRCh38/stats/global or
+
+    parts = request.path.split('/')
+    parts.pop(0)  # Domain
+    parts.pop(0)  # page: jbrest
+    region_set = parts.pop(0)
+    assembly = parts.pop(0)
+    if region_set != 'snp141' or assembly not in ['GRCh38', 'hg19']:
+        log.error('jbrest: unsupported request %s', request.url)
+        return response
+
+    atlas = RegionAtlas(request.registry['snp_search'])
+    what = parts.pop(0)
+    if what == 'features':
+        chrom = parts.pop(0)
+        if not chrom.startswith('chr'):
+            chrom = 'chr' + chrom
+        start = int(request.params.get('start', '-1'))
+        end = int(request.params.get('end', '-1'))
+        if start < 0 or end < 0 or end < start:
+            log.error('jbrest: invalid coordinates %s', request.url)
+            return response
+        snps = atlas.find_snps(assembly, chrom, start, end)
+        features = []
+        for snp in snps:                         # quick view expects half open
+            features.append({'start': snp['start'] - 1, 'end': snp['end'], \
+                             'name': snp['rsid'], 'uniqueID': snp['rsid']})
+        request.response.content_type = 'application/json'
+        request.query_string += "&format=json"
+        return {'features': features}
+    #elif what == 'stats':
+    #    if parts[0] != 'global':
+    #        log.error('jbrest: only global stats supported %s', request.url)
+    #        return response
+    #    counts = atlas.counts(assembly)
+    #    stats = {}
+    #    stats['featureCount'] = counts['SNPs'][assembly]
+    #    stats['featureDensity'] = 0.02  # counts['SNPs'][assembly] / 3000000000.0
+    #    response.body = bytes_(json.dumps(stats), 'utf-8')
+
+    log.error('jbrest unknown command: %s', request.url)
+    return response
 
 @view_config(route_name='suggest', request_method='GET', permission='search')
 def suggest(context, request):
@@ -387,7 +499,6 @@ def suggest(context, request):
     if 'q' in request.params:
         text = request.params.get('q', '')
         requested_genome = request.params.get('genome', '')
-        # print(requested_genome)
 
     result = {
         '@id': '/suggest/?' + urlencode({'genome': requested_genome, 'q': text}, ['q', 'genome']),
@@ -395,6 +506,8 @@ def suggest(context, request):
         'title': 'Suggest',
         '@graph': [],
     }
+    # NOTE: attempt to use suggest on SNPs in es led to es failure during indexing
+    #if text.startswith('rs'):
     es = request.registry[ELASTIC_SEARCH]
     query = {
         "suggest": {
@@ -402,7 +515,7 @@ def suggest(context, request):
                 "text": text,
                 "completion": {
                     "field": "suggest",
-                    "size": 100
+                    "size": 20
                 }
             }
         }
@@ -412,10 +525,8 @@ def suggest(context, request):
     except:
         return result
     else:
-        result['@id'] = '/suggest/?' + urlencode({'genome': requested_genome, 'q': text}, ['q','genome'])
-        result['@graph'] = []
         for item in results['suggest']['default-suggest'][0]['options']:
-            if _GENOME_TO_SPECIES[requested_genome].replace('_', ' ') == item['_source']['payload']['species']:
+            if _GENOME_TO_SPECIES.get(requested_genome,'homo_sapiens').replace('_', ' ') == item['_source']['payload']['species']:
                 result['@graph'].append(item)
         result['@graph'] = result['@graph'][:10]
         return result

--- a/src/encoded/schemas/annotation.json
+++ b/src/encoded/schemas/annotation.json
@@ -141,6 +141,10 @@
                 "transcript expression",
                 "transcription factor motifs",
                 "validated enhancers",
+                "eQTLs",
+                "dsQTLs",
+                "Footprints",
+                "PWMs",
                 "variant calls"
             ]
         },

--- a/src/encoded/schemas/document.json
+++ b/src/encoded/schemas/document.json
@@ -58,7 +58,8 @@
                 "standards document",
                 "strain generation protocol",
                 "transfection protocol",
-                "treatment protocol"
+                "treatment protocol",
+                "sequence logo"
            ]
         },
         "description": {

--- a/src/encoded/schemas/file.json
+++ b/src/encoded/schemas/file.json
@@ -1015,7 +1015,11 @@
                         "transcriptome reference",
                         "TSS reference",
                         "unfiltered alignments",
-                        "variant calls"
+                        "variant calls",
+                        "eQTLs",
+                        "dsQTLs",
+                        "footprints",
+                        "PWMs"
                     ]
                 },
                 {
@@ -1415,6 +1419,10 @@
         "phased variant calls": "annotation",
         "filtered SNPs": "annotation",
         "filtered indels": "annotation",
+        "eQTLs": "annotation",
+        "dsQTLs": "annotation",
+        "Footprints": "annotation",
+        "PWMs": "annotation",
 
         "transcriptome reference": "reference",
         "transcriptome index": "reference",

--- a/src/encoded/static/components/genome_browser.js
+++ b/src/encoded/static/components/genome_browser.js
@@ -61,21 +61,19 @@ function rAssemblyToSources(assembly, region) {
         for (let i = 0; i < positions.length; i += 1) {
             positions[i] = parseInt(positions[i].replace(/,/g, ''), 10);
         }
-        if (positions.length > 1) {
-            if (positions[0] > 10000) {
-                browserCfg.viewStart = positions[0] - 10000;
-            } else {
-                browserCfg.viewStart = 1;
-            }
-            browserCfg.viewEnd = positions[1] + 10000;
-        } else {
-            if (positions[0] > 10000) {
-                browserCfg.viewStart = positions[0] - 10000;
-            } else {
-                browserCfg.viewStart = 1;
-            }
-            browserCfg.viewEnd = positions[0] + 10000;
+        if (positions.length === 1) {
+            positions[1] = positions[0];
         }
+        if ((positions[1] - positions[0]) < 10) {
+            if (positions[0] > 10000) {
+                positions[0] -= 10000;
+            } else {
+                positions[0] = 1;
+            }
+            positions[1] += 10000;
+        }
+        browserCfg.viewStart = positions[0];
+        browserCfg.viewEnd = positions[1];
         browserCfg.positionSet = true;
     }
 
@@ -102,6 +100,13 @@ function rAssemblyToSources(assembly, region) {
                 stylesheet_uri: 'https://s3-us-west-1.amazonaws.com/encoded-build/browser/GRCh38/gencode2_v24.xml',
                 collapseSuperGroups: true,
                 trixURI: 'https://s3-us-west-1.amazonaws.com/encoded-build/browser/GRCh38/gencode.v24.annotation.ix',
+            },
+            {
+                name: 'SNPs',
+                desc: 'dbSNP v141',
+                jbURI: '/jbrest/snp141/GRCh38',
+                jbQuery: 'type=HTMLFeatures',
+                style: [{ style: { HEIGHT: 10 } }],
             },
             {
                 name: 'Repeats',
@@ -134,6 +139,13 @@ function rAssemblyToSources(assembly, region) {
                 stylesheet_uri: 'https://s3-us-west-1.amazonaws.com/encoded-build/browser/hg19/gencode_v19.xml',
                 collapseSuperGroups: true,
                 trixURI: 'https://s3-us-west-1.amazonaws.com/encoded-build/browser/hg19/gencode.v19.annotation.ix',
+            },
+            {
+                name: 'SNPs',
+                desc: 'dbSNP v141',
+                jbURI: '/jbrest/snp141/hg19',
+                jbQuery: 'type=HTMLFeatures',
+                style: [{ style: { HEIGHT: 10 } }],
             },
             {
                 name: 'Repeats',

--- a/src/encoded/static/components/genome_browser.js
+++ b/src/encoded/static/components/genome_browser.js
@@ -55,6 +55,8 @@ function rAssemblyToSources(assembly, region) {
 
     if (region) {
         // console.log('region provided: %s', region);
+        // if a region was set (in region_search or regulome_search), then
+        // parse the 'chr:start-end' format and set the browser window at the region
         const reg = region.split(':');
         browserCfg.chr = reg[0].substring(3, reg[0].length);
         const positions = reg[1].split('-');
@@ -64,13 +66,14 @@ function rAssemblyToSources(assembly, region) {
         if (positions.length === 1) {
             positions[1] = positions[0];
         }
+        // If region is small (e.g. SNP location), then expand the browser window
         if ((positions[1] - positions[0]) < 10) {
-            if (positions[0] > 10000) {
-                positions[0] -= 10000;
+            if (positions[0] > 1000) {
+                positions[0] -= 1000;
             } else {
                 positions[0] = 1;
             }
-            positions[1] += 10000;
+            positions[1] += 1000;
         }
         browserCfg.viewStart = positions[0];
         browserCfg.viewEnd = positions[1];
@@ -462,7 +465,7 @@ class GenomeBrowser extends React.Component {
                 maxWorkers: 4,
                 noHelp: true,
                 noExport: true,
-                rulerLocation: 'right',
+                rulerLocation: 'none',
                 chr: browserCfg.chr,
                 viewStart: browserCfg.viewStart,
                 viewEnd: browserCfg.viewEnd,
@@ -471,6 +474,7 @@ class GenomeBrowser extends React.Component {
                 sources: browserCfg.sources,
                 noTitle: true,
                 disablePoweredBy: true,
+                maxViewWidth: Math.min((browserCfg.viewEnd - browserCfg.viewStart) * 10, 100000),
             });
             this.browser.addViewListener(this.locationChange);
         });

--- a/src/encoded/static/components/region_search.js
+++ b/src/encoded/static/components/region_search.js
@@ -233,8 +233,8 @@ class AdvSearch extends React.Component {
                         <input type="submit" value="Search" className="btn btn-sm btn-info pull-right" />
                     </form>
                     {context.coordinates ?
-                            <p>Searched coordinates: <strong>{context.coordinates}</strong></p>
-                        : null}
+                        <p>Searched coordinates: <strong>{context.coordinates}</strong></p>
+                    : null}
                     {context.regulome_score ?
                         <p><strong>RegulomeDB score: {context.regulome_score}</strong></p>
                     : null}

--- a/src/encoded/static/components/region_search.js
+++ b/src/encoded/static/components/region_search.js
@@ -200,13 +200,7 @@ class AdvSearch extends React.Component {
         const region = id.query.region || '';
 
         if (this.state.genome === '') {
-            let assembly = regionGenomes[0].value;
-            if (context.assembly) {
-                assembly = regionGenomes.find(el =>
-                    context.assembly === el.value || context.assembly === el.display
-                ).value;
-            }
-            this.setState({ genome: assembly });
+            this.setState({ genome: context.assembly || regionGenomes[0].value });
         }
 
         return (
@@ -239,7 +233,10 @@ class AdvSearch extends React.Component {
                         <input type="submit" value="Search" className="btn btn-sm btn-info pull-right" />
                     </form>
                     {context.coordinates ?
-                        <p>Searched coordinates: <strong>{context.coordinates}</strong></p>
+                            <p>Searched coordinates: <strong>{context.coordinates}</strong></p>
+                        : null}
+                    {context.regulome_score ?
+                        <p><strong>RegulomeDB score: {context.regulome_score}</strong></p>
                     : null}
                 </PanelBody>
             </Panel>
@@ -301,9 +298,9 @@ class RegionSearch extends React.Component {
 
         return (
             <div>
-                <h2>Region search</h2>
+                <h2>{context.title}</h2>
                 <AdvSearch {...this.props} />
-                {notification === 'Success' ?
+                {notification.startsWith('Success') ?
                     <div className="panel data-display main-panel">
                         <div className="row">
                             <div className="col-sm-5 col-md-4 col-lg-3">

--- a/src/encoded/static/components/search.js
+++ b/src/encoded/static/components/search.js
@@ -1099,7 +1099,6 @@ export class ResultTable extends React.Component {
         const trimmedSearchBase = searchBase.replace(/[?|&]limit=all/, '');
         let browseAllFiles = true; // True to pass all files to browser
         let browserAssembly = ''; // Assembly to pass to ResultsBrowser component
-        let browserRegion = '';  // Region that may be passed to browser
         let browserDatasets = []; // Datasets will be used to get vis_json blobs
         let browserFiles = []; // Files to pass to ResultsBrowser component
         let assemblyChooser;
@@ -1204,9 +1203,8 @@ export class ResultTable extends React.Component {
                     </div>
                 );
             }
-            browserRegion = this.props.region;
-            if (browserRegion) {
-                this.props.currentRegion(browserAssembly, browserRegion);
+            if (this.props.region) {
+                this.props.currentRegion(browserAssembly, this.props.region);
             }
         }
 
@@ -1281,7 +1279,7 @@ export class ResultTable extends React.Component {
                                         </TabPanelPane>
                                         <TabPanelPane key="browserpane">
                                             {assemblyChooser}
-                                            <ResultBrowser files={results} assembly={browserAssembly} region={browserRegion} datasets={browserDatasets} limitFiles={!browseAllFiles} currentRegion={this.props.currentRegion} />
+                                            <ResultBrowser files={results} assembly={browserAssembly} region={this.props.region} datasets={browserDatasets} limitFiles={!browseAllFiles} currentRegion={this.props.currentRegion} />
                                         </TabPanelPane>
                                     </TabPanel>
                                 :
@@ -1313,6 +1311,7 @@ ResultTable.defaultProps = {
     restrictions: {},
     searchBase: '',
     currentRegion: null,
+    region: null,
 };
 
 ResultTable.childContextTypes = {
@@ -1356,7 +1355,7 @@ ResultTableList.defaultProps = {
 const ResultBrowser = (props) => {
     let visUrl = '';
     const datasetCount = props.datasets.length;
-    let region = props.region;  // optionally make a persistent region
+    let region = props.region; // optionally make a persistent region
     const lastRegion = props.currentRegion();
     if (lastRegion && lastRegion.assembly === props.assembly) {
         region = lastRegion.region;
@@ -1389,15 +1388,16 @@ const ResultBrowser = (props) => {
 };
 
 ResultBrowser.propTypes = {
-    files: PropTypes.array, // Array of files whose browser we're rendering
-    assembly: PropTypes.string, // Filter `files` by this assembly
+    files: PropTypes.array.isRequired, // Array of files whose browser we're rendering
+    assembly: PropTypes.string.isRequired, // Filter `files` by this assembly
     region: PropTypes.string, // Filter `files` by this assembly
-    datasets: PropTypes.array, // One or more '/dataset/ENCSRnnnXXX/' that files belong to
+    datasets: PropTypes.array.isRequired, // One or more '/dataset/ENCSRnnnXXX/' that files belong to
     limitFiles: PropTypes.bool, // True to limit browsing to 20 files
     currentRegion: PropTypes.func,
 };
 
 ResultBrowser.defaultProps = {
+    region: null,
     limitFiles: true,
     currentRegion: null,
 };

--- a/src/encoded/static/components/search.js
+++ b/src/encoded/static/components/search.js
@@ -1099,6 +1099,7 @@ export class ResultTable extends React.Component {
         const trimmedSearchBase = searchBase.replace(/[?|&]limit=all/, '');
         let browseAllFiles = true; // True to pass all files to browser
         let browserAssembly = ''; // Assembly to pass to ResultsBrowser component
+        let browserRegion = '';  // Region that may be passed to browser
         let browserDatasets = []; // Datasets will be used to get vis_json blobs
         let browserFiles = []; // Files to pass to ResultsBrowser component
         let assemblyChooser;
@@ -1203,6 +1204,10 @@ export class ResultTable extends React.Component {
                     </div>
                 );
             }
+            browserRegion = this.props.region;
+            if (browserRegion) {
+                this.props.currentRegion(browserAssembly, browserRegion);
+            }
         }
 
         return (
@@ -1276,7 +1281,7 @@ export class ResultTable extends React.Component {
                                         </TabPanelPane>
                                         <TabPanelPane key="browserpane">
                                             {assemblyChooser}
-                                            <ResultBrowser files={results} assembly={browserAssembly} datasets={browserDatasets} limitFiles={!browseAllFiles} currentRegion={this.props.currentRegion} />
+                                            <ResultBrowser files={results} assembly={browserAssembly} region={browserRegion} datasets={browserDatasets} limitFiles={!browseAllFiles} currentRegion={this.props.currentRegion} />
                                         </TabPanelPane>
                                     </TabPanel>
                                 :
@@ -1300,6 +1305,7 @@ ResultTable.propTypes = {
     searchBase: PropTypes.string,
     onChange: PropTypes.func.isRequired,
     currentRegion: PropTypes.func,
+    region: PropTypes.string,
 };
 
 ResultTable.defaultProps = {
@@ -1350,7 +1356,7 @@ ResultTableList.defaultProps = {
 const ResultBrowser = (props) => {
     let visUrl = '';
     const datasetCount = props.datasets.length;
-    let region; // optionally make a persistent region
+    let region = props.region;  // optionally make a persistent region
     const lastRegion = props.currentRegion();
     if (lastRegion && lastRegion.assembly === props.assembly) {
         region = lastRegion.region;
@@ -1363,12 +1369,9 @@ const ResultBrowser = (props) => {
         // /batch_hub/type%3DExperiment%2C%2Caccession%3D{ENCSR000AAA}%2C%2Caccession%3D{ENCSR000AEI}/{hg19}/vis_blob.json
         for (let ix = 0; ix < datasetCount; ix += 1) {
             const accession = props.datasets[ix].split('/')[2];
-            if (visUrl !== '') {
-                visUrl += '%2C%2C';
-            }
-            visUrl += `accession=${accession}`;
+            visUrl += `%2C%2Caccession=${accession}`;
         }
-        visUrl = `batch_hub/type=Experiment/${visUrl}/${props.assembly}/vis_blob.json`;
+        visUrl = `/batch_hub/type=Dataset${visUrl}/${props.assembly}/vis_blob.json`;
     }
     if (datasetCount > 0) {
         return (
@@ -1386,9 +1389,10 @@ const ResultBrowser = (props) => {
 };
 
 ResultBrowser.propTypes = {
-    files: PropTypes.array.isRequired, // Array of files whose browser we're rendering
-    assembly: PropTypes.string.isRequired, // Filter `files` by this assembly
-    datasets: PropTypes.array.isRequired, // One or more '/dataset/ENCSRnnnXXX/' that files belong to
+    files: PropTypes.array, // Array of files whose browser we're rendering
+    assembly: PropTypes.string, // Filter `files` by this assembly
+    region: PropTypes.string, // Filter `files` by this assembly
+    datasets: PropTypes.array, // One or more '/dataset/ENCSRnnnXXX/' that files belong to
     limitFiles: PropTypes.bool, // True to limit browsing to 20 files
     currentRegion: PropTypes.func,
 };
@@ -1446,12 +1450,21 @@ class Search extends React.Component {
         const notification = context.notification;
         const searchBase = url.parse(this.context.location_href).search || '';
         const facetdisplay = context.facets && context.facets.some(facet => facet.total > 0);
+        const queryParsed = this.context.location_href && url.parse(this.context.location_href, true).query;
+        let region = '';
+
+        if (queryParsed && Object.keys(queryParsed).length) {
+            const regionKey = _(Object.keys(queryParsed)).find(key => key === 'region');
+            if (regionKey) {
+                region = queryParsed.region;
+            }
+        }
 
         return (
             <div>
                 {facetdisplay ?
                     <div className="panel data-display main-panel">
-                        <ResultTable {...this.props} searchBase={searchBase} onChange={this.context.navigate} currentRegion={this.currentRegion} />
+                        <ResultTable {...this.props} searchBase={searchBase} region={region} onChange={this.context.navigate} currentRegion={this.currentRegion} />
                     </div>
                 : <h4>{notification}</h4>}
             </div>

--- a/src/encoded/tests/data/inserts/experiment.json
+++ b/src/encoded/tests/data/inserts/experiment.json
@@ -376,7 +376,8 @@
         "date_released": "2016-01-01",
         "submitted_by": "amet.fusce@est.fermentum",
         "target": "EBF1-human",
-        "uuid": "d9161058-d8c4-4b17-b03b-bfaeabe75e02"
+        "uuid": "d9161058-d8c4-4b17-b03b-bfaeabe75e02",
+        "internal_tags": ["RegulomeDB"]
     },
     {
         "_test": "treatment control",

--- a/src/encoded/tests/features/test_region_search.py
+++ b/src/encoded/tests/features/test_region_search.py
@@ -1,4 +1,3 @@
-import pytest
 
 
 def test_one_region(testapp, workbook):
@@ -11,12 +10,13 @@ def test_one_region(testapp, workbook):
     res = testapp.post_json('/index_region', {'record': True})
     assert res.json['cycle_took']
     assert res.json['title'] == 'region_indexer'
-    #assert res.json['indexed'] > 0  # will be 0 if running all test
+    # assert res.json['indexed'] > 0  # will be 0 if running all test
     time.sleep(1)  # For some reason testing fails without some winks
 
     res = testapp.get('http://0.0.0.0:6543/region-search/?region=chr9%3A1-136133506&genome=GRCh37')
     assert 'Region search' in res.json['title']
-    #assert 'Success: 1 peaks in 1 files belonging to 1 datasets in this region' in res.json['notification']
+    # assert ('Success: 1 peaks in 1 files belonging to 1 datasets in this region'
+    #         in res.json['notification'])
     assert 'Success' in res.json['notification']
     assert 'chr9:1-136133506' in res.json['coordinates']
 
@@ -44,7 +44,7 @@ def test_one_regulome(testapp, workbook):
     # Call to /index_region needed if running only 'test_one_regulome', else harmless
     res = testapp.post_json('/index_region', {'record': True})
     assert res.json['title'] == 'region_indexer'
-    #assert res.json['indexed'] > 0  # will be 0 unless runninging only 'test_one_regulome'
+    # assert res.json['indexed'] > 0  # will be 0 unless runninging only 'test_one_regulome'
     time.sleep(1)  # For some reason testing fails without some winks
 
     res = testapp.get('http://0.0.0.0:6543/regulome-search/?region=chrX%3A107514356-107514356&genome=GRCh37')
@@ -58,5 +58,3 @@ def test_one_regulome(testapp, workbook):
 
     expected = 'http://0.0.0.0:6543/regulome_download/regulome_evidence_hg19_chrx_107514356_107514356.bed'
     assert expected in res.json['download_elements']
-
-

--- a/src/encoded/tests/features/test_region_search.py
+++ b/src/encoded/tests/features/test_region_search.py
@@ -1,0 +1,63 @@
+import pytest
+
+
+def test_one_region(testapp, workbook):
+    # Call to /index needed if running only 'test_region_search' or 'test_one_region', else harmless
+    import time
+    res = testapp.post_json('/index', {'record': True})
+    assert res.json['title'] == 'primary_indexer'
+    assert res.json['cycle_took']
+    # Call to /index_region needed always
+    res = testapp.post_json('/index_region', {'record': True})
+    assert res.json['cycle_took']
+    assert res.json['title'] == 'region_indexer'
+    #assert res.json['indexed'] > 0  # will be 0 if running all test
+    time.sleep(1)  # For some reason testing fails without some winks
+
+    res = testapp.get('http://0.0.0.0:6543/region-search/?region=chr9%3A1-136133506&genome=GRCh37')
+    assert 'Region search' in res.json['title']
+    #assert 'Success: 1 peaks in 1 files belonging to 1 datasets in this region' in res.json['notification']
+    assert 'Success' in res.json['notification']
+    assert 'chr9:1-136133506' in res.json['coordinates']
+
+    assert 1 == len(res.json['@graph'])
+    assert 'ENCSR000DZQ' in res.json['@graph'][0]['accession']
+    assert 3 == len(res.json['@graph'][0]['files'])
+
+    expected = 'http://0.0.0.0:6543/peak_metadata/region=chr9%3A1-136133506&genome=GRCh37/peak_metadata.json'
+    assert expected in res.json['download_elements']
+
+    expected = {
+        'hg19': {
+            'Quick View': '/search/?type=File&assembly=hg19&region=chr9:1-136133506&dataset=/experiments/ENCSR000DZQ/&file_format=bigBed&file_format=bigWig&status=released#browser',
+            'UCSC': 'http://genome.ucsc.edu/cgi-bin/hgTracks?hubClear=http://0.0.0.0:6543/batch_hub/region%3Dchr9%253A1-136133506%2C%2Cgenome%3DGRCh37/hub.txt&db=hg19&position=chr9:-199-136133706'
+        }
+    }
+    assert expected == res.json['visualize_batch']
+
+
+def test_one_regulome(testapp, workbook):
+    # Call to /index needed if running only 'test_one_regulome', else harmless
+    import time
+    res = testapp.post_json('/index', {'record': True})
+    assert res.json['title'] == 'primary_indexer'
+    # Call to /index_region needed if running only 'test_one_regulome', else harmless
+    res = testapp.post_json('/index_region', {'record': True})
+    assert res.json['title'] == 'region_indexer'
+    #assert res.json['indexed'] > 0  # will be 0 unless runninging only 'test_one_regulome'
+    time.sleep(1)  # For some reason testing fails without some winks
+
+    res = testapp.get('http://0.0.0.0:6543/regulome-search/?region=chrX%3A107514356-107514356&genome=GRCh37')
+    assert 'Regulome search' in res.json['title']
+
+    assert 'region-search' in res.json['@type']
+
+    # If running all tests '0 files' is expected.  If running this test alone 'No uuids' is expected.
+    assert 'Success: 1 peaks in 1 files belonging to 1 datasets in this region' in res.json['notification']
+    assert '5' == res.json['regulome_score']
+    assert 'ENCSR000DZQ' == res.json['@graph'][0]['accession']
+
+    expected = 'http://0.0.0.0:6543/regulome_evidence/regulomeDB_hg19_chrx_107514356_107514356.bed'
+    assert expected in res.json['download_elements']
+
+

--- a/src/encoded/tests/features/test_region_search.py
+++ b/src/encoded/tests/features/test_region_search.py
@@ -52,12 +52,11 @@ def test_one_regulome(testapp, workbook):
 
     assert 'region-search' in res.json['@type']
 
-    # If running all tests '0 files' is expected.  If running this test alone 'No uuids' is expected.
     assert 'Success: 1 peaks in 1 files belonging to 1 datasets in this region' in res.json['notification']
     assert '5' == res.json['regulome_score']
     assert 'ENCSR000DZQ' == res.json['@graph'][0]['accession']
 
-    expected = 'http://0.0.0.0:6543/regulome_evidence/regulomeDB_hg19_chrx_107514356_107514356.bed'
+    expected = 'http://0.0.0.0:6543/regulome_download/regulome_evidence_hg19_chrx_107514356_107514356.bed'
     assert expected in res.json['download_elements']
 
 

--- a/src/encoded/tests/test_indexing.py
+++ b/src/encoded/tests/test_indexing.py
@@ -87,6 +87,7 @@ def test_indexing_workbook(testapp, indexer_testapp):
     res = indexer_testapp.post_json('/index', {'record': True})
     assert res.json['indexed'] == 1
 
+    import time
     from ..loadxl import load_all
     from pkg_resources import resource_filename
     inserts = resource_filename('encoded', 'tests/data/inserts/')
@@ -95,9 +96,6 @@ def test_indexing_workbook(testapp, indexer_testapp):
     res = indexer_testapp.post_json('/index', {'record': True})
     assert res.json['updated']
     assert res.json['indexed']
-    ### OPTIONAL: audit via 2-pass is coming...
-    #assert res.json['pass2_took']
-    ### OPTIONAL: audit via 2-pass is coming...
 
     # NOTE: Both vis and region indexers are "followup" or secondary indexers
     #       and must be staged by the primary indexer
@@ -110,8 +108,20 @@ def test_indexing_workbook(testapp, indexer_testapp):
     assert res.json['title'] == 'region_indexer'
     assert res.json['indexed'] > 0
 
+    # primary indexer contents
     res = testapp.get('/search/?type=Biosample')
     assert res.json['total'] > 5
+
+    # vis indexer contents
+    res = testapp.get('/batch_hub/type%3DExperiment/hg19/trackDb.json')
+    assert res.json['ChIP']['view']['groups']['aOIDR']['type'] == 'bigNarrowPeak'
+    assert res.json['tkRNA']['vis_id'] == 'ENCSR000AEN_hg19'
+
+    # region indexer contents via region_search
+    time.sleep(1)  # For some reason this fails without some winks
+    res = testapp.get('/region-search/?region=chr13%3A61800000-78800000&genome=GRCh37')
+    assert res.json['total'] == 1
+    assert res.json['visualize_batch']['hg19']['UCSC']
 
 
 def test_indexing_simple(testapp, indexer_testapp):

--- a/src/encoded/tests/test_indexing.py
+++ b/src/encoded/tests/test_indexing.py
@@ -5,6 +5,7 @@ elasticsearch running as subprocesses.
 """
 
 import pytest
+from time import sleep
 
 pytestmark = [pytest.mark.indexing]
 
@@ -16,7 +17,7 @@ def app_settings(wsgi_server_host_port, elasticsearch_server, postgresql_server)
     settings['create_tables'] = True
     settings['persona.audiences'] = 'http://%s:%s' % wsgi_server_host_port
     settings['elasticsearch.server'] = elasticsearch_server
-    settings['snp_search.server'] = elasticsearch_server  # NOTE: tfrom snovault/serverfixtures.py  Need a region_es version?
+    settings['snp_search.server'] = elasticsearch_server  # NOTE: from snovault/serverfixtures.py
     settings['sqlalchemy.url'] = postgresql_server
     settings['collection_datastore'] = 'elasticsearch'
     settings['item_datastore'] = 'elasticsearch'
@@ -87,7 +88,6 @@ def test_indexing_workbook(testapp, indexer_testapp):
     res = indexer_testapp.post_json('/index', {'record': True})
     assert res.json['indexed'] == 1
 
-    import time
     from ..loadxl import load_all
     from pkg_resources import resource_filename
     inserts = resource_filename('encoded', 'tests/data/inserts/')
@@ -118,14 +118,13 @@ def test_indexing_workbook(testapp, indexer_testapp):
     assert res.json['tkRNA']['vis_id'] == 'ENCSR000AEN_hg19'
 
     # region indexer contents via region_search
-    time.sleep(1)  # For some reason this fails without some winks
+    sleep(1)  # For some reason this fails without some winks
     res = testapp.get('/region-search/?region=chr13%3A61800000-78800000&genome=GRCh37')
     assert res.json['total'] == 1
     assert res.json['visualize_batch']['hg19']['UCSC']
 
 
 def test_indexing_simple(testapp, indexer_testapp):
-    import time
     # First post a single item so that subsequent indexing is incremental
     testapp.post_json('/testing-post-put-patch/', {'required': ''})
     res = indexer_testapp.post_json('/index', {'record': True})
@@ -140,7 +139,7 @@ def test_indexing_simple(testapp, indexer_testapp):
     uuids = [indv_res['uuid'] for indv_res in res.json['@graph'] if 'uuid' in indv_res]
     count = 0
     while uuid not in uuids and count < 20:
-        time.sleep(1)
+        sleep(1)
         res = testapp.get('/search/?type=TestingPostPutPatch')
         uuids = [indv_res['uuid'] for indv_res in res.json['@graph'] if 'uuid' in indv_res]
         count += 1
@@ -151,13 +150,13 @@ def test_indexer_vis_state(dummy_request):
     from encoded.vis_indexer import VisIndexerState
     INDEX = dummy_request.registry.settings['snovault.elasticsearch.index']
     es = dummy_request.registry['elasticsearch']
-    state = VisIndexerState(es,INDEX)
+    state = VisIndexerState(es, INDEX)
     result = state.get_initial_state()
     assert result['title'] == 'vis_indexer'
-    result = state.start_cycle(['1','2','3'], result)
+    result = state.start_cycle(['1', '2', '3'], result)
     assert result['cycle_count'] == 3
     assert result['status'] == 'indexing'
-    cycles = result.get('cycles',0)
+    cycles = result.get('cycles', 0)
     result = state.finish_cycle(result, [])
     assert result['cycles'] == (cycles + 1)
     assert result['status'] == 'done'
@@ -167,7 +166,7 @@ def test_indexer_region_state(dummy_request):
     from encoded.region_indexer import RegionIndexerState
     INDEX = dummy_request.registry.settings['snovault.elasticsearch.index']
     es = dummy_request.registry['elasticsearch']
-    state = RegionIndexerState(es,INDEX)
+    state = RegionIndexerState(es, INDEX)
     result = state.get_initial_state()
     assert result['title'] == 'region_indexer'
     assert result['status'] == 'idle'
@@ -177,9 +176,8 @@ def test_indexer_region_state(dummy_request):
 
 
 def test_listening(testapp, listening_conn):
-    import time
     testapp.post_json('/testing-post-put-patch/', {'required': ''})
-    time.sleep(1)
+    sleep(1)
     listening_conn.poll()
     assert len(listening_conn.notifies) == 1
     notify = listening_conn.notifies.pop()

--- a/src/encoded/vis_defines.py
+++ b/src/encoded/vis_defines.py
@@ -1569,7 +1569,7 @@ def object_is_visualizable(
 
 
 # Currently called in types/shared_calculated_properties.py and in search.py
-def vis_format_url(browser, path, assembly, position=None):
+def vis_format_url(browser, path, assembly, position=None, file_statuses=None):
     '''Given a url to hub.txt, returns the url to an external browser or None.'''
     mapped_assembly = ASSEMBLY_DETAILS[assembly]
     if not mapped_assembly:
@@ -1607,7 +1607,15 @@ def vis_format_url(browser, path, assembly, position=None):
     elif browser == "quickview":
         file_formats = '&file_format=bigBed&file_format=bigWig'
         file_inclusions = '&status=released&status=in+progress'
-        return ('/search/?type=File&assembly=%s&dataset=%s%s%s#browser' % (assembly,path,file_formats,file_inclusions))
+        if file_statuses is not None:
+            file_inclusions = ''
+            for status in file_statuses:
+                file_inclusions += '&status=' + status.replace(' ','+')
+
+        region = ''
+        if position is not None:
+            region = '&region=' + position
+        return ('/search/?type=File&assembly=%s%s&dataset=%s%s%s#browser' % (assembly,region,path,file_formats,file_inclusions))
     #else:
         # ERROR: not supported at this time
     return None

--- a/src/encoded/vis_defines.py
+++ b/src/encoded/vis_defines.py
@@ -1629,13 +1629,13 @@ def vis_format_url(browser, path, assembly, position=None, file_statuses=None):
     elif browser == "quickview":
         file_formats = '&file_format=bigBed&file_format=bigWig'
         file_inclusions = '&status=released&status=in+progress'
-        if file_statuses is not None:
+        if file_statuses:
             file_inclusions = ''
             for status in file_statuses:
                 file_inclusions += '&status=' + status.replace(' ', '+')
 
         region = ''
-        if position is not None:
+        if position:
             region = '&region=' + position
         return ('/search/?type=File&assembly=%s%s&dataset=%s%s%s#browser' %
                 (assembly, region, path, file_formats, file_inclusions))

--- a/src/encoded/visualization.py
+++ b/src/encoded/visualization.py
@@ -1,16 +1,13 @@
-from pyramid.response import Response
 from pyramid.view import view_config
 from pyramid.compat import bytes_
 from snovault import Item
 from collections import OrderedDict
 from copy import deepcopy
 import json
-import os
 from urllib.parse import (
     parse_qs,
     urlencode,
 )
-from snovault.elasticsearch.interfaces import ELASTIC_SEARCH
 from .vis_defines import (
     ASSEMBLY_TO_UCSC_ID,
     VISIBLE_DATASET_STATUSES,
@@ -23,18 +20,18 @@ from .vis_defines import (
     object_is_visualizable
 )
 import time
-from pkg_resources import resource_filename
 
 import logging
 
 log = logging.getLogger(__name__)
-#log.setLevel(logging.DEBUG)
 log.setLevel(logging.INFO)
+
 
 def includeme(config):
     config.add_route('batch_hub', '/batch_hub/{search_params}/{txt}')
     config.add_route('batch_hub:trackdb', '/batch_hub/{search_params}/{assembly}/{txt}')
     config.scan(__name__)
+
 
 PROFILE_START_TIME = 0  # For profiling within this module
 
@@ -63,13 +60,14 @@ ASSEMBLY_FAMILIES = {
 
 sanitize = Sanitize()
 
+
 def urlpage(url):
     '''returns (page,suffix,cmd) from url: as ('track','json','regen') from ./../track.regen.json'''
     url_end = url.split('/')[-1]
     parts = url_end.split('.')
     page = parts[0]
     suffix = parts[-1] if len(parts) > 1 else 'txt'
-    cmd = parts[1]     if len(parts) > 2 else ''
+    cmd = parts[1] if len(parts) > 2 else ''
     return (page, suffix, cmd)
 
 
@@ -127,13 +125,15 @@ class VisCollections(object):
             if self.found > 0:
                 accessions = []
             # Don't bother if cache is primed.
-            # if self.found < (len(accessions) * 3 / 4):  # some heuristic to decide when too few means regenerate
+            # some heuristic to decide when too few means regenerate
+            # if self.found < (len(accessions) * 3 / 4):
             #     missing = list(set(accs) - set(self.vis_datasets.keys()))
 
-        if len(accessions) > 0:  # accessions not found in cache... try generating (for pre-primed-cache access)
+        if len(accessions) > 0:  # accessions not found in cache... try generating
             vis_factory = VisDataset(self.request)
             for accession in accessions:
-                vis_dataset = vis_factory.find_or_build(accession, assembly, dataset=None, hide=hide, must_build=True)
+                vis_dataset = vis_factory.find_or_build(accession, assembly, dataset=None,
+                                                        hide=hide, must_build=True)
                 # vis_dataset could legitimately be {}... no visualizable files.
                 if vis_factory.built:
                     self.built += 1
@@ -149,7 +149,8 @@ class VisCollections(object):
         return "%d gathered: %d found, %d built" % (len(self.vis_datasets), self.found, self.built)
 
     def insert_live_group(self, live_groups, new_tag, new_group):
-        '''Inserts new group into a set of live groups during remodelling to vis_asset coolections.'''
+        '''Inserts new group into a set of live groups during remodelling
+           to vis_asset coolections.'''
         old_groups = live_groups.get("groups", {})
         preferred_order = live_groups.get("preferred_order")
         # Note: all cases where group is dynamically added should be in sort order!
@@ -172,7 +173,6 @@ class VisCollections(object):
 
         old_groups[new_tag] = new_group
         live_groups["groups"] = old_groups
-        # log.debug("Added %s to %s in preferred order" % (new_tag,live_groups.get("tag","a group")))
         return live_groups
 
     def remodel_to_type_collections(self, hide_after=None, prefix=None):
@@ -271,7 +271,8 @@ class VisCollections(object):
                         for subgroup_tag in acc_subgroups.keys():
                             if subgroup_tag not in set_group.get("groups", {}).keys():
                                 # Adding biosamples, targets, and reps
-                                self.insert_live_group(set_group, subgroup_tag, acc_subgroups[subgroup_tag])
+                                self.insert_live_group(set_group, subgroup_tag,
+                                                       acc_subgroups[subgroup_tag])
 
                 # dimensions and filterComposite should not need any extra care:
                 # they get dynamically scaled down during printing
@@ -293,9 +294,11 @@ class VisCollections(object):
         for vis_type in self.vis_by_types.keys():
             vis_by_type = self.vis_by_types[vis_type]
             if vis_by_type:  # could be {}
-                vis_by_type['longLabel']  = "%s %s" % (prefix, vis_by_type['longLabel'])
+                vis_by_type['longLabel'] = "%s %s" % (prefix, vis_by_type['longLabel'])
                 if vis_by_type['shortLabel'].startswith('ENCODE '):
-                    vis_by_type['shortLabel'] = "ENCODE %s %s" % (prefix, vis_by_type['shortLabel'].split(None,1)[1])
+                    vis_by_type['shortLabel'] = ("ENCODE %s %s" %
+                                                 (prefix, vis_by_type['shortLabel'].split(None,
+                                                                                          1)[1]))
                 else:
                     vis_by_type['shortLabel'] = "%s %s" % (prefix, vis_by_type['shortLabel'])
         return self.vis_by_types
@@ -315,10 +318,12 @@ class VisCollections(object):
 
         if self.vis_by_types:
             for tag in sorted(self.vis_by_types.keys()):
-                trackdb_txt += vis_defines.ucsc_single_composite_trackDb(self.vis_by_types[tag], tag)
+                trackdb_txt += vis_defines.ucsc_single_composite_trackDb(self.vis_by_types[tag],
+                                                                         tag)
         else:
             for tag in sorted(self.vis_datasets.keys()):
-                trackdb_txt += vis_defines.ucsc_single_composite_trackDb(self.vis_datasets[tag], tag)
+                trackdb_txt += vis_defines.ucsc_single_composite_trackDb(self.vis_datasets[tag],
+                                                                         tag)
         return trackdb_txt
 
     def stringify(self, prepend_label=None):
@@ -343,9 +348,10 @@ class VisCollections(object):
                     return json.dumps(vis_by_types, indent=4, sort_keys=True)
                 else:
                     return self.ucsc_trackDb()
-        if json_out:
+        elif json_out:
             return "{}"
         return ""
+
 
 class VisDataset(object):
     # Finds, builds, stores, remodels vis_blobs
@@ -506,7 +512,8 @@ class VisDataset(object):
                 tag_order = []
                 for subgroup_title in group_order:
                     subgroup = groups.get(subgroup_title, {})
-                    (subgroup_tag, subgroup) = self.format_groups(subgroup_title, subgroup)  # recursive
+                    (subgroup_tag, subgroup) = self.format_groups(subgroup_title, subgroup)
+                    #                               recursive
                     subgroup["tag"] = subgroup_tag
                     if isinstance(preferred_order, list):
                         preferred_order.append(subgroup_tag)
@@ -518,7 +525,7 @@ class VisDataset(object):
                 # assert(len(live_group["groups"]) == len(groups))
                 if len(live_group['groups']) != len(groups):
                     log.debug("len(live_group['groups']):%d != len(groups):%d" %
-                            (len(live_group['groups']), len(groups)))
+                              (len(live_group['groups']), len(groups)))
                     log.debug(json.dumps(live_group, indent=4))
                 live_group["group_order"] = tag_order
                 live_group["preferred_order"] = preferred_order
@@ -552,14 +559,14 @@ class VisDataset(object):
                     continue
                 assert(subgroup_title in self.vis_defines.supported_subgroups())
                 (subgroup_tag, subgroup) = self.format_groups(subgroup_title,
-                                                                groups[subgroup_title])
+                                                              groups[subgroup_title])
                 if isinstance(preferred_order, list):
                     preferred_order.append(subgroup_tag)
                 if "groups" in subgroup and len(subgroup["groups"]) > 0:
                     title_to_tag[subgroup_title] = subgroup_tag
                     groupings["groups"][subgroup_tag] = subgroup
                     groupings["group_order"].append(subgroup_tag)
-                if "dimensions" in self.vis_def["other_groups"]:  # (empty) "Targets" dim will be included
+                if "dimensions" in self.vis_def["other_groups"]:
                     dimension = self.vis_def["other_groups"]["dimensions"].get(subgroup_title)
                     if dimension is not None:
                         new_dimensions[dimension] = subgroup_tag
@@ -588,7 +595,7 @@ class VisDataset(object):
         '''Returns a dict of biosamples for file.'''
         biosamples = {}
         replicates = file_dataset.get("replicates")
-        if replicates is None or not isinstance(replicates[0],dict):
+        if replicates is None or not isinstance(replicates[0], dict):
             return []
 
         for bio_rep in a_file.get("biological_replicates", []):
@@ -641,7 +648,8 @@ class VisDataset(object):
         return (rep_key, rep_val)
 
     def gather_files_and_reps(self):
-        '''Returns visulaizable files and replicate tags from a first pass through dataset's files.'''
+        '''Returns visulaizable files and replicate tags from a
+           first pass through dataset's files.'''
         files = []
         rep_techs = {}
         ucsc_assembly = self.vis_dataset['ucsc_assembly']
@@ -653,26 +661,27 @@ class VisDataset(object):
             file_format_types = view.get("file_format_type", [])
             file_format = view["type"].split()[0]
             if file_format == "bigBed":
-                format_type = view.get('file_format_type','')
+                format_type = view.get('file_format_type', '')
                 if format_type == 'bedMethyl' or "itemRgb" in view:
                     view["type"] = "bigBed 9 +"  # itemRgb implies at least 9 +
-                elif format_type  == 'narrowPeak':
+                elif format_type == 'narrowPeak':
                     view["type"] = "bigNarrowPeak"
                 elif format_type == 'broadPeak' or "scoreFilter" in view:
                     view["type"] = "bigBed 6 +"  # scoreFilter implies score so 6 +
-            #log.debug("%d files looking for type %s" % (len(dataset["files"]),view["type"]))
             for a_file in self.dataset["files"]:
                 if a_file['status'] not in self.vis_defines.visible_file_statuses():
                     continue
                 if file_format != a_file['file_format']:
                     continue
-                if len(output_types) > 0 and a_file.get('output_type', 'unknown') not in output_types:
+                if len(output_types) > 0 and a_file.get('output_type',
+                                                        'unknown') not in output_types:
                     continue
-                if len(file_format_types) > 0 and \
-                a_file.get('file_format_type', 'unknown') not in file_format_types:
+                if len(file_format_types) > 0 and a_file.get('file_format_type',
+                                                             'unknown') not in file_format_types:
                     continue
-                if 'assembly' not in a_file or \
-                    ASSEMBLY_TO_UCSC_ID.get(a_file['assembly'], a_file['assembly']) != ucsc_assembly:
+                if ('assembly' not in a_file or
+                    ASSEMBLY_TO_UCSC_ID.get(a_file['assembly'],
+                                            a_file['assembly']) != ucsc_assembly):
                     continue
                 if "rep_tech" not in a_file:
                     rep_tech = self.vis_defines.rep_for_file(a_file)
@@ -682,7 +691,8 @@ class VisDataset(object):
                 rep_techs[rep_tech] = rep_tech
                 files.append(a_file)
         if len(files) == 0:
-            log.debug("No visualizable files for %s %s" % (self.dataset["accession"], self.vis_dataset["vis_type"]))
+            log.debug("No visualizable files for %s %s" % (self.dataset["accession"],
+                                                           self.vis_dataset["vis_type"]))
             return (None, None)
 
         # convert rep_techs to simple reps
@@ -701,10 +711,10 @@ class VisDataset(object):
         other_groups = self.vis_def.get("other_groups", []).get("groups", [])
         if "Replicates" in other_groups:
             group = other_groups["Replicates"]
-            group_tag = group["tag"]
             subgroups = group["groups"]
             if "replicate" in subgroups:
-                (repgroup_tag, repgroup) = self.format_groups("replicate", subgroups["replicate"], rep_tags)
+                (repgroup_tag, repgroup) = self.format_groups("replicate", subgroups["replicate"],
+                                                              rep_tags)
                 # Now to hook them into the vis_dataset structure
                 self.vis_dataset["groups"]["REP"]["groups"] = repgroup.get("groups", {})
                 self.vis_dataset["groups"]["REP"]["group_order"] = repgroup.get("group_order", [])
@@ -734,10 +744,11 @@ class VisDataset(object):
             for a_file in files:
                 if a_file['file_format'] not in [file_format, "bed"]:
                     continue
-                if len(output_types) > 0 and a_file.get('output_type', 'unknown') not in output_types:
+                if len(output_types) > 0 and a_file.get('output_type',
+                                                        'unknown') not in output_types:
                     continue
                 if len(file_format_types) > 0 and a_file.get('file_format_type',
-                                                            'unknown') not in file_format_types:
+                                                             'unknown') not in file_format_types:
                     continue
                 rep_tech = a_file["rep_tech"]
                 rep_tag = rep_techs[rep_tech]
@@ -747,13 +758,13 @@ class VisDataset(object):
                     view["tracks"] = []
                 track = {}
                 files_dataset = self.dataset
-                if 'dataset' in a_file and isinstance(a_file['dataset'],dict):
+                if 'dataset' in a_file and isinstance(a_file['dataset'], dict):
                     files_dataset = a_file['dataset']
                 track["name"] = a_file['accession']
-                format_type = a_file.get('file_format_type','?')
+                format_type = a_file.get('file_format_type', '?')
                 if format_type == 'bedMethyl' or "itemRgb" in view:
                     view["type"] = "bigBed 9 +"  # itemRgb implies at least 9 +
-                elif format_type  == 'narrowPeak':
+                elif format_type == 'narrowPeak':
                     view["type"] = "bigNarrowPeak"
                 elif format_type == 'broadPeak' or "scoreFilter" in view:
                     view["type"] = "bigBed 6 +"  # scoreFilter implies score so 6 +
@@ -762,10 +773,13 @@ class VisDataset(object):
                 longLabel = self.vis_def.get('file_defs', {}).get('longLabel')
                 if longLabel is None:
                     longLabel = ("{assay_title} of {biosample_term_name} {output_type} "
-                                "{biological_replicate_number}")
-                longLabel += " {experiment.accession} - {file.accession}"  # Always add the accessions
-                track["longLabel"] = sanitize.label(self.vis_defines.convert_mask(longLabel, files_dataset, a_file))
-                # Specialized addendum comments because subtle details alway get in the way of elegance.
+                                 "{biological_replicate_number}")
+                longLabel += " {experiment.accession} - {file.accession}"  # Always add accessions
+                track["longLabel"] = sanitize.label(self.vis_defines.convert_mask(longLabel,
+                                                                                  files_dataset,
+                                                                                  a_file))
+                # Specialized addendum comments because
+                # subtle details alway get in the way of elegance.
                 addendum = ""
                 submitted_name = a_file.get('submitted_file_name', "none")
                 if "_tophat" in submitted_name:
@@ -776,31 +790,34 @@ class VisDataset(object):
                     track["longLabel"] = track["longLabel"] + " (" + addendum[0:-1] + ")"
 
                 metadata_pairs = {}
-                metadata_pairs['file&#32;download'] = ( \
-                    '"<a href=\'%s%s\' title=\'Download this file from the ENCODE portal\'>%s</a>"' %
-                    (self.host, a_file["href"], a_file["accession"]))
+                metadata_pairs['file&#32;download'] = (
+                    '"<a href=\'%s%s\' title=\'Download this file from the ENCODE portal\'>%s</a>"'
+                    % (self.host, a_file["href"], a_file["accession"]))
                 lab = self.vis_defines.convert_mask("{lab.title}")
                 if len(lab) > 0 and not lab.startswith('unknown'):
-                    metadata_pairs['laboratory'] = '"' + sanitize.label(lab) + '"'  # 'lab' is UCSC word
+                    metadata_pairs['laboratory'] = '"' + sanitize.label(lab) + '"'
                 (rep_key, rep_val) = self.replicates_pair(a_file)
                 if rep_key != "":
                     metadata_pairs[rep_key] = '"' + rep_val + '"'
 
                 # Expecting short label to change when making assay based vis formats
-                shortLabel = self.vis_def.get('file_defs', {}).get('shortLabel',
-                                                            "{replicate} {output_type_short_label}")
-                track["shortLabel"] = sanitize.label(self.vis_defines.convert_mask(shortLabel, files_dataset, a_file))
+                shortLabel = self.vis_def.get('file_defs',
+                                              {}).get('shortLabel',
+                                                      "{replicate} {output_type_short_label}")
+                track["shortLabel"] = sanitize.label(self.vis_defines.convert_mask(shortLabel,
+                                                                                   files_dataset,
+                                                                                   a_file))
 
                 # How about subgroups!
                 membership = {}
                 membership["view"] = view["tag"]
                 view["tracks"].append(track)  # <==== This is how we connect them to the views
                 if view['type'] == 'bigNarrowPeak':
-                    view.pop('scoreFilter',None)  # TODO The vis_defs should be changed
-                    # TODO indivudual vis_defs should have signalFilter, pValueFilter and qValueFilter added as appropriate
-                    if 'signalFilter' not in view:  # NOTE: UCSC is giving warning if no signalFilter!
+                    view.pop('scoreFilter', None)  # TODO The vis_defs should be changed
+                    # TODO individual vis_defs should have signalFilter, pValueFilter and
+                    #      qValueFilter added as appropriate
+                    if 'signalFilter' not in view:  # NOTE: UCSC gives warning if no signalFilter!
                         view['signalFilter'] = "0"
-                    #view['signalFilterLimits'] = "0:18241"  # DEBUG DEBUG
 
                 for (group_tag, group) in self.vis_dataset["groups"].items():
                     # "Replicates", "Biosample", "Targets", "Assay", ... member?
@@ -824,20 +841,20 @@ class VisDataset(object):
                         for (subgroup_tag, subgroup) in subgroups.items():
                             membership[group_tag] = subgroup["tag"]
                             if "url" in subgroup:
-                                metadata_pairs[group_title] = ( \
-                                    '"<a href=\'%s/%s/\' TARGET=\'_blank\' title=\'%s details at the ENCODE portal\'>%s</a>"' %
-                                    (self.host, subgroup["url"], group_title, subgroup["title"]))
+                                metadata_pairs[group_title] = ('"<a href=\'%s/%s/\' TARGET=\'_blank\' title=\'%s details at the ENCODE portal\'>%s</a>"' %
+                                                               (self.host, subgroup["url"],
+                                                                group_title, subgroup["title"]))
                             elif group_title == "Biosample":
-                                bs_value = sanitize.label(files_dataset.get("biosample_summary", ""))
+                                bs_value = sanitize.label(files_dataset.get("biosample_summary",
+                                                                            ""))
                                 if len(bs_value) == 0:
                                     bs_value = subgroup["title"]
                                 biosamples = self.biosamples_for_file(a_file, files_dataset)
                                 if len(biosamples) > 0:
                                     for bs_acc in sorted(biosamples.keys()):
-                                        bs_value += ( \
-                                            " <a href=\'%s%s\' TARGET=\'_blank\' title=\' %s details at the ENCODE portal\'>%s</a>" %
-                                            (self.host, biosamples[bs_acc]["@id"], group_title,
-                                                    bs_acc))
+                                        bs_value += (" <a href=\'%s%s\' TARGET=\'_blank\' title=\' %s details at the ENCODE portal\'>%s</a>" %
+                                                     (self.host, biosamples[bs_acc]["@id"],
+                                                      group_title, bs_acc))
                                 metadata_pairs[group_title] = '"%s"' % (bs_value)
                             else:
                                 metadata_pairs[group_title] = '"%s"' % (subgroup["title"])
@@ -867,10 +884,9 @@ class VisDataset(object):
             if a_file['status'] not in self.vis_defines.visible_file_statuses():
                 continue
             if 'assembly' not in a_file or \
-                ASSEMBLY_TO_UCSC_ID.get(a_file['assembly'], a_file['assembly']) != ucsc_assembly:
+               ASSEMBLY_TO_UCSC_ID.get(a_file['assembly'], a_file['assembly']) != ucsc_assembly:
                 continue
             step_ver = a_file.get("analysis_step_version")  # this embedding could evaporate
-            file_acc = a_file['accession']
             if not step_ver:
                 continue  # can't tell anything without step versions!
             if isinstance(step_ver, str):
@@ -885,31 +901,31 @@ class VisDataset(object):
                         a_file["rep_tech"] = rep_tech
                     for swv_key in sw_versions:
                         if swv_key not in software_files:
-                            software_files[swv_key] = { a_file['@id']: a_file["rep_tech"] }
+                            software_files[swv_key] = {a_file['@id']: a_file["rep_tech"]}
                         else:
                             software_files[swv_key][a_file['@id']] = a_file["rep_tech"]
             if a_file['file_format'] in VISIBLE_FILE_FORMATS:
                 # Looking for pipeline details
                 a_step = step_ver['analysis_step']
                 if not isinstance(a_step, dict):
-                    continue # TODO: Lookup analysis_step?
+                    continue  # TODO: Lookup analysis_step?
                 pipes = a_step.get("pipelines")
                 if not pipes or not isinstance(pipes, list) or len(pipes) == 0:
-                    continue # TODO: Lookup pipeline?
+                    continue  # TODO: Lookup pipeline?
                 for a_pipe in pipes:
                     pipe_key = a_pipe['@id']
                     pipe = {}
                     if pipe_key not in pipeline_files:
                         pipe['title'] = a_pipe.get('title')
                         pipe['version'] = '1'
-                        pipe['lab'] = a_file.get('lab',{}).get('title','unknown')
-                        #pipe['lab'] = a_pipe.get("lab",'unknown')
-                        #if pipe['lab'].startswith('/labs/'):
+                        pipe['lab'] = a_file.get('lab', {}).get('title', 'unknown')
+                        # pipe['lab'] = a_pipe.get("lab",'unknown')
+                        # if pipe['lab'].startswith('/labs/'):
                         #    pipe['lab'] = pipe['lab'][6:-1]
                         if pipe['title']:
                             if 'version' in pipe['title'].lower():  # REALLY LESS THAN IDEAL
                                 pipe['version'] = pipe['title'].lower().split('version')[-1].strip()
-                        pipe['files'] = [ a_file['@id'] ]
+                        pipe['files'] = [a_file['@id']]
                         pipeline_files[pipe_key] = pipe
                     else:
                         pipeline_files[pipe_key]['files'].append(a_file['@id'])
@@ -917,20 +933,22 @@ class VisDataset(object):
         if software_files:
             aligners = {'files': {}, 'rep_techs': {}}
             # TODO: software_type='aligner' is weakly associated!
-            # Note: lab!=/labs/encode-processing-pipeline/ should eliminate analysis_steps themselves
-            params = { 'type': 'SoftwareVersion', 'software.software_type': 'aligner', '@id': software_files.keys() }
-            path = '/search/?%s&software.lab!=/labs/encode-processing-pipeline/&frame=embedded' % (urlencode(params, True))
+            # Note: lab!=/labs/encode-processing-pipeline/ should eliminate analysis_steps
+            params = {'type': 'SoftwareVersion', 'software.software_type': 'aligner',
+                      '@id': software_files.keys()}
+            path = ('/search/?%s&software.lab!=/labs/encode-processing-pipeline/&frame=embedded' %
+                    (urlencode(params, True)))
             results = self.request.embed(path, as_user=True)['@graph']
             # More than one for some: LRNA (star v. tophat)
             for sw_version in results:
                 swv_key = sw_version['@id']
-                #sw_files = software_files[swv_key].keys()
-                aligner = { 'name':sw_version['software']['name'], 'version': sw_version['version']}
+                # sw_files = software_files[swv_key].keys()
+                aligner = {'name': sw_version['software']['name'], 'version': sw_version['version']}
                 aligner_key = aligner['name'].lower()
                 if 'default' not in aligners:
-                    aligners['default'] = { aligner_key: aligner }
-                elif aligner_key not in aligners['default'] or \
-                     aligners['default'][aligner_key]['version'] < aligner['version']:
+                    aligners['default'] = {aligner_key: aligner}
+                elif (aligner_key not in aligners['default'] or
+                      aligners['default'][aligner_key]['version'] < aligner['version']):
                     aligners['default'][aligner_key] = aligner
                 for file_id in software_files[swv_key].keys():
                     rep_tech = software_files[swv_key][file_id]
@@ -939,24 +957,26 @@ class VisDataset(object):
                     elif aligners['files'][file_id]['name'] == aligner['name']:
                         if aligners['files'][file_id]['version'] < aligner['version']:
                             aligners['files'][file_id] = aligner
-                    #else:  # one bam file 2 aligners, not likely
+                    # else:  # one bam file 2 aligners, not likely
                     if rep_tech not in aligners['rep_techs']:
-                        aligners['rep_techs'][rep_tech] = { aligner_key: aligner }
-                    elif aligner_key not in aligners['rep_techs'][rep_tech] or \
-                         aligners['rep_techs'][rep_tech][aligner_key]['version'] < aligner['version']:
+                        aligners['rep_techs'][rep_tech] = {aligner_key: aligner}
+                    elif (aligner_key not in aligners['rep_techs'][rep_tech] or
+                          aligners['rep_techs'][rep_tech][aligner_key]['version']
+                          < aligner['version']):
                         aligners['rep_techs'][rep_tech][aligner_key] = aligner
 
             self.aligners = aligners
-            #aligners = { 'file': {ENCFF000AAA: {name:'STAR': version:'2.5.1a'},..., 'rep_tech': rep1_1: {'star': {'STAR': '2.5.1a'},'tophat':...} }
+            # aligners = { 'file': {ENCFF000AAA: {name:'STAR': version:'2.5.1a'},...,
+            #             'rep_tech': rep1_1: {'star': {'STAR': '2.5.1a'},'tophat':...} }
         if pipeline_files:
-            pipelines =  {}
+            pipelines = {}
             for pipe_key in pipeline_files.keys():
                 pipe = pipeline_files[pipe_key]
                 pipe_files = pipe.pop('files')
                 for file_id in pipe_files:
                     if file_id not in pipelines or pipe['version'] > pipelines[file_id]['version']:
                         pipelines[file_id] = pipe
-            #pipelines = {ENCFF000AAA: {title: 'RNA pipeline', version: 2, lab:'ENCODE DCC'},...}
+            # pipelines = {ENCFF000AAA: {title: 'RNA pipeline', version: 2, lab:'ENCODE DCC'},...}
             self.pipelines = pipelines
 
     def add_pipeline_details(self, a_file, track):
@@ -964,7 +984,7 @@ class VisDataset(object):
         # plumbing for ihec
         if self.aligners:
             # go through derived_from to find aligner, if not found then hope rep_tech works
-            for file_id in a_file.get('derived_from',[]):
+            for file_id in a_file.get('derived_from', []):
                 # easy way: when bam is in derived_from and aligner is associated with bam
                 if file_id in self.aligners['files']:
                     track['aligner'] = self.aligners['files'][file_id]
@@ -985,16 +1005,16 @@ class VisDataset(object):
                 # after all this: IHEC only allows one aligner per experiment!
                 self.vis_dataset['aligner'] = track['aligner']
             if 'aligner' not in self.vis_dataset and 'default' in self.aligners \
-                and len(self.aligners['default'].keys()) >= 1:
-                    track['aligner'] = self.aligners['default'][self.aligners['default'].keys()[0]]
+               and len(self.aligners['default'].keys()) >= 1:
+                track['aligner'] = self.aligners['default'][self.aligners['default'].keys()[0]]
 
         if self.pipelines:
             for file_id in self.pipelines.keys():
                 pipe = self.pipelines[file_id]
                 if file_id == a_file['@id']:
                     track['pipeline'] = pipe
-                if 'pipeline' not in self.vis_dataset or \
-                    pipe['version'] > self.vis_dataset['pipeline']['version']:
+                if 'pipeline' not in self.vis_dataset \
+                   or pipe['version'] > self.vis_dataset['pipeline']['version']:
                     self.vis_dataset['pipeline'] = pipe
 
         # Use step_ver to get at pipeline, but different files may be from different steps!
@@ -1006,14 +1026,14 @@ class VisDataset(object):
             return
 
         # Use analysis_step to get at pipeline, but different files may be from different steps!
-        track['step_version'] = step_ver.get('name','')
+        track['step_version'] = step_ver.get('name', '')
         analysis_step = step_ver.get("analysis_step")
         if not analysis_step:
             return  # oh well
         if not isinstance(analysis_step, dict):
             track['analysis_step'] = analysis_step.split('/')[1]
         else:
-            track['analysis_step'] = analysis_step.get('title','')
+            track['analysis_step'] = analysis_step.get('title', '')
         return
 
     def build(self, hide):
@@ -1021,14 +1041,14 @@ class VisDataset(object):
 
         if self.dataset["status"] not in VISIBLE_DATASET_STATUSES:
             log.debug("%s can't be visualized because it's not unreleased status:%s." %
-                    (self.dataset["accession"], self.dataset["status"]))
+                      (self.dataset["accession"], self.dataset["status"]))
             return {}
         self.vis_defines = VisDefines(self.dataset)
         vis_type = self.vis_defines.get_vis_type()
         self.vis_def = self.vis_defines.get_vis_def(vis_type)
         if self.vis_def is None:
             log.debug("%s (vis_type: %s) has undiscoverable vis_defs." %
-                    (self.dataset["accession"], vis_type))
+                      (self.dataset["accession"], vis_type))
             return {}
         self.vis_dataset = {}
         # log.debug("%s has vis_type: %s." % (self.dataset["accession"],vis_type))
@@ -1037,7 +1057,7 @@ class VisDataset(object):
 
         self.vis_dataset['assembly'] = self.assembly
         self.vis_dataset['ucsc_assembly'] = self.ucsc_assembly
-        self.vis_dataset["vis_id"]  = self.vis_id
+        self.vis_dataset["vis_id"] = self.vis_id
 
         for term in self.vis_defines.encoded_dataset_terms():
             val = self.vis_defines.lookup_embedded_token(term, self.dataset)
@@ -1050,9 +1070,10 @@ class VisDataset(object):
         if ihec_exp_type is not None:
             self.vis_dataset['ihec_exp_type'] = ihec_exp_type
             self.vis_dataset['ihec_sample'] = self.ihec.sample(self.dataset, self.vis_defines)
-        #self.vis_dataset['molecule'] = self.ihec.molecule(self.dataset)
-        #biosample = self.vis_defines.lookup_embedded_token('replicates.library.biosample', self.dataset)
-        #if biosample is not None:
+        # self.vis_dataset['molecule'] = self.ihec.molecule(self.dataset)
+        # biosample = self.vis_defines.lookup_embedded_token('replicates.library.biosample',
+        #                                                    self.dataset)
+        # if biosample is not None:
         #    lineage = self.ihec.lineage(biosample)
         #    if lineage is not None:
         #        self.vis_dataset['lineage'] = lineage
@@ -1060,7 +1081,8 @@ class VisDataset(object):
         #    if differentiation is not None:
         #        self.vis_dataset['differentiation'] = differentiation
 
-        longLabel = self.vis_def.get('longLabel','{assay_term_name} of {biosample_term_name} - {accession}')
+        longLabel = self.vis_def.get('longLabel',
+                                     '{assay_term_name} of {biosample_term_name} - {accession}')
         self.vis_dataset['longLabel'] = sanitize.label(self.vis_defines.convert_mask(longLabel))
         shortLabel = self.vis_def.get('shortLabel', '{accession}')
         self.vis_dataset['shortLabel'] = sanitize.label(self.vis_defines.convert_mask(shortLabel))
@@ -1099,7 +1121,8 @@ class VisDataset(object):
     def as_collection(self):
         # formats the single vis_dataset dict as a collection dict
         if self.vis_dataset is not None:
-            return {self.accession: self.vis_dataset} # NOTE: accession not vis_id, collections are always  one assembly
+            return {self.accession: self.vis_dataset}
+            #       NOTE: accession not vis_id, collections are always  one assembly
         return {}
 
     def remodel_to_ihec_json(self):
@@ -1115,8 +1138,8 @@ class VisDataset(object):
         if self.vis_defines is None:
             self.vis_defines = VisDefines()
         return self.vis_defines.ucsc_single_composite_trackDb(self.vis_dataset, self.accession)
-        #vis_collection = VisCollections(self.request, {self.accession: self.vis_dataset})
-        #return vis_collection.ucsc_trackDb()
+        # vis_collection = VisCollections(self.request, {self.accession: self.vis_dataset})
+        # return vis_collection.ucsc_trackDb()
 
     def stringify(self):
         '''returns string of trakDb.txt or json as appropriate.'''
@@ -1137,7 +1160,8 @@ class VisDataset(object):
 
 
 def vis_cache_add(request, dataset):
-    '''For a single embedded dataset, builds and adds vis_dataset to es cache for each relevant assembly.'''
+    '''For a single embedded dataset, builds and adds vis_dataset
+       to es cache for each relevant assembly.'''
     if not object_is_visualizable(dataset, exclude_quickview=True):
         return []
 
@@ -1151,7 +1175,7 @@ def vis_cache_add(request, dataset):
         if vis_dataset:  # Don't bother caching empties (e.g. {} == no visualizable files).
             vis_datasets.append(vis_dataset)
             log.debug("primed vis_cache with vis_dataset %s '%s'" %
-                        (vis_factory.vis_id, vis_factory.vis_type))
+                      (vis_factory.vis_id, vis_factory.vis_type))
 
     return vis_datasets
 
@@ -1166,16 +1190,17 @@ def generate_trackDb(request, dataset, assembly, hide=False, regen=False):
     accession = dataset['accession']
 
     # If we could detect this as a series dataset, then we could treat this as a batch_trackDb
-    if set(['Experiment', 'Annotation']).isdisjoint(dataset['@type']) and \
-          not set(['Series', 'FileSet']).isdisjoint(dataset['@type']):
+    if set(['Experiment', 'Annotation']).isdisjoint(dataset['@type']) \
+       and not set(['Series', 'FileSet']).isdisjoint(dataset['@type']):
         return generate_set_trackDb(request, accession, dataset, assembly, hide, regen)
 
     vis_factory = VisDataset(request)
-    vis_dataset = vis_factory.find_or_build(accession, assembly, dataset, hide, must_build=regen)
+    vis_factory.find_or_build(accession, assembly, dataset, hide, must_build=regen)
 
-    msg = "%s vis_dataset %s %s len(json):%d %.3f" % (vis_factory.found_or_built(accession, assembly),
-                 vis_factory.vis_id, vis_factory.vis_type, vis_factory.len(),
-                 (time.time() - PROFILE_START_TIME))
+    msg = "%s vis_dataset %s %s len(json):%d %.3f" % (
+                vis_factory.found_or_built(accession, assembly),
+                vis_factory.vis_id, vis_factory.vis_type, vis_factory.len(),
+                (time.time() - PROFILE_START_TIME))
     if vis_factory.regen_requested:  # Want to see message if regen was requested
         log.info(msg)
     else:
@@ -1188,12 +1213,12 @@ def generate_by_accessions(request, accessions, assembly, hide, regen, prepend_l
     '''Actual generation of trackDb for collections (batch and file_sets).'''
 
     vis_collection = VisCollections(request)
-    vis_datasets = vis_collection.find_or_build(accessions, assembly, hide, must_build=regen)
+    vis_collection.find_or_build(accessions, assembly, hide, must_build=regen)
 
     blob = vis_collection.stringify(prepend_label)
 
-    msg = "%s. len(txt):%s  %.3f secs" % \
-                 (vis_collection.found_or_built(), len(blob), (time.time() - PROFILE_START_TIME))
+    msg = ("%s. len(txt):%s  %.3f secs" %
+           (vis_collection.found_or_built(), len(blob), (time.time() - PROFILE_START_TIME)))
     if vis_collection.regen_requested:  # Want to see message if regen was requested
         log.info(msg)
     else:
@@ -1209,34 +1234,38 @@ def generate_set_trackDb(request, accession, dataset, assembly, hide=False, rege
     related_datasets = []
     if 'FileSet' in dataset['@type'] and 'files' in dataset:
         files = dataset['files']
-        if len(files) > 0 and not isinstance(files[0],str):
+        if len(files) > 0 and not isinstance(files[0], str):
             try:
-                related_datasets = [ file['dataset'] for file in files ]
-            except:
-                pass # caught below
+                related_datasets = [file['dataset'] for file in files]
+            except Exception:
+                pass  # caught below
             # Note: should be able to get
     elif 'Series' in dataset['@type'] and 'related_datasets' in dataset:
-        # Note that 'Series' don't actually reach here yet because they are rejected higher up for having no files.
+        # Note that 'Series' don't actually reach here yet because they are rejected higher up
         related_datasets = dataset['related_datasets']
     if len(related_datasets) > 0:
         try:
-            if isinstance(related_datasets[0],dict):
-                sub_accessions = [ related['accession'] for related in related_datasets ]
+            if isinstance(related_datasets[0], dict):
+                sub_accessions = [related['accession'] for related in related_datasets]
             else:
-                sub_accessions = [ related.split('/')[1] for related in related_datasets ]
-        except:
-            pass # caught below
-    sub_accessions = list(set(sub_accessions)) # Only unique accessions need apply
+                sub_accessions = [related.split('/')[1] for related in related_datasets]
+        except Exception:
+            pass  # caught below
+    sub_accessions = list(set(sub_accessions))   # Only unique accessions need apply
     if len(sub_accessions) == 0:
         log.error("failed to find true datasets for files in collection %s" % accession)
         return ""
 
-    return generate_by_accessions(request, sub_accessions, assembly, hide, regen, prepend_label=accession)
+    return generate_by_accessions(request, sub_accessions, assembly, hide, regen,
+                                  prepend_label=accession)
 
 
 def generate_batch_trackDb(request, hide=False, regen=False):
     '''Returns string content for a requested multi-experiment trackDb.txt.'''
-    # local test: RNA-seq: curl https://../batch_hub/type=Experiment,,assay_title=RNA-seq,,award.rfa=ENCODE3,,status=released,,assembly=GRCh38,,replicates.library.biosample.biosample_type=induced+pluripotent+stem+cell+line/GRCh38/trackDb.txt
+    # local test: RNA-seq:
+    # curl https://../batch_hub/type=Experiment,,assay_title=RNA-seq,,award.rfa=ENCODE3,,
+    #              status=released,,assembly=GRCh38,,replicates.library.biosample.biosample_type=
+    #              induced+pluripotent+stem+cell+line/GRCh38/trackDb.txt
 
     assembly = str(request.matchdict['assembly'])
     log.debug("Request for %s trackDb begins   %.3f secs" %
@@ -1268,7 +1297,7 @@ def generate_batch_trackDb(request, hide=False, regen=False):
     return generate_by_accessions(request, accessions, assembly, hide, regen)
 
 
-#def readable_time(secs_float):
+# def readable_time(secs_float):
 #    '''Return string of days, hours, minutes, seconds'''
 #    intervals = [1, 60, 60*60, 60*60*24]
 #    terms = [('second', 'seconds'), ('minute', 'minutes'), ('hour', 'hours'), ('day', 'days')]
@@ -1348,14 +1377,15 @@ def generate_html(context, request):
     if html_requested.startswith('ENCSR'):
         embedded = request.embed(request.resource_path(context))
         accession = embedded['accession']
-        log.debug("generate_html for %s   %.3f secs" % (accession, (time.time() - PROFILE_START_TIME)))
+        log.debug("generate_html for %s   %.3f secs" %
+                  (accession, (time.time() - PROFILE_START_TIME)))
         assert(html_requested == accession)
 
         vis_defines = VisDefines(embedded)
         vis_type = vis_defines.get_vis_type()
         vis_def = vis_defines.get_vis_def(vis_type)
         longLabel = vis_def.get('longLabel',
-                                 '{assay_term_name} of {biosample_term_name} - {accession}')
+                                '{assay_term_name} of {biosample_term_name} - {accession}')
         longLabel = sanitize.label(vis_defines.convert_mask(longLabel))
 
         link = request.host_url + '/experiments/' + accession + '/'
@@ -1370,7 +1400,7 @@ def generate_html(context, request):
         vis_type = html_requested
         vis_def = VisDefines().get_vis_def(vis_type)
         longLabel = vis_def.get('assay_composite', {}).get('longLabel',
-                                                            "Unknown collection of experiments")
+                                                           "Unknown collection of experiments")
         page = '<h2>%s</h2>' % longLabel
 
         # TO IMPROVE: limit the search url to this assay only.
@@ -1381,7 +1411,7 @@ def generate_html(context, request):
             # search_url = (request.url).split('@@hub')[0]
             search_link = '<a href=%s>Original search<a><BR>' % search_url
             page += search_link
-        except:
+        except Exception:
             pass
 
     details = vis_def.get("html_detail")
@@ -1398,14 +1428,13 @@ def generate_batch_hubs(context, request):
 
     results = {}
     (page, suffix, cmd) = urlpage(request.url)
-    log.debug('Requesting %s.%s#%s' % (page,suffix,cmd))
+    log.debug('Requesting %s.%s#%s' % (page, suffix, cmd))
     content_mime = 'text/plain'
     if suffix == 'json':
         content_mime = 'application/json'
 
     if (suffix == 'txt' and page == 'trackDb') or \
-         (suffix == 'json' and page in ['trackDb','ihec','vis_blob']):
-
+       (suffix == 'json' and page in ['trackDb', 'ihec', 'vis_blob']):
         return (generate_batch_trackDb(request), content_mime)
 
     elif page == 'hub' and suffix == 'txt':
@@ -1420,9 +1449,9 @@ def generate_batch_hubs(context, request):
     elif page == 'genomes' and suffix == 'txt':
         search_params = request.matchdict['search_params']
         if search_params.find('bed6+') > -1:
-            search_params = search_params.replace('bed6+,,','bed6%2B,,')
+            search_params = search_params.replace('bed6+,,', 'bed6%2B,,')
         log.debug('search_params: %s' % (search_params))
-        #param_list = parse_qs(request.matchdict['search_params'].replace(',,', '&'))
+        # param_list = parse_qs(request.matchdict['search_params'].replace(',,', '&'))
         param_list = parse_qs(search_params.replace(',,', '&'))
         log.debug('parse_qs: %s' % (param_list))
 
@@ -1470,6 +1499,7 @@ def generate_batch_hubs(context, request):
         content_mime = 'text/html'
         return (generate_html(context, request) + data_policy, content_mime)
 
+
 def respond_with_text(request, text, content_mime):
     '''Resonse that can handle range requests.'''
     # UCSC broke trackhubs and now we must handle byterange requests on these CGI files
@@ -1480,7 +1510,6 @@ def respond_with_text(request, text, content_mime):
     response.accept_ranges = "bytes"
     response.last_modified = time.strftime('%a, %d %b %Y %H:%M:%S GMT', time.gmtime())
     if 'Range' in request.headers:
-        range_request = True
         range = request.headers['Range']
         if range.startswith('bytes'):
             range = range.split('=')[1]
@@ -1488,10 +1517,12 @@ def respond_with_text(request, text, content_mime):
         # One final present... byterange '0-' with no end in sight
         if range[1] == '':
             range[1] = len(response.body) - 1
-        response.content_range = 'bytes %d-%d/%d' % (int(range[0]),int(range[1]),len(response.body))
-        response.app_iter = request.response.app_iter_range(int(range[0]),int(range[1]) + 1)
+        response.content_range = ('bytes %d-%d/%d' % (int(range[0]), int(range[1]),
+                                  len(response.body)))
+        response.app_iter = request.response.app_iter_range(int(range[0]), int(range[1]) + 1)
         response.status_code = 206
     return response
+
 
 @view_config(name='hub', context=Item, request_method='GET', permission='view')
 def hub(context, request):
@@ -1501,7 +1532,7 @@ def hub(context, request):
 
     embedded = request.embed(request.resource_path(context))
 
-    (page,suffix,cmd) = urlpage(request.url)
+    (page, suffix, cmd) = urlpage(request.url)
     content_mime = 'text/plain'
     if suffix == 'json':
         content_mime = 'application/json'
@@ -1521,7 +1552,7 @@ def hub(context, request):
         text = get_genomes_txt(assemblies)
 
     elif (suffix == 'txt' and page == 'trackDb') or \
-         (suffix == 'json' and page in ['trackDb','ihec','vis_blob']):
+         (suffix == 'json' and page in ['trackDb', 'ihec', 'vis_blob']):
         url_ret = (request.url).split('@@hub')
         url_end = url_ret[1][1:]
         text = generate_trackDb(request, embedded, url_end.split('/')[0])


### PR DESCRIPTION
When deploying regulome release 1 Yunhai found a bug. We usually do not set the volume size on deploy. The volmne size is a string in the deploy.py but AWS only accepts int.