### PR TITLE
ENCD-4073 Revert accidental blocked dataset status expansion

### DIFF
--- a/src/encoded/vis_defines.py
+++ b/src/encoded/vis_defines.py
@@ -115,7 +115,7 @@ ASSEMBLY_TO_UCSC_ID = {
 }
 
 
-QUICKVIEW_STATUSES_BLOCKED = ["in progress", "submitted", "deleted", "revoked", "replaced"]
+QUICKVIEW_STATUSES_BLOCKED = ["deleted", "revoked", "replaced"]
 
 VISIBLE_DATASET_STATUSES = ["released"]
 VISIBLE_FILE_STATUSES = ["released"]


### PR DESCRIPTION
Fix was tested on demo: https://reg-41-inital-region-indexing-failure-2a0200d8a-tdreszer.demo.encodedcc.org/experiments/ENCSR425LSX/