### PR TITLE
ENCD-3728 Fix build error

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -50,6 +50,7 @@ const loaders = [
         include: [
             PATHS.static,
             path.resolve(__dirname, 'node_modules/dalliance'),
+            path.resolve(__dirname, 'node_modules/superagent'),
         ],
         loader: 'babel',
     },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -49,6 +49,7 @@ const loaders = [
         test: /\.js$/,
         include: [
             PATHS.static,
+            path.resolve(__dirname, 'node_modules/dagre-d3'),
             path.resolve(__dirname, 'node_modules/dalliance'),
             path.resolve(__dirname, 'node_modules/superagent'),
         ],


### PR DESCRIPTION
After upgrading auth0-lock in ENCD-4045 with their fixes for this problem, we still see the same problem with the superagent npm package. I fixed this by adding superagent to the list of directories that gets processed by babel to convert ES6 used in superagent to ES5 that uglify requires in this version of webpack.

A demo isn’t needed for this ticket. To test this, you need to do a clean build and then look at the webpack output to see that the error message copied into the ticket doesn’t appear.