### PR TITLE
ENCD-4093 Fix initial region indexing failure

### DIFF
--- a/src/encoded/region_indexer.py
+++ b/src/encoded/region_indexer.py
@@ -242,17 +242,8 @@ class RegionIndexerState(IndexerState):
             # There is an efficiency trade off examining many non-dataset uuids
             # # vs. the cost of eliminating those uuids from the list ahead of time.
             assays = list(ENCODED_REGION_REQUIREMENTS.keys())
-            filtered_uuids = list(set(encoded_regionable_datasets(request, assays)).intersection(uuids))
-            uuid_count = len(filtered_uuids)
-            # Initial hand-off of uuids from the primary_indexer is failing.
-            if uuid_count < 5000:
-                log.warn("Found only %d 'regionable' datasets.  Syncing and trying again.", uuid_count)
-                self.es.indices.flush_synced(index='_all')
-                filtered_uuids = list(set(encoded_regionable_datasets(request, assays)).intersection(uuids))
-                uuid_count = len(filtered_uuids)
-                log.warn("Now found %d 'regionable' datasets.", uuid_count)
-            uuids = filtered_uuids
-
+            uuids = list(set(encoded_regionable_datasets(request, assays)).intersection(uuids))
+            uuid_count = len(uuids)
 
         return (list(set(uuids)),False)  # Only unique uuids
 

--- a/src/encoded/region_indexer.py
+++ b/src/encoded/region_indexer.py
@@ -176,7 +176,10 @@ class RegionIndexerState(IndexerState):
         # Not yet started?
         initialized = self.get_obj("indexing")  # http://localhost:9200/snovault/meta/indexing
         if not initialized:
-            self.delete_objs([self.override, self.staged_for_regions_list])
+            self.delete_objs([self.override])
+            staged_count = self.get_count(self.staged_for_regions_list)
+            if staged_count > 0:
+                log.warn('Initial indexing handoff almost dropped %d staged uuids' % (staged_count))
             state = self.get()
             state['status'] = 'uninitialized'
             self.put(state)


### PR DESCRIPTION
Fixes the initial region indexing bug, which turned out to be a race condition in handing off the staged uuids list.  Tested this solution on a demo, (but had to artificially open the race condition window wide to catch it).