### PR TITLE
ENCD-4017 Fulfill ECP requests for home page additions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .aws/
 .coverage
 .gitconfig
+.vscode/
 /.installed.cfg
 /.mr.developer.cfg
 /.cache/

--- a/src/encoded/static/components/app.js
+++ b/src/encoded/static/components/app.js
@@ -34,8 +34,11 @@ const portal = {
             title: 'Encyclopedia',
             children: [
                 { id: 'aboutannotations', title: 'About', url: '/data/annotations/' },
+                { id: 'sep-mm-1' },
+                { id: 'annotationvisualize', title: 'Visualize (SCREEN)', url: 'http://screen.encodeproject.org/' },
                 { id: 'annotationmatrix', title: 'Matrix', url: '/matrix/?type=Annotation&encyclopedia_version=4' },
                 { id: 'annotationsearch', title: 'Search', url: '/search/?type=Annotation&encyclopedia_version=4' },
+                { id: 'annotationmethods', title: 'Methods', url: 'http://screen.encodeproject.org/index/about' },
             ],
         },
         {
@@ -821,6 +824,7 @@ class App extends React.Component {
         return request;
     }
 
+    /* eslint-disable class-methods-use-this */
     fallbackNavigate(href, fragment, options) {
         // Navigate using window.location
         if (options.replace) {
@@ -833,6 +837,7 @@ class App extends React.Component {
             }
         }
     }
+    /* eslint-enable class-methods-use-this */
 
     receiveContextResponse(data) {
         // title currently ignored by browsers

--- a/src/encoded/static/components/home.js
+++ b/src/encoded/static/components/home.js
@@ -38,18 +38,6 @@ function generateQuery(selectedOrganisms, selectedAssayCategory) {
 }
 
 
-// Buttons to introduce people to ENCODE.
-const IntroControls = () => (
-    <div className="intro-controls">
-        <a href="/about/contributors/" role="button" className="intro-controls__element intro-controls__element--33-width">About</a>
-        <a href="/help/getting-started/" role="button" className="intro-controls__element intro-controls__element--33-width">Get Started</a>
-        <a href="/help/rest-api/" role="button" className="intro-controls__element intro-controls__element--33-width">REST API</a>
-        <a href="/matrix/?type=Experiment&status=released" role="button" className="intro-controls__element intro-controls__element--50-width">Data Matrix</a>
-        <a href="/matrix/?type=Annotation&encyclopedia_version=4" role="button" className="intro-controls__element intro-controls__element--50-width">Encyclopedia Matrix</a>
-    </div>
-);
-
-
 // Home-page-only ENCODE search form.
 class EncodeSearch extends React.Component {
     constructor() {
@@ -69,21 +57,28 @@ class EncodeSearch extends React.Component {
 
     render() {
         return (
-            <form action="/search/">
-                <fieldset className="site-search__encode">
-                    <legend className="sr-only">Encode search</legend>
-                    <div className="site-search__input">
-                        <label htmlFor="encode-search">Search ENCODE portal</label>
-                        <Tooltip trigger={<i className="icon icon-info-circle" />} tooltipId="search-encode" css="tooltip-home-info">
-                            Search the entire ENCODE portal by using terms like &ldquo;skin,&rdquo; &ldquo;ChIP-seq,&rdquo; or &ldquo;CTCF.&rdquo;
-                        </Tooltip>
-                        <input id="encode-search" className="form-control" value={this.state.inputText} name="searchTerm" type="text" onChange={this.handleOnChange} />
-                    </div>
-                    <div className="site-search__submit">
-                        <button type="submit" aria-label="ENCODE portal search" title="ENCODE portal search" disabled={this.state.disabledSearch} className="btn btn-info">ENCODE <i className="icon icon-search" /></button>
-                    </div>
-                </fieldset>
-            </form>
+            <div className="site-search__encode">
+                <div className="site-search__controls">
+                    <a href="/about/contributors/" role="button" className="site-search__control-element site-search__control-element--33-width">About ENCODE</a>
+                    <a href="/help/getting-started/" role="button" className="site-search__control-element site-search__control-element--33-width">Get Started</a>
+                    <a href="/matrix/?type=Experiment&status=released" role="button" className="site-search__control-element site-search__control-element--33-width">Experiment Data</a>
+                </div>
+                <form action="/search/">
+                    <fieldset className="site-search__encode">
+                        <legend className="sr-only">Encode search</legend>
+                        <div className="site-search__input">
+                            <label htmlFor="encode-search">Search ENCODE portal</label>
+                            <Tooltip trigger={<i className="icon icon-info-circle" />} tooltipId="search-encode" css="tooltip-home-info">
+                                Search the entire ENCODE portal by using terms like &ldquo;skin,&rdquo; &ldquo;ChIP-seq,&rdquo; or &ldquo;CTCF.&rdquo;
+                            </Tooltip>
+                            <input id="encode-search" className="form-control" value={this.state.inputText} name="searchTerm" type="text" onChange={this.handleOnChange} />
+                        </div>
+                        <div className="site-search__submit">
+                            <button type="submit" aria-label="ENCODE portal search" title="ENCODE portal search" disabled={this.state.disabledSearch} className="btn btn-info">ENCODE <i className="icon icon-search" /></button>
+                        </div>
+                    </fieldset>
+                </form>
+            </div>
         );
     }
 }
@@ -463,46 +458,44 @@ class ScreenSearch extends React.Component {
     render() {
         const disabledSearch = this.state.currSearchTerm.length === 0;
         return (
-            <form>
-                <fieldset className="site-search__screen">
-                    <legend className="sr-only">Screen search</legend>
-                    <div className="site-search__input">
-                        <label htmlFor="screen-search" id="screen-search-label">
-                            Search for Candidate Regulatory Elements
-                            <Tooltip trigger={<i className="icon icon-info-circle" />} tooltipId="search-screen" css="tooltip-home-info">
-                                Search for candidate regulatory elements by entering a gene name or alias, SNP rsID, ccRE accession, or genomic region in the form chr:start-end; or enter a cell type to filter results e.g. &ldquo;chr11:5226493-5403124&rdquo; or &ldquo;rs4846913.&rdquo;
-                            </Tooltip>
-                            <br />
-                            <span className="site-search__note">Hosted by <a href="http://screen.encodeproject.org/">SCREEN</a></span>
-                        </label>
-                        <InputSuggest
-                            value={this.state.currSearchTerm}
-                            items={this.state.suggestedSearchTerms}
-                            inputId="screen-search"
-                            labelledById="screen-search-label"
-                            inputChangeHandler={this.searchTermChange}
-                            inputClickHandler={this.searchTermClick}
-                            inputBlurHandler={this.inputBlur}
-                            itemSelectHandler={this.termSelectHandler}
-                        />
-                    </div>
-                    <div className="site-search__submit">
-                        <a disabled={disabledSearch} aria-label="Human hg19 search" title="Human hg19 search" className="btn btn-info" role="button" href={`http://screen.encodeproject.org/search/?q=${this.state.currSearchTerm}&uuid=0&assembly=hg19`}>Human hg19 <i className="icon icon-search" /></a>
-                        <a disabled={disabledSearch} aria-label="Mouse mm10 search" title="Mouse mm10 search" className="btn btn-info" role="button" href={`http://screen.encodeproject.org/search/?q=${this.state.currSearchTerm}&uuid=0&assembly=mm10`}>Mouse mm10 <i className="icon icon-search" /></a>
-                    </div>
-                </fieldset>
-            </form>
+            <div className="site-search__screen">
+                <div className="site-search__controls">
+                    <a href="/data/annotations/" role="button" className="site-search__control-element site-search__control-element--50-width">About Encyclopedia</a>
+                    <a href="/matrix/?type=Annotation&encyclopedia_version=4&annotation_type=candidate+regulatory+elements" role="button" className="site-search__control-element site-search__control-element--50-width">Encyclopedia Data</a>
+                </div>
+                <form>
+                    <fieldset className="site-search__screen">
+                        <legend className="sr-only">Screen search</legend>
+                        <div className="site-search__input">
+                            <label htmlFor="screen-search" id="screen-search-label">
+                                Search for Candidate Regulatory Elements
+                                <Tooltip trigger={<i className="icon icon-info-circle" />} tooltipId="search-screen" css="tooltip-home-info">
+                                    Search for candidate regulatory elements by entering a gene name or alias, SNP rsID, ccRE accession, or genomic region in the form chr:start-end; or enter a cell type to filter results e.g. &ldquo;chr11:5226493-5403124&rdquo; or &ldquo;rs4846913.&rdquo;
+                                </Tooltip>
+                                <br />
+                                <span className="site-search__note">Hosted by <a href="http://screen.encodeproject.org/">SCREEN</a></span>
+                            </label>
+                            <InputSuggest
+                                value={this.state.currSearchTerm}
+                                items={this.state.suggestedSearchTerms}
+                                inputId="screen-search"
+                                labelledById="screen-search-label"
+                                inputChangeHandler={this.searchTermChange}
+                                inputClickHandler={this.searchTermClick}
+                                inputBlurHandler={this.inputBlur}
+                                itemSelectHandler={this.termSelectHandler}
+                            />
+                        </div>
+                        <div className="site-search__submit">
+                            <a disabled={disabledSearch} aria-label="Human hg19 search" title="Human hg19 search" className="btn btn-info" role="button" href={`http://screen.encodeproject.org/search/?q=${this.state.currSearchTerm}&uuid=0&assembly=hg19`}>Human hg19 <i className="icon icon-search" /></a>
+                            <a disabled={disabledSearch} aria-label="Mouse mm10 search" title="Mouse mm10 search" className="btn btn-info" role="button" href={`http://screen.encodeproject.org/search/?q=${this.state.currSearchTerm}&uuid=0&assembly=mm10`}>Mouse mm10 <i className="icon icon-search" /></a>
+                        </div>
+                    </fieldset>
+                </form>
+            </div>
         );
     }
 }
-
-
-const SiteSearch = () => (
-    <div className="site-search">
-        <EncodeSearch />
-        <ScreenSearch />
-    </div>
-);
 
 
 // Main page component to render the home page
@@ -691,8 +684,11 @@ class AssayClicking extends React.Component {
 
                         <div className="site-banner-intro">
                             <div className="site-banner-intro-content">
-                                <IntroControls />
-                                <SiteSearch />
+                                <div className="site-search">
+                                    <EncodeSearch />
+                                    <hr />
+                                    <ScreenSearch />
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/src/encoded/static/components/home.js
+++ b/src/encoded/static/components/home.js
@@ -58,13 +58,13 @@ class EncodeSearch extends React.Component {
     render() {
         return (
             <div className="site-search__encode">
-                <div className="site-search__controls">
-                    <a href="/about/contributors/" role="button" className="site-search__control-element">About ENCODE Project</a>
-                    <a href="/help/getting-started/" role="button" className="site-search__control-element">Get Started</a>
-                    <a href="/matrix/?type=Experiment&status=released" role="button" className="site-search__control-element">Experiment Data</a>
+                <div className="site-search__reference">
+                    <a href="/about/contributors/" role="button" className="site-search__reference-element">About ENCODE Project</a>
+                    <a href="/help/getting-started/" role="button" className="site-search__reference-element">Getting Started</a>
+                    <a href="/matrix/?type=Experiment&status=released" role="button" className="site-search__reference-element">Experiments</a>
                 </div>
                 <form action="/search/">
-                    <fieldset className="site-search__encode">
+                    <fieldset>
                         <legend className="sr-only">Encode search</legend>
                         <div className="site-search__input">
                             <label htmlFor="encode-search">Search ENCODE portal</label>
@@ -74,7 +74,7 @@ class EncodeSearch extends React.Component {
                             <input id="encode-search" className="form-control" value={this.state.inputText} name="searchTerm" type="text" onChange={this.handleOnChange} />
                         </div>
                         <div className="site-search__submit">
-                            <button type="submit" aria-label="ENCODE portal search" title="ENCODE portal search" disabled={this.state.disabledSearch} className="btn btn-info">ENCODE <i className="icon icon-search" /></button>
+                            <button type="submit" aria-label="ENCODE portal search" title="ENCODE portal search" disabled={this.state.disabledSearch} className="site-search__submit-element">ENCODE <i className="icon icon-search" /></button>
                         </div>
                     </fieldset>
                 </form>
@@ -459,12 +459,12 @@ class ScreenSearch extends React.Component {
         const disabledSearch = this.state.currSearchTerm.length === 0;
         return (
             <div className="site-search__screen">
-                <div className="site-search__controls">
-                    <a href="/data/annotations/" role="button" className="site-search__control-element site-search__control-element--50-width">About Encyclopedia</a>
-                    <a href="/matrix/?type=Annotation&encyclopedia_version=4&annotation_type=candidate+regulatory+elements" role="button" className="site-search__control-element site-search__control-element--50-width">Encyclopedia Annotations</a>
+                <div className="site-search__reference">
+                    <a href="/data/annotations/" role="button" className="site-search__reference-element">About ENCODE Encyclopedia</a>
+                    <a href="/matrix/?type=Annotation&encyclopedia_version=4&annotation_type=candidate+regulatory+elements" role="button" className="site-search__reference-element">Candidate Regulatory Elements</a>
                 </div>
                 <form>
-                    <fieldset className="site-search__screen">
+                    <fieldset>
                         <legend className="sr-only">Screen search</legend>
                         <div className="site-search__input">
                             <label htmlFor="screen-search" id="screen-search-label">
@@ -487,8 +487,8 @@ class ScreenSearch extends React.Component {
                             />
                         </div>
                         <div className="site-search__submit">
-                            <a disabled={disabledSearch} aria-label="Human hg19 search" title="Human hg19 search" className="btn btn-info" role="button" href={`http://screen.encodeproject.org/search/?q=${this.state.currSearchTerm}&uuid=0&assembly=hg19`}>Human hg19 <i className="icon icon-search" /></a>
-                            <a disabled={disabledSearch} aria-label="Mouse mm10 search" title="Mouse mm10 search" className="btn btn-info" role="button" href={`http://screen.encodeproject.org/search/?q=${this.state.currSearchTerm}&uuid=0&assembly=mm10`}>Mouse mm10 <i className="icon icon-search" /></a>
+                            <a disabled={disabledSearch} aria-label="Human hg19 search" title="Human hg19 search" className="site-search__submit-element" role="button" href={`http://screen.encodeproject.org/search/?q=${this.state.currSearchTerm}&uuid=0&assembly=hg19`}>Human hg19 <i className="icon icon-search" /></a>
+                            <a disabled={disabledSearch} aria-label="Mouse mm10 search" title="Mouse mm10 search" className="site-search__submit-element" role="button" href={`http://screen.encodeproject.org/search/?q=${this.state.currSearchTerm}&uuid=0&assembly=mm10`}>Mouse mm10 <i className="icon icon-search" /></a>
                         </div>
                     </fieldset>
                 </form>

--- a/src/encoded/static/components/home.js
+++ b/src/encoded/static/components/home.js
@@ -59,9 +59,9 @@ class EncodeSearch extends React.Component {
         return (
             <div className="site-search__encode">
                 <div className="site-search__controls">
-                    <a href="/about/contributors/" role="button" className="site-search__control-element site-search__control-element--33-width">About ENCODE</a>
-                    <a href="/help/getting-started/" role="button" className="site-search__control-element site-search__control-element--33-width">Get Started</a>
-                    <a href="/matrix/?type=Experiment&status=released" role="button" className="site-search__control-element site-search__control-element--33-width">Experiment Data</a>
+                    <a href="/about/contributors/" role="button" className="site-search__control-element">About ENCODE Project</a>
+                    <a href="/help/getting-started/" role="button" className="site-search__control-element">Get Started</a>
+                    <a href="/matrix/?type=Experiment&status=released" role="button" className="site-search__control-element">Experiment Data</a>
                 </div>
                 <form action="/search/">
                     <fieldset className="site-search__encode">
@@ -461,7 +461,7 @@ class ScreenSearch extends React.Component {
             <div className="site-search__screen">
                 <div className="site-search__controls">
                     <a href="/data/annotations/" role="button" className="site-search__control-element site-search__control-element--50-width">About Encyclopedia</a>
-                    <a href="/matrix/?type=Annotation&encyclopedia_version=4&annotation_type=candidate+regulatory+elements" role="button" className="site-search__control-element site-search__control-element--50-width">Encyclopedia Data</a>
+                    <a href="/matrix/?type=Annotation&encyclopedia_version=4&annotation_type=candidate+regulatory+elements" role="button" className="site-search__control-element site-search__control-element--50-width">Encyclopedia Annotations</a>
                 </div>
                 <form>
                     <fieldset className="site-search__screen">

--- a/src/encoded/static/libs/bootstrap/tooltip.js
+++ b/src/encoded/static/libs/bootstrap/tooltip.js
@@ -1,0 +1,120 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+
+// This module lets you have a tooltip pop up when any component is hovered over or focused. The
+// general usage is:
+//
+// <Tooltip trigger={<Trigger />} tooltipId="html-id-unique-on-page" css="custom-css-classes">
+//     <TooltipContent />
+// </Tooltip>
+//
+// The component that the user can hover over to trigger the tooltip is given in the `trigger`
+// property and appears in the DOM whereever you place the <Tooltip> component. Put the contents
+// of the tooltip between the opening and closing <Tooltip> tags. This can simply be a string if
+// that's all you need, or a full-fledged component.
+
+export default class Tooltip extends React.Component {
+    constructor() {
+        super();
+        this.state = {
+            tooltipDisplayed: false,
+        };
+        this.timer = null;
+        this.hoveringOverTooltip = false;
+        this.handleTriggerMouseEnter = this.handleTriggerMouseEnter.bind(this);
+        this.handleTriggerMouseLeave = this.handleTriggerMouseLeave.bind(this);
+        this.handleTooltipMouseEnter = this.handleTooltipMouseEnter.bind(this);
+        this.handleTooltipMouseLeave = this.handleTooltipMouseLeave.bind(this);
+        this.handleTriggerFocus = this.handleTriggerFocus.bind(this);
+        this.handleTriggerBlur = this.handleTriggerBlur.bind(this);
+    }
+
+    handleTriggerMouseEnter() {
+        // Mouse entered the tooltip trigger element.
+        this.setState({ tooltipDisplayed: true });
+
+        // If we happen to have a running timer, clear it so we don't hide the tooltip while
+        // hovering over the trigger.
+        if (this.timer) {
+            clearTimeout(this.timer);
+            this.timer = null;
+        }
+    }
+
+    handleTriggerMouseLeave() {
+        // Start a timer that might hide the tooltip after a second passes. It won't hide the
+        // tooltip if they're now hovering over the tooltip itself.
+        this.timer = setTimeout(() => {
+            this.timer = null;
+            if (!this.hoveringOverTooltip) {
+                this.setState({ tooltipDisplayed: false });
+            }
+        }, 1000);
+    }
+
+    handleTriggerFocus() {
+        // Show tooltip when keyboard focus lands on tooltip trigger.
+        this.setState({ tooltipDisplayed: true });
+    }
+
+    handleTriggerBlur() {
+        // Hide tooltip when keyboard focus leaves tooltip trigger.
+        this.setState({ tooltipDisplayed: false });
+    }
+
+    handleTooltipMouseEnter() {
+        // Mouse started hovering over the tooltip itself. Prevent the tooltip from hiding even if
+        // the one-second trigger time expires.
+        this.hoveringOverTooltip = true;
+    }
+
+    handleTooltipMouseLeave() {
+        // Mouse stopped hovering over the tooltip itself. If the timer's not running, hide the
+        // tooltip, otherwise let the existing timer hide the tooltip when it expires.
+        this.hoveringOverTooltip = false;
+        if (!this.timer) {
+            this.setState({ tooltipDisplayed: false });
+        }
+    }
+
+    render() {
+        const { trigger, direction, tooltipId, css } = this.props;
+        const tooltipCss = `tooltip ${direction}`;
+        const wrapperCss = `tooltip-container${css ? ` ${css}` : ''}`;
+        return (
+            <div className={wrapperCss}>
+                {this.state.tooltipDisplayed ?
+                    <div className={tooltipCss} role="tooltip" id={tooltipId} onMouseEnter={this.handleTooltipMouseEnter} onMouseLeave={this.handleTooltipMouseLeave}>
+                        <div className="tooltip-arrow" />
+                        <div className="tooltip-inner">{this.props.children}</div>
+                    </div>
+                : null}
+                <button
+                    aria-describedby={this.state.tooltipDisplayed ? tooltipId : ''}
+                    onMouseEnter={this.handleTriggerMouseEnter}
+                    onMouseLeave={this.handleTriggerMouseLeave}
+                    onFocus={this.handleTriggerFocus}
+                    onBlur={this.handleTriggerBlur}
+                    className="tooltip-container__trigger"
+                >
+                    {trigger}
+                </button>
+            </div>
+        );
+    }
+}
+
+Tooltip.propTypes = {
+    trigger: PropTypes.element.isRequired, // Visible tooltip triggering component
+    tooltipId: PropTypes.string.isRequired, // HTML ID of tooltip <div>; unique within page
+    direction: PropTypes.oneOf(['left', 'top', 'bottom', 'right']), // Direction of bootstrap tooltip location
+    css: PropTypes.string, // CSS classes to add to tooltip-container wrapper class
+    children: PropTypes.node,
+};
+
+Tooltip.defaultProps = {
+    direction: 'bottom',
+    css: '',
+    children: null,
+};

--- a/src/encoded/static/libs/bootstrap/tooltip.js
+++ b/src/encoded/static/libs/bootstrap/tooltip.js
@@ -79,8 +79,8 @@ export default class Tooltip extends React.Component {
     }
 
     render() {
-        const { trigger, direction, tooltipId, css } = this.props;
-        const tooltipCss = `tooltip ${direction}`;
+        const { trigger, position, tooltipId, css } = this.props;
+        const tooltipCss = `tooltip ${position}`;
         const wrapperCss = `tooltip-container${css ? ` ${css}` : ''}`;
         return (
             <div className={wrapperCss}>
@@ -108,13 +108,13 @@ export default class Tooltip extends React.Component {
 Tooltip.propTypes = {
     trigger: PropTypes.element.isRequired, // Visible tooltip triggering component
     tooltipId: PropTypes.string.isRequired, // HTML ID of tooltip <div>; unique within page
-    direction: PropTypes.oneOf(['left', 'top', 'bottom', 'right']), // Direction of bootstrap tooltip location
+    position: PropTypes.oneOf(['left', 'top', 'bottom', 'right']), // Position of bootstrap tooltip location
     css: PropTypes.string, // CSS classes to add to tooltip-container wrapper class
     children: PropTypes.node,
 };
 
 Tooltip.defaultProps = {
-    direction: 'bottom',
+    position: 'bottom',
     css: '',
     children: null,
 };

--- a/src/encoded/static/scss/encoded/modules/_home.scss
+++ b/src/encoded/static/scss/encoded/modules/_home.scss
@@ -78,10 +78,6 @@
     position: relative;
 
     @media screen and (min-width: $screen-md-min) {
-        flex: 0 1 70%;
-    }
-
-    @media screen and (min-width: $screen-lg-min) {
         flex: 0 1 60%;
     }
 
@@ -92,19 +88,16 @@
 }
 
 .site-banner-intro {
-    padding: 10px 20px;
+    padding: 10px 10px;
     line-height: 1.8;
     font-size: 1.2rem;
     line-height: 1.8;
 
-    @media screen and (min-width: $screen-md-min) {
-        flex: 0 1 30%;
-        font-size: 1.1rem;
-        line-height: 1.6;
-        border-left: 1px solid #e0e0e0;
+    @media screen and (min-width: $screen-sm-min) {
+        padding: 10px 20px;
     }
 
-    @media screen and (min-width: $screen-lg-min) {
+    @media screen and (min-width: $screen-md-min) {
         flex: 0 1 40%;
         font-size: 1.2rem;
         line-height: 1.8;
@@ -387,4 +380,111 @@
 .news-header {
     @extend .twitter-header;
     border-bottom: 1px solid #e0e0e0;
+}
+
+.intro-controls {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    margin: 0 -5px;
+
+    @media screen and (min-width: $screen-sm-min) {
+        margin: 0;
+    }
+
+    @at-root #{&}__element {
+        @extend .btn;
+        @extend .btn-info;
+        margin: 5px;
+        padding-top: 10px;
+        padding-bottom: 10px;
+        flex: 1 1 auto;
+
+        @media screen and (min-width: $screen-sm-min) {
+            margin: 5px 0;
+
+            &--33-width {
+                flex: 0 0 31%;
+            }
+
+            &--50-width {
+                flex: 0 0 48%;
+            }
+        }
+    }
+}
+
+
+.site-search {
+    width: 100%;
+
+    @at-root #{&}__screen {
+        a {
+            margin-right: 5px;
+
+            &:after {
+                content: "" !important;
+            }
+        }
+    }
+
+    @at-root #{&}__suggested-results {
+        position: absolute;
+        left: 0;
+        right: 0;
+        top: 100%;
+        z-index: 2;
+        background-color: white;
+        border: 1px solid #a0a0a0;
+        box-shadow: 0 8px 16px rgba(0, 0, 0, 0.2);
+        margin: 0;
+        padding: 0;
+        list-style: none;
+
+        li {
+            margin: 0;
+            padding: 0;
+
+            button {
+                display: block;
+                width: 100%;
+                font-size: 1rem;
+                text-align: left;
+                background: none;
+                border: none;
+
+                &.site-search__suggested-results--selected {
+                    background-color: #0a253d;
+                    color: #fff;
+                }
+            }
+        }
+    }
+
+    @at-root #{&}__input {
+        margin-bottom: 10px;
+
+        label {
+            line-height: 1;
+        }
+    }
+
+    @at-root #{&}__input-field {
+        position: relative;
+    }
+
+    @at-root #{&}__note {
+        font-size: 0.9rem;
+        font-weight: normal;
+        font-style: italic;
+    }
+}
+
+// Info icons with tooltips.
+.tooltip-home-info {
+    margin-left: 5px;
+    width: 16px;
+    height: 16px;
+    line-height: 1;
+    vertical-align: baseline;
 }

--- a/src/encoded/static/scss/encoded/modules/_home.scss
+++ b/src/encoded/static/scss/encoded/modules/_home.scss
@@ -383,32 +383,35 @@
 }
 
 
-// Contains buttons for the home page site search.
-.site-search__controls {
+// Contains buttons for the home page buttons leading to other pages.
+.site-search__reference {
     display: flex;
     flex-wrap: wrap;
     justify-content: space-between;
     margin: 0 -5px;
+
+    &-element {
+        @extend .btn;
+        @extend .btn-info;
+        @extend .btn-xs;
+        margin: 5px;
+        padding-top: 5px;
+        padding-bottom: 5px;
+        flex: 1 1 auto;
+    }
 }
 
 
-// Buttons within site-search__controls.
-.site-search__control-element {
-    @extend .btn;
-    @extend .btn-info;
-    margin: 5px;
-    padding-top: 10px;
-    padding-bottom: 10px;
-    flex: 1 1 auto;
+// Contains buttons to perform searches.
+.site-search__submit {
+    @extend .site-search__reference;
+    justify-content: flex-start;
 
-    @media screen and (min-width: $screen-lg-min) {
-        &--33-width {
-            flex: 0 0 30%;
-        }
-
-        &--50-width {
-            flex: 0 0 47.5%;
-        }
+    &-element {
+        @extend .site-search__reference-element;
+        flex: 0 1 auto;
+        padding-left: 10px;
+        padding-right: 10px;
     }
 }
 

--- a/src/encoded/static/scss/encoded/modules/_home.scss
+++ b/src/encoded/static/scss/encoded/modules/_home.scss
@@ -382,34 +382,32 @@
     border-bottom: 1px solid #e0e0e0;
 }
 
-.intro-controls {
+
+// Contains buttons for the home page site search.
+.site-search__controls {
     display: flex;
     flex-wrap: wrap;
     justify-content: space-between;
     margin: 0 -5px;
+}
 
-    @media screen and (min-width: $screen-sm-min) {
-        margin: 0;
-    }
 
-    @at-root #{&}__element {
-        @extend .btn;
-        @extend .btn-info;
-        margin: 5px;
-        padding-top: 10px;
-        padding-bottom: 10px;
-        flex: 1 1 auto;
+// Buttons within site-search__controls.
+.site-search__control-element {
+    @extend .btn;
+    @extend .btn-info;
+    margin: 5px;
+    padding-top: 10px;
+    padding-bottom: 10px;
+    flex: 1 1 auto;
 
-        @media screen and (min-width: $screen-sm-min) {
-            margin: 5px 0;
+    @media screen and (min-width: $screen-lg-min) {
+        &--33-width {
+            flex: 0 0 30%;
+        }
 
-            &--33-width {
-                flex: 0 0 31%;
-            }
-
-            &--50-width {
-                flex: 0 0 48%;
-            }
+        &--50-width {
+            flex: 0 0 47.5%;
         }
     }
 }

--- a/src/encoded/static/scss/encoded/modules/_tooltip.scss
+++ b/src/encoded/static/scss/encoded/modules/_tooltip.scss
@@ -96,3 +96,22 @@ $tooltip-color: #000;
     bottom: 0;
     left: 0;
 }
+
+
+.tooltip-container {
+    position: relative;
+    display: inline-block;
+
+    .tooltip {
+        position: absolute;
+        visibility: visible;
+        opacity: 1;
+        font-weight: normal;
+    }
+
+    @at-root #{&}__trigger {
+        padding: 0;
+        border: none;
+        background: none;
+    }
+}


### PR DESCRIPTION
Two new search fields feature on the home page in place of the descriptive text next to the ENCODE assay category selector image. One simply copies the functionality of the search field in the upper right of every page. The other uses the SCREEN website in two ways:

1. To perform a search of a given term
2. To suggest search terms given a partial search term.

The vast majority of the changes exist in home.js including the new forms and nascent code for a combobox — a combination text-input field an drop-down list. I filed ENCD-4121 to refactor this combobox to its own module. I also filed ENCD-4120 to refactor other components to use the tooltip.js module this branch introduced.