### PR TITLE
ENCD-4123 audit chip

### DIFF
--- a/src/encoded/audit/experiment.py
+++ b/src/encoded/audit/experiment.py
@@ -3354,7 +3354,8 @@ def create_files_mapping(files_list, excluded):
                                                           ] = file_object
 
                 if file_format and file_format == 'bed' and \
-                        file_output and file_output == 'peaks':
+                        file_output and file_output in ['peaks',
+                                                        'peaks and background as input for IDR']:
                     to_return['peaks_files'][file_object['@id']] = file_object
 
                 if file_output and file_output == 'gene quantifications':

--- a/src/encoded/tests/test_audit_experiment.py
+++ b/src/encoded/tests/test_audit_experiment.py
@@ -2161,7 +2161,7 @@ def test_audit_experiment_chip_seq_peaks_with_controls_but_no_qc(
                                              'dataset': base_experiment['@id'],
                                              'file_format_type': 'narrowPeak',
                                              'file_format': 'bed',
-                                             'output_type': 'peaks'})
+                                             'output_type': 'peaks and background as input for IDR'})
     testapp.patch_json(pipeline_bam['@id'], {'title':
                                              'ChIP-seq read mapping'})
     testapp.patch_json(biosample_1['@id'], {'donor': mouse_donor_1['@id'],


### PR DESCRIPTION
adding file output type "peaks and background as input for IDR" to the "peaks" files being audited in experiment.py