### PR TITLE
ENCD-4144 Fix failing impersonation test button size

### DIFF
--- a/src/encoded/static/scss/encoded/modules/_facet.scss
+++ b/src/encoded/static/scss/encoded/modules/_facet.scss
@@ -219,6 +219,7 @@
     font-size: 1.2rem;
     font-weight: bold;
     z-index: 1000;
+    width:70%;
 
     a {
         &:hover {
@@ -348,7 +349,6 @@ div.meta-status {
 
     .pull-right {
         position: relative;
-        z-index: 2000; // Empirical; meant to be a larger than LHS
     }
 
     &.result-table-tabbed {

--- a/src/encoded/static/scss/encoded/modules/_facet.scss
+++ b/src/encoded/static/scss/encoded/modules/_facet.scss
@@ -348,7 +348,7 @@ div.meta-status {
 
     .pull-right {
         position: relative;
-        z-index: 2;
+        z-index: 2000; // Empirical; meant to be a larger than LHS
     }
 
     &.result-table-tabbed {

--- a/src/encoded/static/scss/encoded/modules/_facet.scss
+++ b/src/encoded/static/scss/encoded/modules/_facet.scss
@@ -219,7 +219,7 @@
     font-size: 1.2rem;
     font-weight: bold;
     z-index: 1000;
-    width:70%;
+    max-width: 70%;
 
     a {
         &:hover {

--- a/src/encoded/static/scss/encoded/modules/_facet.scss
+++ b/src/encoded/static/scss/encoded/modules/_facet.scss
@@ -349,6 +349,7 @@ div.meta-status {
 
     .pull-right {
         position: relative;
+        z-index: 2;
     }
 
     &.result-table-tabbed {


### PR DESCRIPTION
This is tricky. Re-writing the HTML to use grid-system would require a lot of testing (I think is ideal) since this code is reused a lot and in many ways. Lowering accession-class (left hand side of table) would also be tricky. The safe-bet is rise the right-hand-side to be higher than left. I did a light search and I could not find a place where that would be a problem, 