### PR TITLE
ENCD-4149 Allow bin test log arg for workbook loading

### DIFF
--- a/src/encoded/loadxl.py
+++ b/src/encoded/loadxl.py
@@ -7,8 +7,9 @@ import os.path
 
 text = type(u'')
 
+DEFAULT_LOG_LEVEL = logging.INFO
 logger = logging.getLogger('encoded')
-logger.setLevel(logging.INFO)  # doesn't work to shut off sqla INFO
+logger.setLevel(DEFAULT_LOG_LEVEL)  # doesn't work to shut off sqla INFO
 
 
 ORDER = [
@@ -89,6 +90,18 @@ IS_ATTACHMENT = [
     'IDR_parameters_pool_pr',
     'cross_correlation_plot'
 ]
+
+
+def _reset_log_level(log_level):
+    '''
+    Resets the default log level, usually for running bin tests
+    '''
+    if logger and log_level is not DEFAULT_LOG_LEVEL:
+        numeric_level = getattr(logging, log_level.upper(), None)
+        if not isinstance(numeric_level, int):
+            raise ValueError('Invalid log level: %s' % log_level)
+        logger.setLevel(log_level)
+
 
 ##############################################################################
 # Pipeline components
@@ -697,7 +710,9 @@ PHASE2_PIPELINES = {
 }
 
 
-def load_all(testapp, filename, docsdir, test=False):
+def load_all(testapp, filename, docsdir, log_level=None, test=False):
+    if log_level is not None:
+        _reset_log_level(log_level)
     for item_type in ORDER:
         try:
             source = read_single_sheet(filename, item_type)

--- a/src/encoded/tests/__init__.py
+++ b/src/encoded/tests/__init__.py
@@ -12,3 +12,4 @@ def pytest_addoption(parser):
     parser.addoption('--browser-arg', nargs=2, dest='browser_args', action='append', type='string')
     parser.addoption('--browser-arg-int', nargs=2, dest='browser_args', action=AppendInt2, type='string')
     parser.addoption('--wsgi-arg', nargs=2, dest='wsgi_args', action='append', type='string')
+    parser.addoption("--log", action="store", default="INFO", help="set logging level")

--- a/src/encoded/tests/features/conftest.py
+++ b/src/encoded/tests/features/conftest.py
@@ -39,6 +39,7 @@ def workbook(app):
     cursor.close()
 
     from webtest import TestApp
+    log_level = pytest.config.getoption("--log")
     environ = {
         'HTTP_ACCEPT': 'application/json',
         'REMOTE_USER': 'TEST',
@@ -49,7 +50,7 @@ def workbook(app):
     from pkg_resources import resource_filename
     inserts = resource_filename('encoded', 'tests/data/inserts/')
     docsdir = [resource_filename('encoded', 'tests/data/documents/')]
-    load_all(testapp, inserts, docsdir)
+    load_all(testapp, inserts, docsdir, log_level=log_level)
 
     testapp.post_json('/index', {})
     yield


### PR DESCRIPTION
This allows bin/test to be called with a --log arugment which will limit the logging output from loadxl.load_all when called from tests.features.conftest.workbook.

Create and troubleshooting tests with that use workbook is a little slow and painful.  This will limit the scroll back in a backwards compatible manner.