### PR TITLE
ENCD-4146 Restore FileDownloadButton constructor

### DIFF
--- a/src/encoded/static/components/file.js
+++ b/src/encoded/static/components/file.js
@@ -243,6 +243,12 @@ DerivedFromFiles.propTypes = {
 
 // Display a file download button.
 class FileDownloadButton extends React.Component {
+    constructor() {
+        super();
+        this.onMouseEnter = this.onMouseEnter.bind(this);
+        this.onMouseLeave = this.onMouseLeave.bind(this);
+    }
+
     onMouseEnter() {
         if (this.props.hoverDL) {
             this.props.hoverDL(true);


### PR DESCRIPTION
Added a constructor to `<FileDownloadButton>` so that `this` is defined properly in `onMouseEnter` and `onMouseLeave`. I don’t know how this ever worked before, but it definitely did for some reason.