### PR TITLE
ENCD-4152 Make organism.scientific_name required

### DIFF
--- a/src/encoded/schemas/changelogs/organism.md
+++ b/src/encoded/schemas/changelogs/organism.md
@@ -1,5 +1,9 @@
 ## Changelog for organism.json
 
+### Schema version 6
+
+* *scientific_name* is now a required property. The empty string default value has also been removed.
+
 ### Schema version 5
 
 * *status* property was restricted to one of  

--- a/src/encoded/schemas/organism.json
+++ b/src/encoded/schemas/organism.json
@@ -3,7 +3,7 @@
     "id": "/profiles/organism.json",
     "$schema": "http://json-schema.org/draft-04/schema#",
     "type": "object",
-    "required": ["name", "taxon_id"],
+    "required": ["name", "taxon_id", "scientific_name"],
     "identifyingProperties": ["uuid", "name", "taxon_id", "scientific_name"],
     "additionalProperties": false,
     "mixinProperties": [
@@ -13,7 +13,7 @@
     ],
     "properties": {
         "schema_version": {
-            "default": "5"
+            "default": "6"
         },
         "name": {
             "title": "Common name",
@@ -26,7 +26,6 @@
             "title": "Binomial name",
             "description": "The genus species for the organism (e.g. 'Mus musculus').",
             "type": "string",
-            "default": "",
             "pattern": "^(\\S+(\\s|\\S)*\\S+|\\S)$|^$"
         },
         "taxon_id": {

--- a/src/encoded/tests/data/inserts/organism.json
+++ b/src/encoded/tests/data/inserts/organism.json
@@ -142,6 +142,7 @@
     },
     {
         "name": "synthetic",
+        "scientific_name": "synthetic",
         "taxon_id": "0",
         "uuid": "5d8f172c-2220-4d76-89e2-e26ed08c42e8",
         "status": "released"

--- a/src/encoded/upgrade/organism.py
+++ b/src/encoded/upgrade/organism.py
@@ -17,3 +17,9 @@ def organism_4_5(value, system):
         value['status'] = 'released'
     elif value.get('status') == 'disabled':
         value['status'] = 'deleted'
+
+
+@upgrade_step('organism', '5', '6')
+def organism_5_6(value, system):
+    # https://encodedcc.atlassian.net/browse/ENCD-4152
+    return


### PR DESCRIPTION
ENCD-4152 Make organism.scientific_name required

* Made Organism.scientific_name required
* Bumped schema version and updated change log
* Added empty upgrade to reflect version bump
* Fixed an organism insert to have scientific_name property