### PR TITLE
ENCD-4154 Remove unused search type arg

### DIFF
--- a/src/encoded/search.py
+++ b/src/encoded/search.py
@@ -665,7 +665,7 @@ def iter_long_json(name, iterable, other):
         yield ']' + other_stuff + '}'
 
 @view_config(route_name='search', request_method='GET', permission='search')
-def search(context, request, search_type=None, return_generator=False):
+def search(context, request, return_generator=False):
     """
     Search view connects to ElasticSearch and returns the results
     """
@@ -694,13 +694,14 @@ def search(context, request, search_type=None, return_generator=False):
     search_term = prepare_search_term(request)
 
     ## converts type= query parameters to list of doc_types to search, "*" becomes super class Item
-    if search_type is None:
+    if (hasattr(context, 'type_info') and
+            hasattr(context.type_info, 'name')
+            and context.type_info.name):
+        doc_types = [context.type_info.name]
+    else:
         doc_types = request.params.getall('type')
         if '*' in doc_types:
             doc_types = ['Item']
-
-    else:
-        doc_types = [search_type]
 
     # Normalize to item_type
     try:
@@ -908,7 +909,7 @@ def collection_view_listing_es(context, request):
     if request.datastore != 'elasticsearch':
         return collection_view_listing_db(context, request)
 
-    return search(context, request, context.type_info.name)
+    return search(context, request)
 
 
 @view_config(route_name='report', request_method='GET', permission='search')


### PR DESCRIPTION
Ben or I could not find where this search_type arg was ever used.  It can't be added as a query parameter because it wasn't set up properly.  Is was in the way for search refactor epic so we're removing it.

SNO-46 for similar snowflakes updates.  Please review along with this.
https://github.com/ENCODE-DCC/snovault/pull/122