### PR TITLE
ENCD-4187 fix ENSEMBL links for mouse.

### DIFF
--- a/src/encoded/static/components/__tests__/dbxref-test.js
+++ b/src/encoded/static/components/__tests__/dbxref-test.js
@@ -66,6 +66,25 @@ describe('Test individual dbxref types', () => {
         });
     });
 
+    describe('Test mouse ENSEMBLE', () => {
+        let dbxLinks;
+
+        beforeAll(() => {
+            const context = { '@type': ['Gene'], organism: { scientific_name: 'Mus musculus' } };
+            const wrapper = mount(
+                <DbxrefList context={context} dbxrefs={['ENSEMBL:ENSMUSG00000005698', 'ENSEMBL:ENSMUSG00000017167']} />
+            );
+
+            dbxLinks = wrapper.find('a');
+        });
+
+        it('has the correct links', () => {
+            expect(dbxLinks.length).toBe(2);
+            expect(dbxLinks.at(0).prop('href')).toEqual('http://www.ensembl.org/Mus_musculus/Gene/Summary?g=ENSMUSG00000005698');
+            expect(dbxLinks.at(1).prop('href')).toEqual('http://www.ensembl.org/Mus_musculus/Gene/Summary?g=ENSMUSG00000017167');
+        });
+    });
+
     describe('Test GeneID', () => {
         let dbxLinks;
 

--- a/src/encoded/static/components/dbxref.js
+++ b/src/encoded/static/components/dbxref.js
@@ -78,6 +78,13 @@ export const dbxrefPrefixMap = {
     },
     ENSEMBL: {
         pattern: 'http://www.ensembl.org/Homo_sapiens/Gene/Summary?g={0}',
+        preprocessor: (context) => {
+            // The URL is for human by default for ENSEMBL dbxrefs.
+            if (context.organism && context.organism.scientific_name === 'Mus musculus') {
+                return { altUrlPattern: 'http://www.ensembl.org/Mus_musculus/Gene/Summary?g={0}' };
+            }
+            return {};
+        },
     },
     GeneID: {
         pattern: 'https://www.ncbi.nlm.nih.gov/gene/{0}',


### PR DESCRIPTION
For targets, there is only one now having ENSEMBL dbxref:
https://www.encodeproject.org/targets/CTCF-mouse/

There will be more for genes.