### PR TITLE
ENCD-4198 Clean up indexer init

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -53,7 +53,8 @@ webtest = git https://github.com/Pylons/webtest.git
 WSGIProxy2 = git https://github.com/lrowe/WSGIProxy2.git
 zope.sqlalchemy = git https://github.com/zopefoundation/zope.sqlalchemy.git
 pytest-bdd = git https://github.com/lrowe/pytest-bdd.git branch=allow-any-step-order
-snovault = git https://github.com/ENCODE-DCC/snovault.git rev=1.0.16
+# snovault = git https://github.com/ENCODE-DCC/snovault.git rev=1.0.16
+snovault = git https://github.com/ENCODE-DCC/snovault.git branch=SNO-51-clean-up-indexer-init
 
 [versions]
 # Hand set versions

--- a/src/encoded/region_indexer.py
+++ b/src/encoded/region_indexer.py
@@ -31,11 +31,11 @@ from snovault.elasticsearch.interfaces import (
     ELASTIC_SEARCH,
     SNP_SEARCH_ES,
     INDEXER,
-    REGION_INDEXER_NAME,
-    VIS_INDEXER_NAME,
 )
 
 log = logging.getLogger(__name__)
+
+_REGION_INDEXER_NAME = 'region' + INDEXER
 
 
 # Region indexer 2.0
@@ -79,10 +79,10 @@ TESTABLE_FILES = ['ENCFF002COS']  # '/static/test/peak_indexer/ENCFF002COS.bed.g
 
 def includeme(config):
     registry = config.registry
-    is_regionindexer = asbool(registry.settings.get(REGION_INDEXER_NAME, False))
-    if is_regionindexer and not registry.get(REGION_INDEXER_NAME):
-        log.warning('Initialized %s', REGION_INDEXER_NAME)
-        registry[REGION_INDEXER_NAME] = RegionIndexer(registry)
+    is_regionindexer = asbool(registry.settings.get(_REGION_INDEXER_NAME, False))
+    if is_regionindexer and not registry.get(_REGION_INDEXER_NAME):
+        log.info('Initialized %s', _REGION_INDEXER_NAME)
+        registry[_REGION_INDEXER_NAME] = RegionIndexer(registry)
     config.add_route('_regionindexer_state', '/_regionindexer_state')
     config.add_route('index_region', '/index_region')
     config.scan(__name__)
@@ -342,7 +342,7 @@ def index_regions(request):
     encoded_INDEX = request.registry.settings['snovault.elasticsearch.index']
     request.datastore = 'elasticsearch'  # Let's be explicit
     dry_run = request.json.get('dry_run', False)
-    indexer = request.registry[REGION_INDEXER_NAME]
+    indexer = request.registry[_REGION_INDEXER_NAME]
     uuids = []
 
 

--- a/src/encoded/region_indexer.py
+++ b/src/encoded/region_indexer.py
@@ -31,11 +31,12 @@ from snovault.elasticsearch.interfaces import (
     ELASTIC_SEARCH,
     SNP_SEARCH_ES,
     INDEXER,
+    REGION_INDEXER_NAME,
+    VIS_INDEXER_NAME,
 )
 
 log = logging.getLogger(__name__)
 
-_REGION_INDEXER_NAME = 'region' + INDEXER
 
 # Region indexer 2.0
 # What it does:
@@ -78,10 +79,10 @@ TESTABLE_FILES = ['ENCFF002COS']  # '/static/test/peak_indexer/ENCFF002COS.bed.g
 
 def includeme(config):
     registry = config.registry
-    is_regionindexer = asbool(registry.settings.get(_REGION_INDEXER_NAME, False))
-    if is_regionindexer and not registry.get(_REGION_INDEXER_NAME):
-        log.warning('Initialized %s', _REGION_INDEXER_NAME)
-        registry[_REGION_INDEXER_NAME] = RegionIndexer(registry)
+    is_regionindexer = asbool(registry.settings.get(REGION_INDEXER_NAME, False))
+    if is_regionindexer and not registry.get(REGION_INDEXER_NAME):
+        log.warning('Initialized %s', REGION_INDEXER_NAME)
+        registry[REGION_INDEXER_NAME] = RegionIndexer(registry)
     config.add_route('_regionindexer_state', '/_regionindexer_state')
     config.add_route('index_region', '/index_region')
     config.scan(__name__)
@@ -341,7 +342,7 @@ def index_regions(request):
     encoded_INDEX = request.registry.settings['snovault.elasticsearch.index']
     request.datastore = 'elasticsearch'  # Let's be explicit
     dry_run = request.json.get('dry_run', False)
-    indexer = request.registry[_REGION_INDEXER_NAME]
+    indexer = request.registry[REGION_INDEXER_NAME]
     uuids = []
 
 

--- a/src/encoded/vis_indexer.py
+++ b/src/encoded/vis_indexer.py
@@ -38,20 +38,19 @@ from .vis_defines import (
 )
 from .visualization import vis_cache_add
 
-from snovault.elasticsearch.interfaces import (
-    INDEXER,
-    VIS_INDEXER_NAME,
-)
+from snovault.elasticsearch.interfaces import INDEXER
+
 
 log = logging.getLogger(__name__)
+_VIS_INDEXER_NAME = 'vis' + INDEXER
 
 
 def includeme(config):
     registry = config.registry
-    is_visindexer = asbool(registry.settings.get(VIS_INDEXER_NAME, False))
-    if is_visindexer and not registry.get(VIS_INDEXER_NAME):
-        log.warning('Initialized %s', VIS_INDEXER_NAME)
-        registry[VIS_INDEXER_NAME] = VisIndexer(registry)
+    is_visindexer = asbool(registry.settings.get(_VIS_INDEXER_NAME, False))
+    if is_visindexer and not registry.get(_VIS_INDEXER_NAME):
+        log.info('Initialized %s', _VIS_INDEXER_NAME)
+        registry[_VIS_INDEXER_NAME] = VisIndexer(registry)
     config.add_route('_visindexer_state', '/_visindexer_state')
     config.add_route('index_vis', '/index_vis')
     config.scan(__name__)
@@ -189,7 +188,7 @@ def index_vis(request):
     record = request.json.get('record', False)
     dry_run = request.json.get('dry_run', False)
     es = request.registry[ELASTIC_SEARCH]
-    indexer = request.registry[VIS_INDEXER_NAME]
+    indexer = request.registry[_VIS_INDEXER_NAME]
 
     # keeping track of state
     state = VisIndexerState(es, INDEX)

--- a/src/encoded/vis_indexer.py
+++ b/src/encoded/vis_indexer.py
@@ -38,18 +38,20 @@ from .vis_defines import (
 )
 from .visualization import vis_cache_add
 
+from snovault.elasticsearch.interfaces import (
+    INDEXER,
+    VIS_INDEXER_NAME,
+)
 
 log = logging.getLogger(__name__)
-
-_VIS_INDEXER_NAME = 'vis' + INDEXER
 
 
 def includeme(config):
     registry = config.registry
-    is_visindexer = asbool(registry.settings.get(_VIS_INDEXER_NAME, False))
-    if is_visindexer and not registry.get(_VIS_INDEXER_NAME):
-        log.warning('Initialized %s', _VIS_INDEXER_NAME)
-        registry[_VIS_INDEXER_NAME] = VisIndexer(registry)
+    is_visindexer = asbool(registry.settings.get(VIS_INDEXER_NAME, False))
+    if is_visindexer and not registry.get(VIS_INDEXER_NAME):
+        log.warning('Initialized %s', VIS_INDEXER_NAME)
+        registry[VIS_INDEXER_NAME] = VisIndexer(registry)
     config.add_route('_visindexer_state', '/_visindexer_state')
     config.add_route('index_vis', '/index_vis')
     config.scan(__name__)
@@ -187,7 +189,7 @@ def index_vis(request):
     record = request.json.get('record', False)
     dry_run = request.json.get('dry_run', False)
     es = request.registry[ELASTIC_SEARCH]
-    indexer = request.registry[_VIS_INDEXER_NAME]
+    indexer = request.registry[VIS_INDEXER_NAME]
 
     # keeping track of state
     state = VisIndexerState(es, INDEX)

--- a/src/encoded/vis_indexer.py
+++ b/src/encoded/vis_indexer.py
@@ -4,6 +4,7 @@ from elasticsearch.exceptions import (
     NotFoundError,
     TransportError,
 )
+from pyramid.settings import asbool
 from pyramid.view import view_config
 from sqlalchemy.exc import StatementError
 
@@ -40,13 +41,18 @@ from .visualization import vis_cache_add
 
 log = logging.getLogger(__name__)
 
+_VIS_INDEXER_NAME = 'vis' + INDEXER
+
 
 def includeme(config):
-    config.add_route('index_vis', '/index_vis')
-    config.add_route('_visindexer_state', '/_visindexer_state')
-    config.scan(__name__)
     registry = config.registry
-    registry['vis'+INDEXER] = VisIndexer(registry)
+    is_visindexer = asbool(registry.settings.get(_VIS_INDEXER_NAME, False))
+    if is_visindexer and not registry.get(_VIS_INDEXER_NAME):
+        log.warning('Initialized %s', _VIS_INDEXER_NAME)
+        registry[_VIS_INDEXER_NAME] = VisIndexer(registry)
+    config.add_route('_visindexer_state', '/_visindexer_state')
+    config.add_route('index_vis', '/index_vis')
+    config.scan(__name__)
 
 class VisIndexerState(IndexerState):
     # Accepts handoff of uuids from primary indexer. Keeps track of uuids and vis_indexer state by cycle.
@@ -181,7 +187,7 @@ def index_vis(request):
     record = request.json.get('record', False)
     dry_run = request.json.get('dry_run', False)
     es = request.registry[ELASTIC_SEARCH]
-    indexer = request.registry['vis'+INDEXER]
+    indexer = request.registry[_VIS_INDEXER_NAME]
 
     # keeping track of state
     state = VisIndexerState(es, INDEX)


### PR DESCRIPTION
Goes with SNO-51 PR, This also make the vis and region indexer string names into variables

The encoded process did need an instance of an Indexer attached to the requests for multi processing indexing, but only because update_object used self.es.  But ELASTICSEARCH is attached to every request and update_object gets a request. 

Removing that dependency allows update_object_in_snapshot in mpindexer.py to call update_object as a staticmethod.

Lo and behold there is a bunch of failing tests...I'll see if those can be easily resolved.  If not then dropping PR.