### PR TITLE
ENCD-4263 Only show released quality metrics

### DIFF
--- a/src/encoded/static/components/file.js
+++ b/src/encoded/static/components/file.js
@@ -359,13 +359,15 @@ class FileComponent extends React.Component {
         const itemClass = globals.itemClass(context, 'view-item');
         const aliasList = (context.aliases && context.aliases.length) ? context.aliases.join(', ') : '';
         const datasetAccession = globals.atIdToAccession(context.dataset);
+        const loggedIn = !!(this.context.session && this.context.session['auth.userid']);
         const adminUser = !!this.context.session_properties.admin;
 
-        // Collect up relevant pipelines.
+        // Collect up relevant pipelines and quality metrics.
         let pipelines = [];
         if (context.analysis_step_version && context.analysis_step_version.analysis_step.pipelines && context.analysis_step_version.analysis_step.pipelines.length) {
             pipelines = context.analysis_step_version.analysis_step.pipelines;
         }
+        const qualityMetrics = context.quality_metrics.filter(qc => loggedIn || qc.status === 'released');
 
         return (
             <div className={itemClass}>
@@ -567,8 +569,8 @@ class FileComponent extends React.Component {
                     <DocumentsPanel title="File format specifications" documentSpecs={[{ documents: this.state.fileFormatSpecs }]} />
                 : null}
 
-                {context.quality_metrics && context.quality_metrics.length ?
-                    <QualityMetricsPanel qcMetrics={context.quality_metrics} file={context} />
+                {qualityMetrics.length ?
+                    <QualityMetricsPanel qcMetrics={qualityMetrics} file={context} />
                 : null}
             </div>
         );


### PR DESCRIPTION
Quality metrics objects get embedded in File objects regardless of their status. Until this branch, all quality metrics objects from a File search appear in the File `@graph` array. This branch changes the front end to filter out non-released status quality metrics objects if the user is logged out. This includes quality metrics in the file association graph as well as in the modal that appears when you click on a file in the graph or from the “i” button in the file tables. Non-released quality metrics objects appear in the JSON even if you’re logged out, and that will be addressed more generally in another ticket.