### PR TITLE
ENCD-4267 Remove files redirect from apache config

### DIFF
--- a/etc/encoded-apache.conf
+++ b/etc/encoded-apache.conf
@@ -201,7 +201,6 @@ RewriteRule ^/ENCODE/otherTerms$    /help/getting-started/?    [last,redirect=pe
 RewriteRule ^/ENCODE/integrativeAnalysis/VM$    http://encodedcc.stanford.edu/ftp/encodevm/?    [last,redirect=permanent]
 RewriteRule ^/ENCODE/dataStandards$    /data-standards/?    [last,redirect=permanent]
 RewriteCond %{REQUEST_METHOD}    =GET
-RewriteRule ^/files/$    /search/?type=file    [last,redirect=permanent]
 RewriteRule ^/encyclopedia/visualize    http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&hgt.customText=http://bib.umassmed.edu/~iyers/encode_elements/display/tracks.txt    [last,redirect=permanent]
 
 # Fallback


### PR DESCRIPTION
The redirect from /files/ to /search/?type=file caused the /files/#!add mechanism to fail. “files” is the only object type that gets redirected, and according to Bek he thinks Ben wanted this because our old /files/ page killed the system. As our new /files/ page with the charts doesn’t kill the system, we can go back to _not_ redirecting.