### PR TITLE
ENCD-4239 Add biosample_type to query string on matrix click

### DIFF
--- a/src/encoded/static/components/matrix.js
+++ b/src/encoded/static/components/matrix.js
@@ -283,8 +283,9 @@ class Matrix extends React.Component {
                                                 // this.state.yGroupOpen[key]), extract just the
                                                 // group rows that are under the display limit.
                                                 const groupRows = (this.state.yGroupOpen[group.key] || this.state.allYGroupsOpen) ? groupBuckets : groupBuckets.slice(0, yLimit);
+                                                const yGroupQueryComponent = `${primaryYGrouping}=${globals.encodedURIComponent(group.key)}`;
                                                 rows.push(...groupRows.map((yb) => {
-                                                    const href = `${searchBase}&${secondaryYGrouping}=${globals.encodedURIComponent(yb.key)}`;
+                                                    const href = `${searchBase}&${secondaryYGrouping}=${globals.encodedURIComponent(yb.key)}&${yGroupQueryComponent}`;
                                                     return (
                                                         <tr key={`yb-${yb.key}`}>
                                                             <th style={{ backgroundColor: '#ddd', border: 'solid 1px white' }}><a href={href}>{yb.key}</a></th>
@@ -295,7 +296,7 @@ class Matrix extends React.Component {
                                                                     // scale color between white and the series color
                                                                     cellColor.lightness(cellColor.lightness() + ((1 - (value / matrix.max_cell_doc_count)) * (100 - cellColor.lightness())));
                                                                     const textColor = cellColor.luminosity() > 0.5 ? '#000' : '#fff';
-                                                                    const cellHref = `${searchBase}&${secondaryYGrouping}=${globals.encodedURIComponent(yb.key)}&${xGrouping}=${globals.encodedURIComponent(xb.key)}`;
+                                                                    const cellHref = `${searchBase}&${secondaryYGrouping}=${globals.encodedURIComponent(yb.key)}&${xGrouping}=${globals.encodedURIComponent(xb.key)}&${yGroupQueryComponent}`;
                                                                     const title = `${yb.key} / ${xb.key}: ${value}`;
                                                                     return (
                                                                         <td key={xb.key} style={{ backgroundColor: cellColor.hexString() }}>


### PR DESCRIPTION
Clicking the biosample_term_name in gray on the left column, or clicking individual matrix cells, now includes the biosample_type for that group in the query string for the search page that you go to when you click either of those.