### PR TITLE
ENCD-4223 Make internal_tags badges clickable to search pages

### DIFF
--- a/src/encoded/static/components/__tests__/objectutils-test.js
+++ b/src/encoded/static/components/__tests__/objectutils-test.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+// Import test component and data.
+import { InternalTags } from '../objectutils';
+
+
+describe('InternalTags', () => {
+    let context;
+    let wrapper;
+    const testTags = ['ENTEx', 'SESCC'];
+
+    beforeAll(() => {
+        context = {
+            '@type': ['HumanDonor', 'Donor', 'Item'],
+            internal_tags: testTags,
+        };
+        wrapper = mount(
+            <InternalTags context={context} />
+        );
+    });
+
+    test('generates two links', () => {
+        const internalTagLinks = wrapper.find('a');
+        expect(internalTagLinks).toHaveLength(2);
+    });
+
+
+    test('generates the right images in each link', () => {
+        const uris = testTags.map(tag => `/static/img/tag-${tag}.png`);
+        wrapper.find('a').forEach((link, i) => {
+            const image = link.find('img');
+            expect(image).toHaveLength(1);
+            expect(image.prop('src')).toEqual(uris[i]);
+            expect(image.prop('alt')).toContain(testTags[i]);
+        });
+    });
+});

--- a/src/encoded/static/components/biosample.js
+++ b/src/encoded/static/components/biosample.js
@@ -10,7 +10,7 @@ import * as globals from './globals';
 import { ProjectBadge } from './image';
 import { RelatedItems } from './item';
 import { Breadcrumbs } from './navigation';
-import { singleTreatment, treatmentDisplay, PanelLookup, AlternateAccession, DisplayAsJson } from './objectutils';
+import { singleTreatment, treatmentDisplay, PanelLookup, AlternateAccession, DisplayAsJson, InternalTags } from './objectutils';
 import pubReferenceList from './reference';
 import Status from './status';
 import { BiosampleSummaryString, CollectBiosampleDocs, BiosampleTable } from './typeutils';
@@ -56,12 +56,6 @@ class BiosampleComponent extends React.Component {
 
         // Get a list of reference links, if any
         const references = pubReferenceList(context.references);
-
-        // Render tags badges
-        let tagBadges;
-        if (context.internal_tags && context.internal_tags.length) {
-            tagBadges = context.internal_tags.map(tag => <img key={tag} src={`/static/img/tag-${tag}.png`} alt={`${tag} tag`} />);
-        }
 
         return (
             <div className={itemClass}>
@@ -332,10 +326,10 @@ class BiosampleComponent extends React.Component {
                                         </div>
                                     : null}
 
-                                    {tagBadges ?
+                                    {context.internal_tags && context.internal_tags.length > 0 ?
                                         <div className="tag-badges" data-test="tags">
                                             <dt>Tags</dt>
-                                            <dd>{tagBadges}</dd>
+                                            <dd><InternalTags context={context} /></dd>
                                         </div>
                                     : null}
                                 </dl>

--- a/src/encoded/static/components/dataset.js
+++ b/src/encoded/static/components/dataset.js
@@ -11,7 +11,7 @@ import { FetchedItems } from './fetched';
 import { auditDecor } from './audit';
 import Status from './status';
 import pubReferenceList from './reference';
-import { donorDiversity, publicDataset, AlternateAccession, DisplayAsJson } from './objectutils';
+import { donorDiversity, publicDataset, AlternateAccession, DisplayAsJson, InternalTags } from './objectutils';
 import { softwareVersionList } from './software';
 import { SortTablePanel, SortTable } from './sorttable';
 import { ProjectBadge } from './image';
@@ -77,12 +77,6 @@ class AnnotationComponent extends React.Component {
 
         // Get a list of reference links, if any
         const references = pubReferenceList(context.references);
-
-        // Render tags badges
-        let tagBadges;
-        if (context.internal_tags && context.internal_tags.length) {
-            tagBadges = context.internal_tags.map(tag => <img src={`/static/img/tag-${tag}.png`} alt={`${tag} tag`} />);
-        }
 
         return (
             <div className={itemClass}>
@@ -213,10 +207,10 @@ class AnnotationComponent extends React.Component {
                                         </div>
                                     : null}
 
-                                    {tagBadges ?
+                                    {context.internal_tags && context.internal_tags.length > 0 ?
                                         <div className="tag-badges" data-test="tags">
                                             <dt>Tags</dt>
-                                            <dd>{tagBadges}</dd>
+                                            <dd><InternalTags context={context} /></dd>
                                         </div>
                                     : null}
                                 </dl>
@@ -273,12 +267,6 @@ class PublicationDataComponent extends React.Component {
 
         // Render the publication links
         const referenceList = pubReferenceList(context.references);
-
-        // Render tags badges
-        let tagBadges;
-        if (context.internal_tags && context.internal_tags.length) {
-            tagBadges = context.internal_tags.map(tag => <img src={`/static/img/tag-${tag}.png`} alt={`${tag} tag`} />);
-        }
 
         return (
             <div className={itemClass}>
@@ -376,10 +364,10 @@ class PublicationDataComponent extends React.Component {
                                         </div>
                                     : null}
 
-                                    {tagBadges ?
+                                    {context.internal_tags && context.internal_tags.length > 0 ?
                                         <div className="tag-badges" data-test="tags">
                                             <dt>Tags</dt>
-                                            <dd>{tagBadges}</dd>
+                                            <dd><InternalTags context={context} /></dd>
                                         </div>
                                     : null}
                                 </dl>
@@ -436,12 +424,6 @@ class ReferenceComponent extends React.Component {
 
         // Get a list of reference links, if any
         const references = pubReferenceList(context.references);
-
-        // Render tags badges
-        let tagBadges;
-        if (context.internal_tags && context.internal_tags.length) {
-            tagBadges = context.internal_tags.map(tag => <img src={`/static/img/tag-${tag}.png`} alt={`${tag} tag`} />);
-        }
 
         return (
             <div className={itemClass}>
@@ -539,10 +521,10 @@ class ReferenceComponent extends React.Component {
                                         </div>
                                     : null}
 
-                                    {tagBadges ?
+                                    {context.internal_tags && context.internal_tags.length > 0 ?
                                         <div className="tag-badges" data-test="tags">
                                             <dt>Tags</dt>
-                                            <dd>{tagBadges}</dd>
+                                            <dd><InternalTags context={context} /></dd>
                                         </div>
                                     : null}
                                 </dl>
@@ -602,12 +584,6 @@ class ProjectComponent extends React.Component {
 
         // Get a list of reference links
         const references = pubReferenceList(context.references);
-
-        // Render tags badges
-        let tagBadges;
-        if (context.internal_tags && context.internal_tags.length) {
-            tagBadges = context.internal_tags.map(tag => <img src={`/static/img/tag-${tag}.png`} alt={`${tag} tag`} />);
-        }
 
         return (
             <div className={itemClass}>
@@ -726,10 +702,10 @@ class ProjectComponent extends React.Component {
                                         </div>
                                     : null}
 
-                                    {tagBadges ?
+                                    {context.internal_tags && context.internal_tags.length > 0 ?
                                         <div className="tag-badges" data-test="tags">
                                             <dt>Tags</dt>
-                                            <dd>{tagBadges}</dd>
+                                            <dd><InternalTags context={context} /></dd>
                                         </div>
                                     : null}
                                 </dl>
@@ -789,12 +765,6 @@ class UcscBrowserCompositeComponent extends React.Component {
 
         // Get a list of reference links, if any
         const references = pubReferenceList(context.references);
-
-        // Render tags badges
-        let tagBadges;
-        if (context.internal_tags && context.internal_tags.length) {
-            tagBadges = context.internal_tags.map(tag => <img src={`/static/img/tag-${tag}.png`} alt={`${tag} tag`} />);
-        }
 
         return (
             <div className={itemClass}>
@@ -899,10 +869,10 @@ class UcscBrowserCompositeComponent extends React.Component {
                                         </div>
                                     : null}
 
-                                    {tagBadges ?
+                                    {context.internal_tags && context.internal_tags.length > 0 ?
                                         <div className="tag-badges" data-test="tags">
                                             <dt>Tags</dt>
-                                            <dd>{tagBadges}</dd>
+                                            <dd><InternalTags context={context} /></dd>
                                         </div>
                                     : null}
                                 </dl>
@@ -1275,12 +1245,6 @@ export class SeriesComponent extends React.Component {
         }
         const terms = (context.biosample_term_name && context.biosample_term_name.length) ? _.uniq(context.biosample_term_name) : [];
 
-        // Render tags badges
-        let tagBadges;
-        if (context.internal_tags && context.internal_tags.length) {
-            tagBadges = context.internal_tags.map(tag => <img src={`/static/img/tag-${tag}.png`} alt={`${tag} tag`} />);
-        }
-
         // Calculate the donor diversity.
         const diversity = donorDiversity(context);
 
@@ -1390,10 +1354,10 @@ export class SeriesComponent extends React.Component {
                                         </div>
                                     : null}
 
-                                    {tagBadges ?
+                                    {context.internal_tags && context.internal_tags.length > 0 ?
                                         <div className="tag-badges" data-test="tags">
                                             <dt>Tags</dt>
-                                            <dd>{tagBadges}</dd>
+                                            <dd><InternalTags context={context} /></dd>
                                         </div>
                                     : null}
                                 </dl>

--- a/src/encoded/static/components/donor.js
+++ b/src/encoded/static/components/donor.js
@@ -308,13 +308,6 @@ const MouseDonor = (props) => {
                             </div>
                         : null}
 
-                        {context.internal_tags && context.internal_tags.length > 0 ?
-                            <div className="tag-badges" data-test="tags">
-                                <dt>Tags</dt>
-                                <dd><InternalTags context={context} /></dd>
-                            </div>
-                        : null}
-
                         {context.submitter_comment ?
                             <div data-test="submittercomment">
                                 <dt>Submitter comment</dt>
@@ -454,13 +447,6 @@ const FlyWormDonor = (props) => {
                             <div data-test="submittercomment">
                                 <dt>Submitter comment</dt>
                                 <dd>{context.submitter_comment}</dd>
-                            </div>
-                        : null}
-
-                        {context.internal_tags && context.internal_tags.length > 0 ?
-                            <div className="tag-badges" data-test="tags">
-                                <dt>Tags</dt>
-                                <dd><InternalTags context={context} /></dd>
                             </div>
                         : null}
                     </dl>

--- a/src/encoded/static/components/donor.js
+++ b/src/encoded/static/components/donor.js
@@ -11,7 +11,7 @@ import GeneticModificationSummary from './genetic_modification';
 import * as globals from './globals';
 import { RelatedItems } from './item';
 import { Breadcrumbs } from './navigation';
-import { requestObjects, AlternateAccession, DisplayAsJson } from './objectutils';
+import { requestObjects, AlternateAccession, DisplayAsJson, InternalTags } from './objectutils';
 import pubReferenceList from './reference';
 import { PickerActions } from './search';
 import { SortTablePanel, SortTable } from './sorttable';
@@ -23,12 +23,6 @@ import formatMeasurement from './../libs/formatMeasurement';
 const HumanDonor = (props) => {
     const { context, biosample } = props;
     const references = pubReferenceList(context.references);
-
-    // Render tags badges
-    let tagBadges;
-    if (context.internal_tags && context.internal_tags.length) {
-        tagBadges = context.internal_tags.map(tag => <img key={tag} src={`/static/img/tag-${tag}.png`} alt={`${tag} tag`} />);
-    }
 
     return (
         <div>
@@ -125,10 +119,10 @@ const HumanDonor = (props) => {
                             </div>
                         : null}
 
-                        {tagBadges ?
+                        {context.internal_tags && context.internal_tags.length > 0 ?
                             <div className="tag-badges" data-test="tags">
                                 <dt>Tags</dt>
-                                <dd>{tagBadges}</dd>
+                                <dd><InternalTags context={context} /></dd>
                             </div>
                         : null}
                     </dl>
@@ -210,12 +204,6 @@ const MouseDonor = (props) => {
     if (biosample && biosample.donor && biosample.donor.url) {
         const donorUrl = url.parse(biosample.donor.url);
         donorUrlDomain = donorUrl.hostname || '';
-    }
-
-    // Render tags badges.
-    let tagBadges;
-    if (context.internal_tags && context.internal_tags.length) {
-        tagBadges = context.internal_tags.map(tag => <img key={tag} src={`/static/img/tag-${tag}.png`} alt={`${tag} tag`} />);
     }
 
     return (
@@ -320,10 +308,10 @@ const MouseDonor = (props) => {
                             </div>
                         : null}
 
-                        {tagBadges ?
+                        {context.internal_tags && context.internal_tags.length > 0 ?
                             <div className="tag-badges" data-test="tags">
                                 <dt>Tags</dt>
-                                <dd>{tagBadges}</dd>
+                                <dd><InternalTags context={context} /></dd>
                             </div>
                         : null}
 
@@ -365,12 +353,6 @@ globals.panelViews.register(MouseDonor, 'MouseDonor');
 const FlyWormDonor = (props) => {
     const { context, biosample } = props;
     let donorUrlDomain;
-
-    // Render tags badges.
-    let tagBadges;
-    if (context.internal_tags && context.internal_tags.length) {
-        tagBadges = context.internal_tags.map(tag => <img key={tag} src={`/static/img/tag-${tag}.png`} alt={`${tag} tag`} />);
-    }
 
     return (
         <div>
@@ -475,10 +457,10 @@ const FlyWormDonor = (props) => {
                             </div>
                         : null}
 
-                        {tagBadges ?
+                        {context.internal_tags && context.internal_tags.length > 0 ?
                             <div className="tag-badges" data-test="tags">
                                 <dt>Tags</dt>
-                                <dd>{tagBadges}</dd>
+                                <dd><InternalTags context={context} /></dd>
                             </div>
                         : null}
                     </dl>

--- a/src/encoded/static/components/experiment.js
+++ b/src/encoded/static/components/experiment.js
@@ -13,7 +13,7 @@ import { FileGallery } from './filegallery';
 import { CartToggle } from './cart';
 import { ProjectBadge } from './image';
 import { Breadcrumbs } from './navigation';
-import { singleTreatment, AlternateAccession, DisplayAsJson } from './objectutils';
+import { singleTreatment, AlternateAccession, DisplayAsJson, InternalTags } from './objectutils';
 import pubReferenceList from './reference';
 import { SortTablePanel, SortTable } from './sorttable';
 import Status from './status';
@@ -443,10 +443,6 @@ class ExperimentComponent extends React.Component {
         const references = pubReferenceList(context.references);
 
         // Render tags badges.
-        let tagBadges;
-        if (context.internal_tags && context.internal_tags.length) {
-            tagBadges = context.internal_tags.map(tag => <img key={tag} src={`/static/img/tag-${tag}.png`} alt={`${tag} tag`} />);
-        }
 
         return (
             <div className={itemClass}>
@@ -644,10 +640,10 @@ class ExperimentComponent extends React.Component {
 
                                     {libSubmitterComments}
 
-                                    {tagBadges ?
+                                    {context.internal_tags && context.internal_tags.length > 0 ?
                                         <div className="tag-badges" data-test="tags">
                                             <dt>Tags</dt>
-                                            <dd>{tagBadges}</dd>
+                                            <dd><InternalTags context={context} /></dd>
                                         </div>
                                     : null}
                                 </dl>

--- a/src/encoded/static/components/objectutils.js
+++ b/src/encoded/static/components/objectutils.js
@@ -138,8 +138,8 @@ export function requestObjects(atIds, uri, filteringObjects) {
     // complete.
     return Promise.all(objectChunks.map((objectChunk) => {
         // Build URL containing file search for specific files for each chunk of files.
-        const url = uri.concat(objectChunk.reduce((combined, current) => `${combined}&${globals.encodedURIComponent('@id')}=${globals.encodedURIComponent(current)}`, ''));
-        return fetch(url, {
+        const objectUrl = uri.concat(objectChunk.reduce((combined, current) => `${combined}&${globals.encodedURIComponent('@id')}=${globals.encodedURIComponent(current)}`, ''));
+        return fetch(objectUrl, {
             method: 'GET',
             headers: {
                 Accept: 'application/json',
@@ -633,4 +633,30 @@ AlternateAccession.propTypes = {
 
 AlternateAccession.defaultProps = {
     altAcc: null,
+};
+
+
+/**
+ * Display a list of internal_tags for an object as badges that link to a corresponding search.
+ */
+export const InternalTags = ({ context, css }) => {
+    if (context.internal_tags && context.internal_tags.length > 0) {
+        const tagBadges = context.internal_tags.map((tag) => {
+            const tagSearchUrl = `/search/?type=${context['@type'][0]}&internal_tags=${globals.encodedURIComponent(tag)}`;
+            return <a href={tagSearchUrl} key={tag}><img src={`/static/img/tag-${tag}.png`} alt={`Search for all ${context['@type'][0]} with internal tag ${tag}`} /></a>;
+        });
+        return <span className={css}>{tagBadges}</span>;
+    }
+    return null;
+};
+
+InternalTags.propTypes = {
+    /** encode object being displayed */
+    context: PropTypes.object.isRequired,
+    /** CSS class to assign to <span> surrounding all the badges */
+    css: PropTypes.string,
+};
+
+InternalTags.defaultProps = {
+    css: '',
 };

--- a/src/encoded/static/components/objectutils.js
+++ b/src/encoded/static/components/objectutils.js
@@ -637,23 +637,22 @@ AlternateAccession.defaultProps = {
 
 
 /**
- * Display a list of internal_tags for an object as badges that link to a corresponding search.
+ * Display a list of internal_tags for an object as badges that link to a corresponding search. The
+ * object in `context` must have at least one `internal_tags` value or the results are
+ * unpredictable.
  */
 export const InternalTags = ({ context, css }) => {
-    if (context.internal_tags && context.internal_tags.length > 0) {
-        const tagBadges = context.internal_tags.map((tag) => {
-            const tagSearchUrl = `/search/?type=${context['@type'][0]}&internal_tags=${globals.encodedURIComponent(tag)}`;
-            return <a href={tagSearchUrl} key={tag}><img src={`/static/img/tag-${tag}.png`} alt={`Search for all ${context['@type'][0]} with internal tag ${tag}`} /></a>;
-        });
-        return <span className={css}>{tagBadges}</span>;
-    }
-    return null;
+    const tagBadges = context.internal_tags.map((tag) => {
+        const tagSearchUrl = `/search/?type=${context['@type'][0]}&internal_tags=${globals.encodedURIComponent(tag)}`;
+        return <a href={tagSearchUrl} key={tag}><img src={`/static/img/tag-${tag}.png`} alt={`Search for all ${context['@type'][0]} with internal tag ${tag}`} /></a>;
+    });
+    return <span className={css}>{tagBadges}</span>;
 };
 
 InternalTags.propTypes = {
     /** encode object being displayed */
     context: PropTypes.object.isRequired,
-    /** CSS class to assign to <span> surrounding all the badges */
+    /** Optional CSS class to assign to <span> surrounding all the badges */
     css: PropTypes.string,
 };
 

--- a/src/encoded/tests/data/inserts/human_donor.json
+++ b/src/encoded/tests/data/inserts/human_donor.json
@@ -122,5 +122,29 @@
         "lab": "j-michael-cherry",
         "organism": "human",
         "uuid": "ba1e3e4f-7ca1-4546-86c3-42df0134d627"
+    },
+    {
+        "accession": "ENCDO271OUW",
+        "age": "51",
+        "age_units": "year",
+        "aliases": [
+            "gtex:ENC-DEJ",
+            "gtex:PT-1LVAN",
+            "gtex:ENC-004",
+            "bradley-bernstein:Donor GTEX-1LVAN"
+        ],
+        "award": "ENCODE2",
+        "external_ids": [
+            "GEO:SAMN05897787"
+        ],
+        "internal_tags": [
+            "ENTEx",
+            "SESCC"
+        ],
+        "lab": "encode2-project",
+        "life_stage": "adult",
+        "organism": "/organisms/human/",
+        "sex": "female",
+        "status": "released"
     }
 ]


### PR DESCRIPTION
* I replaced a lot of duplicated code with a new InternalTags component that’s in objectutils.js, as the HTML generation is a bit more complicated with the links.
* I feel like these new `<a>` should have title attributes to help explain to sighted users what these buttons will lead to, but the vast majority of a11y sites say to never use title attributes as they might get read by some screen readers, duplicating the alt attribute on the `<img>`, so I didn’t use the title attribute. I’m thinking this is something yet to be worked out in the industry.
* Fixed a couple eslint errors in objectutils.js.
* Removed the internal_tags checks for `<FlyWomDonor>` and `<MouseDonor>` because only HumanDonor has `internal_tags` as a property.