### PR TITLE
ENCD-4231 matched set controls

### DIFF
--- a/src/encoded/static/components/dataset.js
+++ b/src/encoded/static/components/dataset.js
@@ -56,6 +56,7 @@ class AnnotationComponent extends React.Component {
         const context = this.props.context;
         const itemClass = globals.itemClass(context, 'view-item');
         const adminUser = !!(this.context.session_properties && this.context.session_properties.admin);
+        const experimentsUrl = `/search/?type=Experiment&possible_controls.accession=${context.accession}`;
 
         // Build up array of documents attached to this dataset
         const datasetDocuments = (context.documents && context.documents.length) ? context.documents : [];
@@ -228,6 +229,8 @@ class AnnotationComponent extends React.Component {
                 {/* Display the file widget with the facet, graph, and tables */}
                 <FileGallery context={context} encodevers={encodevers} showReplicateNumber={false} />
 
+                <FetchedItems {...this.props} url={experimentsUrl} Component={ControllingExperiments} />
+
                 <DocumentsPanelReq documents={datasetDocuments} />
             </div>
         );
@@ -258,6 +261,7 @@ class PublicationDataComponent extends React.Component {
         const context = this.props.context;
         const itemClass = globals.itemClass(context, 'view-item');
         const adminUser = !!(this.context.session_properties && this.context.session_properties.admin);
+        const experimentsUrl = `/search/?type=Experiment&possible_controls.accession=${context.accession}`;
 
         // Build up array of documents attached to this dataset
         const datasetDocuments = (context.documents && context.documents.length) ? context.documents : [];
@@ -391,6 +395,8 @@ class PublicationDataComponent extends React.Component {
                 {/* Display the file widget with the facet, graph, and tables */}
                 <FileGallery context={context} encodevers={globals.encodeVersion(context)} showReplicateNumber={false} hideGraph />
 
+                <FetchedItems {...this.props} url={experimentsUrl} Component={ControllingExperiments} />
+
                 <DocumentsPanelReq documents={datasetDocuments} />
             </div>
         );
@@ -421,6 +427,7 @@ class ReferenceComponent extends React.Component {
         const context = this.props.context;
         const itemClass = globals.itemClass(context, 'view-item');
         const adminUser = !!(this.context.session_properties && this.context.session_properties.admin);
+        const experimentsUrl = `/search/?type=Experiment&possible_controls.accession=${context.accession}`;
 
         // Build up array of documents attached to this dataset
         const datasetDocuments = (context.documents && context.documents.length) ? context.documents : [];
@@ -554,6 +561,8 @@ class ReferenceComponent extends React.Component {
                 {/* Display the file widget with the facet, graph, and tables */}
                 <FileGallery context={context} encodevers={globals.encodeVersion(context)} hideGraph altFilterDefault />
 
+                <FetchedItems {...this.props} url={experimentsUrl} Component={ControllingExperiments} />
+
                 <DocumentsPanelReq documents={datasetDocuments} />
             </div>
         );
@@ -584,6 +593,7 @@ class ProjectComponent extends React.Component {
         const context = this.props.context;
         const itemClass = globals.itemClass(context, 'view-item');
         const adminUser = !!(this.context.session_properties && this.context.session_properties.admin);
+        const experimentsUrl = `/search/?type=Experiment&possible_controls.accession=${context.accession}`;
 
         // Build up array of documents attached to this dataset
         const datasetDocuments = (context.documents && context.documents.length) ? context.documents : [];
@@ -741,6 +751,8 @@ class ProjectComponent extends React.Component {
                 {/* Display the file widget with the facet, graph, and tables */}
                 <FileGallery context={context} encodevers={globals.encodeVersion(context)} hideGraph />
 
+                <FetchedItems {...this.props} url={experimentsUrl} Component={ControllingExperiments} />
+
                 <DocumentsPanelReq documents={datasetDocuments} />
             </div>
         );
@@ -771,6 +783,7 @@ class UcscBrowserCompositeComponent extends React.Component {
         const context = this.props.context;
         const itemClass = globals.itemClass(context, 'view-item');
         const adminUser = !!(this.context.session_properties && this.context.session_properties.admin);
+        const experimentsUrl = `/search/?type=Experiment&possible_controls.accession=${context.accession}`;
 
         // Build up array of documents attached to this dataset
         const datasetDocuments = (context.documents && context.documents.length) ? context.documents : [];
@@ -913,6 +926,8 @@ class UcscBrowserCompositeComponent extends React.Component {
 
                 {/* Display the file widget with the facet, graph, and tables */}
                 <FileGallery context={context} encodevers={globals.encodeVersion(context)} hideGraph />
+
+                <FetchedItems {...this.props} url={experimentsUrl} Component={ControllingExperiments} />
 
                 <DocumentsPanelReq documents={datasetDocuments} />
             </div>
@@ -1425,9 +1440,7 @@ export class SeriesComponent extends React.Component {
                     session={this.context.session}
                 />
 
-                {seriesType === 'MatchedSet' ?
-                    <FetchedItems {...this.props} url={experimentsUrl} Component={ControllingExperiments} />
-                : null}
+                <FetchedItems {...this.props} url={experimentsUrl} Component={ControllingExperiments} />
 
                 <DocumentsPanelReq documents={datasetDocuments} />
             </div>

--- a/src/encoded/static/components/experiment.js
+++ b/src/encoded/static/components/experiment.js
@@ -7,7 +7,6 @@ import { auditDecor } from './audit';
 import { DocumentsPanelReq } from './doc';
 import * as globals from './globals';
 import { DbxrefList } from './dbxref';
-import { ExperimentTable } from './dataset';
 import { FetchedItems } from './fetched';
 import { FileGallery } from './filegallery';
 import { CartToggle } from './cart';
@@ -17,7 +16,7 @@ import { singleTreatment, AlternateAccession, DisplayAsJson } from './objectutil
 import pubReferenceList from './reference';
 import { SortTablePanel, SortTable } from './sorttable';
 import Status from './status';
-import { BiosampleSummaryString, BiosampleOrganismNames, CollectBiosampleDocs, AwardRef, Supersede } from './typeutils';
+import { BiosampleSummaryString, BiosampleOrganismNames, CollectBiosampleDocs, AwardRef, Supersede, ControllingExperiments } from './typeutils';
 
 
 const anisogenicValues = [
@@ -149,37 +148,6 @@ function AssayDetails(replicates, libVals, libSpecials, libComps) {
     // Finally, return the array of JSX renderings of all assay details.
     return components;
 }
-
-
-const ControllingExperiments = (props) => {
-    const context = props.context;
-
-    if (props.items.length) {
-        return (
-            <div>
-                <ExperimentTable
-                    {...props}
-                    items={props.items}
-                    limit={5}
-                    url={props.url}
-                    title={`Experiments with ${context.accession} as a control:`}
-                />
-            </div>
-        );
-    }
-    return null;
-};
-
-ControllingExperiments.propTypes = {
-    context: PropTypes.object.isRequired, // Experiment object containing the table being rendered
-    items: PropTypes.array, // Experiments to display in the table
-    url: PropTypes.string, // URL to go to full search results corresponding to the table
-};
-
-ControllingExperiments.defaultProps = {
-    items: [],
-    url: '',
-};
 
 
 class ExperimentComponent extends React.Component {

--- a/src/encoded/static/components/typeutils.js
+++ b/src/encoded/static/components/typeutils.js
@@ -316,3 +316,132 @@ export const Supersede = ({ context }) => {
 Supersede.propTypes = {
     context: PropTypes.object.isRequired, // Object containing supersedes/superseded_by to display
 };
+
+
+/**
+ * Display a count of experiments in the footer, with a link to the corresponding search if needed.
+ */
+const ExperimentTableFooter = ({ items, total, url }) => (
+    <div>
+        <span>Displaying {items.length} of {total} </span>
+        {items.length < total ? <a className="btn btn-info btn-xs pull-right" href={url}>View all</a> : null}
+    </div>
+);
+
+ExperimentTableFooter.propTypes = {
+    /** Array of experiments that were displayed in the table */
+    items: PropTypes.array.isRequired,
+    /** Total number of experiments */
+    total: PropTypes.number,
+    /** URL to link to equivalent experiment search results */
+    url: PropTypes.string.isRequired,
+};
+
+ExperimentTableFooter.defaultProps = {
+    total: 0,
+};
+
+
+const experimentTableColumns = {
+    accession: {
+        title: 'Accession',
+        display: item => <a href={item['@id']} title={`View page for experiment ${item.accession}`}>{item.accession}</a>,
+    },
+
+    assay_term_name: {
+        title: 'Assay',
+    },
+
+    biosample_term_name: {
+        title: 'Biosample term name',
+    },
+
+    target: {
+        title: 'Target',
+        getValue: item => item.target && item.target.label,
+    },
+
+    description: {
+        title: 'Description',
+    },
+
+    title: {
+        title: 'Lab',
+        getValue: item => (item.lab && item.lab.title ? item.lab.title : null),
+    },
+};
+
+
+export const ExperimentTable = ({ items, limit, total, url, title }) => {
+    // If there's a limit on entries to display and the array is greater than that limit, then
+    // clone the array with just that specified number of elements.
+    const experiments = limit > 0 && limit < items.length ? items.slice(0, limit) : items;
+
+    return (
+        <div>
+            <SortTablePanel title={title}>
+                <SortTable list={experiments} columns={experimentTableColumns} footer={<ExperimentTableFooter items={experiments} total={total} url={url} />} />
+            </SortTablePanel>
+        </div>
+    );
+};
+
+ExperimentTable.propTypes = {
+    /** List of experiments to display in the table */
+    items: PropTypes.array.isRequired,
+    /** Maximum number of experiments to display in the table */
+    limit: PropTypes.number,
+    /** Total number of experiments */
+    total: PropTypes.number,
+    /** URI to go to equivalent search results */
+    url: PropTypes.string.isRequired,
+    /** Title for the table of experiments; can be string or component */
+    title: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.node,
+    ]),
+};
+
+ExperimentTable.defaultProps = {
+    limit: 0,
+    total: 0,
+    title: '',
+};
+
+
+/**
+ * Display a table of experiments with the dataset in `context` as a possible_controls.
+ */
+export const ControllingExperiments = ({ context, items, total, url }) => {
+    if (items.length > 0) {
+        return (
+            <div>
+                <ExperimentTable
+                    items={items}
+                    limit={5}
+                    total={total}
+                    url={url}
+                    title={`Experiments with ${context.accession} as a control:`}
+                />
+            </div>
+        );
+    }
+    return null;
+};
+
+ControllingExperiments.propTypes = {
+    /** Dataset object containing the table being rendered */
+    context: PropTypes.object.isRequired,
+    /** Experiments to display in the table */
+    items: PropTypes.array,
+    /** Total number of items from search (can be larger than items.length) */
+    total: PropTypes.number,
+    /** URL to retrieve search results to fill the table */
+    url: PropTypes.string,
+};
+
+ControllingExperiments.defaultProps = {
+    items: [],
+    total: 0,
+    url: '',
+};


### PR DESCRIPTION
I moved ExperimentTable and its dependencies from dataset.js to typeutils.js, and I moved ControllingExperiments from experiment.js to typeutils.js. This is to avoid the possibility of having circular imports, and that’s the purpose of typeutils.js — to have React components and functions that are specific for encode object types but could get shared between related types. In this case, both Series and Experiments could both rely on the same ControllingExperiments component, which depends on ExperimentTable.