### PR TITLE
ENCD-4245-skip-restricted-acl

### DIFF
--- a/src/encoded/tests/test_status_trigger.py
+++ b/src/encoded/tests/test_status_trigger.py
@@ -613,3 +613,31 @@ def test_set_status_skip_acl_on_restricted_files(testapp, content, mocker, file,
     assert File.set_public_s3.call_count == 0
     res = testapp.get(file['@id'])
     assert res.json['status'] == 'released'
+
+
+@mock_sts
+@mock_s3
+def test_set_status_skip_acl_on_not_available_file(testapp, content, mocker, file, dummy_request, root):
+    from encoded.types.file import File
+    mocker.spy(File, 'set_public_s3')
+    # Create mock bucket.
+    import boto3
+    client = boto3.client('s3')
+    client.create_bucket(Bucket='test_upload_bucket')
+    # Generate creds.
+    testapp.patch_json(file['@id'], {'status': 'uploading'})
+    dummy_request.registry.settings['file_upload_bucket'] = 'test_upload_bucket'
+    testapp.post_json(file['@id'] + '@@upload', {})
+    # Get bucket name and key.
+    file_item = root.get_by_uuid(file['uuid'])
+    external = file_item._get_external_sheet()
+    # Put mock object in bucket.
+    client.put_object(Body=b'ABCD', Key=external['key'], Bucket=external['bucket'])
+    # Set to in progress.
+    testapp.patch_json(file['@id'], {'status': 'in progress', 'no_file_available': True})
+    res = testapp.get(file['@id'])
+    assert res.json['status'] == 'in progress'
+    testapp.patch_json(file['@id'] + '@@set_status?update=true', {'status': 'released'})
+    assert File.set_public_s3.call_count == 0
+    res = testapp.get(file['@id'])
+    assert res.json['status'] == 'released'

--- a/src/encoded/types/file.py
+++ b/src/encoded/types/file.py
@@ -445,9 +445,9 @@ class File(Item):
         )
         if not status_set or not asbool(request.params.get('update')):
             return False
-        # Skip setting object ACL in s3 if file is restricted.
+        # Skip setting object ACL in s3 if file is restricted or not available.
         properties = self.upgrade_properties()
-        if properties.get('restricted'):
+        if properties.get('restricted') or properties.get('no_file_available'):
             return True
         # Change permission in S3.
         try:

--- a/src/encoded/types/file.py
+++ b/src/encoded/types/file.py
@@ -445,6 +445,10 @@ class File(Item):
         )
         if not status_set or not asbool(request.params.get('update')):
             return False
+        # Skip setting object ACL in s3 if file is restricted.
+        properties = self.upgrade_properties()
+        if properties.get('restricted'):
+            return True
         # Change permission in S3.
         try:
             if new_status in self.public_s3_statuses:

--- a/src/encoded/types/file.py
+++ b/src/encoded/types/file.py
@@ -437,6 +437,19 @@ class File(Item):
             external['key']
         ).put(ACL='private')
 
+    def _should_set_object_acl(self):
+        '''
+        Skip setting ACL on certain objects.
+        '''
+        properties = self.upgrade_properties()
+        skip_acl_prop_keys = [
+            'restricted',
+            'no_file_available',
+        ]
+        if any(properties.get(prop_key) for prop_key in set(skip_acl_prop_keys)):
+            return False
+        return True
+
     def set_status(self, new_status, request, parent=True):
         status_set = super(File, self).set_status(
             new_status,
@@ -445,22 +458,19 @@ class File(Item):
         )
         if not status_set or not asbool(request.params.get('update')):
             return False
-        # Skip setting object ACL in s3 if file is restricted or not available.
-        properties = self.upgrade_properties()
-        if properties.get('restricted') or properties.get('no_file_available'):
-            return True
-        # Change permission in S3.
-        try:
-            if new_status in self.public_s3_statuses:
-                self.set_public_s3()
-            elif new_status in self.private_s3_statuses:
-                self.set_private_s3()
-        except ClientError as e:
-            # Demo trying to set ACL on production object?
-            if e.response['Error']['Code'] == 'AccessDenied':
-                logging.warn(e)
-            else:
-                raise e
+        if self._should_set_object_acl():
+            # Change permission in S3.
+            try:
+                if new_status in self.public_s3_statuses:
+                    self.set_public_s3()
+                elif new_status in self.private_s3_statuses:
+                    self.set_private_s3()
+            except ClientError as e:
+                # Demo trying to set ACL on production object?
+                if e.response['Error']['Code'] == 'AccessDenied':
+                    logging.warn(e)
+                else:
+                    raise e
         return True
 
 


### PR DESCRIPTION
Avoid making any ACL calls when setting status on restricted files.