### PR TITLE
[2nd] ENCD-4195 update ontology with mintchip slimming

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -149,7 +149,7 @@ recipe = collective.recipe.cmd
 on_install = true
 on_update = true
 cmds =
-    curl -o ontology.json https://s3-us-west-1.amazonaws.com/encoded-build/ontology/ontology-2018-11-05.json
+    curl -o ontology.json https://s3-us-west-1.amazonaws.com/encoded-build/ontology/ontology-2018-11-12.json
 
 [aws-ip-ranges]
 recipe = collective.recipe.cmd

--- a/src/encoded/commands/generate_ontology.py
+++ b/src/encoded/commands/generate_ontology.py
@@ -186,7 +186,8 @@ slim_shims = {
         'OBI:0001861': ['DNA methylation'],  # MRE-seq
         'OBI:0002086': ['DNA methylation'],  # TAB-seq
         'OBI:0000716': ['DNA binding'], # ChIP-seq
-        'OBI:0001919': ['3D chromatin structure'] # 5C
+        'OBI:0001919': ['3D chromatin structure'], # 5C
+        'OBI:0002160': ['DNA binding']  # Mint-ChIP-seq
     },
     'organ': {
         'NTR:0001407': ['brain'],

--- a/src/encoded/docs/updating_ontologies.md
+++ b/src/encoded/docs/updating_ontologies.md
@@ -39,7 +39,7 @@ How to update the ontology versions
 6.  Update the following information
     
     Site release version: 78
-    ontology.json file: ontology-2018-11-05.json
+    ontology.json file: ontology-2018-11-12.json
     [UBERON release date]: 2018-02-28
     [OBI release date]: 2018-08-27
     [EFO release date]: 2018-10-15


### PR DESCRIPTION
forced 'mint-chip-seq' to shim to 'dna binding' assay category as it was noticed in v78rc1 that it was no longer shimming to the assay category due to some updated at OBI
regenerated ontology.json, uploaded it to aws, updated buildout to look for the new ontology.json