### PR TITLE
ENCD-4297 Fix back button behavior and page jumping

### DIFF
--- a/src/encoded/static/components/app.js
+++ b/src/encoded/static/components/app.js
@@ -753,7 +753,6 @@ class App extends React.Component {
 
         const options = {};
         const actionUrl = url.parse(url.resolve(this.state.href, target.action));
-        options.replace = actionUrl.pathname === url.parse(this.state.href).pathname;
         let search = serialize(target);
         if (target.getAttribute('data-removeempty')) {
             search = search.split('&').filter(item => item.slice(-1) !== '=').join('&');

--- a/src/encoded/static/components/search.js
+++ b/src/encoded/static/components/search.js
@@ -971,12 +971,14 @@ export class FacetList extends React.Component {
         return (
             <div className={`box facets${addClasses ? ` ${addClasses}` : ''}`}>
                 <div className={`orientation${this.props.orientation === 'horizontal' ? ' horizontal' : ''}`}>
-                    {context ? <DocTypeTitle searchResults={context} wrapper={children => <h1>{children} {docTypeTitleSuffix}</h1>} /> : null}
-                    {clearButton ?
-                        <div className="clear-filters-control">
-                            <a href={context.clear_filters}>Clear Filters <i className="icon icon-times-circle" /></a>
-                        </div>
-                    : null}
+                    <div className="search-header-control">
+                        {context ? <DocTypeTitle searchResults={context} wrapper={children => <h1>{children} {docTypeTitleSuffix}</h1>} /> : null}
+                        {clearButton ?
+                            <div className="clear-filters-control">
+                                <a href={context.clear_filters}>Clear Filters <i className="icon icon-times-circle" /></a>
+                            </div>
+                        : null}
+                    </div>
                     {mode === 'picker' && !hideTextFilter ? <TextFilter {...this.props} filters={filters} /> : ''}
                     {facets.map((facet) => {
                         if (hideTypes && facet.field === 'type') {

--- a/src/encoded/static/components/summary.js
+++ b/src/encoded/static/components/summary.js
@@ -34,7 +34,7 @@ const SummaryTitle = (props) => {
     }
 
     return (
-        <div>
+        <div className="summary-header__title_control">
             <div className="summary-header__title">
                 <h1>{context.title}</h1>
                 {context.views ?

--- a/src/encoded/static/scss/encoded/modules/_facet.scss
+++ b/src/encoded/static/scss/encoded/modules/_facet.scss
@@ -69,11 +69,26 @@
     @at-root #{&}--summary {
         margin-top: -30px;
         margin-bottom: 30px;
-        text-align: left;
+        position: absolute;
+        bottom: 10px;
+        left: 0px;
 
         @media print {
             display: none;
         }
+    }
+}
+
+.search-header-control {
+    position: relative;
+    padding-bottom: 25px;
+}
+
+.col-sm-5 {
+    .clear-filters-control {
+        position: absolute;
+        bottom: 5px;
+        left: 0px;
     }
 }
 
@@ -406,7 +421,7 @@ div.meta-status {
         }
     }
 }
- 
+
 .main-panel {
     position: relative;
     z-index: 0;

--- a/src/encoded/static/scss/encoded/modules/_summary.scss
+++ b/src/encoded/static/scss/encoded/modules/_summary.scss
@@ -7,7 +7,7 @@
     }
 
     @at-root #{&}__title {
-        margin-bottom: 30px;
+        padding-bottom: 40px;
 
         h1 {
             @include facet-title;
@@ -16,6 +16,10 @@
 
     .clear-filters-control--summary {
         margin: 5px 0 0;
+    }
+
+    .summary-header__title_control {
+        position: relative;
     }
 }
 


### PR DESCRIPTION
This commit should fix 2 issues:
(1) when you select facets and then type in Search bar and then go back, the last facet you selected is not saved in the history
(2) when you select facets, the list of facets jumps down to display "Clear facets" - the jumping can cause you to click on the wrong thing while you are making selections