### PR TITLE
ENCD-4325 Juicebox browser

### DIFF
--- a/src/encoded/static/components/filegallery.js
+++ b/src/encoded/static/components/filegallery.js
@@ -9,11 +9,12 @@ import { auditDecor, auditsDisplayed, AuditIcon } from './audit';
 import { FetchedData, Param } from './fetched';
 import * as globals from './globals';
 import { Graph, JsonGraph, GraphException } from './graph';
-import { requestFiles, DownloadableAccession, BrowserSelector } from './objectutils';
+import { requestFiles, DownloadableAccession } from './objectutils';
 import { qcIdToDisplay } from './quality_metric';
 import { softwareVersionList } from './software';
 import { SortTablePanel, SortTable } from './sorttable';
 import Status from './status';
+import { visOpenBrowser, visFilterBrowserFiles, visFileSelectable, visSortBrowsers } from './vis_defines';
 
 
 const MINIMUM_COALESCE_COUNT = 5; // Minimum number of files in a coalescing group
@@ -85,7 +86,8 @@ export class FileTable extends React.Component {
     }
 
     fileClick(file) {
-        if (this.props.setInfoNodeId && this.props.setInfoNodeVisible) {
+        const { setInfoNodeId, setInfoNodeVisible } = this.props;
+        if (setInfoNodeId && setInfoNodeVisible) {
             const node = {
                 '@type': ['File'],
                 metadata: {
@@ -93,16 +95,17 @@ export class FileTable extends React.Component {
                 },
                 schemas: this.props.schemas,
             };
-            this.props.setInfoNodeId(node);
-            this.props.setInfoNodeVisible(true);
+            setInfoNodeId(node);
+            setInfoNodeVisible(true);
         }
     }
 
     handleCollapse(table) {
-        // Handle a click on a collapse button by toggling the corresponding tableCollapse state var
-        const collapsed = _.clone(this.state.collapsed);
-        collapsed[table] = !collapsed[table];
-        this.setState({ collapsed });
+        this.setState((state) => {
+            const collapsed = _.clone(state.collapsed);
+            collapsed[table] = !collapsed[table];
+            return { collapsed };
+        });
     }
 
     handleCollapseProc() {
@@ -122,28 +125,29 @@ export class FileTable extends React.Component {
             context,
             items,
             graphedFiles,
+            filterOptions,
             filePanelHeader,
             encodevers,
-            selectedFilterValue,
-            filterOptions,
             showFileCount,
+            browserOptions,
             session,
             adminUser,
+            selectedFilterValue,
             showReplicateNumber,
         } = this.props;
-        let selectedAssembly;
-        let selectedAnnotation;
         const loggedIn = !!(session && session['auth.userid']);
 
+        // Establish the selected assembly and annotation.
+        let selectedAssembly = null;
+        let selectedAnnotation = null;
+        if (selectedFilterValue && filterOptions[selectedFilterValue]) {
+            selectedAssembly = filterOptions[selectedFilterValue].assembly;
+            selectedAnnotation = filterOptions[selectedFilterValue].annotation;
+        }
+
         let datasetFiles = _((items && items.length) ? items : []).uniq(file => file['@id']);
-
-        if (datasetFiles.length) {
+        if (datasetFiles.length > 0) {
             const unfilteredCount = datasetFiles.length;
-
-            if (selectedFilterValue && filterOptions[selectedFilterValue]) {
-                selectedAssembly = filterOptions[selectedFilterValue].assembly;
-                selectedAnnotation = filterOptions[selectedFilterValue].annotation;
-            }
 
             // Filter all the files according to the given filters, and remove duplicates
             datasetFiles = _(datasetFiles).filter((file) => {
@@ -226,6 +230,7 @@ export class FileTable extends React.Component {
                                 restrictedTip: this.state.restrictedTip,
                                 fileClick: this.fileClick,
                                 graphedFiles,
+                                browserOptions,
                                 loggedIn,
                                 adminUser,
                             }}
@@ -262,21 +267,44 @@ export class FileTable extends React.Component {
 }
 
 FileTable.propTypes = {
-    context: PropTypes.object.isRequired, // Dataset-type object being rendered
-    items: PropTypes.array.isRequired, // Array of files to appear in the table
-    graphedFiles: PropTypes.object, // Specifies which files are in the graph
-    filePanelHeader: PropTypes.object, // Table header component
-    encodevers: PropTypes.string, // ENCODE version of the experiment
-    selectedFilterValue: PropTypes.string, // Selected filter from popup menu
-    filterOptions: PropTypes.array, // Array of assambly/annotation from file array
-    showFileCount: PropTypes.bool, // True to show count of files in table
-    setInfoNodeId: PropTypes.func, // Function to call to set the currently selected node ID
-    setInfoNodeVisible: PropTypes.func, // Function to call to set the visibility of the node's modal
-    session: PropTypes.object, // Persona user session
-    adminUser: PropTypes.bool, // True if user is an admin user
-    schemas: PropTypes.object, // Object from /profiles/ containing all schemas
-    noDefaultClasses: PropTypes.bool, // True to strip SortTable panel of default CSS classes
-    showReplicateNumber: PropTypes.bool, // True to show replicate number
+    /** Dataset-type object being rendered */
+    context: PropTypes.object.isRequired,
+    /** Array of files to appear in the table */
+    items: PropTypes.array.isRequired,
+    /** Specifies which files are in the graph */
+    graphedFiles: PropTypes.object,
+    /** Table header component */
+    filePanelHeader: PropTypes.object,
+    /** ENCODE version of the experiment */
+    encodevers: PropTypes.string,
+    browserOptions: PropTypes.shape({
+        /** Currently selected genome browser */
+        currentBrowser: PropTypes.string,
+        /** Called when user selects a browser */
+        browserFileSelectHandler: PropTypes.func.isRequired,
+        /** Files selected for browsing */
+        selectedBrowserFiles: PropTypes.array,
+    }),
+    /** Selected filter from popup menu */
+    selectedFilterValue: PropTypes.string,
+    /** Array of assambly/annotation from file array */
+    filterOptions: PropTypes.array,
+    /** True to show count of files in table */
+    showFileCount: PropTypes.bool,
+    /** Function to call to set the currently selected node ID */
+    setInfoNodeId: PropTypes.func,
+    /** Function to call to set the visibility of the node's modal */
+    setInfoNodeVisible: PropTypes.func,
+    /** User session */
+    session: PropTypes.object,
+    /** True if user is an admin user */
+    adminUser: PropTypes.bool,
+    /** Object from /profiles/ containing all schemas */
+    schemas: PropTypes.object,
+    /** True to strip SortTable panel of default CSS classes */
+    noDefaultClasses: PropTypes.bool,
+    /** True to show replicate number */
+    showReplicateNumber: PropTypes.bool,
 };
 
 FileTable.defaultProps = {
@@ -286,6 +314,10 @@ FileTable.defaultProps = {
     selectedFilterValue: 'default',
     filterOptions: [],
     showFileCount: false,
+    browserOptions: {
+        currentBrowser: '',
+        selectedBrowserFiles: [],
+    },
     setInfoNodeId: null,
     setInfoNodeVisible: null,
     session: null,
@@ -303,6 +335,19 @@ FileTable.contextTypes = {
 
 // Configuration for process file table
 FileTable.procTableColumns = {
+    visualize: {
+        title: 'Visualize',
+        display: (item, meta) => {
+            const selectedFile = meta.browserOptions.selectedBrowserFiles.find(file => file['@id'] === item['@id']);
+            const selectable = visFileSelectable(item, meta.browserOptions.selectedBrowserFiles, meta.browserOptions.currentBrowser);
+            return (
+                <div className="file-table-visualizer">
+                    <input name={item['@id']} type="checkbox" checked={!!selectedFile} disabled={!selectable && !selectedFile} onClick={meta.browserOptions.browserFileSelectHandler} />
+                </div>
+            );
+        },
+        sorter: false,
+    },
     accession: {
         title: 'Accession',
         display: (item, meta) => {
@@ -951,6 +996,64 @@ function collectAssembliesAnnotations(files) {
 }
 
 
+/**
+ * Render the visualization controls, including the browser selector and Visulize button.
+ */
+class VisualizationControls extends React.Component {
+    constructor() {
+        super();
+        this.handleBrowserChange = this.handleBrowserChange.bind(this);
+        this.handleVisualize = this.handleVisualize.bind(this);
+    }
+
+    /**
+     * Called when the user selects a new option from the browser menu.
+     */
+    handleBrowserChange(e) {
+        const { browserChangeHandler } = this.props;
+        browserChangeHandler(e.target.value);
+    }
+
+    /**
+     * Called when the user clicks the Visualize button.
+     */
+    handleVisualize() {
+        const { visualizeHandler } = this.props;
+        visualizeHandler();
+    }
+
+    render() {
+        const { browsers, currentBrowser } = this.props;
+
+        return (
+            <div className="file-gallery-controls__visualization-selector">
+                <select className="form-control--select" value={currentBrowser} onChange={this.handleBrowserChange}>
+                    {browsers.map(browser => (
+                        <option key={browser} value={browser}>{browser}</option>
+                    ))}
+                </select>
+                <button className="btn btn-info" onClick={this.handleVisualize} type="button">Visualize</button>
+            </div>
+        );
+    }
+}
+
+VisualizationControls.propTypes = {
+    /** All available browsers */
+    browsers: PropTypes.array.isRequired,
+    /** Currently selected browser */
+    currentBrowser: PropTypes.string,
+    /** Callback to handle new browser selection */
+    browserChangeHandler: PropTypes.func.isRequired,
+    /** Callback to handle click in Visualize button */
+    visualizeHandler: PropTypes.func.isRequired,
+};
+
+VisualizationControls.defaultProps = {
+    currentBrowser: '',
+};
+
+
 // Displays the file filtering controls for the file association graph and file tables.
 
 class FilterControls extends React.Component {
@@ -959,51 +1062,54 @@ class FilterControls extends React.Component {
 
         // Bind this to non-React methods.
         this.handleAssemblyAnnotationChange = this.handleAssemblyAnnotationChange.bind(this);
-        this.handleInclusionChange = this.handleInclusionChange.bind(this);
     }
 
     handleAssemblyAnnotationChange(e) {
         this.props.handleAssemblyAnnotationChange(e.target.value);
     }
 
-    // Called when the switch button is clicked.
-    handleInclusionChange() {
-        this.props.handleInclusionChange(!this.props.inclusionOn);
-    }
-
     render() {
-        const { filterOptions, selectedFilterValue, inclusionOn } = this.props;
+        const { filterOptions, selectedFilterValue, browsers, currentBrowser, browserChangeHandler, visualizeHandler } = this.props;
 
-        return (
-            <div className="file-gallery-controls">
-                <div className="file-gallery-controls__assembly-selector">
-                    {filterOptions.length ?
-                        <FilterMenu selectedFilterValue={selectedFilterValue} filterOptions={filterOptions} handleFilterChange={this.handleAssemblyAnnotationChange} />
+        if (filterOptions.length > 0 || browsers.length > 0) {
+            return (
+                <div className="file-gallery-controls">
+                    {filterOptions.length > 0 ?
+                        <div className="file-gallery-controls__assembly-selector">
+                            <FilterMenu selectedFilterValue={selectedFilterValue} filterOptions={filterOptions} handleFilterChange={this.handleAssemblyAnnotationChange} />
+                        </div>
+                    : null}
+                    {browsers.length > 0 ?
+                        <VisualizationControls browsers={browsers} currentBrowser={currentBrowser} browserChangeHandler={browserChangeHandler} visualizeHandler={visualizeHandler} />
                     : null}
                 </div>
-                <div className="file-gallery-controls__inclusion-selector">
-                    <div className="checkbox--right">
-                        <label htmlFor="filterIncArchive">Include deprecated files
-                            <input name="filterIncArchive" type="checkbox" checked={inclusionOn} onChange={this.handleInclusionChange} />
-                        </label>
-                    </div>
-                </div>
-            </div>
-        );
+            );
+        }
+        return null;        
     }
 }
 
 FilterControls.propTypes = {
+    /** Assembly/annotation combos available */
     filterOptions: PropTypes.array.isRequired,
+    /** Currently-selected assembly/annotation <select> value */
     selectedFilterValue: PropTypes.string,
+    /** Array of browsers available in this experiment */
+    browsers: PropTypes.array,
+    /** Name of currently selected browser */
+    currentBrowser: PropTypes.string,
+    /** File @ids selected for the browser */
     handleAssemblyAnnotationChange: PropTypes.func.isRequired,
-    handleInclusionChange: PropTypes.func.isRequired,
-    inclusionOn: PropTypes.bool, // True to make the inclusion box checked
+    /** Called then the user selects a different browser */
+    browserChangeHandler: PropTypes.func.isRequired,
+    /** Called when the user clicks the Visualize button */
+    visualizeHandler: PropTypes.func.isRequired,
 };
 
 FilterControls.defaultProps = {
     selectedFilterValue: '0',
-    inclusionOn: false,
+    browsers: [],
+    currentBrowser: '',
 };
 
 
@@ -1653,6 +1759,27 @@ FileGraph.defaultProps = {
 };
 
 
+/**
+ * Display the checkbox for the user to choose whether to include depcrecated files in the graph
+ * and table displays.
+ */
+const InclusionSelector = ({ inclusionOn, handleInclusionChange }) => (
+    <div className="checkbox--right">
+        <label htmlFor="filterIncArchive">
+            Include deprecated files
+            <input name="filterIncArchive" type="checkbox" checked={inclusionOn} onChange={handleInclusionChange} />
+        </label>
+    </div>
+);
+
+InclusionSelector.propTypes = {
+    /** True if the inclusion checkbox should be on */
+    inclusionOn: PropTypes.bool.isRequired,
+    /** Function to call when checkbox is clicked */
+    handleInclusionChange: PropTypes.func.isRequired,
+};
+
+
 // Function to render the file gallery, and it gets called after the file search results (for files associated with
 // the displayed experiment) return.
 
@@ -1666,31 +1793,42 @@ class FileGalleryRendererComponent extends React.Component {
 
         // Initialize React state variables.
         this.state = {
-            selectedFilterValue: 'default', // <select> value of selected filter
-            relatedFiles: [],
-            inclusionOn: adminUser, // True to exclude files with certain statuses
+            /** <select> value of selected assembly/annotation */
+            selectedFilterValue: 'default',
+            /** <select> value of selected browser */
+            currentBrowser: '',
+            /** Files selected for a browser */
+            selectedBrowserFiles: [],
+            /** All files associated with this dataset */
+            files: [],
+            /** True to exclude files with certain statuses */
+            inclusionOn: adminUser,
         };
+
+        /** Array of objects with the assemblies and annotations available for the files */
+        this.availableAssembliesAnnotations = [];
+        /** used to see if related_files has been updated */
+        this.prevRelatedFileAtIds = [];
 
         // Bind `this` to non-React methods.
         this.setInfoNodeId = this.setInfoNodeId.bind(this);
         this.setInfoNodeVisible = this.setInfoNodeVisible.bind(this);
         this.setFilter = this.setFilter.bind(this);
+        this.getSelectedAssemblyAnnotation = this.getSelectedAssemblyAnnotation.bind(this);
+        this.getAvailableBrowsers = this.getAvailableBrowsers.bind(this);
+        this.updateFiles = this.updateFiles.bind(this);
         this.handleAssemblyAnnotationChange = this.handleAssemblyAnnotationChange.bind(this);
         this.handleInclusionChange = this.handleInclusionChange.bind(this);
         this.filterForInclusion = this.filterForInclusion.bind(this);
         this.closeModal = this.closeModal.bind(this);
         this.handleNodeClick = this.handleNodeClick.bind(this);
+        this.handleBrowserChange = this.handleBrowserChange.bind(this);
+        this.handleBrowserFileSelect = this.handleBrowserFileSelect.bind(this);
+        this.handleVisualize = this.handleVisualize.bind(this);
     }
 
     componentWillMount() {
-        const { context, data } = this.props;
-        const relatedFileIds = context.related_files && context.related_files.length ? context.related_files : [];
-        if (relatedFileIds.length) {
-            const searchedFiles = data ? data['@graph'] : []; // Array of searched files arrives in data.@graph result
-            requestFiles(relatedFileIds, searchedFiles).then((relatedFiles) => {
-                this.setState({ relatedFiles });
-            });
-        }
+        this.updateFiles();
     }
 
     // Set the default filter after the graph has been analyzed once.
@@ -1701,16 +1839,7 @@ class FileGalleryRendererComponent extends React.Component {
     }
 
     componentDidUpdate() {
-        const { context, data } = this.props;
-        const relatedFileIds = context.related_files && context.related_files.length ? context.related_files : [];
-        if (relatedFileIds.length) {
-            const searchedFiles = data ? data['@graph'] : []; // Array of searched files arrives in data.@graph result
-            requestFiles(relatedFileIds, searchedFiles).then((relatedFiles) => {
-                if (relatedFiles.length !== this.state.relatedFiles.length) {
-                    this.setState({ relatedFiles });
-                }
-            });
-        }
+        this.updateFiles();
     }
 
     // Called from child components when the selected node changes.
@@ -1727,15 +1856,96 @@ class FileGalleryRendererComponent extends React.Component {
         this.setState({ selectedFilterValue: value });
     }
 
-    // React to a filter menu selection. The synthetic event given in `e`
+    /**
+     * Get the currently selected assembly and annotation.
+     */
+    getSelectedAssemblyAnnotation() {
+        if (this.state.selectedFilterValue && this.availableAssembliesAnnotations[this.state.selectedFilterValue]) {
+            const selectedAssemblyAnnotation = this.availableAssembliesAnnotations[this.state.selectedFilterValue];
+            return {
+                selectedAssembly: selectedAssemblyAnnotation.assembly,
+                selectedAnnotation: selectedAssemblyAnnotation.annotation,
+            };
+        }
+        return { selectedAssembly: null, selectedAnnotation: null };
+    }
+
+    /**
+     * Given the currently selected assembly/annotation, get a list of the available browsers.
+     */
+    getAvailableBrowsers() {
+        const { selectedAssembly } = this.getSelectedAssemblyAnnotation();
+        if (selectedAssembly && this.props.context.visualize && this.props.context.visualize[selectedAssembly]) {
+            return visSortBrowsers(this.props.context.visualize[selectedAssembly]);
+        }
+        return [];
+    }
+
+    /**
+     * Retrieve dataset.related_files to combine with the files directly associated with the
+     * dataset and update the `files` state variable. I only check for length changes and not
+     * content changes. In addition, collect all the assemblies/annotations associated with the
+     * combined files so we can choose a visualization browser.
+     */
+    updateFiles() {
+        const { context, data } = this.props;
+        let relatedPromise;
+        const relatedFileAtIds = context.related_files && context.related_files.length > 0 ? context.related_files : [];
+        const datasetFiles = data ? data['@graph'] : [];
+
+        // The number of related_files has changed (or we have related_files for the first time).
+        // Request them and add them to the files from the original file request.
+        if (relatedFileAtIds.length !== this.prevRelatedFileAtIds.length) {
+            this.prevRelatedFileAtIds = relatedFileAtIds;
+            if (relatedFileAtIds.length > 0) {
+                relatedPromise = requestFiles(relatedFileAtIds, datasetFiles).then((relatedFiles) => {
+                    if (relatedFiles.length !== this.state.relatedFiles.length) {
+                        return datasetFiles.concat(relatedFiles);
+                    }
+                    return null;
+                });
+            } else {
+                // No related_files, so just use files directly in the dataset.files.
+                relatedPromise = Promise.resolve(datasetFiles);
+            }
+        } else {
+            relatedPromise = Promise.resolve(datasetFiles);
+        }
+
+        // Whether we have related_files or not, get all files' assemblies and annotations, and
+        // the first genome browser for them.
+        relatedPromise.then((allFiles) => {
+            if (allFiles.length !== this.state.files.length) {
+                this.setState({ files: allFiles });
+
+                // From the new set of files, calculate the currently selected assembly and annotation to display in
+                // the graph and tables.
+                this.availableAssembliesAnnotations = collectAssembliesAnnotations(allFiles);
+
+                // Generate the array of browsers for the currently selected assembly.
+                const browsers = this.getAvailableBrowsers();
+                if (browsers.length > 0 && !this.state.currentBrowser) {
+                    this.setState({
+                        currentBrowser: browsers[0],
+                        selectedBrowserFiles: visFilterBrowserFiles(allFiles, browsers[0], true),
+                    });
+                }
+            }
+        });
+    }
+
+    /**
+     * Called when the user selects an assembly/annotation to view.
+     */
     handleAssemblyAnnotationChange(value) {
         this.setFilter(value);
     }
 
-    // When the exclusion filter changes from typcially the user clicking the checkbox in
-    // <FilterControls>,
-    handleInclusionChange(checked) {
-        this.setState({ inclusionOn: checked });
+    /**
+     * Called when the user checks/unchecks the inclusion filter checkbox.
+     */ 
+    handleInclusionChange() {
+        this.setState(state => ({ inclusionOn: !state.inclusionOn }));
     }
 
     // If the inclusionOn state property is enabled, we'll just display all the files we got. If
@@ -1766,35 +1976,70 @@ class FileGalleryRendererComponent extends React.Component {
         this.setInfoNodeVisible(false);
     }
 
+    /**
+     * Called when the user chooses a new browser from the menu.
+     * @param {string} browser Name of browser user selected
+     */
+    handleBrowserChange(browser) {
+        this.setState({
+            currentBrowser: browser,
+            selectedBrowserFiles: visFilterBrowserFiles(this.state.files, browser),
+        });
+    }
+
+    /**
+     * Called when the user clicks the Visualize button.
+     */
+    handleVisualize() {
+        const { selectedAssembly } = this.getSelectedAssemblyAnnotation();
+        visOpenBrowser(this.props.context, this.state.currentBrowser, selectedAssembly, this.state.selectedBrowserFiles, this.context.location_href);
+    }
+
+    /**
+     * Called when the user selects/deselects a file for visualization in the file table.
+     * @param {object} synthEvent Event from React event handler
+     */
+    handleBrowserFileSelect(synthEvent) {
+        // The @id of the affected file is in the name of the clicked <input>.
+        const clickedFileAtId = synthEvent.target.name;
+        this.setState((state) => {
+            const matchingIndex = state.selectedBrowserFiles.findIndex(file => file['@id'] === clickedFileAtId);
+            if (matchingIndex === -1) {
+                // Add clicked file to array of selected files.
+                const matchingFile = state.files.find(file => file['@id'] === clickedFileAtId);
+                return { selectedBrowserFiles: state.selectedBrowserFiles.concat(matchingFile) };
+            }
+
+            // Remove clicked file from array of selected files.
+            return { selectedBrowserFiles: state.selectedBrowserFiles.slice(0, matchingIndex).concat(state.selectedBrowserFiles.slice(matchingIndex + 1)) };
+        });
+    }
+
     render() {
-        const { context, data, schemas, hideGraph, showReplicateNumber } = this.props;
-        let selectedAssembly = '';
-        let selectedAnnotation = '';
+        const { context, schemas, hideGraph, showReplicateNumber } = this.props;
         let allGraphedFiles;
         let meta;
-        const files = (data ? data['@graph'] : []).concat(this.state.relatedFiles); // Array of searched files arrives in data.@graph result
-        if (files.length === 0) {
+        if (this.state.files.length === 0) {
             return null;
         }
-
-        const filterOptions = files.length ? collectAssembliesAnnotations(files) : [];
-
-        if (this.state.selectedFilterValue && filterOptions[this.state.selectedFilterValue]) {
-            selectedAssembly = filterOptions[this.state.selectedFilterValue].assembly;
-            selectedAnnotation = filterOptions[this.state.selectedFilterValue].annotation;
-        }
+        const { selectedAssembly, selectedAnnotation } = this.getSelectedAssemblyAnnotation();
 
         // Get a list of files for the graph (filters out excluded files if requested by the user).
-        const includedFiles = this.filterForInclusion(files);
+        const includedFiles = this.filterForInclusion(this.state.files);
 
         const fileTable = (
             <FileTable
                 {...this.props}
                 items={includedFiles}
                 selectedFilterValue={this.state.selectedFilterValue}
-                filterOptions={filterOptions}
+                filterOptions={this.availableAssembliesAnnotations}
                 graphedFiles={allGraphedFiles}
                 handleFilterChange={this.handleFilterChange}
+                browserOptions={{
+                    browserFileSelectHandler: this.handleBrowserFileSelect,
+                    currentBrowser: this.state.currentBrowser,
+                    selectedBrowserFiles: this.state.selectedBrowserFiles,
+                }}
                 encodevers={globals.encodeVersion(context)}
                 session={this.context.session}
                 infoNodeId={this.state.infoNode}
@@ -1819,29 +2064,34 @@ class FileGalleryRendererComponent extends React.Component {
             QualityMetric: 'quality-metric',
         };
         const modalClass = meta ? `graph-modal-${modalTypeMap[meta.type]}` : '';
+        const browsers = this.getAvailableBrowsers();
 
         return (
             <Panel>
                 <PanelHeading addClasses="file-gallery-heading">
                     <h4>Files</h4>
-                    <div className="file-gallery-visualize">
-                        {context.visualize ?
-                            <BrowserSelector visualizeCfg={context.visualize} />
-                        : null}
-                    </div>
                 </PanelHeading>
 
-                {/* Display the strip of filgering controls */}
                 <FilterControls
                     selectedFilterValue={this.state.selectedFilterValue}
-                    filterOptions={filterOptions}
+                    filterOptions={this.availableAssembliesAnnotations}
                     inclusionOn={this.state.inclusionOn}
+                    browsers={browsers}
+                    currentBrowser={this.state.currentBrowser}
+                    selectedBrowserFiles={this.state.selectedBrowserFiles}
                     handleAssemblyAnnotationChange={this.handleAssemblyAnnotationChange}
                     handleInclusionChange={this.handleInclusionChange}
+                    browserChangeHandler={this.handleBrowserChange}
+                    visualizeHandler={this.handleVisualize}
                 />
 
                 {!hideGraph ?
-                    <TabPanel tabs={{ graph: 'Association graph', tables: 'File details' }}>
+                    <TabPanel
+                        tabPanelCss="file-gallery-tab-bar"
+                        tabs={{ graph: 'Association graph', tables: 'File details' }}
+                        decoration={<InclusionSelector inclusionOn={this.state.inclusionOn} handleInclusionChange={this.handleInclusionChange} />}
+                        decorationClasses="file-gallery__inclusion-selector"
+                    >
                         <TabPanelPane key="graph">
                             <FileGraph
                                 dataset={context}
@@ -1916,6 +2166,7 @@ FileGalleryRendererComponent.contextTypes = {
     session: PropTypes.object,
     session_properties: PropTypes.object,
     location_href: PropTypes.string,
+    navigate: PropTypes.func,
 };
 
 const FileGalleryRenderer = auditDecor(FileGalleryRendererComponent);

--- a/src/encoded/static/components/globals.js
+++ b/src/encoded/static/components/globals.js
@@ -98,15 +98,16 @@ export function encodedURI(uri) {
 
 
 // Just like encodeURIComponent, but also encodes parentheses (Redmine #4242). Replace spaces with
-// `space` parameter, or '+' if not provided.
+// `options.space` parameter, or '+' if not provided. Encodes equals sign if `options.encodeEquals`
+// set to true, or leaves the equals sign unencoded.
 // http://stackoverflow.com/questions/8143085/passing-and-through-a-uri-causes-a-403-error-how-can-i-encode-them#answer-8143232
-export function encodedURIComponent(str, space) {
-    const spaceReplace = space || '+';
-    return encodeURIComponent(str)
+export function encodedURIComponent(str, options = {}) {
+    const spaceReplace = options.space || '+';
+    const preEquals = encodeURIComponent(str)
         .replace(/\(/g, '%28')
         .replace(/\)/g, '%29')
-        .replace(/%20/g, spaceReplace)
-        .replace(/%3D/g, '=');
+        .replace(/%20/g, spaceReplace);
+    return options.encodeEquals ? preEquals : preEquals.replace(/%3D/g, '=');
 }
 
 

--- a/src/encoded/static/components/search.js
+++ b/src/encoded/static/components/search.js
@@ -1360,7 +1360,7 @@ export class ResultTable extends React.Component {
                                 <hr />
                                 <CartSearchControls searchResults={context} />
                                 {browserAvail ?
-                                    <TabPanel tabs={{ listpane: 'List', browserpane: <BrowserTabQuickView /> }} selectedTab={this.state.selectedTab} handleTabClick={this.handleTabClick} addClasses="browser-tab-bg" tabFlange>
+                                    <TabPanel tabs={{ listpane: 'List', browserpane: <BrowserTabQuickView /> }} selectedTab={this.state.selectedTab} handleTabClick={this.handleTabClick} navCss="browser-tab-bg" tabFlange>
                                         <TabPanelPane key="listpane">
                                             <ResultTableList results={results} columns={columns} tabbed />
                                         </TabPanelPane>

--- a/src/encoded/static/components/vis_defines.js
+++ b/src/encoded/static/components/vis_defines.js
@@ -6,7 +6,7 @@ import * as globals from './globals';
 /**
  * Maximum number of hic files allowed to be selected at once.
  */
-const MAX_HIC_FILES_SELECTED = 2;
+const MAX_HIC_FILES_SELECTED = 8;
 
 
 /**
@@ -107,7 +107,8 @@ export const visOpenBrowser = (dataset, browser, assembly, files, datasetUrl) =>
         delete parsedUrl.query;
         const fileQueries = files.map((file) => {
             parsedUrl.pathname = file.href;
-            return globals.encodedURIComponent(`{hicUrl=${url.format(parsedUrl)}}`, { encodeEquals: true });
+            const name = file.biological_replicates && file.biological_replicates.length > 0 ? `Replicate ${file.biological_replicates.join(',')}` : '';
+            return globals.encodedURIComponent(`{hicUrl=${url.format(parsedUrl)}${name}}`, { encodeEquals: true });
         });
         href = `http://aidenlab.org/juicebox/?juicebox=${fileQueries.join(',')}`;
         break;

--- a/src/encoded/static/components/vis_defines.js
+++ b/src/encoded/static/components/vis_defines.js
@@ -1,0 +1,202 @@
+import _ from 'underscore';
+import url from 'url';
+import * as globals from './globals';
+
+
+/**
+ * Maximum number of hic files allowed to be selected at once.
+ */
+const MAX_HIC_FILES_SELECTED = 2;
+
+
+/**
+ * If you modify ASSEMBLY_DETAILS in vis_defines.py, this object might need corresponding
+ * modifications.
+ */
+const ASSEMBLY_DETAILS = {
+    GRCh38: {
+        species: 'Homo sapiens',
+        ucsc_assembly: 'hg38',
+        ensembl_host: 'www.ensembl.org',
+    },
+    'GRCh38-minimal': {
+        species: 'Homo sapiens',
+        ucsc_assembly: 'hg38',
+        ensembl_host: 'www.ensembl.org',
+    },
+    hg19: {
+        species: 'Homo sapiens',
+        ucsc_assembly: 'hg19',
+        ensembl_host: 'grch37.ensembl.org',
+    },
+    mm10: {
+        species: 'Mus musculus',
+        ucsc_assembly: 'mm10',
+        ensembl_host: 'www.ensembl.org',
+    },
+    'mm10-minimal': {
+        species: 'Mus musculus',
+        ucsc_assembly: 'mm10',
+        ensembl_host: 'www.ensembl.org',
+    },
+    mm9: {
+        species: 'Mus musculus',
+        ucsc_assembly: 'mm9',
+    },
+    dm6: {
+        species: 'Drosophila melanogaster',
+        ucsc_assembly: 'dm6',
+    },
+    dm3: {
+        species: 'Drosophila melanogaster',
+        ucsc_assembly: 'dm3',
+    },
+    ce11: {
+        species: 'Caenorhabditis elegans',
+        ucsc_assembly: 'ce11',
+    },
+    ce10: {
+        species: 'Caenorhabditis elegans',
+        ucsc_assembly: 'ce10',
+    },
+    ce6: {
+        species: 'Caenorhabditis elegans',
+        ucsc_assembly: 'ce6',
+    },
+};
+
+/**
+ * File types allowed for each browser.
+ */
+const browserFileTypes = {
+    UCSC: [],
+    'Quick View': ['bigWig', 'bigBed'],
+    Ensembl: ['bigWig', 'bigBed'],
+    hic: ['hic'],
+};
+
+
+/**
+ * Open a browser visualization in a new tab. If called from a React component, that component must
+ * be mounted.
+ * @param {object} dataset Dataset object whose files we're visualizing
+ * @param {string} browser Specifies browser to use: UCSC, Quick View, Ensembl, hic currently
+ *                         acceptable
+ * @param {string} assembly Assembly to use with visualizer
+ * @param {array} files Array of files to visualize if applicable
+ * @param {string} datasetUrl URL of `dataset` parameter
+ */
+export const visOpenBrowser = (dataset, browser, assembly, files, datasetUrl) => {
+    let href;
+    switch (browser) {
+    case 'UCSC': {
+        // UCSC does not use `files` under any circumstances.
+        const ucscAssembly = ASSEMBLY_DETAILS[assembly].ucsc_assembly;
+        href = `http://genome.ucsc.edu/cgi-bin/hgTracks?hubClear=${datasetUrl}@@hub/hub.txt&db=${ucscAssembly}`;
+        break;
+    }
+    case 'Quick View': {
+        const fileQueries = files.map(file => `accession=${globals.atIdToAccession(file['@id'])}`);
+        href = `/search/?type=File&assembly=${assembly}&dataset=${dataset['@id']}&${fileQueries.join('&')}#browser`;
+        break;
+    }
+    case 'hic': {
+        const parsedUrl = url.parse(datasetUrl);
+        delete parsedUrl.path;
+        delete parsedUrl.search;
+        delete parsedUrl.query;
+        const fileQueries = files.map((file) => {
+            parsedUrl.pathname = file.href;
+            return globals.encodedURIComponent(`{hicUrl=${url.format(parsedUrl)}}`, { encodeEquals: true });
+        });
+        href = `http://aidenlab.org/juicebox/?juicebox=${fileQueries.join(',')}`;
+        break;
+    }
+    case 'Ensembl': {
+        if (ASSEMBLY_DETAILS[assembly].ensembl_host) {
+            href = `http://${ASSEMBLY_DETAILS[assembly].ensembl_host}/Trackhub?url=${datasetUrl};species=${ASSEMBLY_DETAILS[assembly].species.replace(/ /g, '_')}`;
+        }
+        break;
+    }
+    default:
+        break;
+    }
+    if (href) {
+        window.open(href, '_blank');
+    }
+};
+
+
+/**
+ * Filter files down to the ones that should be selected by default for the given browser.
+ * @param {array} files Files to filter according to what a browser uses
+ * @param {string} browser Browser to filter files against; see `browserFileTypes`
+ * @param {boolean} limits True to place browser-specific limits on resulting files, if any
+ * @return {array} `files` that can be browsed with `browser`.
+ */
+export const visFilterBrowserFiles = (files, browser, limits = false) => {
+    // Filter the given files to ones qualified for the given browser, and only those files with
+    // "released" status.
+    const qualifiedFileTypes = browserFileTypes[browser];
+    let qualifiedFiles = files.filter(file => qualifiedFileTypes.indexOf(file.file_type) !== -1 && file.status === 'released');
+
+    // For the hic browser, sort to prioritize "mapping quality thresholded chromatin interactions"
+    // output_types.
+    if (browser === 'hic') {
+        qualifiedFiles = qualifiedFiles.sort(file => (file.output_type === 'mapping quality thresholded chromatin interactions' ? -1 : 0));
+        if (limits) {
+            qualifiedFiles = qualifiedFiles.slice(0, MAX_HIC_FILES_SELECTED);
+        }
+    }
+    return qualifiedFiles;
+};
+
+
+/**
+ * Determine whether a file is selectable for the currently selected genome browser.
+ * @param {object} file File to check against its browser selectable state
+ * @param {array} selectedFiles Files that are currently selected
+ * @param {string} browser Currently selected browser
+ */
+export const visFileSelectable = (file, selectedFiles, browser) => {
+    let selectable = false;
+    switch (browser) {
+    case 'UCSC':
+        // Always not selectable.
+        break;
+    case 'Quick View':
+        selectable = browserFileTypes[browser].indexOf(file.file_type) !== -1;
+        break;
+    case 'hic':
+        selectable = (browserFileTypes[browser].indexOf(file.file_type) !== -1) && (selectedFiles.length < MAX_HIC_FILES_SELECTED);
+        break;
+    case 'Ensembl':
+        // Always not selectable.
+        break;
+    default:
+        // Should never happen, but not selectable if it does.
+        break;
+    }
+    return selectable;
+};
+
+
+/**
+ * The order that browsers should appear when sorted.
+ */
+const browserOrder = [
+    'UCSC',
+    'Quick View',
+    'hic',
+    'Ensembl',
+];
+
+
+/**
+ * Given an array of browsers, sort them according to the order in the `browserOrder` global above.
+ * @param {array} browsers Array of browsers to sort
+ * @return {array} Same contents as `browsers` but sorted according to `browserOrder`
+ */
+export const visSortBrowsers = browsers => (
+    _.sortBy(browsers, browser => browserOrder.indexOf(browser))
+);

--- a/src/encoded/static/components/vis_defines.js
+++ b/src/encoded/static/components/vis_defines.js
@@ -107,7 +107,7 @@ export const visOpenBrowser = (dataset, browser, assembly, files, datasetUrl) =>
         delete parsedUrl.query;
         const fileQueries = files.map((file) => {
             parsedUrl.pathname = file.href;
-            const name = file.biological_replicates && file.biological_replicates.length > 0 ? `&name=Replicate ${file.biological_replicates.join(',')}` : '';
+            const name = file.biological_replicates && file.biological_replicates.length > 0 ? `&name=${dataset.accession}/${file.title}, Replicate ${file.biological_replicates.join(',')}` : '';
             return globals.encodedURIComponent(`{hicUrl=${url.format(parsedUrl)}${name}}`, { encodeEquals: true });
         });
         href = `http://aidenlab.org/juicebox/?juicebox=${fileQueries.join(',')}`;

--- a/src/encoded/static/components/vis_defines.js
+++ b/src/encoded/static/components/vis_defines.js
@@ -107,7 +107,7 @@ export const visOpenBrowser = (dataset, browser, assembly, files, datasetUrl) =>
         delete parsedUrl.query;
         const fileQueries = files.map((file) => {
             parsedUrl.pathname = file.href;
-            const name = file.biological_replicates && file.biological_replicates.length > 0 ? `&name=${dataset.accession}/${file.title}, Replicate ${file.biological_replicates.join(',')}` : '';
+            const name = file.biological_replicates && file.biological_replicates.length > 0 ? `&name=${dataset.accession} / ${file.title}, Replicate ${file.biological_replicates.join(',')}` : '';
             return globals.encodedURIComponent(`{hicUrl=${url.format(parsedUrl)}${name}}`, { encodeEquals: true });
         });
         href = `http://aidenlab.org/juicebox/?juicebox=${fileQueries.join(',')}`;

--- a/src/encoded/static/components/vis_defines.js
+++ b/src/encoded/static/components/vis_defines.js
@@ -107,7 +107,7 @@ export const visOpenBrowser = (dataset, browser, assembly, files, datasetUrl) =>
         delete parsedUrl.query;
         const fileQueries = files.map((file) => {
             parsedUrl.pathname = file.href;
-            const name = file.biological_replicates && file.biological_replicates.length > 0 ? `Replicate ${file.biological_replicates.join(',')}` : '';
+            const name = file.biological_replicates && file.biological_replicates.length > 0 ? `&name=Replicate ${file.biological_replicates.join(',')}` : '';
             return globals.encodedURIComponent(`{hicUrl=${url.format(parsedUrl)}${name}}`, { encodeEquals: true });
         });
         href = `http://aidenlab.org/juicebox/?juicebox=${fileQueries.join(',')}`;

--- a/src/encoded/static/libs/bootstrap/panel.js
+++ b/src/encoded/static/libs/bootstrap/panel.js
@@ -157,7 +157,7 @@ class TabPanel extends React.Component {
     }
 
     render() {
-        const { tabs, addClasses, moreComponents, moreComponentsClasses, tabFlange, decoration, decorationClasses } = this.props;
+        const { tabs, tabPanelCss, navCss, moreComponents, moreComponentsClasses, tabFlange, decoration, decorationClasses } = this.props;
         let children = [];
         let firstPaneIndex = -1; // React.Children.map index of first <TabPanelPane> component
 
@@ -179,9 +179,9 @@ class TabPanel extends React.Component {
         }
 
         return (
-            <div>
+            <div className={tabPanelCss}>
                 <div className="tab-nav">
-                    <ul className={`nav nav-tabs${addClasses ? ` ${addClasses}` : ''}`} role="tablist">
+                    <ul className={`nav nav-tabs${navCss ? ` ${navCss}` : ''}`} role="tablist">
                         {Object.keys(tabs).map((tab, i) => {
                             const currentTab = this.props.selectedTab ? this.props.selectedTab : this.state.currentTab ? this.state.currentTab : i === 0 ? tab : '';
 
@@ -207,26 +207,38 @@ class TabPanel extends React.Component {
 }
 
 TabPanel.propTypes = {
-    tabs: PropTypes.object.isRequired, // Object with tab=>pane specifications
-    selectedTab: PropTypes.string, // key of tab to select (must provide handleTabClick) too.
-    addClasses: PropTypes.string, // Classes to add to navigation <ul>
-    moreComponents: PropTypes.object, // Other components to render in the tab bar
-    moreComponentsClasses: PropTypes.string, // Classes to add to moreComponents wrapper <div>
-    tabFlange: PropTypes.bool, // True to show a small full-width strip under active tab
-    decoration: PropTypes.object, // Component to render in the tab bar
-    decorationClasses: PropTypes.string, // CSS classes to wrap decoration in
-    handleTabClick: PropTypes.func, // If selectedTab is provided, then parent must keep track of it
+    /** Object with tab=>pane specifications */
+    tabs: PropTypes.object.isRequired,
+    /** CSS class for the entire tab panel <div> */
+    tabPanelCss: PropTypes.string,
+    /** key of tab to select (must provide handleTabClick) too. */
+    selectedTab: PropTypes.string,
+    /** Classes to add to navigation <ul> */
+    navCss: PropTypes.string,
+    /** Other components to render in the tab bar */
+    moreComponents: PropTypes.object,
+    /** Classes to add to moreComponents wrapper <div> */
+    moreComponentsClasses: PropTypes.string,
+    /** True to show a small full-width strip under active tab */
+    tabFlange: PropTypes.bool,
+    /** Component to render in the tab bar */
+    decoration: PropTypes.object,
+    /** CSS classes to wrap decoration in */
+    decorationClasses: PropTypes.string,
+    /** If selectedTab is provided, then parent must keep track of it */
+    handleTabClick: PropTypes.func,
     children: PropTypes.node,
 };
 
 TabPanel.defaultProps = {
     selectedTab: '',
-    addClasses: '',
+    tabPanelCss: null,
+    navCss: null,
     moreComponents: null,
     moreComponentsClasses: '',
     tabFlange: false,
     decoration: null,
-    decorationClasses: '',
+    decorationClasses: null,
     handleTabClick: null,
     children: null,
 };

--- a/src/encoded/static/scss/encoded/modules/_panels.scss
+++ b/src/encoded/static/scss/encoded/modules/_panels.scss
@@ -299,8 +299,20 @@ a[href^="http://encodedcc.sdsc.edu/warehouse/"]:after {
         margin-right: 5px;
     }
 
-    @at-root #{&}__inclusion-selector {
+    @at-root #{&}__visualization-selector {
         flex: 0 1 auto;
+
+        select {
+            display: inline-block;
+            width: auto;
+            margin-right: 5px;
+            vertical-align: top;
+        }
+
+        button {
+            height: 34px;
+            vertical-align: top;
+        }
     }
 }
 
@@ -338,6 +350,26 @@ a[href^="http://encodedcc.sdsc.edu/warehouse/"]:after {
         pointer-events: none;
     }
 }
+
+.file-gallery-tab-bar {
+    .tab-nav {
+        display: flex;
+        justify-content: space-between;
+        align-content: stretch;
+        align-items: stretch;
+    }
+
+    .file-gallery__inclusion-selector {
+        flex: 0 1 auto;
+        align-self: center;
+        margin-right: 10px;
+    }
+}
+
+.file-table-visualizer {
+    text-align: center;
+}
+
 
 // File gallery title bars that collapse
 .collapsing-title-icon {

--- a/src/encoded/tests/data/inserts/file.json
+++ b/src/encoded/tests/data/inserts/file.json
@@ -2300,5 +2300,59 @@
         "submitted_by": "facilisi.tristique@potenti.vivamus",
         "file_format": "sra",
         "dataset": "ENCSR765JPC"
+    },
+    {
+        "accession": "ENCFF355OWW",
+        "aliases": [
+            "erez-lieberman:HIC036-hic30"
+        ],
+        "assembly": "hg19",
+        "award": "U54HG006998",
+        "dataset": "ENCSR000AJK",
+        "file_format": "hic",
+        "file_size": 3279889636,
+        "lab": "ali-mortazavi",
+        "md5sum": "2600b6928d28a4c5c932552ee8f84ab9",
+        "output_type": "chromatin interactions",
+        "replicate": "380dc621-8574-498e-a133-9fc162464007",
+        "status": "released",
+        "submitted_by": "facilisi.tristique@potenti.vivamus",
+        "uuid": "0713dad6-5376-4a6c-a591-2542006a229c"
+    },
+    {
+        "accession": "ENCFF784GFP",
+        "aliases": [
+            "erez-lieberman:HIC036-hic"
+        ],
+        "assembly": "hg19",
+        "award": "U54HG006998",
+        "dataset": "ENCSR000AJK",
+        "file_format": "hic",
+        "file_size": 4367743691,
+        "lab": "ali-mortazavi",
+        "md5sum": "1f9c658e22e885a39a5cf37ed1613512",
+        "output_type": "chromatin interactions",
+        "replicate": "380dc621-8574-498e-a133-9fc162464007",
+        "status": "released",
+        "submitted_by": "facilisi.tristique@potenti.vivamus",
+        "uuid": "7e1ff030-0d63-48d5-8447-ff69234f1b0c"
+    },
+    {
+        "accession": "ENCFF812THZ",
+        "aliases": [
+            "erez-lieberman:HIC034-hic30"
+        ],
+        "assembly": "hg19",
+        "award": "U54HG006998",
+        "dataset": "ENCSR000AJK",
+        "file_format": "hic",
+        "file_size": 9731729568,
+        "lab": "ali-mortazavi",
+        "md5sum": "e77a125126ea493e1159fbee8da014e7",
+        "output_type": "mapping quality thresholded chromatin interactions",
+        "replicate": "380dc621-8574-498e-a133-9fc162464007",
+        "status": "released",
+        "submitted_by": "facilisi.tristique@potenti.vivamus",
+        "uuid": "d62004d1-a54c-4853-8105-a0a17cc971a5"
     }
 ]

--- a/src/encoded/tests/features/test_trackhubs.py
+++ b/src/encoded/tests/features/test_trackhubs.py
@@ -139,15 +139,15 @@ def test_hub_field(testapp, workbook, expected):
 
 def test_visualize(submitter_testapp, workbook):
     expected = {
-        'GRCh38': {
-            'Ensembl': 'http://www.ensembl.org/Trackhub?url=http://localhost/experiments/ENCSR000AEN/@@hub/hub.txt;species=Homo_sapiens',
-            'Quick View': '/search/?type=File&assembly=GRCh38&dataset=/experiments/ENCSR000AEN/&file_format=bigBed&file_format=bigWig&status=released&status=in+progress#browser',
-            'UCSC': 'http://genome.ucsc.edu/cgi-bin/hgTracks?hubClear=http://localhost/experiments/ENCSR000AEN/@@hub/hub.txt&db=hg38'
-        },
-        'hg19': {
-            'Quick View': '/search/?type=File&assembly=hg19&dataset=/experiments/ENCSR000AEN/&file_format=bigBed&file_format=bigWig&status=released&status=in+progress#browser',
-            'UCSC': 'http://genome.ucsc.edu/cgi-bin/hgTracks?hubClear=http://localhost/experiments/ENCSR000AEN/@@hub/hub.txt&db=hg19'
-        }
+        'GRCh38': [
+            "Ensembl",
+            "Quick View",
+            "UCSC",
+        ],
+        'hg19': [
+            "Quick View",
+            "UCSC"
+        ]
     }
     res = submitter_testapp.get("/experiments/ENCSR000AEN/")
-    assert expected == res.json['visualize']
+    assert set(expected['GRCh38']) == set(res.json['visualize']['GRCh38']) and set(expected['hg19']) == set(res.json['visualize']['hg19'])

--- a/src/encoded/types/shared_calculated_properties.py
+++ b/src/encoded/types/shared_calculated_properties.py
@@ -300,7 +300,7 @@ class CalculatedVisualize:
         hub_url = urljoin(request.resource_url(request.root), hub)
         viz = {}
         vis_assembly = set()
-        viewable_file_formats = ['bigWig', 'bigBed']
+        viewable_file_formats = ['bigWig', 'bigBed', 'hic']
         viewable_file_status = ['released', 'in progress']
         vis_assembly = {
             properties['assembly']
@@ -315,23 +315,8 @@ class CalculatedVisualize:
             browsers = browsers_available(status, [assembly_name],
                                           self.base_types, self.item_type,
                                           files, accession, request)
-            if len(browsers) == 0:
-                continue
-            browser_urls = {}
-            if 'ucsc' in browsers:
-                ucsc_url = vis_format_url("ucsc", hub_url, assembly_name)
-                if ucsc_url is not None:
-                    browser_urls['UCSC'] = ucsc_url
-            if 'ensembl' in browsers:
-                ensembl_url = vis_format_url("ensembl", hub_url, assembly_name)
-                if ensembl_url is not None:
-                    browser_urls['Ensembl'] = ensembl_url
-            if 'quickview' in browsers:
-                quickview_url = vis_format_url("quickview", request.path, assembly_name)
-                if quickview_url is not None:
-                    browser_urls['Quick View'] = quickview_url
-            if browser_urls:
-                viz[assembly_name] = browser_urls
+            if len(browsers) > 0:
+                viz[assembly_name] = browsers
         if viz:
             return viz
         else:

--- a/src/encoded/vis_defines.py
+++ b/src/encoded/vis_defines.py
@@ -1535,7 +1535,7 @@ def browsers_available(
             vis_blob = vis_cache.get(accession=accession, assembly=assembly)
         if not vis_blob and file_assemblies is None and files is not None:
             file_assemblies = visualizable_assemblies(assemblies, files)
-        if file_types is not None:
+        if file_types is None:
             continue
         if ('ucsc' not in browsers
                 and 'ucsc_assembly' in mapped_assembly.keys()

--- a/src/encoded/vis_defines.py
+++ b/src/encoded/vis_defines.py
@@ -1487,9 +1487,9 @@ def visualizable_assemblies(
     return list(file_assemblies)
 
 
-def file_to_type(file):
+def _file_to_type(process_file):
     '''Used with map to convert list of files to their types'''
-    return file['file_type']
+    return process_file['file_type']
 
 # Currently called in types/shared_calculated_properties.py
 def browsers_available(
@@ -1517,13 +1517,12 @@ def browsers_available(
     browsers = set()
     full_set = {'ucsc', 'ensembl', 'quickview', 'hic'}
     file_assemblies = None
+    file_types = None
     if request is not None:
         vis_cache = VisCache(request)
     if files is not None:
         # Make a set of all file types in all dataset files
-        file_types = set(map(file_to_type, files))
-    else:
-        file_types = None
+        file_types = set(map(_file_to_type, files))
     for assembly in assemblies:
         mapped_assembly = ASSEMBLY_DETAILS.get(assembly)
         if not mapped_assembly:
@@ -1536,21 +1535,20 @@ def browsers_available(
             vis_blob = vis_cache.get(accession=accession, assembly=assembly)
         if not vis_blob and file_assemblies is None and files is not None:
             file_assemblies = visualizable_assemblies(assemblies, files)
+        if file_types is not None:
+            continue
         if ('ucsc' not in browsers
                 and 'ucsc_assembly' in mapped_assembly.keys()
-                and file_types is not None
                 and not BROWSER_FILE_TYPES['ucsc'].isdisjoint(file_types)):
             if vis_blob or files is None or assembly in file_assemblies:
                 browsers.add('UCSC')
         if ('ensembl' not in browsers
                 and 'ensembl_host' in mapped_assembly.keys()
-                and file_types is not None
                 and not BROWSER_FILE_TYPES['ensembl'].isdisjoint(file_types)):
             if vis_blob or files is None or assembly in file_assemblies:
                 browsers.add('Ensembl')
         if ('quickview' not in browsers
                 and 'quickview' in mapped_assembly.keys()
-                and file_types is not None
                 and not BROWSER_FILE_TYPES['quickview'].isdisjoint(file_types)):
             # NOTE: quickview may not have vis_blob as 'in progress'
             #   files can also be displayed
@@ -1561,7 +1559,6 @@ def browsers_available(
                 browsers.add('Quick View')
         if ('hic' not in browsers
                 and 'hic' in mapped_assembly.keys()
-                and file_types is not None
                 and not BROWSER_FILE_TYPES['hic'].isdisjoint(file_types)):
             if file_assemblies is not None and assembly in file_assemblies:
                 browsers.add('hic')

--- a/src/encoded/vis_defines.py
+++ b/src/encoded/vis_defines.py
@@ -28,6 +28,7 @@ ASSEMBLY_DETAILS = {
                         'ucsc_assembly':    'hg38',
                         'ensembl_host':     'www.ensembl.org',
                         'quickview':        True,
+                        'hic':              True,
                         'comment':          'Ensembl works'
     },
     'GRCh38-minimal': { 'species':          'Homo sapiens',     'assembly_reference': 'GRCh38',
@@ -40,6 +41,7 @@ ASSEMBLY_DETAILS = {
                         'ucsc_assembly':    'hg19',
                         'NA_ensembl_host':  'grch37.ensembl.org',
                         'quickview':        True,
+                        'hic':              True,
                         'comment':          'Ensembl DOES NOT WORK'
     },
     'mm10': {           'species':          'Mus musculus',     'assembly_reference': 'GRCm38',
@@ -101,6 +103,13 @@ ASSEMBLY_DETAILS = {
     },
 }
 
+BROWSER_FILE_TYPES = {
+    'ucsc': {'bigWig', 'bigBed'},
+    'ensembl': {'bigWig', 'bigBed'},
+    'quickview': {'bigWig', 'bigBed'},
+    'hic': {'hic'},
+}
+
 # Distinct from ASSEMBLY_DETAILS['ucsc_assembly'] as that defines allowed mappings
 ASSEMBLY_TO_UCSC_ID = {
     'GRCh38-minimal': 'hg38',
@@ -121,7 +130,8 @@ VISIBLE_DATASET_STATUSES = ["released"]
 VISIBLE_FILE_STATUSES = ["released"]
 BIGWIG_FILE_TYPES = ['bigWig']
 BIGBED_FILE_TYPES = ['bigBed']
-VISIBLE_FILE_FORMATS = BIGBED_FILE_TYPES + BIGWIG_FILE_TYPES
+HIC_FILE_TYPES = ['hic']
+VISIBLE_FILE_FORMATS = BIGBED_FILE_TYPES + BIGWIG_FILE_TYPES + HIC_FILE_TYPES
 VISIBLE_DATASET_TYPES = ["Experiment", "Annotation"]
 VISIBLE_DATASET_TYPES_LC = ["experiment", "annotation"]
 
@@ -1477,6 +1487,10 @@ def visualizable_assemblies(
     return list(file_assemblies)
 
 
+def file_to_type(file):
+    '''Used with map to convert list of files to their types'''
+    return file['file_type']
+
 # Currently called in types/shared_calculated_properties.py
 def browsers_available(
     status,
@@ -1501,10 +1515,15 @@ def browsers_available(
     elif item_type not in VISIBLE_DATASET_TYPES_LC:
             return []
     browsers = set()
-    full_set = {'ucsc', 'ensembl', 'quickview'}
+    full_set = {'ucsc', 'ensembl', 'quickview', 'hic'}
     file_assemblies = None
     if request is not None:
         vis_cache = VisCache(request)
+    if files is not None:
+        # Make a set of all file types in all dataset files
+        file_types = set(map(file_to_type, files))
+    else:
+        file_types = None
     for assembly in assemblies:
         mapped_assembly = ASSEMBLY_DETAILS.get(assembly)
         if not mapped_assembly:
@@ -1518,22 +1537,34 @@ def browsers_available(
         if not vis_blob and file_assemblies is None and files is not None:
             file_assemblies = visualizable_assemblies(assemblies, files)
         if ('ucsc' not in browsers
-                and 'ucsc_assembly' in mapped_assembly.keys()):
+                and 'ucsc_assembly' in mapped_assembly.keys()
+                and file_types is not None
+                and not BROWSER_FILE_TYPES['ucsc'].isdisjoint(file_types)):
             if vis_blob or files is None or assembly in file_assemblies:
-                browsers.add('ucsc')
+                browsers.add('UCSC')
         if ('ensembl' not in browsers
-                and 'ensembl_host' in mapped_assembly.keys()):
+                and 'ensembl_host' in mapped_assembly.keys()
+                and file_types is not None
+                and not BROWSER_FILE_TYPES['ensembl'].isdisjoint(file_types)):
             if vis_blob or files is None or assembly in file_assemblies:
-                browsers.add('ensembl')
+                browsers.add('Ensembl')
         if ('quickview' not in browsers
-                and 'quickview' in mapped_assembly.keys()):
+                and 'quickview' in mapped_assembly.keys()
+                and file_types is not None
+                and not BROWSER_FILE_TYPES['quickview'].isdisjoint(file_types)):
             # NOTE: quickview may not have vis_blob as 'in progress'
             #   files can also be displayed
             #       Ideally we would also look at files' statuses and formats.
             #   However, the (calculated)files property only contains
             #   'released' files so it doesn't really help for quickview!
             if vis_blob is not None or status not in QUICKVIEW_STATUSES_BLOCKED:
-                browsers.add('quickview')
+                browsers.add('Quick View')
+        if ('hic' not in browsers
+                and 'hic' in mapped_assembly.keys()
+                and file_types is not None
+                and not BROWSER_FILE_TYPES['hic'].isdisjoint(file_types)):
+            if file_assemblies is not None and assembly in file_assemblies:
+                browsers.add('hic')
         if browsers == full_set:  # No use continuing
             break
     return list(browsers)
@@ -1565,7 +1596,7 @@ def object_is_visualizable(
         return len(browsers) > 0
 
 
-# Currently called in types/shared_calculated_properties.py and in search.py
+# Currently called in search.py
 def vis_format_url(browser, path, assembly, position=None):
     '''Given a url to hub.txt, returns the url to an external browser or None.'''
     mapped_assembly = ASSEMBLY_DETAILS[assembly]


### PR DESCRIPTION
This branch has both front end and back end changes, with the bulk being in the front end.

The back end changes do change the API for datasets in that the `visualize` property used to contain a dict with assemblies as keys, and each assembly was a dict with the browser names as keys and the corresponding URL as the value.

This changes in this branch so that each assembly is now an array of browser names because the URL processing now gets handled in the front end because the URLs can change depending on user selections.