### PR TITLE
ENCD-4444 Highlight selected facet terms numbers

### DIFF
--- a/src/encoded/static/components/search.js
+++ b/src/encoded/static/components/search.js
@@ -578,7 +578,7 @@ function termSelected(term, facet, filters) {
                 matchingFilter = filter;
                 return true;
             }
-        } else if (filterFieldName === facet.field && filter.term === term) {
+        } else if (filterFieldName === facet.field && filter.term === String(term)) {
             // The facet field and the given term match a filter, so save that filter so we can
             // extract its `remove` link.
             matchingFilter = filter;


### PR DESCRIPTION
Terms that are numbers were interpreted by JS as numbers and when compared to strings, were not matching and returning false, even when they were selected as filters.