### PR TITLE
ENCD-4408 mobile menu readability

### DIFF
--- a/src/encoded/static/scss/bootstrap/_navbar.scss
+++ b/src/encoded/static/scss/bootstrap/_navbar.scss
@@ -48,6 +48,7 @@
 // content for the user's viewport.
 
 .navbar-collapse {
+  max-height: $navbar-collapse-max-height;
   overflow-x: visible;
   padding-right: $navbar-padding-horizontal;
   padding-left:  $navbar-padding-horizontal;

--- a/src/encoded/static/scss/bootstrap/_navbar.scss
+++ b/src/encoded/static/scss/bootstrap/_navbar.scss
@@ -48,7 +48,6 @@
 // content for the user's viewport.
 
 .navbar-collapse {
-  max-height: $navbar-collapse-max-height;
   overflow-x: visible;
   padding-right: $navbar-padding-horizontal;
   padding-left:  $navbar-padding-horizontal;

--- a/src/encoded/static/scss/encoded/modules/_navbar.scss
+++ b/src/encoded/static/scss/encoded/modules/_navbar.scss
@@ -125,7 +125,7 @@
     &>li {
         &>a {
             padding: 5px 20px;
-            color: #444 !important;
+            color: white !important;
             font-weight: 300;
         }
     }

--- a/src/encoded/static/scss/encoded/modules/_navbar.scss
+++ b/src/encoded/static/scss/encoded/modules/_navbar.scss
@@ -68,6 +68,10 @@
     margin-bottom: 0;
 }
 
+.navbar-collapse {
+    max-height: none;
+}
+
 .test-warning {
     position: relative;
     padding: 5px 0 7px;


### PR DESCRIPTION
Should fix two style bugs on mobile:
(1) the sub-categories under the main links are very difficult to read, the contrast is not high enough
(2) when you click on a menu link to see the sub-categories, it is not obvious that the menu is scrollable (I made the menu the full height to avoid this problem)