### PR TITLE
ENCD-4217 Rendering error series objects

### DIFF
--- a/src/encoded/static/components/dataset.js
+++ b/src/encoded/static/components/dataset.js
@@ -1181,8 +1181,9 @@ const organismDevelopmentSeriesTableColumns = {
             }
             if (biosamples && biosamples.length) {
                 lifeStageBiosample = _(biosamples).find(biosample => biosample.life_stage);
+                return lifeStageBiosample.life_stage;
             }
-            return lifeStageBiosample.life_stage;
+            return null;
         },
     },
 
@@ -1393,7 +1394,7 @@ export class SeriesComponent extends React.Component {
                     </PanelBody>
                 </Panel>
 
-                {context.related_datasets.length ?
+                {experimentList.length ?
                     <div>
                         <SortTablePanel title={`Experiments in ${seriesTitle} ${context.accession}`}>
                             <SortTable

--- a/src/encoded/tests/data/inserts/experiment.json
+++ b/src/encoded/tests/data/inserts/experiment.json
@@ -494,6 +494,23 @@
     },
     {
         "_test": "worm development series 2",
+        "accession": "ENCSR375GSQ",
+        "assay_term_name": "RNA-seq",
+        "award": "U41HG007355",
+        "biosample_ontology": "whole_organisms_UBERON_0000468",
+        "target": "fkh-10-celegans",
+        "description": "RNA-seq on fkh-10 deletion strain (RB884) embryos, 80 minutes after egg bleaching.",
+        "lab": "robert-waterston",
+        "status": "released",
+        "date_released": "2016-01-01",
+        "date_submitted": "2015-02-21",
+        "aliases": ["robert-waterston:life_stage_bug_experiment"],
+        "submitted_by": "dignissim.euismod@amet.habitant",
+        "uuid": "21ee48a4-d172-42a2-9306-13a8ca317daf",
+        "experiment_classification": ["functional genomics assay"]
+    },
+    {
+        "_test": "worm development series 2",
         "accession": "ENCSR862BAF",
         "assay_term_name": "RNA-seq",
         "award": "U41HG007355",

--- a/src/encoded/tests/data/inserts/organism_development_series.json
+++ b/src/encoded/tests/data/inserts/organism_development_series.json
@@ -15,5 +15,21 @@
         "uuid": "2911e217-4a37-4fd2-b48f-a8480b029b5f",
         "date_released": "2016-01-01",
         "submitter_comment": "We missed a developmental stage because because nobody wanted to watch the worms for hours on end."
+    },
+    {
+        "_test": "organism development series with experiment and deleted replicate",
+        "accession": "ENCSR301DEV",
+        "award": "U41HG007355",
+        "description": "Development series RNA-seq on fkh-10 deletion strain (RB884) embryos, varying minutes after egg bleaching.",
+        "lab": "robert-waterston",
+        "status": "released",
+        "submitted_by": "facilisi.tristique@potenti.vivamus",
+        "related_datasets": [
+            "/experiments/ENCSR375GSQ"
+        ],
+        "uuid": "2921e211-4a37-4fd2-b41f-a1480b039b5f",
+        "date_released": "2016-02-06",
+        "submitter_comment": "We missed a developmental stage because because nobody wanted to watch the worms for hours on end."
     }
+
 ]

--- a/src/encoded/tests/data/inserts/replicate.json
+++ b/src/encoded/tests/data/inserts/replicate.json
@@ -317,6 +317,19 @@
         "submitted_by": "/users/4c23ec32-c7c8-4ac0-affb-04befcc881d4/"
     },
     {
+        "_test": "organism development series 2 rep 33",
+        "aliases": [
+            "robert-waterston:replicate_life stage bug"
+        ],
+        "library": "ENCLB857STI",
+        "experiment": "/experiments/ENCSR375GSQ/",
+        "technical_replicate_number": 33,
+        "biological_replicate_number": 33,
+        "status": "deleted",
+        "uuid": "c21bc58c-0a11-4b1f-b4b3-d84113cfea0b",
+        "submitted_by": "/users/4c23ec32-c7c8-4ac0-affb-04befcc881d4/"
+    },
+    {
         "_test": "organism development series 2 rep 1",
         "aliases": [
             "robert-waterston:replicate_RB884_680_1_1"


### PR DESCRIPTION
Series objects with life_stage value not present caused a rendering error.
Now tables will insert a null value for those cases.
This ticket also fixes another related error uncovered during debugging: headers were displayed for tables that did not exist (due to related datasets not being viewable).