### PR TITLE
ENCD-4464 add GM category enums

### DIFF
--- a/src/encoded/schemas/changelogs/genetic_modification.md
+++ b/src/encoded/schemas/changelogs/genetic_modification.md
@@ -2,6 +2,9 @@
 
 ### Minor changes since schema version 7
 
+* A combination of *introduced_elements* and *modified_site_nonspecific* can satisfy the *category* dependency for *insertion*.
+* *episome* was added to the *category* enum, and modifications with this *category* require the *introduced_elements* property.
+* The *introduced_elements* property was added for characterization of groups of elements.
 * A minimum of 0 is set for *start* and *end* in *modified_site_by_coordinates*
 * The dependency of *method* on *reagents* specification was changed, *reagents* are no longer required to be specified for the relevant types of modification methods.
 * Zygosity is now required for modifications of *method* TALEN

--- a/src/encoded/schemas/genetic_modification.json
+++ b/src/encoded/schemas/genetic_modification.json
@@ -228,7 +228,7 @@
             }
         },
         "introduced_elements": {
-            "comment": "introduced_elements are currently restricted to sets of indeterminate elements to be characterized.",
+            "comment": "introduced_elements are currently restricted to sets of indeterminate elements to be characterized either on episome or randomly inserted.",
             "oneOf": [
                 {
                     "properties": {

--- a/src/encoded/schemas/genetic_modification.json
+++ b/src/encoded/schemas/genetic_modification.json
@@ -244,7 +244,7 @@
                     "required": ["modified_site_nonspecific"],
                     "properties": {
                         "category": {
-                            "enun": ["insertion"]
+                            "enum": ["insertion"]
                         },
                         "purpose": {
                             "enum": ["characterization"]

--- a/src/encoded/schemas/genetic_modification.json
+++ b/src/encoded/schemas/genetic_modification.json
@@ -238,7 +238,10 @@
                         "purpose": {
                             "enum": ["characterization"]
                         }
-                    },
+                    }
+                },
+                {
+                    "required": ["modified_site_nonspecific"],
                     "properties": {
                         "category": {
                             "enun": ["insertion"]

--- a/src/encoded/schemas/genetic_modification.json
+++ b/src/encoded/schemas/genetic_modification.json
@@ -102,34 +102,37 @@
             "comment": "Insertions need to specify introduced_tags, introduced_sequence, introduced_gene, or introduced_elements at modified_site_nonspecific. Replacements need to specify introduced_sequence. Deletions need either target id, coordinates or deleted sequence specified. Interference needs target id specified and mutagenesis needs treatment specified. Episome needs to specify introduced_elements.",
             "oneOf": [
                 {
-                    "anyOf": [
+                    "oneOf": [
                         {
-                            "required": ["introduced_tags"],
-                            "properties": {
-                                "category": {
-                                    "enum": ["insertion"]
-                                },
-                                "purpose": {
-                                    "enum": ["tagging"]
+                            "anyOf": [
+                            {
+                                "required": ["introduced_tags"],
+                                "properties": {
+                                    "category": {
+                                        "enum": ["insertion"]
+                                    },
+                                    "purpose": {
+                                        "enum": ["tagging"]
+                                    }
+                                }
+                            },
+                            {
+                                "required": ["introduced_sequence"],
+                                "properties": {
+                                    "category": {
+                                        "enum": ["insertion"]
+                                    }
+                                }
+                            },
+                            {
+                                "required": ["introduced_gene"],
+                                "properties": {
+                                    "category": {
+                                        "enum": ["insertion"]
+                                    }
                                 }
                             }
-                        },
-                        {
-                            "required": ["introduced_sequence"],
-                            "properties": {
-                                "category": {
-                                    "enum": ["insertion"]
-                                }
-                            }
-                        },
-                        {
-                            "required": ["introduced_gene"],
-                            "properties": {
-                                "category": {
-                                    "enum": ["insertion"]
-                                }
-                            }
-                        },
+                        ]},
                         {
                             "required": ["modified_site_nonspecific", "introduced_elements"],
                             "properties": {
@@ -223,6 +226,30 @@
                     "enum": ["tagging"]
                 }
             }
+        },
+        "introduced_elements": {
+            "comment": "introduced_elements are currently restricted to sets of indeterminate elements to be characterized.",
+            "oneOf": [
+                {
+                    "properties": {
+                        "category": {
+                            "enum": ["episome"]
+                        },
+                        "purpose": {
+                            "enum": ["characterization"]
+                        }
+                    },
+                    "required": ["modified_site_nonspecific"],
+                    "properties": {
+                        "category": {
+                            "enun": ["insertion"]
+                        },
+                        "purpose": {
+                            "enum": ["characterization"]
+                        }
+                    }
+                }
+            ]
         },
         "guide_rna_sequences": {
             "comment": "Guide RNA sequences apply only to modification_technique = CRISPR.",

--- a/src/encoded/schemas/genetic_modification.json
+++ b/src/encoded/schemas/genetic_modification.json
@@ -239,7 +239,6 @@
                             "enum": ["characterization"]
                         }
                     },
-                    "required": ["modified_site_nonspecific"],
                     "properties": {
                         "category": {
                             "enun": ["insertion"]

--- a/src/encoded/schemas/genetic_modification.json
+++ b/src/encoded/schemas/genetic_modification.json
@@ -228,7 +228,7 @@
             }
         },
         "introduced_elements": {
-            "comment": "introduced_elements are currently restricted to sets of indeterminate elements to be characterized either on episome or randomly inserted.",
+            "comment": "introduced_elements are currently restricted to sets of indeterminate elements to be characterized either on episome or inserted randomly.",
             "oneOf": [
                 {
                     "properties": {

--- a/src/encoded/schemas/genetic_modification.json
+++ b/src/encoded/schemas/genetic_modification.json
@@ -59,6 +59,13 @@
                         },
                         {
                             "required": ["modified_site_nonspecific"]
+                        },
+                        {
+                            "properties": {
+                                "category": {
+                                    "enum": ["episome"]
+                                }
+                            }
                         }
                     ],
                     "properties": {
@@ -92,7 +99,7 @@
             ]
         },
         "category": {
-            "comment": "Insertions need to specify introduced_tags, introduced_sequence, or introduced_gene. Replacements need to specify introduced_sequence. Deletions need either target id, coordinates or deleted sequence specified. Interference needs target id specified and mutagenesis needs treatment specified.",
+            "comment": "Insertions need to specify introduced_tags, introduced_sequence, introduced_gene, or introduced_elements at modified_site_nonspecific. Replacements need to specify introduced_sequence. Deletions need either target id, coordinates or deleted sequence specified. Interference needs target id specified and mutagenesis needs treatment specified. Episome needs to specify introduced_elements.",
             "oneOf": [
                 {
                     "anyOf": [
@@ -117,6 +124,14 @@
                         },
                         {
                             "required": ["introduced_gene"],
+                            "properties": {
+                                "category": {
+                                    "enum": ["insertion"]
+                                }
+                            }
+                        },
+                        {
+                            "required": ["modified_site_nonspecific", "introduced_elements"],
                             "properties": {
                                 "category": {
                                     "enum": ["insertion"]
@@ -162,6 +177,14 @@
                         },
                         "purpose": {
                             "enum": ["repression"]
+                        }
+                    }
+                },
+                {
+                    "required": ["introduced_elements"],
+                    "properties": {
+                        "category": {
+                            "enum": ["episome"]
                         }
                     }
                 },
@@ -361,7 +384,8 @@
                 "interference",
                 "insertion",
                 "mutagenesis",
-                "replacement"
+                "replacement",
+                "episome"
             ]
         },
         "purpose":{
@@ -528,6 +552,15 @@
             "comment": "See gene.json for available identifiers.",
             "type": "string",
             "linkTo": "Gene"
+        },
+        "introduced_elements": {
+            "title": "Introduced elements",
+            "description": "The origin of a group of elements used for a functional characterization assay.",
+            "type": "string",
+            "enum": [
+                "sheared genomic DNA",
+                "synthesized DNA"
+            ]
         },
         "method": {
             "title": "Method",

--- a/src/encoded/tests/data/inserts/genetic_modification.json
+++ b/src/encoded/tests/data/inserts/genetic_modification.json
@@ -215,11 +215,11 @@
         "accession": "ENCGM359MPR",
         "status": "released",
         "award": "/awards/U41HG007355/",
-        "lab": "/labs/jay-shendure/",
+        "lab": "/labs/kevin-white/",
         "uuid": "78b475d5-efd5-43d5-9322-c5e95737cc2d",
         "submitted_by": "amet.fusce@est.fermentum",
         "aliases": [
-            "jay-shendure:MPRA_1"
+            "kevin-white:MPRA_1"
         ],
         "category": "insertion",
         "purpose": "characterization",

--- a/src/encoded/tests/data/inserts/genetic_modification.json
+++ b/src/encoded/tests/data/inserts/genetic_modification.json
@@ -194,5 +194,38 @@
         "introduced_gene": "/genes/a9288b44-6ef4-460e-a3d6-464fd625b103",
         "documents": ["encode:MCF-7_Farnham_treatment_protocol"],
         "method": "CRISPR"
+    },
+    {
+        "accession": "ENCGM246STR",
+        "status": "released",
+        "award": "/awards/U41HG007355/",
+        "lab": "/labs/kevin-white/",
+        "uuid": "537e5e98-9392-4263-bac1-6f80e65ca0c9",
+        "submitted_by": "amet.fusce@est.fermentum",
+        "aliases": [
+            "kevin-white:STARR-seq_1"
+        ],
+        "category": "episome",
+        "purpose": "characterization",
+        "introduced_elements": "sheared genomic DNA",
+        "documents": ["encode:MCF-7_Farnham_treatment_protocol"],
+        "method": "transient transfection"
+    },
+    {
+        "accession": "ENCGM359MPR",
+        "status": "released",
+        "award": "/awards/U41HG007355/",
+        "lab": "/labs/jay-shendure/",
+        "uuid": "78b475d5-efd5-43d5-9322-c5e95737cc2d",
+        "submitted_by": "amet.fusce@est.fermentum",
+        "aliases": [
+            "jay-shendure:MPRA_1"
+        ],
+        "category": "insertion",
+        "purpose": "characterization",
+        "introduced_elements": "synthesized DNA",
+        "modified_site_nonspecific": "random",
+        "documents": ["encode:MCF-7_Farnham_treatment_protocol"],
+        "method": "transduction"
     }
 ]

--- a/src/encoded/tests/test_schema_genetic_modification.py
+++ b/src/encoded/tests/test_schema_genetic_modification.py
@@ -349,6 +349,7 @@ def test_tale_replacement_properties(testapp, tale_replacement, source):
     res = testapp.post_json('/genetic_modification', tale_replacement, expect_errors=True)
     assert res.status_code == 201
 
+
 def test_mpra_properties(testapp, mpra):
     # introduced_elements combined with modified_site_nonspecific can satisfy insertion dependency
     res = testapp.post_json('/genetic_modification', mpra, expect_errors=True)
@@ -359,6 +360,7 @@ def test_mpra_properties(testapp, mpra):
     mpra.update({'modified_site_nonspecific': 'random'})
     res = testapp.post_json('/genetic_modification', mpra, expect_errors=True)
     assert res.status_code == 201
+
 
 def test_starr_seq_properties(testapp, starr_seq):
     # Episome modifications need to include introduced_elements and satisfy characterization dependency

--- a/src/encoded/tests/test_schema_genetic_modification.py
+++ b/src/encoded/tests/test_schema_genetic_modification.py
@@ -112,6 +112,26 @@ def tale_replacement(lab, award):
         'zygosity': 'heterozygous'
     }
 
+@pytest.fixture
+def mpra(lab, award):
+    return {
+        'lab': lab['@id'],
+        'award': award['@id'],
+        'category': 'insertion',
+        'purpose': 'characterization',
+        'method': 'transduction'
+    }
+
+
+@pytest.fixture
+def starr_seq(lab, award):
+    return {
+        'lab': lab['@id'],
+        'award': award['@id'],
+        'category': 'episome',
+        'purpose': 'characterization',
+        'method': 'transient transfection'
+    }
 
 def test_crispr_deletion_missing_site(testapp, crispr_deletion):
     # modified_site_(by_target_id|by_coordinates|by_sequence) must be specified for deletions
@@ -327,4 +347,23 @@ def test_tale_replacement_properties(testapp, tale_replacement, source):
     assert res.status_code == 422
     tale_replacement.update({'introduced_sequence': 'TTATCGATCGATTTGAGCATAGAAATGGCCGATTTATATGCCCGA'})
     res = testapp.post_json('/genetic_modification', tale_replacement, expect_errors=True)
+    assert res.status_code == 201
+
+def test_mpra_properties(testapp, mpra):
+    # introduced_elements combined with modified_site_nonspecific can satisfy insertion dependency
+    res = testapp.post_json('/genetic_modification', mpra, expect_errors=True)
+    assert res.status_code == 422
+    mpra.update({'introduced_elements': 'synthesized DNA'})
+    res = testapp.post_json('/genetic_modification', mpra, expect_errors=True)
+    assert res.status_code == 422
+    mpra.update({'modified_site_nonspecific': 'random'})
+    res = testapp.post_json('/genetic_modification', mpra, expect_errors=True)
+    assert res.status_code == 201
+
+def test_starr_seq_properties(testapp, starr_seq):
+    # Episome modifications need to include introduced_elements and satisfy characterization dependency
+    res = testapp.post_json('/genetic_modification', starr_seq, expect_errors=True)
+    assert res.status_code == 422
+    starr_seq.update({'introduced_elements': 'sheared genomic DNA'})
+    res = testapp.post_json('/genetic_modification', starr_seq, expect_errors=True)
     assert res.status_code == 201


### PR DESCRIPTION
Changes were made to the GM schema in order to accommodate the STARR-seq and lentiMPRA assays.
Added new property introduced_elements for the group of elements to be characterized in both assays.
Added new category enum episome with introduced_elements dependency.
Changed dependencies to allow characterization to be specified without modified site.
