### PR TITLE
ENCD-4487-reset-upload-bucket

### DIFF
--- a/src/encoded/tests/test_types_file.py
+++ b/src/encoded/tests/test_types_file.py
@@ -286,6 +286,7 @@ def test_file_update_bucket_as_submitter(submitter_testapp, dummy_request, file_
     )
 
 
+@mock_s3
 @mock_sts
 def test_file_reset_file_upload_bucket_on_upload_credentials(testapp, root, dummy_request, file_with_external_sheet):
     dummy_request.registry.settings['file_upload_bucket'] = 'test_file_bucket'

--- a/src/encoded/tests/test_types_file.py
+++ b/src/encoded/tests/test_types_file.py
@@ -286,6 +286,7 @@ def test_file_update_bucket_as_submitter(submitter_testapp, dummy_request, file_
     )
 
 
+@mock_sts
 def test_file_reset_file_upload_bucket_on_upload_credentials(testapp, root, dummy_request, file_with_external_sheet):
     dummy_request.registry.settings['file_upload_bucket'] = 'test_file_bucket'
     dummy_request.registry.settings['pds_public_bucket'] = 'pds_public_bucket_test'

--- a/src/encoded/tests/test_types_file.py
+++ b/src/encoded/tests/test_types_file.py
@@ -284,3 +284,26 @@ def test_file_update_bucket_as_submitter(submitter_testapp, dummy_request, file_
         {'new_bucket': 'unknown bucket'},
         status=403
     )
+
+
+def test_file_reset_file_upload_bucket_on_upload_credentials(testapp, root, dummy_request, file_with_external_sheet):
+    dummy_request.registry.settings['file_upload_bucket'] = 'test_file_bucket'
+    dummy_request.registry.settings['pds_public_bucket'] = 'pds_public_bucket_test'
+    dummy_request.registry.settings['pds_private_bucket'] = 'pds_private_bucket_test'
+    res = testapp.patch_json(file_with_external_sheet['@id'] + '@@update_bucket', {'new_bucket': 'pds_public_bucket_test'})
+    file_item = root.get_by_uuid(file_with_external_sheet['uuid'])
+    external = file_item._get_external_sheet()
+    assert external.get('key') == 'xyz.bed'
+    assert external.get('bucket') == 'pds_public_bucket_test'
+    testapp.patch_json(
+        file_with_external_sheet['@id'],
+        {
+            'status': 'uploading'
+        }
+    )
+    file_item = root.get_by_uuid(file_with_external_sheet['uuid'])
+    res = testapp.post_json(file_with_external_sheet['@id'] + '@@upload', {})
+    file_item = root.get_by_uuid(file_with_external_sheet['uuid'])
+    external = file_item._get_external_sheet()
+    assert external.get('bucket') == 'test_file_bucket'
+    assert res.json['@graph'][0]['upload_credentials']['upload_url'] == 's3://test_file_bucket/xyz.bed'

--- a/src/encoded/types/file.py
+++ b/src/encoded/types/file.py
@@ -600,10 +600,12 @@ def post_upload(context, request):
         raise HTTPForbidden('status must be "uploading" to issue new credentials')
 
     accession_or_external = properties.get('accession') or properties['external_accession']
+    file_upload_bucket = request.registry.settings['file_upload_bucket']
     external = context.propsheets.get('external', None)
+    registry = request.registry
     if external is None:
         # Handle objects initially posted as another state.
-        bucket = request.registry.settings['file_upload_bucket']
+        bucket = file_upload_bucket
         uuid = context.uuid
         mapping = context.schema['file_format_file_extension']
         file_extension = mapping[properties['file_format']]
@@ -613,6 +615,12 @@ def post_upload(context, request):
             date=date, file_extension=file_extension, uuid=uuid, **properties)
     elif external.get('service') == 's3':
         bucket = external['bucket']
+        # Must reset file to point to file_upload_bucket (keep AWS public dataset in sync).
+        if bucket != file_upload_bucket:
+            registry.notify(BeforeModified(context, request))
+            context._set_external_sheet({'bucket': file_upload_bucket})
+            registry.notify(AfterModified(context, request))
+            bucket = file_upload_bucket
         key = external['key']
     else:
         raise HTTPNotFound(
@@ -634,7 +642,6 @@ def post_upload(context, request):
         new_properties = properties.copy()
         new_properties['status'] = 'uploading'
 
-    registry = request.registry
     registry.notify(BeforeModified(context, request))
     context.update(new_properties, {'external': creds})
     registry.notify(AfterModified(context, request))


### PR DESCRIPTION
Make file object point to upload bucket if upload credentials are regenerated.