### PR TITLE
ENCD-4418 Add biosample_ontology dbxrefs to biosample page

### DIFF
--- a/src/encoded/static/components/biosample.js
+++ b/src/encoded/static/components/biosample.js
@@ -58,6 +58,9 @@ class BiosampleComponent extends React.Component {
         // Get a list of reference links, if any
         const references = pubReferenceList(context.references);
 
+        // Collect dbxrefs from biosample.dbxrefs and biosample.biosample_ontology.dbxrefs.
+        const dbxrefs = (context.dbxrefs || []).concat(context.biosample_ontology.dbxrefs || []);
+
         return (
             <div className={itemClass}>
                 <header className="row">
@@ -301,10 +304,10 @@ class BiosampleComponent extends React.Component {
                                         <dd>{context.award.project}</dd>
                                     </div>
 
-                                    {context.dbxrefs && context.dbxrefs.length ?
+                                    {dbxrefs.length ?
                                         <div data-test="externalresources">
                                             <dt>External resources</dt>
-                                            <dd><DbxrefList context={context} dbxrefs={context.dbxrefs} /></dd>
+                                            <dd><DbxrefList context={context} dbxrefs={dbxrefs} /></dd>
                                         </div>
                                     : null}
 


### PR DESCRIPTION
I now add the embedded `biosample_ontology.dbxrefs` string arrays to biosample.dbxrefs and display the combined result. I check for the existence of both arrays before using them, though they seem to always exist. They both exist in the schema as optional arrays though, so I’d prefer to check for their existence first.

A subsequent ticket will remove some dbxrefs we use for `biosample_ontology.dbxrefs` from some biosample objects, but that shouldn’t cause changes to the front end. We temporarily see duplicate dbxrefs on the biosample page with this change, but that situation should be temporary until the data get updated.