### PR TITLE
ENCD-4494 Remove duplicated lab files from dataset embed

### DIFF
--- a/src/encoded/types/dataset.py
+++ b/src/encoded/types/dataset.py
@@ -527,7 +527,6 @@ class Series(Dataset, CalculatedSeriesAssay, CalculatedSeriesBiosample, Calculat
         'related_datasets.possible_controls.lab',
         'related_datasets.target.organism',
         'related_datasets.references',
-        'files.lab',
         'files.platform',
         'files.lab',
         'files.analysis_step_version.analysis_step',


### PR DESCRIPTION
ENCD-4494: remove duplicated embedding of 'files.lab' in "organism_development_series"

Line 530 was removed deleted from dataset.py