### PR TITLE
ENCD-4494-remove-duplicate-embedding

### DIFF
--- a/src/encoded/types/dataset.py
+++ b/src/encoded/types/dataset.py
@@ -511,7 +511,6 @@ class Series(Dataset, CalculatedSeriesAssay, CalculatedSeriesBiosample, Calculat
         'related_datasets.possible_controls.lab',
         'related_datasets.target.organism',
         'related_datasets.references',
-        'files.lab',
         'files.platform',
         'files.lab',
         'files.analysis_step_version.analysis_step',


### PR DESCRIPTION
Removed files.lab from line 514 as it was redundant