### PR TITLE
ENCD-4524 update audit matrix

### DIFF
--- a/src/encoded/static/components/auditmatrix.js
+++ b/src/encoded/static/components/auditmatrix.js
@@ -151,10 +151,8 @@ class AuditMatrix extends React.Component {
         const matrixSearch = matrixBase + (matrixBase ? '&' : '?');
         const notification = context.notification;
         const visualizeLimit = 500;
+        const facets = context.facets;
         if (notification === 'Success' || notification === 'No results found') {
-            const xFacets = matrix.x.facets.map(f => _.findWhere(context.facets, { field: f })).filter(f => f);
-            let yFacets = matrix.y.facets.map(f => _.findWhere(context.facets, { field: f })).filter(f => f);
-            yFacets = yFacets.concat(_.reject(context.facets, f => _.contains(matrix.x.facets, f.field) || _.contains(matrix.y.facets, f.field)));
             const xGrouping = matrix.x.group_by;
             const primaryYGrouping = matrix.y.group_by[0];
             const secondaryYGrouping = matrix.y.group_by[1];
@@ -231,32 +229,28 @@ class AuditMatrix extends React.Component {
                 <div>
                     <div className="panel data-display main-panel">
                         <div className="row matrix__facet--horizontal">
-                            <div className="col-sm-5 col-md-4 col-lg-3 sm-no-padding" style={{ paddingRight: 0 }}>
+                            <div className="matrix-header">
                                 <div className="row">
                                     <div className="col-sm-11">
                                         <div>
                                             <h1>{context.title}</h1>
-                                            <div>
-                                                <p>Enter search terms to filter the {type} included in the matrix.</p>
-                                                <TextFilter filters={context.filters} searchBase={matrixSearch} onChange={this.onChange} />
-                                            </div>
                                         </div>
                                     </div>
                                 </div>
                             </div>
-                            <div className="col-sm-7 col-md-8 col-lg-9 sm-no-padding" style={{ paddingLeft: 0 }}>
-                                <FacetList
-                                    facets={xFacets}
-                                    filters={context.filters}
-                                    orientation="horizontal"
-                                    searchBase={matrixSearch}
-                                    onFilter={this.onFilter}
-                                />
-                            </div>
                         </div>
                         <div className="row">
                             <div className="col-sm-5 col-md-4 col-lg-3 sm-no-padding" style={{ paddingRight: 0 }}>
-                                <FacetList facets={yFacets} filters={context.filters} searchBase={matrixSearch} onFilter={this.onFilter} />
+                                <div className="matrix-general-search">
+                                    <p>Enter search terms to filter the {type} included in the matrix.</p>
+                                    <div className="general-search-entry">
+                                        <i className="icon icon-search" />
+                                        <div className="searchform">
+                                            <TextFilter filters={context.filters} searchBase={matrixSearch} onChange={this.onChange} />
+                                        </div>
+                                    </div>
+                                </div>
+                                <FacetList facets={facets} filters={context.filters} searchBase={matrixSearch} onFilter={this.onFilter} />
                             </div>
                             <div className="col-sm-7 col-md-8 col-lg-9 sm-no-padding">
                                 <div className="matrix-wrapper">

--- a/src/encoded/static/components/search.js
+++ b/src/encoded/static/components/search.js
@@ -1063,7 +1063,7 @@ export class FacetList extends React.Component {
         return (
             <div className={`box facets${addClasses ? ` ${addClasses}` : ''}`}>
                 <div className={`orientation${this.props.orientation === 'horizontal' ? ' horizontal' : ''}`}>
-                    {(context && clearButton) ?
+                    {(context || clearButton) ?
                         <div className="search-header-control">
                             {context ? <DocTypeTitle searchResults={context} wrapper={children => <h1>{children} {docTypeTitleSuffix}</h1>} /> : null}
                             {clearButton ?

--- a/src/encoded/static/components/search.js
+++ b/src/encoded/static/components/search.js
@@ -1063,14 +1063,16 @@ export class FacetList extends React.Component {
         return (
             <div className={`box facets${addClasses ? ` ${addClasses}` : ''}`}>
                 <div className={`orientation${this.props.orientation === 'horizontal' ? ' horizontal' : ''}`}>
-                    <div className="search-header-control">
-                        {context ? <DocTypeTitle searchResults={context} wrapper={children => <h1>{children} {docTypeTitleSuffix}</h1>} /> : null}
-                        {clearButton ?
-                            <div className="clear-filters-control">
-                                <a href={context.clear_filters}>Clear Filters <i className="icon icon-times-circle" /></a>
-                            </div>
-                        : null}
-                    </div>
+                    {(context && clearButton) ?
+                        <div className="search-header-control">
+                            {context ? <DocTypeTitle searchResults={context} wrapper={children => <h1>{children} {docTypeTitleSuffix}</h1>} /> : null}
+                            {clearButton ?
+                                <div className="clear-filters-control">
+                                    <a href={context.clear_filters}>Clear Filters <i className="icon icon-times-circle" /></a>
+                                </div>
+                            : null}
+                        </div>
+                    : null}
                     {mode === 'picker' && !hideTextFilter ? <TextFilter {...this.props} filters={filters} /> : ''}
                     {facets.map((facet) => {
                         if (hideTypes && facet.field === 'type') {


### PR DESCRIPTION
We removed horizontal facets from the matrix page as part of the typeahead facet changes but forgot to also remove them from the audit matrix.
One other small change: the matrix pages had an empty "search-header-control" space which is now not created when not needed.