### PR TITLE
ENCD-4414 Allow users to add exp to carts from series

### DIFF
--- a/src/encoded/static/components/cart/add_multiple.js
+++ b/src/encoded/static/components/cart/add_multiple.js
@@ -146,10 +146,10 @@ CartAddAllSearchComponent.mapDispatchToProps = (dispatch, ownProps) => ({
     setInProgress: enable => dispatch(cartOperationInProgress(enable)),
 });
 
-const CartAddAllInternal = connect(CartAddAllSearchComponent.mapStateToProps, CartAddAllSearchComponent.mapDispatchToProps)(CartAddAllSearchComponent);
+const CartAddAllSearchInternal = connect(CartAddAllSearchComponent.mapStateToProps, CartAddAllSearchComponent.mapDispatchToProps)(CartAddAllSearchComponent);
 
 export const CartAddAllSearch = (props, reactContext) => (
-    <CartAddAllInternal searchResults={props.searchResults} session={reactContext.session} fetch={reactContext.fetch} />
+    <CartAddAllSearchInternal searchResults={props.searchResults} session={reactContext.session} fetch={reactContext.fetch} />
 );
 
 CartAddAllSearch.propTypes = {
@@ -181,10 +181,10 @@ class CartAddAllElementsComponent extends React.Component {
     }
 
     render() {
-        const { savedCartObj, inProgress, css } = this.props;
+        const { savedCartObj, inProgress } = this.props;
         const cartName = (savedCartObj && Object.keys(savedCartObj).length > 0 ? savedCartObj.name : '');
         return (
-            <div className={css}>
+            <div className="cart__add-all-element-control">
                 <button
                     disabled={inProgress}
                     className="btn btn-info btn-sm"
@@ -205,22 +205,18 @@ CartAddAllElementsComponent.propTypes = {
     elements: PropTypes.array.isRequired,
     /** True if cart updating operation is in progress */
     inProgress: PropTypes.bool.isRequired,
-    /** CSS classes to add to the wrapper div around the button */
-    css: PropTypes.string,
     /** Function to call when Add All clicked */
     addAllResults: PropTypes.func.isRequired,
 };
 
 CartAddAllElementsComponent.defaultProps = {
     savedCartObj: null,
-    css: null, // To prevent class attribute generation if no classes desired
 };
 
 CartAddAllElementsComponent.mapStateToProps = (state, ownProps) => ({
     savedCartObj: state.savedCartObj,
     elements: ownProps.elements,
     inProgress: state.inProgress,
-    css: ownProps.css,
 });
 
 CartAddAllElementsComponent.mapDispatchToProps = (dispatch, ownProps) => ({
@@ -231,20 +227,17 @@ const CartAddAllElementsInternal = connect(CartAddAllElementsComponent.mapStateT
 
 
 // Public component used to bind to context properties.
-export const CartAddAllElements = ({ elements, css }, reactContext) => (
-    <CartAddAllElementsInternal elements={elements} css={css} session={reactContext.session} fetch={reactContext.fetch} />
+export const CartAddAllElements = ({ elements }, reactContext) => (
+    <CartAddAllElementsInternal elements={elements} session={reactContext.session} fetch={reactContext.fetch} />
 );
 
 CartAddAllElements.propTypes = {
     /** New elements to add to cart as array of dataset objects */
     elements: PropTypes.array,
-    /** CSS classes to add to button */
-    css: PropTypes.string,
 };
 
 CartAddAllElements.defaultProps = {
     elements: [],
-    css: null,
 };
 
 CartAddAllElements.contextTypes = {

--- a/src/encoded/static/components/cart/add_multiple.js
+++ b/src/encoded/static/components/cart/add_multiple.js
@@ -13,7 +13,7 @@ import { MaximumElementsLoggedoutModal, CART_MAXIMUM_ELEMENTS_LOGGEDOUT, getAllo
 /**
  * Button to add all qualifying elements to the user's cart.
  */
-class CartAddAllComponent extends React.Component {
+class CartAddAllSearchComponent extends React.Component {
     constructor() {
         super();
         this.state = {
@@ -111,7 +111,7 @@ class CartAddAllComponent extends React.Component {
     }
 }
 
-CartAddAllComponent.propTypes = {
+CartAddAllSearchComponent.propTypes = {
     /** Existing cart contents before adding new items */
     elements: PropTypes.array.isRequired,
     /** Current cart saved object */
@@ -128,39 +128,126 @@ CartAddAllComponent.propTypes = {
     session: PropTypes.object,
 };
 
-CartAddAllComponent.defaultProps = {
+CartAddAllSearchComponent.defaultProps = {
     inProgress: false,
     savedCartObj: null,
     session: null,
 };
 
-const mapStateToProps = (state, ownProps) => ({
+CartAddAllSearchComponent.mapStateToProps = (state, ownProps) => ({
     elements: state.elements,
     savedCartObj: state.savedCartObj,
     inProgress: state.inProgress,
     searchResults: ownProps.searchResults,
     session: ownProps.session,
 });
-const mapDispatchToProps = (dispatch, ownProps) => ({
+CartAddAllSearchComponent.mapDispatchToProps = (dispatch, ownProps) => ({
     addAllResults: elementsForCart => dispatch(addMultipleToCartAndSave(elementsForCart, !!(ownProps.session && ownProps.session['auth.userid']), ownProps.fetch)),
     setInProgress: enable => dispatch(cartOperationInProgress(enable)),
 });
 
-const CartAddAllInternal = connect(mapStateToProps, mapDispatchToProps)(CartAddAllComponent);
+const CartAddAllInternal = connect(CartAddAllSearchComponent.mapStateToProps, CartAddAllSearchComponent.mapDispatchToProps)(CartAddAllSearchComponent);
 
-const CartAddAll = (props, reactContext) => (
-    <CartAddAllInternal searchResults={props.searchResults} session={reactContext.session} sessionProperties={reactContext.session_properties} fetch={reactContext.fetch} />
+export const CartAddAllSearch = (props, reactContext) => (
+    <CartAddAllInternal searchResults={props.searchResults} session={reactContext.session} fetch={reactContext.fetch} />
 );
 
-CartAddAll.propTypes = {
+CartAddAllSearch.propTypes = {
     /** Search result object of elements to add to cart */
     searchResults: PropTypes.object.isRequired,
 };
 
-CartAddAll.contextTypes = {
+CartAddAllSearch.contextTypes = {
     session: PropTypes.object,
-    session_properties: PropTypes.object,
     fetch: PropTypes.func,
 };
 
-export default CartAddAll;
+
+/**
+ * Renders a button to add all elements from an array of dataset objects to the current cart.
+ */
+class CartAddAllElementsComponent extends React.Component {
+    constructor() {
+        super();
+        this.handleClick = this.handleClick.bind(this);
+    }
+
+    /**
+     * Handle a click in the button to add all datasets from a list to the current cart.
+     */
+    handleClick() {
+        const elementAtIds = this.props.elements.map(element => element['@id']);
+        this.props.addAllResults(elementAtIds);
+    }
+
+    render() {
+        const { savedCartObj, inProgress, css } = this.props;
+        const cartName = (savedCartObj && Object.keys(savedCartObj).length > 0 ? savedCartObj.name : '');
+        return (
+            <div className={css}>
+                <button
+                    disabled={inProgress}
+                    className="btn btn-info btn-sm"
+                    onClick={this.handleClick}
+                    title={`Add all related experiments to cart${cartName ? `: ${cartName}` : ''}`}
+                >
+                    Add all items to cart
+                </button>
+            </div>
+        );
+    }
+}
+
+CartAddAllElementsComponent.propTypes = {
+    /** Current cart saved object */
+    savedCartObj: PropTypes.object,
+    /** New elements to add to cart as array of dataset objects */
+    elements: PropTypes.array.isRequired,
+    /** True if cart updating operation is in progress */
+    inProgress: PropTypes.bool.isRequired,
+    /** CSS classes to add to the wrapper div around the button */
+    css: PropTypes.string,
+    /** Function to call when Add All clicked */
+    addAllResults: PropTypes.func.isRequired,
+};
+
+CartAddAllElementsComponent.defaultProps = {
+    savedCartObj: null,
+    css: null, // To prevent class attribute generation if no classes desired
+};
+
+CartAddAllElementsComponent.mapStateToProps = (state, ownProps) => ({
+    savedCartObj: state.savedCartObj,
+    elements: ownProps.elements,
+    inProgress: state.inProgress,
+    css: ownProps.css,
+});
+
+CartAddAllElementsComponent.mapDispatchToProps = (dispatch, ownProps) => ({
+    addAllResults: elements => dispatch(addMultipleToCartAndSave(elements, !!(ownProps.session && ownProps.session['auth.userid']), ownProps.fetch)),
+});
+
+const CartAddAllElementsInternal = connect(CartAddAllElementsComponent.mapStateToProps, CartAddAllElementsComponent.mapDispatchToProps)(CartAddAllElementsComponent);
+
+
+// Public component used to bind to context properties.
+export const CartAddAllElements = ({ elements, css }, reactContext) => (
+    <CartAddAllElementsInternal elements={elements} css={css} session={reactContext.session} fetch={reactContext.fetch} />
+);
+
+CartAddAllElements.propTypes = {
+    /** New elements to add to cart as array of dataset objects */
+    elements: PropTypes.array,
+    /** CSS classes to add to button */
+    css: PropTypes.string,
+};
+
+CartAddAllElements.defaultProps = {
+    elements: [],
+    css: null,
+};
+
+CartAddAllElements.contextTypes = {
+    session: PropTypes.object,
+    fetch: PropTypes.func,
+};

--- a/src/encoded/static/components/cart/index.js
+++ b/src/encoded/static/components/cart/index.js
@@ -31,7 +31,7 @@ import {
     NO_ACTION,
 } from './actions';
 import cartAddElements from './add_elements';
-import CartAddAll from './add_multiple';
+import { CartAddAllSearch, CartAddAllElements } from './add_multiple';
 import cartCacheSaved from './cache_saved';
 import CartBatchDownload from './batch_download';
 import Cart from './cart';
@@ -179,7 +179,8 @@ export const cartIsUnsaved = () => {
 
 // Include any symbols needed outside the "cart" directory.
 export {
-    CartAddAll,
+    CartAddAllSearch,
+    CartAddAllElements,
     CartBatchDownload,
     cartCacheSaved,
     CartClear,

--- a/src/encoded/static/components/cart/search_controls.js
+++ b/src/encoded/static/components/cart/search_controls.js
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import CartAddAll from './add_multiple';
+import { CartAddAllSearch } from './add_multiple';
 import { isAllowedElementsPossible } from './util';
 
 
@@ -15,7 +15,7 @@ const CartSearchControls = ({ searchResults }) => {
     if (isAllowedElementsPossible(searchResults.filters)) {
         return (
             <div className="cart__search-controls">
-                <CartAddAll searchResults={searchResults} />
+                <CartAddAllSearch searchResults={searchResults} />
             </div>
         );
     }

--- a/src/encoded/static/components/cart/toggle.js
+++ b/src/encoded/static/components/cart/toggle.js
@@ -26,7 +26,7 @@ class CartToggleComponent extends React.Component {
     }
 
     render() {
-        const { elements, elementAtId, savedCartObj, loggedIn, inProgress } = this.props;
+        const { elements, elementAtId, savedCartObj, css, loggedIn, inProgress } = this.props;
         const inCart = elements.indexOf(elementAtId) > -1;
         const cartName = (savedCartObj && Object.keys(savedCartObj).length > 0 ? savedCartObj.name : '');
         const cartAtLimit = !loggedIn && elements.length >= CART_MAXIMUM_ELEMENTS_LOGGEDOUT;
@@ -37,7 +37,7 @@ class CartToggleComponent extends React.Component {
         // "name" attribute needed for BDD test targeting.
         return (
             <button
-                className={`cart__toggle${inCart ? ' cart__toggle--in-cart' : ''}`}
+                className={`cart__toggle${inCart ? ' cart__toggle--in-cart' : ''}${css ? ` ${css}` : ''}`}
                 onClick={this.handleClick}
                 disabled={inProgress || (!loggedIn && !inCart && cartAtLimit)}
                 title={cartAtLimitToolTip || inProgressToolTip || inCartToolTip}
@@ -58,6 +58,8 @@ CartToggleComponent.propTypes = {
     savedCartObj: PropTypes.object,
     /** @id of element being added to cart */
     elementAtId: PropTypes.string.isRequired,
+    /** CSS to add to toggle */
+    css: PropTypes.string,
     /** Function to call to add `elementAtId` to cart */
     onAddToCartClick: PropTypes.func.isRequired,
     /** Function to call to remove `elementAtId` from cart  */
@@ -71,6 +73,7 @@ CartToggleComponent.propTypes = {
 CartToggleComponent.defaultProps = {
     elements: [],
     savedCartObj: null,
+    css: '',
     loggedIn: false,
     inProgress: false,
 };
@@ -80,6 +83,7 @@ const mapStateToProps = (state, ownProps) => ({
     savedCartObj: state.savedCartObj,
     inProgress: state.inProgress,
     elementAtId: ownProps.element['@id'],
+    css: ownProps.css,
     loggedIn: ownProps.loggedIn,
 });
 
@@ -94,8 +98,8 @@ const CartToggleInternal = connect(mapStateToProps, mapDispatchToProps)(CartTogg
 const CartToggle = (props, reactContext) => (
     <CartToggleInternal
         element={props.element}
+        css={props.css}
         loggedIn={!!(reactContext.session && reactContext.session['auth.userid'])}
-        sessionProperties={reactContext.session_properties}
         fetch={reactContext.fetch}
     />
 );
@@ -103,11 +107,16 @@ const CartToggle = (props, reactContext) => (
 CartToggle.propTypes = {
     /** Object being added */
     element: PropTypes.object.isRequired,
+    /** CSS to add to toggle */
+    css: PropTypes.string,
+};
+
+CartToggle.defaultProps = {
+    css: '',
 };
 
 CartToggle.contextTypes = {
     session: PropTypes.object,
-    session_properties: PropTypes.object,
     fetch: PropTypes.func,
 };
 

--- a/src/encoded/static/components/dataset.js
+++ b/src/encoded/static/components/dataset.js
@@ -1310,7 +1310,7 @@ export class SeriesComponent extends React.Component {
             addAllToCartControl = (
                 <div className="experiment-table__header">
                     <h4 className="experiment-table__title">{`Experiments in ${seriesTitle} ${context.accession}`}</h4>
-                    <CartAddAllElements elements={experimentList} css="experiment-table__control" />
+                    <CartAddAllElements elements={experimentList} />
                 </div>
             );
         }

--- a/src/encoded/static/components/dataset.js
+++ b/src/encoded/static/components/dataset.js
@@ -4,6 +4,7 @@ import _ from 'underscore';
 import { Panel, PanelBody } from '../libs/bootstrap/panel';
 import DropdownButton from '../libs/bootstrap/button';
 import { DropdownMenu } from '../libs/bootstrap/dropdown-menu';
+import { CartToggle, CartAddAllElements } from './cart';
 import * as globals from './globals';
 import { Breadcrumbs } from './navigation';
 import { DbxrefList } from './dbxref';
@@ -85,7 +86,7 @@ class AnnotationComponent extends React.Component {
             <div className={itemClass}>
                 <header className="row">
                     <div className="col-sm-12">
-                        <Breadcrumbs crumbs={crumbs} crumbsReleased={crumbsReleased}/>
+                        <Breadcrumbs crumbs={crumbs} crumbsReleased={crumbsReleased} />
                         <h2>Summary for annotation file set {context.accession}</h2>
                         <AlternateAccession altAcc={context.alternate_accessions} />
                         <Supersede context={context} />
@@ -1017,6 +1018,11 @@ const basicTableColumns = {
         title: 'Status',
         display: experiment => <Status item={experiment} badgeSize="small" />,
     },
+    cart: {
+        title: 'Cart',
+        display: experiment => <CartToggle element={experiment} />,
+        sorter: false,
+    },
 };
 
 const treatmentSeriesTableColumns = {
@@ -1059,6 +1065,12 @@ const treatmentSeriesTableColumns = {
     status: {
         title: 'Status',
         display: experiment => <Status item={experiment} badgeSize="small" />,
+    },
+
+    cart: {
+        title: 'Cart',
+        display: experiment => <CartToggle element={experiment} />,
+        sorter: false,
     },
 };
 
@@ -1116,6 +1128,12 @@ const replicationTimingSeriesTableColumns = {
     status: {
         title: 'Status',
         display: experiment => <Status item={experiment} badgeSize="small" />,
+    },
+
+    cart: {
+        title: 'Cart',
+        display: experiment => <CartToggle element={experiment} />,
+        sorter: false,
     },
 };
 
@@ -1205,6 +1223,12 @@ const organismDevelopmentSeriesTableColumns = {
         title: 'Status',
         display: experiment => <Status item={experiment} badgeSize="small" />,
     },
+
+    cart: {
+        title: 'Cart',
+        display: experiment => <CartToggle element={experiment} />,
+        sorter: false,
+    },
 };
 
 
@@ -1278,6 +1302,18 @@ export class SeriesComponent extends React.Component {
 
         // Filter out any files we shouldn't see.
         const experimentList = context.related_datasets.filter(dataset => dataset.status !== 'revoked' && dataset.status !== 'replaced' && dataset.status !== 'deleted');
+
+        // If we display a table of related experiments, have to render the control to add all of
+        // them to the current cart.
+        let addAllToCartControl;
+        if (experimentList.length > 0) {
+            addAllToCartControl = (
+                <div className="experiment-table__header">
+                    <h4 className="experiment-table__title">{`Experiments in ${seriesTitle} ${context.accession}`}</h4>
+                    <CartAddAllElements elements={experimentList} css="experiment-table__control" />
+                </div>
+            );
+        }
 
         return (
             <div className={itemClass}>
@@ -1394,9 +1430,9 @@ export class SeriesComponent extends React.Component {
                     </PanelBody>
                 </Panel>
 
-                {experimentList.length ?
+                {addAllToCartControl ?
                     <div>
-                        <SortTablePanel title={`Experiments in ${seriesTitle} ${context.accession}`}>
+                        <SortTablePanel header={addAllToCartControl}>
                             <SortTable
                                 list={experimentList}
                                 columns={seriesComponent.table}
@@ -1404,7 +1440,7 @@ export class SeriesComponent extends React.Component {
                             />
                         </SortTablePanel>
                     </div>
-                : null }
+                : null}
 
                 {/* Display list of released and unreleased files */}
                 <FetchedItems

--- a/src/encoded/static/scss/encoded/modules/_cart.scss
+++ b/src/encoded/static/scss/encoded/modules/_cart.scss
@@ -501,14 +501,15 @@ $deleted-bg: #ffe0e0;
 .experiment-table {
     @at-root #{&}__header {
         display: flex;
+
+        .cart__add-all-element-control {
+            flex: 0 1 auto;
+            margin: -5px -5px -5px 10px;
+        }
     }
 
     @at-root #{&}__title {
         flex: 1 1 auto;
     }
 
-    @at-root #{&}__control {
-        flex: 0 1 auto;
-        margin: -5px -5px -5px 10px;
-    }
 }

--- a/src/encoded/static/scss/encoded/modules/_cart.scss
+++ b/src/encoded/static/scss/encoded/modules/_cart.scss
@@ -158,7 +158,6 @@
     @at-root #{&}__toggle {
         display: block;
         padding: 6px;
-        margin-left: auto;
         border: 1px solid;
         background-color: #fff;
         border-color: rgb(216, 216, 216) rgb(209, 209, 209) rgb(186, 186, 186);
@@ -168,7 +167,7 @@
         fill: #000;
         fill-opacity: 0;
         -webkit-appearance: none; // Avoid apparent chrome bug
-    
+
         svg {
             display: block;
             height: 1.2rem;
@@ -495,4 +494,21 @@ $deleted-bg: #ffe0e0;
     background-color: #fff;
     border-top: 1px solid #a0a0a0;
     border-bottom: 1px solid #a0a0a0;
+}
+
+
+// Experiment tables with a cart control in the header.
+.experiment-table {
+    @at-root #{&}__header {
+        display: flex;
+    }
+
+    @at-root #{&}__title {
+        flex: 1 1 auto;
+    }
+
+    @at-root #{&}__control {
+        flex: 0 1 auto;
+        margin: -5px -5px -5px 10px;
+    }
 }

--- a/src/encoded/static/scss/encoded/modules/_facet.scss
+++ b/src/encoded/static/scss/encoded/modules/_facet.scss
@@ -495,11 +495,12 @@ div.meta-status {
         z-index: 3;
     }
 
+    // Cart control in search results
     @at-root #{&}__cart-control {
         flex: 0 0 35px;
 
-        @at-root #{&}--unsaved {
-            background-color: #ffc0c0;
+        .cart__toggle {
+            margin-left: auto;
         }
     }
 }


### PR DESCRIPTION
Most changes are in cart/add_multiple.js. The existing `CartAddAll` component is for adding all search results to the cart, and got renamed to `CartAddAllSearch` to distinguish it from the new `CartAddAllElements` component which has the much simpler job of adding an array of dataset objects to the cart. It gets called from the “Add all items to cart” button that appears in any type of Series page.