### PR TITLE
ENCD-4530 Fix duplicate alternate accessions

### DIFF
--- a/src/encoded/static/components/antibody.js
+++ b/src/encoded/static/components/antibody.js
@@ -114,7 +114,9 @@ const LotComponent = (props, reactContext) => {
                 <div className="col-sm-12">
                     <Breadcrumbs root="/search/?type=AntibodyLot" crumbs={crumbs} crumbsReleased={crumbsReleased} />
                     <h2>{context.accession}</h2>
-                    <AlternateAccession altAcc={context.alternate_accessions} />
+                    <div className="replacement-accessions">
+                        <AlternateAccession altAcc={context.alternate_accessions} />
+                    </div>
                     <h3>
                         {targetKeys.length ?
                             <span>

--- a/src/encoded/static/components/biosample.js
+++ b/src/encoded/static/components/biosample.js
@@ -69,7 +69,9 @@ class BiosampleComponent extends React.Component {
                         <h2>
                             {context.accession}{' / '}<span className="sentence-case">{context.biosample_ontology.classification}</span>
                         </h2>
-                        <AlternateAccession altAcc={context.alternate_accessions} />
+                        <div className="replacement-accessions">
+                            <AlternateAccession altAcc={context.alternate_accessions} />
+                        </div>
                         {this.props.auditIndicators(context.audit, 'biosample-audit', { session: this.context.session })}
                         <DisplayAsJson />
                     </div>

--- a/src/encoded/static/components/dataset.js
+++ b/src/encoded/static/components/dataset.js
@@ -17,7 +17,7 @@ import { SortTablePanel, SortTable } from './sorttable';
 import { ProjectBadge } from './image';
 import { DocumentsPanelReq } from './doc';
 import { FileGallery, DatasetFiles } from './filegallery';
-import { AwardRef, Supersede, ControllingExperiments } from './typeutils';
+import { AwardRef, ReplacementAccessions, ControllingExperiments } from './typeutils';
 
 // Return a summary of the given biosamples, ready to be displayed in a React component.
 export function annotationBiosampleSummary(annotation) {
@@ -85,10 +85,9 @@ class AnnotationComponent extends React.Component {
             <div className={itemClass}>
                 <header className="row">
                     <div className="col-sm-12">
-                        <Breadcrumbs crumbs={crumbs} crumbsReleased={crumbsReleased}/>
+                        <Breadcrumbs crumbs={crumbs} crumbsReleased={crumbsReleased} />
                         <h2>Summary for annotation file set {context.accession}</h2>
-                        <AlternateAccession altAcc={context.alternate_accessions} />
-                        <Supersede context={context} />
+                        <ReplacementAccessions context={context} />
                         {this.props.auditIndicators(context.audit, 'annotation-audit', { session: this.context.session })}
                         <DisplayAsJson />
                     </div>
@@ -1285,8 +1284,7 @@ export class SeriesComponent extends React.Component {
                     <div className="col-sm-12">
                         <Breadcrumbs crumbs={crumbs} crumbsReleased={crumbsReleased} />
                         <h2>Summary for {seriesTitle} {context.accession}</h2>
-                        <AlternateAccession altAcc={context.alternate_accessions} />
-                        <Supersede context={context} />
+                        <ReplacementAccessions context={context} />
                         {this.props.auditIndicators(context.audit, 'series-audit', { session: this.context.session })}
                         <DisplayAsJson />
                     </div>

--- a/src/encoded/static/components/dataset.js
+++ b/src/encoded/static/components/dataset.js
@@ -280,7 +280,9 @@ class PublicationDataComponent extends React.Component {
                     <div className="col-sm-12">
                         <Breadcrumbs crumbs={crumbs} crumbsReleased={crumbsReleased} />
                         <h2>Summary for publication file set {context.accession}</h2>
-                        <AlternateAccession altAcc={context.alternate_accessions} />
+                        <div className="replacement-accessions">
+                            <AlternateAccession altAcc={context.alternate_accessions} />
+                        </div>
                         {this.props.auditIndicators(context.audit, 'publicationdata-audit', { session: this.context.session })}
                         <DisplayAsJson />
                     </div>
@@ -442,7 +444,9 @@ class ReferenceComponent extends React.Component {
                     <div className="col-sm-12">
                         <Breadcrumbs crumbs={crumbs} crumbsReleased={crumbsReleased} />
                         <h2>Summary for reference file set {context.accession}</h2>
-                        <AlternateAccession altAcc={context.alternate_accessions} />
+                        <div className="replacement-accessions">
+                            <AlternateAccession altAcc={context.alternate_accessions} />
+                        </div>
                         {this.props.auditIndicators(context.audit, 'reference-audit', { session: this.context.session })}
                         <DisplayAsJson />
                     </div>
@@ -607,7 +611,9 @@ class ProjectComponent extends React.Component {
                     <div className="col-sm-12">
                         <Breadcrumbs crumbs={crumbs} crumbsReleased={crumbsReleased} />
                         <h2>Summary for project file set {context.accession}</h2>
-                        <AlternateAccession altAcc={context.alternate_accessions} />
+                        <div className="replacement-accessions">
+                            <AlternateAccession altAcc={context.alternate_accessions} />
+                        </div>
                         {this.props.auditIndicators(context.audit, 'project-audit', { session: this.context.session })}
                         <DisplayAsJson />
                     </div>
@@ -793,7 +799,9 @@ class UcscBrowserCompositeComponent extends React.Component {
                     <div className="col-sm-12">
                         <Breadcrumbs crumbs={crumbs} crumbsReleased={crumbsReleased} />
                         <h2>Summary for UCSC browser composite file set {context.accession}</h2>
-                        <AlternateAccession altAcc={context.alternate_accessions} />
+                        <div className="replacement-accessions">
+                            <AlternateAccession altAcc={context.alternate_accessions} />
+                        </div>
                         {this.props.auditIndicators(context.audit, 'ucscbrowsercomposite-audit', { session: this.context.session })}
                         <DisplayAsJson />
                     </div>

--- a/src/encoded/static/components/donor.js
+++ b/src/encoded/static/components/donor.js
@@ -570,7 +570,9 @@ class DonorComponent extends React.Component {
                     <div className="col-sm-12">
                         <Breadcrumbs crumbs={crumbs} crumbsReleased={crumbsReleased} />
                         <h2>{context.accession}</h2>
-                        <AlternateAccession altAcc={context.alternate_accessions} />
+                        <div className="replacement-accessions">
+                            <AlternateAccession altAcc={context.alternate_accessions} />
+                        </div>
                         {this.props.auditIndicators(context.audit, 'donor-audit', { session: this.context.session })}
                         {this.props.auditDetail(context.audit, 'donor-audit', { session: this.context.session, except: context['@id'] })}
                         <DisplayAsJson />

--- a/src/encoded/static/components/experiment.js
+++ b/src/encoded/static/components/experiment.js
@@ -16,7 +16,7 @@ import { singleTreatment, DisplayAsJson, InternalTags } from './objectutils';
 import pubReferenceList from './reference';
 import { SortTablePanel, SortTable } from './sorttable';
 import Status from './status';
-import { BiosampleSummaryString, BiosampleOrganismNames, CollectBiosampleDocs, AwardRef, Supersede, ControllingExperiments } from './typeutils';
+import { BiosampleSummaryString, BiosampleOrganismNames, CollectBiosampleDocs, AwardRef, ReplacementAccessions, ControllingExperiments } from './typeutils';
 
 
 const anisogenicValues = [
@@ -419,7 +419,7 @@ class ExperimentComponent extends React.Component {
                     <div className="col-sm-12">
                         <Breadcrumbs root="/search/?type=Experiment" crumbs={crumbs} crumbsReleased={crumbsReleased} />
                         <h2>Experiment summary for {context.accession}</h2>
-                        <Supersede context={context} />
+                        <ReplacementAccessions context={context} />
                         <div className="cart__toggle--header">
                             <CartToggle element={context} />
                         </div>

--- a/src/encoded/static/components/file.js
+++ b/src/encoded/static/components/file.js
@@ -8,13 +8,13 @@ import { auditDecor } from './audit';
 import { DbxrefList } from './dbxref';
 import { DocumentsPanel } from './doc';
 import * as globals from './globals';
-import { requestFiles, requestObjects, requestSearch, RestrictedDownloadButton, AlternateAccession, DisplayAsJson } from './objectutils';
+import { requestFiles, requestObjects, requestSearch, RestrictedDownloadButton, DisplayAsJson } from './objectutils';
 import { ProjectBadge } from './image';
 import { QualityMetricsPanel } from './quality_metric';
 import { PickerActions } from './search';
 import { SortTablePanel, SortTable } from './sorttable';
 import Status from './status';
-import { Supersede } from './typeutils';
+import { ReplacementAccessions } from './typeutils';
 
 
 // Columns to display in Deriving/Derived From file tables
@@ -374,9 +374,12 @@ class FileComponent extends React.Component {
                 <header className="row">
                     <div className="col-sm-12">
                         <h2>File summary for {context.title} (<span className="sentence-case">{context.file_format}</span>)</h2>
-                        <AlternateAccession altAcc={context.alternate_accessions} />
-                        {context.restricted ? <h4 className="superseded-acc">Restricted file</h4> : null}
-                        <Supersede context={context} />
+                        {context.restricted ?
+                            <div className="replacement-accessions">
+                                <h4>Restricted file</h4>
+                            </div>
+                        : null}
+                        <ReplacementAccessions context={context} />
                         {this.props.auditIndicators(context.audit, 'file-audit', { session: this.context.session })}
                         {this.props.auditDetail(context.audit, 'file-audit', { session: this.context.session, except: context['@id'] })}
                         <DisplayAsJson />

--- a/src/encoded/static/components/item.js
+++ b/src/encoded/static/components/item.js
@@ -49,7 +49,9 @@ const Item = (props) => {
             <header className="row">
                 <div className="col-sm-12">
                     <h2>{title}</h2>
-                    <AlternateAccession altAcc={context.alternate_accessions} />
+                    <div className="replacement-accessions">
+                        <AlternateAccession altAcc={context.alternate_accessions} />
+                    </div>
                     <DisplayAsJson />
                 </div>
             </header>

--- a/src/encoded/static/components/objectutils.js
+++ b/src/encoded/static/components/objectutils.js
@@ -635,15 +635,13 @@ export const AlternateAccession = (props) => {
 
     if (altAcc && altAcc.length) {
         return (
-            <div className="replacement-accessions">
-                <h4 className="replacement-accessions__alternate">
-                    {altAcc.length === 1 ?
-                        <span>Alternate accession: {altAcc[0]}</span>
-                    :
-                        <span>Alternate accessions: {altAcc.join(', ')}</span>
-                    }
-                </h4>
-            </div>
+            <h4 className="replacement-accessions__alternate">
+                {altAcc.length === 1 ?
+                    <span>Alternate accession: {altAcc[0]}</span>
+                :
+                    <span>Alternate accessions: {altAcc.join(', ')}</span>
+                }
+            </h4>
         );
     }
 

--- a/src/encoded/static/components/objectutils.js
+++ b/src/encoded/static/components/objectutils.js
@@ -635,13 +635,15 @@ export const AlternateAccession = (props) => {
 
     if (altAcc && altAcc.length) {
         return (
-            <h4 className="replacement-accessions__alternate">
-                {altAcc.length === 1 ?
-                    <span>Alternate accession: {altAcc[0]}</span>
-                :
-                    <span>Alternate accessions: {altAcc.join(', ')}</span>
-                }
-            </h4>
+            <div className="replacement-accessions">
+                <h4 className="replacement-accessions__alternate">
+                    {altAcc.length === 1 ?
+                        <span>Alternate accession: {altAcc[0]}</span>
+                    :
+                        <span>Alternate accessions: {altAcc.join(', ')}</span>
+                    }
+                </h4>
+            </div>
         );
     }
 

--- a/src/encoded/static/components/typeutils.js
+++ b/src/encoded/static/components/typeutils.js
@@ -295,44 +295,39 @@ export function fileStatusList(session, sessionProperties) {
 }
 
 
-// Display supersedes/superseded_by lists.
-export const Supersede = ({ context }) => {
+/**
+ *  Display supersedes/superseded_by/alternate_accessions lists.
+ */
+export const ReplacementAccessions = ({ context }) => {
     const alternateAccessions = context.alternate_accessions || [];
+    const supersededByAtIds = context.superseded_by || [];
+    const supersedes = (context.supersedes && context.supersedes.map(supersedesAtId => globals.atIdToAccession(supersedesAtId))) || [];
 
-    // Make array of supersedes accessions
-    let supersedes = [];
-    if (context.supersedes && context.supersedes.length) {
-        supersedes = context.supersedes.map(supersede => globals.atIdToAccession(supersede));
-    }
-
-    let supersededByOutput = null;
-    if (context.superseded_by && context.superseded_by.length > 0) {
-        supersededByOutput = (
-            <h4 className="replacement-accessions__superseded-by">
-                <span>Superseded by </span>
-                {context.superseded_by.map((supersededBy, index) => (
-                    <span key={supersededBy}>
-                        {index > 0 ? <span>, </span> : null}
-                        <a href={supersededBy}>{globals.atIdToAccession(supersededBy)}</a>
-                    </span>
-                ))}
-            </h4>
-        );
-    }
-
-    if (supersededByOutput || supersedes.length > 0 || alternateAccessions.length > 0) {
+    if (alternateAccessions.length > 0 || supersededByAtIds.length > 0 || supersedes.length > 0) {
         return (
             <div className="replacement-accessions">
                 <AlternateAccession altAcc={alternateAccessions} />
-                {supersededByOutput}
-                {supersedes.length ? <h4 className="replacement-accessions__supersedes">Supersedes {supersedes.join(', ')}</h4> : null}
+                {supersededByAtIds.length > 0 ?
+                    <h4 className="replacement-accessions__superseded-by">
+                        <span>Superseded by </span>
+                        {supersededByAtIds.map((supersededByAtId, index) => (
+                            <span key={supersededByAtId}>
+                                {index > 0 ? <span>, </span> : null}
+                                <a href={supersededByAtId}>{globals.atIdToAccession(supersededByAtId)}</a>
+                            </span>
+                        ))}
+                    </h4>
+                : null}
+                {supersedes.length > 0 ?
+                    <h4 className="replacement-accessions__supersedes">Supersedes {supersedes.join(', ')}</h4>
+                : null}
             </div>
         );
     }
     return null;
 };
 
-Supersede.propTypes = {
+ReplacementAccessions.propTypes = {
     context: PropTypes.object.isRequired, // Object containing supersedes/superseded_by to display
 };
 


### PR DESCRIPTION
* The biggest change is in the `Supersede` component of typeutils.js. I cleaned up the code to all be more consistent and easy to maintain. I also renamed `Supersede` to `ReplacementAccessions` to more accurately reflect its current role.
* I also modified a restricted-file display in the header of file pages so that it stops using CSS styles I removed in this ticket’s predecessor.