### PR TITLE
ENCD-4158 Let apache cfg set on deploy

### DIFF
--- a/cloud-config-cluster.yml
+++ b/cloud-config-cluster.yml
@@ -201,14 +201,7 @@ runcmd:
 - sudo -u encoded sh -c 'cat /dev/urandom | head -c 256 | base64 > session-secret.b64'
 - sudo -u encoded bin/create-mapping production.ini --app-name app
 - sudo -u encoded bin/index-annotations production.ini --app-name app
-- if test "%(REGION_INDEX)s" = "False"
-- then
--    sudo -u encoded cp /srv/encoded/etc/encoded-apache.conf /srv/encoded/etc/encoded-apache.conf.original
--    sudo -u encoded sh -c "grep -v encoded\-regionindexer /srv/encoded/etc/encoded-apache.conf.original | grep -v _region > /srv/encoded/etc/encoded-apache.conf"
--    sudo -u encoded cp /srv/encoded/base.ini /srv/encoded/base.ini.original
--    sudo -u encoded sh -c "sed 's/vis_indexer, region_indexer/vis_indexer/' /srv/encoded/base.ini.original > /srv/encoded/base.ini"
-- fi
-- ln -s /srv/encoded/etc/encoded-apache.conf /etc/apache2/sites-available/encoded.conf
+- ln -s /srv/encoded/etc/%(APACHE_CFG)s-apache.conf /etc/apache2/sites-available/encoded.conf
 - ln -s /srv/encoded/etc/logging-apache.conf /etc/apache2/conf-available/logging.conf
 - a2enmod headers
 - a2enmod proxy_http

--- a/cloud-config.yml
+++ b/cloud-config.yml
@@ -197,14 +197,7 @@ runcmd:
 - sudo -u encoded sh -c 'cat /dev/urandom | head -c 256 | base64 > session-secret.b64'
 - sudo -u encoded bin/create-mapping production.ini --app-name app
 - sudo -u encoded bin/index-annotations production.ini --app-name app
-- if test "%(REGION_INDEX)s" = "False"
-- then
--    sudo -u encoded cp /srv/encoded/etc/encoded-apache.conf /srv/encoded/etc/encoded-apache.conf.original
--    sudo -u encoded sh -c "grep -v encoded\-regionindexer /srv/encoded/etc/encoded-apache.conf.original | grep -v _region > /srv/encoded/etc/encoded-apache.conf"
--    sudo -u encoded cp /srv/encoded/base.ini /srv/encoded/base.ini.original
--    sudo -u encoded sh -c "sed 's/vis_indexer, region_indexer/vis_indexer/' /srv/encoded/base.ini.original > /srv/encoded/base.ini"
-- fi
-- ln -s /srv/encoded/etc/encoded-apache.conf /etc/apache2/sites-available/encoded.conf
+- ln -s /srv/encoded/etc/%(APACHE_CFG)s-apache.conf /etc/apache2/sites-available/encoded.conf
 - ln -s /srv/encoded/etc/logging-apache.conf /etc/apache2/conf-available/logging.conf
 - a2enmod headers
 - a2enmod proxy_http

--- a/etc/no-region-apache.conf
+++ b/etc/no-region-apache.conf
@@ -1,0 +1,208 @@
+KeepAliveTimeout 75
+
+
+# The socket directory must be readable by the daemon process user
+WSGISocketPrefix /var/run/wsgi
+WSGIDaemonProcess encoded user=encoded group=encoded processes=6 threads=1 display-name=encoded-app
+# No need for embedded interpreters
+WSGIRestrictEmbedded On
+# Pass the authorization header so basic auth works
+WSGIPassAuthorization On
+
+# Indexer. Configure first to avoid catchall '/'
+WSGIDaemonProcess encoded-indexer user=encoded group=encoded processes=1 threads=1 display-name=encoded-indexer
+WSGIScriptAlias /_indexer /srv/encoded/parts/production-indexer/wsgi process-group=encoded-indexer application-group=%{GLOBAL}
+
+# visindexer. Configure first to avoid catchall '/'
+WSGIDaemonProcess encoded-visindexer user=encoded group=encoded processes=1 threads=1 display-name=encoded-visindexer
+WSGIScriptAlias /_visindexer /srv/encoded/parts/production-visindexer/wsgi process-group=encoded-indexer application-group=%{GLOBAL}
+
+# https://github.com/GrahamDumpleton/mod_wsgi/issues/2
+SetEnvIf Request_Method HEAD X_REQUEST_METHOD=HEAD
+
+LogFormat "%v:%p %h %l %u %t \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\" %{X-Stats}o&server_time=%D" vhost_combined_stats
+
+<Directory /srv/encoded/parts/production-indexer>
+    Order deny,allow
+    Allow from all
+    <IfModule access_compat_module>
+        Require all granted
+    </IfModule>
+</Directory>
+
+<Directory /srv/encoded/parts/production-visindexer>
+    Order deny,allow
+    Allow from all
+    <IfModule access_compat_module>
+        Require all granted
+    </IfModule>
+</Directory>
+
+<Directory /srv/encoded/parts/production-regionindexer>
+    Order deny,allow
+    Allow from all
+    <IfModule access_compat_module>
+        Require all granted
+    </IfModule>
+</Directory>
+
+
+# Specifying process-group and application-group here ensures processes are started on httpd start
+WSGIScriptAlias / /srv/encoded/parts/production/wsgi process-group=encoded application-group=%{GLOBAL}
+
+<Directory /srv/encoded/parts/production>
+    Order deny,allow
+    Allow from all
+    <IfModule access_compat_module>
+        Require all granted
+    </IfModule>
+    # Limit upload size to 500 MB (375MB before base64 encoding)
+    LimitRequestBody 524288000
+    # Apache adds -gzip to outgoing ETag in mod_deflate, remove inbound.
+    # https://issues.apache.org/bugzilla/show_bug.cgi?id=39727
+    RequestHeader edit If-Match    -gzip\"$    \"
+    RequestHeader edit If-None-Match    -gzip\"$    \"
+
+    # CORS support
+    Header always set Access-Control-Allow-Origin "*"
+    Header always set Access-Control-Allow-Methods "GET, HEAD"
+    Header always set Access-Control-Allow-Headers "Accept, Origin, Range, X-Requested-With"
+    Header always set Access-Control-Expose-Headers: "Content-Length, Content-Range, Content-Type"
+
+    # CORS preflight
+    RewriteCond %{REQUEST_METHOD} OPTIONS
+    RewriteRule ^ - [redirect=200,last]
+</Directory>
+
+# Serve static resources directly from Apache
+Alias /static /srv/encoded/src/encoded/static
+Alias /favicon.ico /srv/encoded/src/encoded/static/img/favicon.ico
+
+<Directory /srv/encoded/src/encoded/static>
+    Order deny,allow
+    Allow from all
+    <IfModule access_compat_module>
+        Require all granted
+    </IfModule>
+</Directory>
+
+# Compress JSON responses.
+AddOutputFilterByType DEFLATE application/javascript application/json text/css text/html text/javascript
+
+# Source map type (to enable compression)
+<FilesMatch \.js\.map$>
+    ForceType application/json
+</FilesMatch>
+
+RewriteEngine On
+
+# Exclude robots from all but production site
+RewriteCond %{HTTP_HOST} =www.encodeproject.org
+RewriteRule ^/robots\.txt$  /static/robots.txt  [last,passthrough]
+RewriteRule ^/robots\.txt$  /static/dev-robots.txt  [last,passthrough]
+
+# Google site verification
+RewriteRule ^/google[0-9a-f]+.html$  /static$0  [last,passthrough]
+
+# Proxy modencode comparative page
+<Location /comparative>
+   ProxyPass    http://cake.encodedcc.org/comparative
+   ProxyPassReverse  http://cake.encodedcc.org/comparative
+</Location>
+
+# Proxy internal redirects for file downloads
+SSLProxyEngine On
+RewriteCond %{ENV:REDIRECT_STATUS} .
+RewriteRule ^/_proxy/(.+)$  $1  [proxy]
+
+# Forbid PUT/PATCH/POST to plain http
+RewriteCond %{HTTP:X-Forwarded-Proto} =http
+RewriteCond %{REQUEST_METHOD} !^(GET|HEAD)$
+RewriteCond %{HTTP_HOST} ^(www\.encodeproject\.org|test\.encodedcc\.org)$
+RewriteRule ^ - [forbidden]
+
+# Forbid basic auth to plain http
+RewriteCond %{HTTP:X-Forwarded-Proto} =http
+RewriteCond %{HTTP:Authorization} .
+RewriteCond %{HTTP_HOST} ^(www\.encodeproject\.org|test\.encodedcc\.org)$
+RewriteRule ^ - [forbidden]
+
+ErrorDocument 403 "Forbidden. HTTPS required for authenticated access."
+
+# Redirect no-www to https://www.encodeproject.org
+RewriteCond %{HTTP_HOST} =encodeproject.org
+RewriteCond %{REQUEST_METHOD} ^(GET|HEAD)$
+RewriteCond %{HTTP:Authorization} !.
+RewriteRule ^ https://www.encodeproject.org%{REQUEST_URI} [redirect=permanent,last,qsappend]
+
+# Redirect to https
+RewriteCond %{HTTP:X-Forwarded-Proto} =http
+RewriteCond %{HTTP_HOST} ^(www\.encodeproject\.org|test\.encodedcc\.org)$
+RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [redirect=permanent,last,qsappend]
+
+# Forbid PUT/PATCH/POST
+#RewriteEngine On
+#RewriteCond %{REQUEST_METHOD} ^(PUT|POST|PATCH)
+#RewriteRule .* - [F]
+
+# Forbid POST/PATCH/PUT but allow login
+#<IfModule mod_rewrite.c>
+# RewriteCond %{REQUEST_METHOD} ^(POST|PUT|PATCH)
+# RewriteCond %{REQUEST_URI} !/login [NC]
+# RewriteRule .* -[F]
+#</IfModule>
+
+###################
+# Portal redirects
+
+# Normalize index.html etc.
+RewriteRule ^/ENCODE$    $0/    [nocase]
+RewriteRule ^/encode/(.*)$    /ENCODE/$1
+RewriteRule ^/ENCODE/FAQ$    $0/
+RewriteRule ^(/ENCODE/.+)\.html$    $1
+RewriteRule ^(/ENCODE(/|/.+/))index$    $1
+
+# Redirect
+RewriteRule ^/ENCODE/$    /?    [last,redirect=permanent]
+RewriteRule ^/ENCODE/search$    /search/?type=experiment    [last,redirect=permanent]
+RewriteRule ^/ENCODE/dataSummary$    /search/?type=experiment    [last,redirect=permanent]
+RewriteRule ^/ENCODE/dataMatrix/encodeDataMatrixMouse$    /search/?type=experiment&replicates.library.biosample.donor.organism.scientific_name=Mus\ musculus    [last,redirect=permanent]
+RewriteRule ^/ENCODE/dataMatrix/encodeDataMatrixHuman$    /search/?type=experiment&replicates.library.biosample.donor.organism.scientific_name=Homo\ sapiens    [last,redirect=permanent]
+RewriteRule ^/ENCODE/dataMatrix/encodeChipMatrixHuman$    /search/?type=experiment&replicates.library.biosample.donor.organism.scientific_name=Homo\ sapiens&assay_term_name=ChIP-seq    [last,redirect=permanent]
+RewriteRule ^/ENCODE/dataMatrix/encodeDataSummaryHuman$    /search/?type=experiment&replicates.library.biosample.donor.organism.scientific_name=Homo\ sapiens    [last,redirect=permanent]
+RewriteRule ^/ENCODE/dataMatrix/encodeChipMatrixMouse$    /search/?type=experiment&replicates.library.biosample.donor.organism.scientific_name=Mus\ musculus&assay_term_name=ChIP-seq    [last,redirect=permanent]
+RewriteRule ^/ENCODE/dataMatrix/encodeDataSummaryMouse$    /search/?type=experiment&replicates.library.biosample.donor.organism.scientific_name=Mus\ musculus    [last,redirect=permanent]
+RewriteRule ^/ENCODE/terms$    /about/data-use-policy/?    [last,redirect=permanent]
+RewriteRule ^/ENCODE/cellTypes$    /search/?type=biosample&organism.scientific_name=Homo\ sapiens    [last,redirect=permanent]
+RewriteRule ^/ENCODE/cellTypesMouse$    /search/?type=biosample&organism.scientific_name=Mus\ musculus    [last,redirect=permanent]
+RewriteRule ^/ENCODE/antibodies$    /search/?type=antibody_approval    [last,redirect=permanent]
+RewriteRule ^/ENCODE/softwareTools$    /software/?    [last,redirect=permanent]
+RewriteRule ^/ENCODE/experiment_guidelines$    /about/experiment-guidelines/?    [last,redirect=permanent]
+RewriteRule ^/ENCODE/platform_characterization$    /data-standards/platform-characterization/?    [last,redirect=permanent]
+RewriteRule ^/ENCODE/qualityMetrics$    /data-standards/2012-quality-metrics/?    [last,redirect=permanent]
+RewriteRule ^/ENCODE/contributors$    /about/contributors/?    [last,redirect=permanent]
+RewriteRule ^/ENCODE/analysis$    /about/2012-integrative-analysis/?    [last,redirect=permanent]
+RewriteRule ^/ENCODE/pubsOther$    /publications/?    [last,redirect=permanent]
+RewriteRule ^/ENCODE/pubsEncode$    /publications/?    [last,redirect=permanent]
+RewriteRule ^/ENCODE/fileFormats$    /help/file-formats/?    [last,redirect=permanent]
+RewriteRule ^/ENCODE/contacts$    /help/contacts/?    [last,redirect=permanent]
+RewriteRule ^/ENCODE/FAQ/$    /tutorials/?    [last,redirect=permanent]
+RewriteRule ^/ENCODE/usageResources$    /tutorials/?    [last,redirect=permanent]
+RewriteRule ^/ENCODE/releaseLog$    /about/contributors/?    [last,redirect=permanent]
+RewriteRule ^/ENCODE/pilot$    /about/contributors/?    [last,redirect=permanent]
+RewriteRule ^/ENCODE/downloads$    /help/getting-started/?    [last,redirect=permanent]
+RewriteRule ^/ENCODE/downloadsMouse$    /help/getting-started/?    [last,redirect=permanent]
+RewriteRule ^/ENCODE/otherTerms$    /help/getting-started/?    [last,redirect=permanent]
+RewriteRule ^/ENCODE/integrativeAnalysis/VM$    http://encodedcc.stanford.edu/ftp/encodevm/?    [last,redirect=permanent]
+RewriteRule ^/ENCODE/dataStandards$    /data-standards/?    [last,redirect=permanent]
+RewriteCond %{REQUEST_METHOD}    =GET
+RewriteRule ^/encyclopedia/visualize    http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&hgt.customText=http://bib.umassmed.edu/~iyers/encode_elements/display/tracks.txt    [last,redirect=permanent]
+
+# Fallback
+RewriteRule ^/ENCODE/.*$    -    [gone]
+
+# Redirect to genome browser
+RewriteRule ^/cgi-bin/hgTracks$    http://genome.ucsc.edu/cgi-bin/hgTracks    [last,redirect=permanent]
+RewriteRule ^/cgi-bin/hgTables$    http://genome.ucsc.edu/cgi-bin/hgTables    [last,redirect=permanent]
+RewriteRule ^/cgi-bin/hgTrackUi$    http://genome.ucsc.edu/cgi-bin/hgTrackUi    [last,redirect=permanent]
+RewriteRule ^/cgi-bin/hgHubConnect$    http://genome.ucsc.edu/cgi-bin/hgHubConnect    [last,redirect=permanent]


### PR DESCRIPTION
This allows apache config file to be set on deployment depending on the role or the newly added --apache-cfg arg.  This fix the region indexer config issue too.   

This is helpful for the remote index worker as those deployments have special configs too.

TODO; See if we can inherit the conf that is similar between the files.