### PR TITLE
ENCD-4543-fix-status-hierarchy

### DIFF
--- a/src/encoded/types/base.py
+++ b/src/encoded/types/base.py
@@ -91,7 +91,9 @@ STATUS_TRANSITION_TABLE = {
     'replaced': [],
     'disabled': ['disabled', 'current'],
     'current': ['current'],
-    'uploading': ['uploading', 'upload failed', 'content error']
+    'uploading': ['uploading', 'upload failed', 'content error'],
+    'content error': ['uploading'],
+    'upload failed': ['uploading'],
 }
 
 # Used to calculate whether new_status is more or less than current_status.

--- a/src/encoded/types/base.py
+++ b/src/encoded/types/base.py
@@ -106,6 +106,8 @@ STATUS_HIERARCHY = {
     'disabled': 10,
     'deleted': 0,
     'replaced': -10,
+    'content error': -20,
+    'upload failed': -20,
 }
 
 


### PR DESCRIPTION
This should prevent KeyError when using set_status to go from content error/upload failed to uploading.