### PR TITLE
ENCD-4510 Fix human donor children calc prop

### DIFF
--- a/src/encoded/tests/test_types_donor.py
+++ b/src/encoded/tests/test_types_donor.py
@@ -2,7 +2,7 @@ import pytest
 
 
 @pytest.fixture
-def parent(testapp, award, lab, human):
+def parent_human_donor(testapp, award, lab, human):
     item = {
         'lab': lab['@id'],
         'award': award['@id'],
@@ -12,7 +12,7 @@ def parent(testapp, award, lab, human):
 
 
 @pytest.fixture
-def child(testapp, award, lab, human):
+def child_human_donor(testapp, award, lab, human):
     item = {
         'lab': lab['@id'],
         'award': award['@id'],
@@ -21,9 +21,8 @@ def child(testapp, award, lab, human):
     return testapp.post_json('/human_donor', item).json['@graph'][0]
 
 
-# patch parent to child, check that children are a calculated property for the parent
-def test_types_calculated_children(testapp, parent, child):
-    testapp.patch_json(child['@id'],
-                             {'parents': [parent['@id']]}).json['@graph'][0]
-    res = testapp.get(parent['@id'] + '@@index-data')
-    assert res.json['object']['children'] == [child['@id']]
+def test_types_calculated_children(testapp, parent_human_donor, child_human_donor):
+    testapp.patch_json(child_human_donor['@id'],
+                             {'parents': [parent_human_donor['@id']]}).json['@graph'][0]
+    res = testapp.get(parent_human_donor['@id'] + '@@index-data')
+    assert res.json['object']['children'] == [child_human_donor['@id']]

--- a/src/encoded/tests/test_types_donor.py
+++ b/src/encoded/tests/test_types_donor.py
@@ -1,0 +1,29 @@
+import pytest
+
+
+@pytest.fixture
+def parent(testapp, award, lab, human):
+    item = {
+        'lab': lab['@id'],
+        'award': award['@id'],
+        'organism': human['@id']
+    }
+    return testapp.post_json('/human_donor', item).json['@graph'][0]
+
+
+@pytest.fixture
+def child(testapp, award, lab, human):
+    item = {
+        'lab': lab['@id'],
+        'award': award['@id'],
+        'organism': human['@id']
+    }
+    return testapp.post_json('/human_donor', item).json['@graph'][0]
+
+
+# patch parent to child, check that children are a calculated property for the parent
+def test_types_calculated_children(testapp, parent, child):
+    testapp.patch_json(child['@id'],
+                             {'parents': [parent['@id']]}).json['@graph'][0]
+    res = testapp.get(parent['@id'] + '@@index-data')
+    assert res.json['object']['children'] == [child['@id']]

--- a/src/encoded/types/donor.py
+++ b/src/encoded/types/donor.py
@@ -169,5 +169,5 @@ class HumanDonor(Donor):
         },
         "notSubmittable": True,
     })
-    def children(self, request, parents):
-        return paths_filtered_by_status(request, parents)
+    def children(self, request, children):
+        return paths_filtered_by_status(request, children)


### PR DESCRIPTION
The code that calculates the children property was instead calculating the parents themselves. 

I fixed it in src/encoded/types/donor.py so that children are calculated properly and added a file (src/encoded/tests/test_types_donor.py) with a test to make sure the children are indeed calculated and placed in the children property of the specified parents.