### PR TITLE
Simplify homepage logic. Just delete the homepage if you don't want it.

### DIFF
--- a/src/encoded/static/components/app.js
+++ b/src/encoded/static/components/app.js
@@ -23,7 +23,6 @@ import cartStore, {
 import * as globals from './globals';
 import Navigation from './navigation';
 import Footer from './footer';
-import Home from './home';
 import { requestSearch } from './objectutils';
 import newsHead from './page';
 
@@ -1023,20 +1022,13 @@ class App extends React.Component {
         // Switching between collections may leave component in place
         const key = context && context['@id'] && context['@id'].split('?')[0];
         const currentAction = this.currentAction();
-        const isHomePage = context.default_page && context.default_page.name === 'homepage' && (!hrefUrl.hash || hrefUrl.hash === '#logged-out');
-        if (isHomePage) {
+        if (!currentAction && context.default_page) {
             context = context.default_page;
-            content = <Home context={context} />;
-            containerClass = 'container-homepage';
-        } else {
-            if (!currentAction && context.default_page) {
-                context = context.default_page;
-            }
-            if (context) {
-                const ContentView = globals.contentViews.lookup(context, currentAction);
-                content = <ContentView context={context} />;
-                containerClass = 'container';
-            }
+        }
+        if (context) {
+            const ContentView = globals.contentViews.lookup(context, currentAction);
+            content = <ContentView context={context} />;
+            containerClass = 'container';
         }
         const errors = this.state.errors.map(i => <div key={i} className="alert alert-error" />);
 
@@ -1098,7 +1090,7 @@ class App extends React.Component {
                             <div id="layout">
                                 <Provider store={cartStore}>
                                     <div>
-                                        <Navigation isHomePage={isHomePage} />
+                                        <Navigation />
                                         <div id="content" className={containerClass} key={key}>
                                             {content}
                                         </div>

--- a/src/encoded/static/components/home.js
+++ b/src/encoded/static/components/home.js
@@ -585,6 +585,8 @@ export default class Home extends React.Component {
     }
 }
 
+globals.contentViews.register(Home, 'Portal');
+
 
 // Given retrieved data, draw all home-page charts.
 const ChartGallery = props => (

--- a/src/encoded/static/components/index.js
+++ b/src/encoded/static/components/index.js
@@ -40,6 +40,7 @@ require('./region_search');
 require('./auditmatrix');
 require('./gene');
 require('./biosample_type');
+require('./home');
 
 
 module.exports = require('./app');

--- a/src/encoded/static/components/navigation.js
+++ b/src/encoded/static/components/navigation.js
@@ -81,7 +81,7 @@ export default class Navigation extends React.Component {
                         <GlobalSections />
                         <CartStatus />
                         <UserActions />
-                        {this.props.isHomePage ? null : <ContextActions />}
+                        <ContextActions />
                         <Search />
                     </Navbar>
                 </div>
@@ -101,14 +101,6 @@ export default class Navigation extends React.Component {
         );
     }
 }
-
-Navigation.propTypes = {
-    isHomePage: PropTypes.bool, // True if current page is home page
-};
-
-Navigation.defaultProps = {
-    isHomePage: false,
-};
 
 Navigation.contextTypes = {
     location_href: PropTypes.string,

--- a/src/encoded/tests/data/inserts/page.json
+++ b/src/encoded/tests/data/inserts/page.json
@@ -1,6 +1,6 @@
 [
     {
-        "name": "homepage",
+        "name": "testpage",
         "title": "The ENCODE Project",
         "status": "released",
         "uuid": "27f9abd9-0081-4ade-8c82-95ec12b3a7dd",

--- a/src/encoded/tests/features/page.feature
+++ b/src/encoded/tests/features/page.feature
@@ -2,7 +2,7 @@
 Feature: Portal pages
 
     Scenario: Render page layout
-        When I visit "/pages/homepage/"
+        When I visit "/pages/testpage/"
         And I wait for the content to load
         Then I should see an element with the css selector "div.col-md-4"
 

--- a/src/encoded/tests/test_views.py
+++ b/src/encoded/tests/test_views.py
@@ -287,7 +287,30 @@ def test_page_nested_in_progress(workbook, anontestapp):
     return anontestapp.get('/test-section/subpage-in-progress/', status=403)
 
 
-def test_page_homepage(workbook, anontestapp):
+def test_page_homepage(workbook, anontestapp, testapp):
+    item = {
+        "name": "homepage",
+        "title": "The ENCODE Project",
+        "status": "released",
+        "layout": {
+            "rows": [
+                {
+                    "cols": [
+                        {"blocks": ["#block1"]}
+                    ]
+                }
+            ],
+            "blocks": [
+                {
+                    "@id": "#block1",
+                    "@type": "richtextblock",
+                    "body": "<h1>ENCODE: The Encyclopedia of DNA Elements</h1>"
+                }
+            ]
+        }
+    }
+    testapp.post_json('/pages', item, status=201)
+
     res = anontestapp.get('/pages/homepage/', status=200)
     assert res.json['canonical_uri'] == '/'
 

--- a/src/encoded/types/page.py
+++ b/src/encoded/types/page.py
@@ -157,9 +157,12 @@ def page_view_page(context, request):
     })
 def collection_default_page(context, request):
     try:
-        return request.embed('/pages/%s/@@page' % context.__name__, as_user=True)
+        result = request.embed('/pages/%s/@@page' % context.__name__, as_user=True)
     except KeyError:
         pass
+    else:
+        if result['status'] != 'deleted':
+            return result
 
 
 @calculated_property(
@@ -173,6 +176,9 @@ def collection_default_page(context, request):
     })
 def root_default_page(context, request):
     try:
-        return request.embed('/pages/homepage/@@page', as_user=True)
+        result = request.embed('/pages/homepage/@@page', as_user=True)
     except KeyError:
         pass
+    else:
+        if result['status'] != 'deleted':
+            return result


### PR DESCRIPTION
Rather than special casing when we're at the homepage instead just make delete the homepage if its unwanted. This avoids returning the page contents in the json response as default_page.

This also fixes a bug where going to https://www.encodeproject.org/# (with the hash sign) brings up the page.