### PR TITLE
ENCD-4412 Add Clear Cart item to cart menu

### DIFF
--- a/src/encoded/static/components/__tests__/cart-test.js
+++ b/src/encoded/static/components/__tests__/cart-test.js
@@ -20,6 +20,7 @@ const initialCart = {
     elements: [],
     name: 'Third cart',
     current: '/carts/9570dbda-191d-42c3-8ac9-f479ca55f6f6/',
+    inProgress: false,
 };
 const mockStore = configureStore();
 
@@ -295,7 +296,9 @@ describe('Cart manager while logged in as submitter', () => {
     });
 
     test('the column count is correct', () => {
-        const tableHeaderCells = cartManager.find('.table.table-sortable thead tr th');
+        const tableHeaderRows = cartManager.find('.table.table-sortable thead tr');
+        expect(tableHeaderRows).toHaveLength(2);
+        const tableHeaderCells = tableHeaderRows.at(1).find('th');
         expect(tableHeaderCells).toHaveLength(5);
     });
 
@@ -413,7 +416,9 @@ describe('Cart manager while logged in as admin', () => {
     });
 
     test('the column count is correct', () => {
-        const tableHeaderCells = cartManager.find('.table.table-sortable thead tr th');
+        const tableHeaderRows = cartManager.find('.table.table-sortable thead tr');
+        expect(tableHeaderRows).toHaveLength(2);
+        const tableHeaderCells = tableHeaderRows.at(1).find('th');
         expect(tableHeaderCells).toHaveLength(6);
     });
 

--- a/src/encoded/static/components/cart/cart.js
+++ b/src/encoded/static/components/cart/cart.js
@@ -11,7 +11,7 @@ import { itemClass, encodedURIComponent, parseAndLogError } from '../globals';
 import { requestObjects, DisplayAsJson } from '../objectutils';
 import { ResultTableList } from '../search';
 import CartBatchDownload from './batch_download';
-import CartClear from './clear';
+import CartClearButton from './clear';
 import { cartRetrieve } from './database';
 import CartMergeShared from './merge_shared';
 
@@ -520,7 +520,7 @@ const CartTools = ({ elements, selectedTerms, savedCartObj, viewableElements, fi
             />
         : null}
         {cartType === 'OBJECT' ? <CartMergeShared sharedCartObj={sharedCart} viewableElements={viewableElements} /> : null}
-        {cartType === 'ACTIVE' || cartType === 'MEMORY' ? <CartClear /> : null}
+        {cartType === 'ACTIVE' || cartType === 'MEMORY' ? <CartClearButton /> : null}
     </div>
 );
 

--- a/src/encoded/static/components/cart/manager.js
+++ b/src/encoded/static/components/cart/manager.js
@@ -764,7 +764,6 @@ class CartManagerComponent extends React.Component {
         );
         return (
             <SortTablePanel header={cartPanelHeader}>
-                <CartCounts cartManager={cartContext} />
                 <SortTable
                     list={cartContext['@graph']}
                     columns={cartTableColumns}
@@ -777,6 +776,7 @@ class CartManagerComponent extends React.Component {
                         updateCartManager: this.retrieveUpdatedCart,
                         fetch,
                     }}
+                    title={<CartCounts cartManager={cartContext} />}
                     rowClasses={
                         (item) => {
                             if (item['@id'] === currentCart) {

--- a/src/encoded/static/components/cart/status.js
+++ b/src/encoded/static/components/cart/status.js
@@ -9,6 +9,7 @@ import { DropdownMenu, DropdownMenuSep } from '../../libs/bootstrap/dropdown-men
 import { Nav, NavItem } from '../../libs/bootstrap/navbar';
 import { svgIcon } from '../../libs/svg-icons';
 import { truncateString } from '../globals';
+import { CartClearModal } from './clear';
 import CartShare from './share';
 
 
@@ -44,8 +45,7 @@ CartNavTitle.propTypes = {
 
 
 /**
- * Navigation bar item for the cart menu, including a simple link to the cart page, as well as a
- * button that brings up the Share Cart modal.
+ * Navigation bar item for the cart menu.
  */
 class CartStatusComponent extends React.Component {
     constructor() {
@@ -53,9 +53,12 @@ class CartStatusComponent extends React.Component {
         this.state = {
             /** True if Share Cart modal is visible */
             shareModalOpen: false,
+            clearModalOpen: false,
         };
         this.shareCartClick = this.shareCartClick.bind(this);
         this.closeShareCart = this.closeShareCart.bind(this);
+        this.clearCartClick = this.clearCartClick.bind(this);
+        this.closeClearCart = this.closeClearCart.bind(this);
     }
 
     /**
@@ -72,25 +75,42 @@ class CartStatusComponent extends React.Component {
         this.setState({ shareModalOpen: false });
     }
 
+    /**
+     * Called when the Share Cart menu item is clicked.
+     */
+    clearCartClick() {
+        this.setState({ clearModalOpen: true });
+    }
+
+    /**
+     * Called when the Share Cart modal close buttons are clicked.
+     */
+    closeClearCart() {
+        this.setState({ clearModalOpen: false });
+    }
+
     render() {
         const { elements, savedCartObj, inProgress, openDropdown, dropdownClick, loggedIn } = this.props;
 
         if (loggedIn || elements.length > 0 || inProgress) {
             // Define the menu items for the Cart Status menu.
-            const cartName = truncateString(savedCartObj && Object.keys(savedCartObj).length > 0 ? savedCartObj.name : '', 30);
+            const cartName = (loggedIn && savedCartObj && savedCartObj.name) ? truncateString(savedCartObj.name, 50) : '';
             const menuItems = [];
-            const viewCartItem = <a key="view" href="/cart-view/">View cart{cartName ? <span>: {cartName}</span> : null}</a>;
+            const viewCartItem = <a key="view" href="/cart-view/">View cart</a>;
+            const clearCartItem = <button key="clear" onClick={this.clearCartClick}>Clear cart</button>;
             if (loggedIn) {
+                menuItems.push(<span key="name" className="disabled-menu-item">{`Current: ${cartName}`}</span>, <DropdownMenuSep key="sep-1" />);
                 if (elements.length > 0) {
                     menuItems.push(
                         viewCartItem,
-                        <button key="share" onClick={this.shareCartClick}>Share cart{cartName ? <span>: {cartName}</span> : null}</button>,
-                        <DropdownMenuSep key="sep" />
+                        <button key="share" onClick={this.shareCartClick}>Share cart</button>,
+                        clearCartItem,
+                        <DropdownMenuSep key="sep-2" />
                     );
                 }
                 menuItems.push(<a key="manage" href="/cart-manager/">Cart manager</a>);
             } else {
-                menuItems.push(viewCartItem);
+                menuItems.push(viewCartItem, clearCartItem);
             }
 
             return (
@@ -108,6 +128,7 @@ class CartStatusComponent extends React.Component {
                         </DropdownMenu>
                     </NavItem>
                     {this.state.shareModalOpen ? <CartShare userCart={savedCartObj} closeShareCart={this.closeShareCart} /> : null}
+                    {this.state.clearModalOpen ? <CartClearModal closeClickHandler={this.closeClearCart} /> : null}
                 </Nav>
             );
         }

--- a/src/encoded/static/components/cart/status.js
+++ b/src/encoded/static/components/cart/status.js
@@ -94,7 +94,7 @@ class CartStatusComponent extends React.Component {
 
         if (loggedIn || elements.length > 0 || inProgress) {
             // Define the menu items for the Cart Status menu.
-            const cartName = (loggedIn && savedCartObj && savedCartObj.name) ? truncateString(savedCartObj.name, 50) : '';
+            const cartName = (loggedIn && savedCartObj && savedCartObj.name) ? truncateString(savedCartObj.name, 22) : '';
             const menuItems = [];
             const viewCartItem = <a key="view" href="/cart-view/">View cart</a>;
             const clearCartItem = <button key="clear" onClick={this.clearCartClick}>Clear cart</button>;

--- a/src/encoded/static/scss/encoded/modules/_cart.scss
+++ b/src/encoded/static/scss/encoded/modules/_cart.scss
@@ -524,6 +524,7 @@ $deleted-bg: #ffe0e0;
     padding: 2px 10px;
     text-align: center;
     font-size: 0.9rem;
+    font-weight: normal;
     color: #606060;
     background-color: #fff;
     border-top: 1px solid #a0a0a0;

--- a/src/encoded/static/scss/encoded/modules/_navbar.scss
+++ b/src/encoded/static/scss/encoded/modules/_navbar.scss
@@ -128,10 +128,14 @@
     overflow: hidden;
 
     &>li {
-        &>a {
-            padding: 5px 20px;
+        &>a, &>button, &>span {
+            display: block;
+            padding: 5px 15px 5px 25px;
             color: white !important;
             font-weight: 300;
+            line-height: 20px;
+            background-color: transparent;
+            border: none;
         }
     }
     .sub-menu {

--- a/src/encoded/static/scss/encoded/modules/_navbar.scss
+++ b/src/encoded/static/scss/encoded/modules/_navbar.scss
@@ -149,7 +149,8 @@
         padding: 10px 0;
 
         &>li {
-            &>a, &>button {
+            &>a, &>button, &>span {
+                display: inline-block;
                 width: 100%;
                 margin: 0;
                 padding: 2px 30px 2px 20px;

--- a/src/encoded/tests/features/cart.feature
+++ b/src/encoded/tests/features/cart.feature
@@ -36,7 +36,7 @@ Feature: Cart
         When I visit "/search/?type=Experiment"
         And I dismiss the alert
         Then the browser's URL should be "/cart-view/"
-        When I press "Clear cart"
+        When I press "clear-cart-actuator"
         Then I should see an element with the css selector ".modal"
         When I press "clear-cart-submit"
         Then I should not see an element with the css selector ".modal"


### PR DESCRIPTION
The most significant change is the refactorization of `CartClear`, which used to handle the trigger button as well as the modal it triggered. The modal now gets rendered by the new `CartClearModal` component so that both a now-separate button (now called `CartClearButton`) as well as the new menu item can trigger the Clear Cart warning modal.

Because “Clear Cart” would be the third item in the cart menu needing the current cart name, and because we now have a non-selectable menu item in the “Data” menu (“Collections”), now seemed the time to have a non-selectable menu item displaying the current cart name in the cart menu so I could remove them from each of “View cart,” “Share cart,” and “Clear cart.” I implemented this using a `<span>` within the menu `<li>`, so I had to add the `<span>` to the menu CSS, including an inline-block style so that this `<span>` gets the same margins as other menu items.
