### PR TITLE
ENCD-4542 Display biosample table on GM pages

### DIFF
--- a/src/encoded/static/components/genetic_modification.js
+++ b/src/encoded/static/components/genetic_modification.js
@@ -628,7 +628,7 @@ class GeneticModificationComponent extends React.Component {
 
                 <RelatedItems
                     title="Biosamples using this genetic modification"
-                    url={`/search/?type=Biosample&genetic_modifications.uuid=${context.uuid}`}
+                    url={`/search/?type=Biosample&applied_modifications.uuid=${context.uuid}`}
                     Component={BiosampleTable}
                 />
             </div>


### PR DESCRIPTION
The table of biosamples that a particular GM references used to use the submitter-set biosample property `genetic_modifications`. This property still exists but a newer calculated property, `applied_modifications`, now references GMs that modify the biosample. GM pages did a GET request searching for biosamples that are modified by the GM using `genetic_modifications`, but this no longer returned anything. This branch now uses `applied_modifications` in this search.

Note that Donor objects still use `genetic_modifications` and this has not changed. `applied_modifications` is a property of biosamples only.