### PR TITLE
ENCD-4560 update typeaheads after selections

### DIFF
--- a/src/encoded/static/components/search.js
+++ b/src/encoded/static/components/search.js
@@ -722,6 +722,7 @@ class Facet extends React.Component {
         // Set initial React commponent state.
         this.state = {
             initialState: true,
+            unsanitizedSearchTerm: '',
             searchTerm: '',
         };
 
@@ -734,6 +735,8 @@ class Facet extends React.Component {
     }
 
     handleSearch(event) {
+        // Unsanitized search term entered by user for display
+        this.setState({ unsanitizedSearchTerm: event.target.value });
         // Search term entered by the user
         const filterVal = String(sanitizedString(event.target.value));
         this.setState({ searchTerm: filterVal });
@@ -854,7 +857,7 @@ class Facet extends React.Component {
                             <div className="typeahead-entry" role="search">
                                 <i className="icon icon-search" />
                                 <div className="searchform">
-                                    <input type="search" aria-label={`search to filter list of terms for facet ${titleComponent}`} placeholder="Search" value={this.state.value} onChange={this.handleSearch} name={`search${titleComponent.replace(/\s+/g, '')}`} />
+                                    <input type="search" aria-label={`search to filter list of terms for facet ${titleComponent}`} placeholder="Search" value={this.state.unsanitizedSearchTerm} onChange={this.handleSearch} name={`search${titleComponent.replace(/\s+/g, '')}`} />
                                 </div>
                             </div>
                         : null}


### PR DESCRIPTION
Two bug fixes here:
(1) When user types in a typeahead, and then chooses another facet, the typeahead facet terms should update according to the new filter (previously they did not). This is accomplished by moving the filtering into the render() function and by only keeping the search term, not the full filtered list, in state.
(2) Previously typeahead search bars would show or not show depending on how many terms were available and this introduced bugs (confusing behavior) if you searched on them and then selected/deselected other filters, because searches could be in state but not displayed. Now we will show the search bars for all typeaheads no matter how many terms there are.