### PR TITLE
ENCD-4548 fix fallback images on collection pages

### DIFF
--- a/src/encoded/static/components/objectutils.js
+++ b/src/encoded/static/components/objectutils.js
@@ -683,15 +683,57 @@ InternalTags.defaultProps = {
 };
 
 /**
+ * Display image with fallback for non-existent image links
+ */
+export class ImageWithFallback extends React.Component {
+    constructor() {
+        super();
+
+        // Initialize image src and alt tags to be empty to ensure component mounts
+        this.state = {
+            imageUrl: '',
+            imageAlt: '',
+        };
+        this.onError = this.onError.bind(this);
+    }
+
+    // Once the component has mounted, update image src and alt tag
+    componentDidMount() {
+        this.setState({
+            imageUrl: this.props.imageUrl,
+            imageAlt: this.props.imageAlt,
+        });
+    }
+
+    // Display default "not found" image for non-existent image src
+    onError() {
+        this.setState({
+            imageUrl: '/static/img/brokenImage.png',
+            imageAlt: 'Not found',
+        });
+    }
+
+    render() {
+        return (
+            <img
+                onError={this.onError}
+                src={this.state.imageUrl}
+                alt={this.state.imageAlt}
+            />
+        );
+    }
+}
+
+ImageWithFallback.propTypes = {
+    imageUrl: PropTypes.string.isRequired,
+    imageAlt: PropTypes.string.isRequired,
+};
+
+/**
  * Display internal tag badges for collection pages
  */
 export const MatrixInternalTags = ({ context }) => {
-    // if user manually enters an internal tag that does not exist into the url, display default "not found" image
-    function addDefaultSrc(ev) {
-        ev.target.src = '/static/img/brokenImage.png';
-        ev.target.alt = 'Collection not found';
-    }
-    // collect internal tags that are filters
+    // Collect internal tags that are filters
     const internalTags = [];
     context.filters.forEach((filter) => {
         if (filter.field === 'internal_tags') {
@@ -700,7 +742,7 @@ export const MatrixInternalTags = ({ context }) => {
             }
         }
     });
-    const tagBadges = internalTags.map(tag => (<img src={`/static/img/tag-${tag}.png`} onError={addDefaultSrc} key={tag} alt={`${tag} collection logo`} />));
+    const tagBadges = internalTags.map(tag => (<ImageWithFallback imageUrl={`/static/img/tag-${tag}.png`} imageAlt={`${tag} collection logo`} key={tag} />));
     return <div className="matrix-tag">{tagBadges}</div>;
 };
 

--- a/src/encoded/static/components/objectutils.js
+++ b/src/encoded/static/components/objectutils.js
@@ -689,7 +689,8 @@ export class ImageWithFallback extends React.Component {
     constructor() {
         super();
 
-        // Initialize image src and alt tags to be empty to ensure component mounts
+        // Initialize image src and alt tags to be empty
+        // These should not be set to props values prior to the component mounting or the onError function may not execute for broken image urls on certain browsers (Chrome in particular)
         this.state = {
             imageUrl: '',
             imageAlt: '',
@@ -697,7 +698,8 @@ export class ImageWithFallback extends React.Component {
         this.onError = this.onError.bind(this);
     }
 
-    // Once the component has mounted, update image src and alt tag
+    // Only once the component has mounted, update image src and alt tag
+    // This ensures that the component mounts and that the onError function will execute for broken image urls
     componentDidMount() {
         this.setState({
             imageUrl: this.props.imageUrl,
@@ -737,7 +739,7 @@ export const MatrixInternalTags = ({ context }) => {
     const internalTags = [];
     context.filters.forEach((filter) => {
         if (filter.field === 'internal_tags') {
-            if (filter.term !== '*') {
+            if ((filter.term !== '*') && !internalTags.includes(filter.term)) {
                 internalTags.push(filter.term);
             }
         }


### PR DESCRIPTION
Collections pages display a collections logo. In the case where someone attempts to search for a collections page that does not exist, we have a fallback image. This fallback image was not getting displayed on some browsers. The new "ImageWithFallback" component fixes this issue by ensuring that the onError function is loaded.