### PR TITLE
ENCD-4564 add target typeahead to AntibodyLot pages

### DIFF
--- a/src/encoded/schemas/antibody_lot.json
+++ b/src/encoded/schemas/antibody_lot.json
@@ -186,6 +186,11 @@
         "targets.investigated_as": {
             "title": "Target of antibody"
         },
+        "targets.label": {
+            "title": "Target of antibody",
+            "type": "typeahead",
+            "length": "long"
+        },
         "characterizations.characterization_method": {
             "title": "Characterization method"
         },


### PR DESCRIPTION
We are adding "targets.label" as a typeahead facet on search and report pages for type=AntibodyLot. It is placed right below the current "Target of antibody" and is titled "Target of antibody" itself. Re-naming the current "Target of antibody" to be "Target category" is in another ticket in this sprint.