### PR TITLE
ENCD-4565 remove back slashes from search terms

### DIFF
--- a/src/encoded/static/components/search.js
+++ b/src/encoded/static/components/search.js
@@ -730,7 +730,11 @@ TypeTerm.propTypes = {
 };
 
 // Sanitize user input and facet terms for comparison: convert to lowercase, remove white space and asterisks (which cause regular expression error)
-const sanitizedString = inputString => inputString.toLowerCase().replace(/ /g, '').replace(/[*]/g, '');
+const sanitizedString = inputString => inputString.toLowerCase()
+    .replace(/ /g, '') // remove spaces (to allow multiple word searches)
+    .replace(/[*]/g, '') // remove stars (these cause console errors)
+    .replace(/\\/g, '') // remove backslashes (these cause console errors)
+    .replace(/\//g, ''); // remove forward slashes (for consistency handling slashes)
 
 class Facet extends React.Component {
     constructor() {

--- a/src/encoded/static/components/search.js
+++ b/src/encoded/static/components/search.js
@@ -733,8 +733,7 @@ TypeTerm.propTypes = {
 const sanitizedString = inputString => inputString.toLowerCase()
     .replace(/ /g, '') // remove spaces (to allow multiple word searches)
     .replace(/[*]/g, '') // remove stars (these cause console errors)
-    .replace(/\\/g, '') // remove backslashes (these cause console errors)
-    .replace(/\//g, ''); // remove forward slashes (for consistency handling slashes)
+    .replace(/\\|\//g, ''); // remove slashes (back slashes cause console errors)
 
 class Facet extends React.Component {
     constructor() {

--- a/src/encoded/static/components/search.js
+++ b/src/encoded/static/components/search.js
@@ -732,8 +732,7 @@ TypeTerm.propTypes = {
 // Sanitize user input and facet terms for comparison: convert to lowercase, remove white space and asterisks (which cause regular expression error)
 const sanitizedString = inputString => inputString.toLowerCase()
     .replace(/ /g, '') // remove spaces (to allow multiple word searches)
-    .replace(/[*]/g, '') // remove stars (these cause console errors)
-    .replace(/\\|\//g, ''); // remove slashes (back slashes cause console errors)
+    .replace(/[*?()+[\]\\/]/g, ''); // remove certain special characters (these cause console errors)
 
 class Facet extends React.Component {
     constructor() {


### PR DESCRIPTION
Back slashes entered in the typeahead search bars cause console errors. In order to prevent this, we will remove back slashes from search terms. We will also remove forward slashes for consistency handling slashes. 