### PR TITLE
ENCD-4581 Temp install java 8 through aws

### DIFF
--- a/cloud-config-cluster.yml
+++ b/cloud-config-cluster.yml
@@ -118,8 +118,6 @@ packages:
 - lzop
 - nodejs
 - ntp
-- oracle-java8-installer
-- oracle-java8-set-default
 - postgresql-9.3
 - pv
 - python2.7-dev
@@ -163,6 +161,15 @@ runcmd:
 -   fi
 - fi
 - set -ex
+# Manually install java
+- sudo -u ubuntu aws s3 cp --region=us-west-2 --recursive s3://encoded-conf-prod/.aws ~ubuntu/.aws
+- sudo mkdir -p /usr/lib/jvm
+- sudo chmod 777 /usr/lib/jvm
+- sudo tar -xzvf /home/ubuntu/.aws/jdk-8u211-linux-x64.tar.gz --directory /usr/lib/jvm/
+- sudo -u ubuntu rm -r /home/ubuntu/.aws
+- sudo chmod 755 /usr/lib/jvm
+- sudo update-alternatives --install /usr/bin/java java /usr/lib/jvm/jdk1.8.0_211/bin/java 100
+# Manually install java
 - update-rc.d elasticsearch defaults
 - sudo bash /etc/elasticsearch/cluster.sh %(CLUSTER_NAME)s
 - sudo /usr/share/elasticsearch/bin/elasticsearch-plugin install discovery-ec2

--- a/cloud-config-elasticsearch.yml
+++ b/cloud-config-elasticsearch.yml
@@ -47,8 +47,6 @@ packages:
 - build-essential
 - elasticsearch
 - libssl-dev
-- oracle-java8-installer
-- oracle-java8-set-default
 - python2.7-dev
 - python3.4-dev
 - python-software-properties
@@ -94,6 +92,15 @@ runcmd:
 -   fi
 - fi
 - set -ex
+# Manually install java
+- sudo -u ubuntu aws s3 cp --region=us-west-2 --recursive s3://encoded-conf-prod/.aws ~ubuntu/.aws
+- sudo mkdir -p /usr/lib/jvm
+- sudo chmod 777 /usr/lib/jvm
+- sudo tar -xzvf /home/ubuntu/.aws/jdk-8u211-linux-x64.tar.gz --directory /usr/lib/jvm/
+- sudo -u ubuntu rm -r /home/ubuntu/.aws
+- sudo chmod 755 /usr/lib/jvm
+- sudo update-alternatives --install /usr/bin/java java /usr/lib/jvm/jdk1.8.0_211/bin/java 100
+# Manually install java
 - update-rc.d elasticsearch defaults
 - sudo bash /etc/elasticsearch/cluster.sh %(CLUSTER_NAME)s
 - sudo /usr/share/elasticsearch/bin/elasticsearch-plugin install discovery-ec2

--- a/cloud-config-no-es.yml
+++ b/cloud-config-no-es.yml
@@ -85,8 +85,6 @@ packages:
 - lzop
 - nodejs
 - ntp
-- oracle-java8-installer
-- oracle-java8-set-default
 - postgresql-9.3
 - pv
 - python2.7-dev
@@ -108,6 +106,16 @@ output:
 runcmd:
 - sudo -u ubuntu mv /home/ubuntu/.ssh/authorized_keys /home/ubuntu/.ssh/authorized_keys2
 - sudo -u ubuntu aws s3 cp --region=us-west-2 %(S3_AUTH_KEYS)s /home/ubuntu/.ssh/authorized_keys
+# Manually install java
+- sudo -u ubuntu aws s3 cp --region=us-west-2 --recursive s3://encoded-conf-prod/.aws ~ubuntu/.aws
+- sudo mkdir -p /usr/lib/jvm
+- sudo chmod 777 /usr/lib/jvm
+- sudo tar -xzvf /home/ubuntu/.aws/jdk-8u211-linux-x64.tar.gz --directory /usr/lib/jvm/
+- sudo -u ubuntu rm -r /home/ubuntu/.aws
+- sudo chmod 755 /usr/lib/jvm
+- sudo update-alternatives --install /usr/bin/java java /usr/lib/jvm/jdk1.8.0_211/bin/java 100
+# Manually install java
+- sudo update-alternatives --install /usr/bin/java java /usr/lib/jvm/jdk1.8.0_201/bin/java 100
 - cp /etc/redis/redis.conf /etc/redis/redis.conf.default
 - sed -i -e 's/port 6379/port %(REDIS_PORT)s/' /etc/redis/redis.conf
 - sed -i -e 's/bind 127\.0\.0\.1/bind 0\.0\.0\.0/' /etc/redis/redis.conf

--- a/cloud-config.yml
+++ b/cloud-config.yml
@@ -118,8 +118,6 @@ packages:
 - lzop
 - nodejs
 - ntp
-- oracle-java8-installer
-- oracle-java8-set-default
 - postgresql-9.3
 - pv
 - python2.7-dev
@@ -141,6 +139,15 @@ output:
 runcmd:
 - sudo -u ubuntu mv /home/ubuntu/.ssh/authorized_keys /home/ubuntu/.ssh/authorized_keys2
 - sudo -u ubuntu aws s3 cp --region=us-west-2 %(S3_AUTH_KEYS)s /home/ubuntu/.ssh/authorized_keys
+# Manually install java
+- sudo -u ubuntu aws s3 cp --region=us-west-2 --recursive s3://encoded-conf-prod/.aws ~ubuntu/.aws
+- sudo mkdir -p /usr/lib/jvm
+- sudo chmod 777 /usr/lib/jvm
+- sudo tar -xzvf /home/ubuntu/.aws/jdk-8u211-linux-x64.tar.gz --directory /usr/lib/jvm/
+- sudo -u ubuntu rm -r /home/ubuntu/.aws
+- sudo chmod 755 /usr/lib/jvm
+- sudo update-alternatives --install /usr/bin/java java /usr/lib/jvm/jdk1.8.0_211/bin/java 100
+# Manually install java
 - cp /etc/redis/redis.conf /etc/redis/redis.conf.default
 - sed -i -e 's/port 6379/port %(REDIS_PORT)s/' /etc/redis/redis.conf
 - sed -i -e 's/bind 127\.0\.0\.1/bind 0\.0\.0\.0/' /etc/redis/redis.conf


### PR DESCRIPTION
Temporary change that downloads java 8 211 from our aws prod s3 bucket and manually installs. Java 8 is behind a user login and we need to update to java 11, since 9/10 are not major releases.