### PR TITLE
ENCD-4619 add experiment_classification to data insert

### DIFF
--- a/src/encoded/tests/data/inserts/experiment.json
+++ b/src/encoded/tests/data/inserts/experiment.json
@@ -826,6 +826,7 @@
         "date_released": "2015-08-31",
         "accession": "ENCSR123MRN",
         "uuid": "e828ec88-8f74-437f-8bf7-8535ee34819e",
+        "experiment_classification": ["functional genomics assay"]
     },
     {
         "_test": "CRISPR screen test",


### PR DESCRIPTION
From ENCD-4558, a merge conflict wasn't handled correctly. This fixes it by adding back a required property to an insert.