### PR TITLE
Fix CORB warning in Chrome. OPTIONS should return 204 No Content.

### DIFF
--- a/etc/encoded-apache.conf
+++ b/etc/encoded-apache.conf
@@ -76,7 +76,7 @@ WSGIScriptAlias / /srv/encoded/parts/production/wsgi process-group=encoded appli
 
     # CORS preflight
     RewriteCond %{REQUEST_METHOD} OPTIONS
-    RewriteRule ^ - [redirect=200,last]
+    RewriteRule ^ - [redirect=204,last]
 </Directory>
 
 # Serve static resources directly from Apache


### PR DESCRIPTION
Was seeing CORB warnings when making CORS requests because the CORS preflight OPTIONS request was returning data. Switching to a 204 No Content response fixes it.