### PR TITLE
ENCD-4657-add-s3-uri-to-metadata

### DIFF
--- a/src/encoded/batch_download.py
+++ b/src/encoded/batch_download.py
@@ -431,7 +431,7 @@ def metadata_tsv(context, request):
                 data_row.extend(audit_info)
                 rows.append(data_row)
     fout = io.StringIO()
-    writer = csv.writer(fout, delimiter='\t')
+    writer = csv.writer(fout, delimiter='\t', lineterminator='\n')
     header.extend([prop for prop in _audit_mapping])
     writer.writerow(header)
     writer.writerows(rows)

--- a/src/encoded/batch_download.py
+++ b/src/encoded/batch_download.py
@@ -49,7 +49,7 @@ _tsv_mapping = OrderedDict([
     ('Biosample genetic modifications methods', ['replicates.library.biosample.applied_modifications.method']),
     ('Biosample genetic modifications categories', ['replicates.library.biosample.applied_modifications.category']),                                   
     ('Biosample genetic modifications targets', ['replicates.library.biosample.applied_modifications.modified_site_by_target_id']),                                   
-    ('Biosample genetic modifications gene targets', ['replicates.library.biosample.applied_modifications.modified_site_by_gene_id']),                                   
+    ('Biosample genetic modifications geexne targets', ['replicates.library.biosample.applied_modifications.modified_site_by_gene_id']),                                   
     ('Biosample genetic modifications site coordinates', ['replicates.library.biosample.applied_modifications.modified_site_by_coordinates.assembly',
                                                           'replicates.library.biosample.applied_modifications.modified_site_by_coordinates.chromosome',
                                                           'replicates.library.biosample.applied_modifications.modified_site_by_coordinates.start',
@@ -86,7 +86,8 @@ _tsv_mapping = OrderedDict([
     ('Controlled by', ['files.controlled_by']),
     ('File Status', ['files.status']),
     ('No File Available', ['files.no_file_available']),
-    ('Restricted', ['files.restricted'])
+    ('Restricted', ['files.restricted']),
+    ('s3_uri', ['files.s3_uri']),
 ])
 
 _audit_mapping = OrderedDict([

--- a/src/encoded/batch_download.py
+++ b/src/encoded/batch_download.py
@@ -49,7 +49,7 @@ _tsv_mapping = OrderedDict([
     ('Biosample genetic modifications methods', ['replicates.library.biosample.applied_modifications.method']),
     ('Biosample genetic modifications categories', ['replicates.library.biosample.applied_modifications.category']),                                   
     ('Biosample genetic modifications targets', ['replicates.library.biosample.applied_modifications.modified_site_by_target_id']),                                   
-    ('Biosample genetic modifications geexne targets', ['replicates.library.biosample.applied_modifications.modified_site_by_gene_id']),                                   
+    ('Biosample genetic modifications gene targets', ['replicates.library.biosample.applied_modifications.modified_site_by_gene_id']),                                   
     ('Biosample genetic modifications site coordinates', ['replicates.library.biosample.applied_modifications.modified_site_by_coordinates.assembly',
                                                           'replicates.library.biosample.applied_modifications.modified_site_by_coordinates.chromosome',
                                                           'replicates.library.biosample.applied_modifications.modified_site_by_coordinates.start',

--- a/src/encoded/tests/test_batch_download.py
+++ b/src/encoded/tests/test_batch_download.py
@@ -1,10 +1,6 @@
 # Use workbook fixture from BDD tests (including elasticsearch)
 import json
 import pytest
-from moto import (
-    mock_s3,
-    mock_sts
-)
 from encoded.tests.features.conftest import app
 from encoded.tests.features.conftest import app_settings
 from encoded.tests.features.conftest import workbook
@@ -20,22 +16,6 @@ exp_file_1 = {'file_type': 'fastq',
 exp_file_2 = {'file_type': 'bam',
               'restricted': False}
 exp_file_3 = {'file_type': 'gz'}
-
-
-@pytest.fixture
-def uploading_file(testapp, award, experiment, lab, replicate, dummy_request):
-    item = {
-        'award': award['@id'],
-        'dataset': experiment['@id'],
-        'lab': lab['@id'],
-        'replicate': replicate['@id'],
-        'file_format': 'tsv',
-        'file_size': 2534535,
-        'md5sum': '00000000000000000000000000000000',
-        'output_type': 'raw data',
-        'status': 'uploading',
-    }
-    return item
 
 
 @pytest.fixture


### PR DESCRIPTION
Adds s3_uri to metadata and tests header fields and actual report generated from ES. 