### PR TITLE
ENCD-4656 Fix BDD Travis CI test failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,6 +80,7 @@ script:
         --browser-arg tunnel-identifier "$TRAVIS_JOB_NUMBER" \
         --browser-arg-int build  "$TRAVIS_BUILD_NUMBER" \
         --browser-arg-int idleTimeout 300 \
+        --browser-arg-int maxDuration 3000 \
         --browser-arg name "$TRAVIS_REPO_SLUG $TRAVIS_BRANCH $TRAVIS_COMMIT" \
         --browser-arg browser "$BROWSER" \
         --browser-arg platform "Linux"

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,3 +5,4 @@ addopts =
     --instafail
     --splinter-make-screenshot-on-failure=false
     --splinter-implicit-wait=5
+    --assert=plain

--- a/src/encoded/tests/features/forms.feature
+++ b/src/encoded/tests/features/forms.feature
@@ -7,16 +7,17 @@ Feature: Edit forms
         And I click the element with the css selector ".icon-gear"
         And I click the link to "/antibodies/ENCAB728YTO/#!edit"
         And I wait for the content to load
-        And I wait for 5 seconds
+        And I wait for 20 seconds
         Then I should see an element with the css selector "form.rf-Form"
         When I fill in "antigen_description" with "It's not a very nice antigen"
         And I press "save"
+        And I wait for 30 seconds
         And I wait for the content to load
         Then I should see "It's not a very nice antigen"
 
     Scenario: Leaving a dirty form without saving asks for confirmation
         When I visit "/antibodies/ENCAB728YTO/#!edit"
-        And I wait for 5 seconds
+        And I wait for 20 seconds
         And I fill in "antigen_description" with "It's not a very nice antigen"
         And I click the link with text "ENCODE"
         And I dismiss the alert
@@ -24,14 +25,14 @@ Feature: Edit forms
         # Make sure we don't leave a dirty form that will interfere with subsequent tests
         When I click the link with text "ENCODE"
         And I accept the alert
-        And I wait for 5 seconds
+        And I wait for 20 seconds
 
     Scenario: Validation errors are shown in context
         When I visit "/antibodies/ENCAB728YTO/#!edit"
         And I wait for an element with the css selector "form.rf-Form" to load
         And I fill in "date_created" with "bogus"
         And I wait for an element with the css selector ".rf-Message + input[name=date_created]" to load
-        Then I should see "is not any of" within 2 seconds
+        Then I should see "is not any of" within 5 seconds
         # Make sure we don't leave a dirty form that will interfere with subsequent tests
         When I click the link with text "ENCODE"
         And I accept the alert

--- a/src/encoded/tests/features/page.feature
+++ b/src/encoded/tests/features/page.feature
@@ -15,10 +15,12 @@ Feature: Portal pages
         When I visit "/pages/"
         And I wait for the content to load
         And I press "Add"
+        And I wait for 20 seconds
         And I wait for the form to fully load
         And I fill in "name" with "test"
         And I fill in "title" with "Test"
         And I press "Save"
+        And I wait for 30 seconds
         And I wait for the content to load
         Then the browser's URL should contain "/test/"
         And the title should contain the text "Test"


### PR DESCRIPTION
Mostly adding longer delays to common problem areas. Earlier changes to Travis delay mechanisms didn’t seem to help. Successful BDD tests now take 30 minutes. Also includes an attempt to fix the “test failed, but when we reran the test to collect info, it passed” kinds of failures. Will only know if this fix helps as we move forward.