### PR TITLE
ENCD-4668 Update moment parsing string

### DIFF
--- a/src/encoded/static/components/news.js
+++ b/src/encoded/static/components/news.js
@@ -242,7 +242,7 @@ const DateFacet = (props) => {
                         <li key={term.key} className="news-facet__item">
                             <a href={termHref} className={termFilter ? 'selected' : ''}>
                                 <span className="news-facet__item-title">
-                                    {moment(term.key).format('MMMM YYYY')}&nbsp;
+                                    {moment(term.key, ['MMMM, YYYY', 'YYYY-MM']).format('MMMM YYYY')}&nbsp;
                                 </span>
                                 <span className="news-facet__item-count">
                                     ({term.doc_count})


### PR DESCRIPTION
For some reason I had an incorrect moment() parsing string, and for some reason that now causes this problem, as well as a deprecation warning in the console. This one fix gets rid of the “Invalid date” facet terms as well as the console warning.