### PR TITLE
ENCD-4062 Fix read name details dependency

### DIFF
--- a/src/encoded/schemas/file.json
+++ b/src/encoded/schemas/file.json
@@ -200,8 +200,8 @@
                 }
             }
         },
-        "readname_details": {
-            "comment": "Only fastq files can have readname_details specified.",
+        "read_name_details": {
+            "comment": "Only fastq files can have read_name_details specified.",
             "properties": {
                 "file_format": {
                     "enum": ["fastq"]
@@ -980,7 +980,7 @@
             ]
         },
         "read_name_details": {
-            "title": "Fastq readname details",
+            "title": "Fastq read name details",
             "description": "For high-throughput sequencing FASTQ files, details of the read name structure",
             "comment":"Zero-based position of flowcell, lane, etc. information within FASTQ read names splitted using space and : as delimiters",
             "type": "object",
@@ -990,28 +990,28 @@
                 "flowcell_id_location": {
                     "title": "Flowcell identifier location",
                     "description": "Location of the flowcell identifier in the read name",
-                    "comment": "Zero-based location of the flowcell identifier in the readname, if you split read name using space and : as delimiters",
+                    "comment": "Zero-based location of the flowcell identifier in the read name, if you split read name using space and : as delimiters",
                     "type": "integer",
                     "minimum": 0
                 },
                 "lane_id_location": {
                     "title": "Lane identifier location",
                     "description": "Location of the lane identifier in the read name",
-                    "comment": "Zero-based location of the lane identifier in the readname, if you split the read name using space and : as delimiters",
+                    "comment": "Zero-based location of the lane identifier in the read name, if you split the read name using space and : as delimiters",
                     "type": "integer",
                     "minimum": 0
                 },
                 "read_number_location": {
                     "title": "Read number (1 or 2) identifier location",
                     "description": "Location of the read number in the read name",
-                    "comment": "Zero-based location of the read number in the readname, if you split the read name using space and : as delimiters",
+                    "comment": "Zero-based location of the read number in the read name, if you split the read name using space and : as delimiters",
                     "type": "integer",
                     "minimum": 0
                 },
                 "barcode_location": {
                     "title": "Barcode location",
                     "description": "Location of the barcode in the read name",
-                    "comment": "Zero-based location of the barcode in the readname, if you split the read name using space and : as delimiters",
+                    "comment": "Zero-based location of the barcode in the read name, if you split the read name using space and : as delimiters",
                     "type": "integer",
                     "minimum": 0
                 }

--- a/src/encoded/tests/test_schema_file.py
+++ b/src/encoded/tests/test_schema_file.py
@@ -273,6 +273,24 @@ def file_database_output_type(testapp, experiment, award, lab, replicate):
     return item
 
 
+@pytest.fixture
+def file_good_bam(testapp, experiment, award, lab, replicate, platform1):
+    item = {
+        'dataset': experiment['@id'],
+        'replicate': replicate['@id'],
+        'lab': lab['@id'],
+        'file_size': 345,
+        'platform': platform1['@id'],
+        'award': award['@id'],
+        'assembly': 'GRCh38',
+        'file_format': 'bam',
+        'output_type': 'alignments',
+        'md5sum': '136e501c4bacf4fab87debab20d76648',
+        'status': 'in progress'
+    }
+    return item
+
+
 def test_file_post(file_no_replicate):
     assert file_no_replicate['biological_replicates'] == []
 
@@ -420,7 +438,7 @@ def test_revoke_detail(testapp, file_with_bad_revoke_detail):
     assert res.status_code == 201
 
 
-def test_read_name_details(testapp, file_no_error):
+def test_read_name_details(testapp, file_no_error, file_good_bam):
     file = testapp.post_json('/file', file_no_error).json['@graph'][0]
     testapp.patch_json(
         file['@id'], {'read_name_details': {
@@ -428,8 +446,12 @@ def test_read_name_details(testapp, file_no_error):
             'barcode_location': 5}
         },
         status=200)
+    file = testapp.post_json('/file', file_good_bam).json['@graph'][0]
     testapp.patch_json(
-        file['@id'], {'file_format': 'bam'},
+        file['@id'], {'read_name_details': {
+            'flowcell_id_location': 2,
+            'barcode_location': 5}
+        },
         status=422)
 
 


### PR DESCRIPTION
Fixed the dependency making read_name_details available only if file_format = fastq.