### PR TITLE
ENCD-3567 Upgrade React JS to current version

### DIFF
--- a/jest/environment.js
+++ b/jest/environment.js
@@ -1,19 +1,4 @@
-'use strict';
-jest.mock('scriptjs');
-var jsdom = require('jsdom').jsdom;
+import { configure } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
 
-if (window.DOMParser === undefined) {
-    // jsdom
-    window.DOMParser = function DOMParser() {};
-    window.DOMParser.prototype.parseFromString = function parseFromString(markup, type) {
-        var parsingMode = 'auto';
-        type = type || '';
-        if (type.indexOf('xml') >= 0) {
-            parsingMode = 'xml';
-        } else if (type.indexOf('html') >= 0) {
-            parsingMode = 'html';
-        }
-        var doc = jsdom(markup, {parsingMode: parsingMode});
-        return doc;
-    };
-}
+configure({ adapter: new Adapter() });

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,12 @@
         "regenerator-runtime": "^0.12.0"
       }
     },
+    "@types/node": {
+      "version": "12.0.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.4.tgz",
+      "integrity": "sha512-j8YL2C0fXq7IONwl/Ud5Kt0PeXw22zGERt+HSSnwbKOJVsAGkEz3sFCYwaF9IOuoG1HOtE0vKCj6sXF7Q0+Vaw==",
+      "dev": true
+    },
     "abab": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
@@ -60,6 +66,32 @@
           "version": "3.3.0",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
           "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+          "dev": true
+        }
+      }
+    },
+    "airbnb-prop-types": {
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/airbnb-prop-types/-/airbnb-prop-types-2.13.2.tgz",
+      "integrity": "sha512-2FN6DlHr6JCSxPPi25EnqGaXC4OC3/B3k1lCd6MMYrZ51/Gf/1qDfaR+JElzWa+Tl7cY2aYOlsYJGFeQyVHIeQ==",
+      "dev": true,
+      "requires": {
+        "array.prototype.find": "^2.0.4",
+        "function.prototype.name": "^1.1.0",
+        "has": "^1.0.3",
+        "is-regex": "^1.0.4",
+        "object-is": "^1.0.1",
+        "object.assign": "^4.1.0",
+        "object.entries": "^1.1.0",
+        "prop-types": "^15.7.2",
+        "prop-types-exact": "^1.2.0",
+        "react-is": "^16.8.6"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "16.8.6",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
+          "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==",
           "dev": true
         }
       }
@@ -237,6 +269,12 @@
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
       "dev": true
     },
+    "array-filter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-1.0.0.tgz",
+      "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM=",
+      "dev": true
+    },
     "array-find-index": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
@@ -270,6 +308,27 @@
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
       "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
       "dev": true
+    },
+    "array.prototype.find": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.1.0.tgz",
+      "integrity": "sha512-Wn41+K1yuO5p7wRZDl7890c3xvv5UBrfVXTVIe28rSQb6LS0fZMDrQB6PAcxQFRFy6vJTLDc3A2+3CjQdzVKRg==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.13.0"
+      }
+    },
+    "array.prototype.flat": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.1.tgz",
+      "integrity": "sha512-rVqIs330nLJvfC7JqYvEWwqVr5QjYF1ib02i3YJtR/fICO6527Tjpc/e4Mvmxh3GIePPreRXMdaGyC99YphWEw==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.10.0",
+        "function-bind": "^1.1.1"
+      }
     },
     "arrify": {
       "version": "1.0.1",
@@ -403,6 +462,63 @@
         "react-transition-group": "^2.2.1",
         "trim": "0.0.1",
         "url-join": "^1.1.0"
+      },
+      "dependencies": {
+        "react": {
+          "version": "15.6.2",
+          "resolved": "https://registry.npmjs.org/react/-/react-15.6.2.tgz",
+          "integrity": "sha1-26BDSrQ5z+gvEI8PURZjkIF5qnI=",
+          "requires": {
+            "create-react-class": "^15.6.0",
+            "fbjs": "^0.8.9",
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.0",
+            "prop-types": "^15.5.10"
+          },
+          "dependencies": {
+            "fbjs": {
+              "version": "0.8.17",
+              "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
+              "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
+              "requires": {
+                "core-js": "^1.0.0",
+                "isomorphic-fetch": "^2.1.1",
+                "loose-envify": "^1.0.0",
+                "object-assign": "^4.1.0",
+                "promise": "^7.1.1",
+                "setimmediate": "^1.0.5",
+                "ua-parser-js": "^0.7.18"
+              }
+            }
+          }
+        },
+        "react-dom": {
+          "version": "15.6.2",
+          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.6.2.tgz",
+          "integrity": "sha1-Qc+t9pO3V/rycIRDodH9WgK+9zA=",
+          "requires": {
+            "fbjs": "^0.8.9",
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.0",
+            "prop-types": "^15.5.10"
+          },
+          "dependencies": {
+            "fbjs": {
+              "version": "0.8.17",
+              "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
+              "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
+              "requires": {
+                "core-js": "^1.0.0",
+                "isomorphic-fetch": "^2.1.1",
+                "loose-envify": "^1.0.0",
+                "object-assign": "^4.1.0",
+                "promise": "^7.1.1",
+                "setimmediate": "^1.0.5",
+                "ua-parser-js": "^0.7.18"
+              }
+            }
+          }
+        }
       }
     },
     "auth0-password-policies": {
@@ -1612,27 +1728,28 @@
       }
     },
     "cheerio": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
-      "integrity": "sha1-qbqoYKP5tZWmuBsahocxIe06Jp4=",
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.3.tgz",
+      "integrity": "sha512-0td5ijfUPuubwLUu0OBoe98gZj8C/AA+RW3v67GPlGOrvxWjZmBXiBCRU+I8VEiNyJzjth40POfHiz2RB3gImA==",
       "dev": true,
       "requires": {
         "css-select": "~1.2.0",
-        "dom-serializer": "~0.1.0",
+        "dom-serializer": "~0.1.1",
         "entities": "~1.1.1",
         "htmlparser2": "^3.9.1",
-        "lodash.assignin": "^4.0.9",
-        "lodash.bind": "^4.1.4",
-        "lodash.defaults": "^4.0.1",
-        "lodash.filter": "^4.4.0",
-        "lodash.flatten": "^4.2.0",
-        "lodash.foreach": "^4.3.0",
-        "lodash.map": "^4.4.0",
-        "lodash.merge": "^4.4.0",
-        "lodash.pick": "^4.2.1",
-        "lodash.reduce": "^4.4.0",
-        "lodash.reject": "^4.4.0",
-        "lodash.some": "^4.4.0"
+        "lodash": "^4.15.0",
+        "parse5": "^3.0.1"
+      },
+      "dependencies": {
+        "parse5": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
+          "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*"
+          }
+        }
       }
     },
     "chokidar": {
@@ -1788,6 +1905,7 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
       "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
+      "dev": true,
       "requires": {
         "color-name": "^1.0.0"
       }
@@ -2098,9 +2216,9 @@
       }
     },
     "css-what": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.2.tgz",
-      "integrity": "sha512-wan8dMWQ0GUeF7DGEPVjhHemVW/vy6xUYmFzRY8RYqgA0JtXC9rJmbScBjqSu6dg9q0lwPQy6ZAmJVr3PPTvqQ==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
+      "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==",
       "dev": true
     },
     "cssesc": {
@@ -2424,6 +2542,12 @@
       "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
       "dev": true
     },
+    "discontinuous-range": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+      "integrity": "sha1-44Mx8IRLukm5qctxx3FYWqsbxlo=",
+      "dev": true
+    },
     "doctrine": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
@@ -2442,21 +2566,13 @@
       }
     },
     "dom-serializer": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
-      "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
+      "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
       "dev": true,
       "requires": {
-        "domelementtype": "~1.1.1",
-        "entities": "~1.1.1"
-      },
-      "dependencies": {
-        "domelementtype": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
-          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
-          "dev": true
-        }
+        "domelementtype": "^1.3.0",
+        "entities": "^1.1.1"
       }
     },
     "domain-browser": {
@@ -2612,21 +2728,90 @@
       "dev": true
     },
     "enzyme": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-2.9.1.tgz",
-      "integrity": "sha1-B9XOaRJBJA+4F78sSxjW5TAkDfY=",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.10.0.tgz",
+      "integrity": "sha512-p2yy9Y7t/PFbPoTvrWde7JIYB2ZyGC+NgTNbVEGvZ5/EyoYSr9aG/2rSbVvyNvMHEhw9/dmGUJHWtfQIEiX9pg==",
       "dev": true,
       "requires": {
-        "cheerio": "^0.22.0",
-        "function.prototype.name": "^1.0.0",
+        "array.prototype.flat": "^1.2.1",
+        "cheerio": "^1.0.0-rc.2",
+        "function.prototype.name": "^1.1.0",
+        "has": "^1.0.3",
+        "html-element-map": "^1.0.0",
+        "is-boolean-object": "^1.0.0",
+        "is-callable": "^1.1.4",
+        "is-number-object": "^1.0.3",
+        "is-regex": "^1.0.4",
+        "is-string": "^1.0.4",
         "is-subset": "^0.1.1",
-        "lodash": "^4.17.4",
+        "lodash.escape": "^4.0.1",
+        "lodash.isequal": "^4.5.0",
+        "object-inspect": "^1.6.0",
         "object-is": "^1.0.1",
-        "object.assign": "^4.0.4",
+        "object.assign": "^4.1.0",
         "object.entries": "^1.0.4",
         "object.values": "^1.0.4",
-        "prop-types": "^15.5.10",
-        "uuid": "^3.0.1"
+        "raf": "^3.4.0",
+        "rst-selector-parser": "^2.2.3",
+        "string.prototype.trim": "^1.1.2"
+      },
+      "dependencies": {
+        "lodash.escape": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
+          "integrity": "sha1-yQRGkMIeBClL6qUXcS/e0fqI3pg=",
+          "dev": true
+        },
+        "lodash.isequal": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+          "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
+          "dev": true
+        }
+      }
+    },
+    "enzyme-adapter-react-16": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.14.0.tgz",
+      "integrity": "sha512-7PcOF7pb4hJUvjY7oAuPGpq3BmlCig3kxXGi2kFx0YzJHppqX1K8IIV9skT1IirxXlu8W7bneKi+oQ10QRnhcA==",
+      "dev": true,
+      "requires": {
+        "enzyme-adapter-utils": "^1.12.0",
+        "has": "^1.0.3",
+        "object.assign": "^4.1.0",
+        "object.values": "^1.1.0",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.6",
+        "react-test-renderer": "^16.0.0-0",
+        "semver": "^5.7.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "16.8.6",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
+          "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        }
+      }
+    },
+    "enzyme-adapter-utils": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.12.0.tgz",
+      "integrity": "sha512-wkZvE0VxcFx/8ZsBw0iAbk3gR1d9hK447ebnSYBf95+r32ezBq+XDSAvRErkc4LZosgH8J7et7H7/7CtUuQfBA==",
+      "dev": true,
+      "requires": {
+        "airbnb-prop-types": "^2.13.2",
+        "function.prototype.name": "^1.1.0",
+        "object.assign": "^4.1.0",
+        "object.fromentries": "^2.0.0",
+        "prop-types": "^15.7.2",
+        "semver": "^5.6.0"
       }
     },
     "enzyme-matchers": {
@@ -3846,24 +4031,28 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "aproba": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+          "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3873,12 +4062,14 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -3887,34 +4078,40 @@
         },
         "chownr": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+          "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
           "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true,
           "optional": true
         },
         "debug": {
           "version": "2.6.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3923,25 +4120,29 @@
         },
         "deep-extend": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
+          "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
           "dev": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+          "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "dev": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+          "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3950,13 +4151,15 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3972,7 +4175,8 @@
         },
         "glob": {
           "version": "7.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3986,13 +4190,15 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true,
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.21",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
+          "integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -4001,7 +4207,8 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+          "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -4010,7 +4217,8 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -4020,18 +4228,21 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
         "ini": {
           "version": "1.3.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
             "number-is-nan": "^1.0.0"
@@ -4039,13 +4250,15 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -4053,12 +4266,14 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         },
         "minipass": {
           "version": "2.2.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
+          "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "dev": true,
           "requires": {
             "safe-buffer": "^5.1.1",
@@ -4067,7 +4282,8 @@
         },
         "minizlib": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
+          "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -4076,7 +4292,8 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "requires": {
             "minimist": "0.0.8"
@@ -4084,13 +4301,15 @@
         },
         "ms": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true,
           "optional": true
         },
         "needle": {
           "version": "2.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.0.tgz",
+          "integrity": "sha512-eFagy6c+TYayorXw/qtAdSvaUpEbBsDwDyxYFgLZ0lTojfH7K+OdBqAF7TAFwDokJaGpubpSGG0wO3iC0XPi8w==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -4101,7 +4320,8 @@
         },
         "node-pre-gyp": {
           "version": "0.10.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.10.0.tgz",
+          "integrity": "sha512-G7kEonQLRbcA/mOoFoxvlMrw6Q6dPf92+t/l0DFSMuSlDoWaI9JWIyPwK0jyE1bph//CUEL65/Fz1m2vJbmjQQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -4119,7 +4339,8 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -4129,13 +4350,15 @@
         },
         "npm-bundled": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.3.tgz",
+          "integrity": "sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow==",
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.1.10",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.10.tgz",
+          "integrity": "sha512-AQC0Dyhzn4EiYEfIUjCdMl0JJ61I2ER9ukf/sLxJUcZHfo+VyEfz2rMJgLZSS1v30OxPQe1cN0LZA1xbcaVfWA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -4145,7 +4368,8 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -4157,18 +4381,21 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
             "wrappy": "1"
@@ -4176,19 +4403,22 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -4198,19 +4428,22 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.7",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.7.tgz",
+          "integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -4222,7 +4455,8 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true,
               "optional": true
             }
@@ -4230,7 +4464,8 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -4245,7 +4480,8 @@
         },
         "rimraf": {
           "version": "2.6.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+          "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -4254,42 +4490,49 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
           "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "dev": true,
           "optional": true
         },
         "semver": {
           "version": "5.5.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true,
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
             "code-point-at": "^1.0.0",
@@ -4299,7 +4542,8 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -4308,7 +4552,8 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -4316,13 +4561,15 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true,
           "optional": true
         },
         "tar": {
           "version": "4.4.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.1.tgz",
+          "integrity": "sha512-O+v1r9yN4tOsvl90p5HAP4AEqbYhx4036AGMm075fH9F8Qwi3oJ+v4u50FkT/KkvywNGtwkk0zRI+8eYm1X/xg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -4337,13 +4584,15 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+          "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -4352,12 +4601,14 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
+          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
           "dev": true
         }
       }
@@ -4979,6 +5230,15 @@
       "integrity": "sha512-P+M65QY2JQ5Y0G9KKdlDpo0zK+/OHptU5AaBwUfAIDJZk1MYf32Frm84EcOytfJE0t5JvkAnKlmjsXDnWzCJmQ==",
       "dev": true
     },
+    "html-element-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/html-element-map/-/html-element-map-1.0.1.tgz",
+      "integrity": "sha512-BZSfdEm6n706/lBfXKWa4frZRZcT5k1cOusw95ijZsHlI+GdgY0v95h6IzO3iIDf2ROwq570YTwqNPqHcNMozw==",
+      "dev": true,
+      "requires": {
+        "array-filter": "^1.0.0"
+      }
+    },
     "html-encoding-sniffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
@@ -4989,23 +5249,23 @@
       }
     },
     "htmlparser2": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.0.tgz",
-      "integrity": "sha512-J1nEUGv+MkXS0weHNWVKJJ+UrLfePxRWpN3C9bEi9fLxL2+ggW94DQvgYVXsaT30PGwYRIZKNZXuyMhp3Di4bQ==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
+      "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
       "dev": true,
       "requires": {
-        "domelementtype": "^1.3.0",
+        "domelementtype": "^1.3.1",
         "domhandler": "^2.3.0",
         "domutils": "^1.5.1",
         "entities": "^1.1.1",
         "inherits": "^2.0.1",
-        "readable-stream": "^3.0.6"
+        "readable-stream": "^3.1.1"
       },
       "dependencies": {
         "readable-stream": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.1.1.tgz",
-          "integrity": "sha512-DkN66hPyqDhnIQ6Jcsvx9bFjhw214O4poMBcIMgPVpQvNy9a0e0Uhg5SqySyDKAmUlwt8LonTBz1ezOnM8pUdA==",
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -5294,6 +5554,12 @@
         "binary-extensions": "^1.0.0"
       }
     },
+    "is-boolean-object": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.0.0.tgz",
+      "integrity": "sha1-mPiygDBoQhmpXzdc+9iM40Bd/5M=",
+      "dev": true
+    },
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
@@ -5421,6 +5687,12 @@
         "kind-of": "^3.0.2"
       }
     },
+    "is-number-object": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.3.tgz",
+      "integrity": "sha1-8mWrian0RQNO9q/xWo8AsA9VF5k=",
+      "dev": true
+    },
     "is-plain-obj": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
@@ -5490,6 +5762,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
+    "is-string": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.4.tgz",
+      "integrity": "sha1-zDqbaYV9Yh6WNyWiTK7shzuCbmQ=",
+      "dev": true
     },
     "is-subset": {
       "version": "0.1.1",
@@ -6541,18 +6819,6 @@
       "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
       "dev": true
     },
-    "lodash.assignin": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.assignin/-/lodash.assignin-4.2.0.tgz",
-      "integrity": "sha1-uo31+4QesKPoBEIysOJjqNxqKKI=",
-      "dev": true
-    },
-    "lodash.bind": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-4.2.1.tgz",
-      "integrity": "sha1-euMBfpOWIqwxt9fX3LGzTbFpDTU=",
-      "dev": true
-    },
     "lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
@@ -6565,12 +6831,6 @@
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
       "dev": true
     },
-    "lodash.defaults": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-      "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=",
-      "dev": true
-    },
     "lodash.escape": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
@@ -6580,22 +6840,10 @@
         "lodash._root": "^3.0.0"
       }
     },
-    "lodash.filter": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
-      "integrity": "sha1-ZosdSYFgOuHMWm+nYBQ+SAtMSs4=",
-      "dev": true
-    },
-    "lodash.flatten": {
+    "lodash.flattendeep": {
       "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
-      "dev": true
-    },
-    "lodash.foreach": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
-      "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM=",
+      "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+      "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
       "dev": true
     },
     "lodash.isarguments": {
@@ -6643,22 +6891,10 @@
         "lodash.isarray": "^3.0.0"
       }
     },
-    "lodash.map": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
-      "integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM=",
-      "dev": true
-    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
-      "dev": true
-    },
-    "lodash.merge": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
-      "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ==",
       "dev": true
     },
     "lodash.mergewith": {
@@ -6667,34 +6903,10 @@
       "integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ==",
       "dev": true
     },
-    "lodash.pick": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
-      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=",
-      "dev": true
-    },
-    "lodash.reduce": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.reduce/-/lodash.reduce-4.6.0.tgz",
-      "integrity": "sha1-8atrg5KZrUj3hKu/R2WW8DuRTTs=",
-      "dev": true
-    },
-    "lodash.reject": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.reject/-/lodash.reject-4.6.0.tgz",
-      "integrity": "sha1-gNZJLcFHCGS79YNTO2UfQqn1JBU=",
-      "dev": true
-    },
     "lodash.restparam": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
       "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
-      "dev": true
-    },
-    "lodash.some": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
-      "integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0=",
       "dev": true
     },
     "lodash.template": {
@@ -6970,6 +7182,12 @@
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.23.0.tgz",
       "integrity": "sha512-3IE39bHVqFbWWaPOMHZF98Q9c3LDKGTmypMiTM2QygGXXElkFWIH7GxfmlwmY2vwa+wmNsoYZmG2iusf1ZjJoA=="
     },
+    "moo": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/moo/-/moo-0.4.3.tgz",
+      "integrity": "sha512-gFD2xGCl8YFgGHsqJ9NKRVdwlioeW3mI1iqfLNYQOv0+6JRwG58Zk9DIGQgyIaffSYaO1xsKnMaYzzNr1KyIAw==",
+      "dev": true
+    },
     "ms": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
@@ -7046,6 +7264,19 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "nearley": {
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.16.0.tgz",
+      "integrity": "sha512-Tr9XD3Vt/EujXbZBv6UAHYoLUSMQAxSsTnm9K3koXzjzNWY195NqALeyrzLZBKzAkL3gl92BcSogqrHjD8QuUg==",
+      "dev": true,
+      "requires": {
+        "commander": "^2.19.0",
+        "moo": "^0.4.3",
+        "railroad-diagrams": "^1.0.0",
+        "randexp": "0.4.6",
+        "semver": "^5.4.1"
+      }
     },
     "node-fetch": {
       "version": "1.7.3",
@@ -7293,6 +7524,12 @@
           }
         }
       }
+    },
+    "object-inspect": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
+      "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==",
+      "dev": true
     },
     "object-is": {
       "version": "1.0.1",
@@ -8479,12 +8716,31 @@
       }
     },
     "prop-types": {
-      "version": "15.6.2",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
-      "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
       "requires": {
-        "loose-envify": "^1.3.1",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.8.1"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "16.8.6",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
+          "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA=="
+        }
+      }
+    },
+    "prop-types-exact": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/prop-types-exact/-/prop-types-exact-1.2.0.tgz",
+      "integrity": "sha512-K+Tk3Kd9V0odiXFP9fwDHUYRyvK3Nun3GVyPapSIs5OBkITAm15W0CPFD/YKTkMUAbc0b9CUwRQp2ybiBIq+eA==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3",
+        "object.assign": "^4.1.0",
+        "reflect.ownkeys": "^0.2.0"
       }
     },
     "prr": {
@@ -8543,10 +8799,35 @@
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
       "dev": true
     },
+    "raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "dev": true,
+      "requires": {
+        "performance-now": "^2.1.0"
+      }
+    },
+    "railroad-diagrams": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+      "integrity": "sha1-635iZ1SN3t+4mcG5Dlc3RVnN234=",
+      "dev": true
+    },
     "ramda": {
       "version": "0.21.0",
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.21.0.tgz",
       "integrity": "sha1-oAGr7bP/YQd9T/HVd9RN536NCjU="
+    },
+    "randexp": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+      "dev": true,
+      "requires": {
+        "discontinuous-range": "1.0.0",
+        "ret": "~0.1.10"
+      }
     },
     "randomatic": {
       "version": "3.1.1",
@@ -8574,64 +8855,25 @@
       }
     },
     "react": {
-      "version": "15.6.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-15.6.2.tgz",
-      "integrity": "sha1-26BDSrQ5z+gvEI8PURZjkIF5qnI=",
+      "version": "16.8.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.8.6.tgz",
+      "integrity": "sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==",
       "requires": {
-        "create-react-class": "^15.6.0",
-        "fbjs": "^0.8.9",
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.0",
-        "prop-types": "^15.5.10"
-      },
-      "dependencies": {
-        "fbjs": {
-          "version": "0.8.17",
-          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
-          "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
-          "requires": {
-            "core-js": "^1.0.0",
-            "isomorphic-fetch": "^2.1.1",
-            "loose-envify": "^1.0.0",
-            "object-assign": "^4.1.0",
-            "promise": "^7.1.1",
-            "setimmediate": "^1.0.5",
-            "ua-parser-js": "^0.7.18"
-          }
-        }
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.13.6"
       }
     },
-    "react-addons-test-utils": {
-      "version": "15.6.2",
-      "resolved": "https://registry.npmjs.org/react-addons-test-utils/-/react-addons-test-utils-15.6.2.tgz",
-      "integrity": "sha1-wStu/cIkfBDae4dw0YUICnsEcVY=",
-      "dev": true
-    },
     "react-dom": {
-      "version": "15.6.2",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.6.2.tgz",
-      "integrity": "sha1-Qc+t9pO3V/rycIRDodH9WgK+9zA=",
+      "version": "16.8.6",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.6.tgz",
+      "integrity": "sha512-1nL7PIq9LTL3fthPqwkvr2zY7phIPjYrT0jp4HjyEQrEROnw4dG41VVwi/wfoCneoleqrNX7iAD+pXebJZwrwA==",
       "requires": {
-        "fbjs": "^0.8.9",
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.0",
-        "prop-types": "^15.5.10"
-      },
-      "dependencies": {
-        "fbjs": {
-          "version": "0.8.17",
-          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
-          "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
-          "requires": {
-            "core-js": "^1.0.0",
-            "isomorphic-fetch": "^2.1.1",
-            "loose-envify": "^1.0.0",
-            "object-assign": "^4.1.0",
-            "promise": "^7.1.1",
-            "setimmediate": "^1.0.5",
-            "ua-parser-js": "^0.7.18"
-          }
-        }
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.13.6"
       }
     },
     "react-is": {
@@ -8659,29 +8901,22 @@
       }
     },
     "react-test-renderer": {
-      "version": "15.6.2",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-15.6.2.tgz",
-      "integrity": "sha1-0DM0NPwsQ4CSaWyncNpe1IA376g=",
+      "version": "16.8.6",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.8.6.tgz",
+      "integrity": "sha512-H2srzU5IWYT6cZXof6AhUcx/wEyJddQ8l7cLM/F7gDXYyPr4oq+vCIxJYXVGhId1J706sqziAjuOEjyNkfgoEw==",
       "dev": true,
       "requires": {
-        "fbjs": "^0.8.9",
-        "object-assign": "^4.1.0"
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "react-is": "^16.8.6",
+        "scheduler": "^0.13.6"
       },
       "dependencies": {
-        "fbjs": {
-          "version": "0.8.17",
-          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
-          "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
-          "dev": true,
-          "requires": {
-            "core-js": "^1.0.0",
-            "isomorphic-fetch": "^2.1.1",
-            "loose-envify": "^1.0.0",
-            "object-assign": "^4.1.0",
-            "promise": "^7.1.1",
-            "setimmediate": "^1.0.5",
-            "ua-parser-js": "^0.7.18"
-          }
+        "react-is": {
+          "version": "16.8.6",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
+          "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==",
+          "dev": true
         }
       }
     },
@@ -9113,6 +9348,12 @@
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.3.0.tgz",
       "integrity": "sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw=="
     },
+    "reflect.ownkeys": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/reflect.ownkeys/-/reflect.ownkeys-0.2.0.tgz",
+      "integrity": "sha1-dJrO7H8/34tj+SegSAnpDFwLNGA=",
+      "dev": true
+    },
     "regenerate": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
@@ -9348,6 +9589,16 @@
       "integrity": "sha1-K/GYveFnys+lHAqSjoS2i74XH84=",
       "dev": true
     },
+    "rst-selector-parser": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz",
+      "integrity": "sha1-gbIw6i/MYGbInjRy3nlChdmwPZE=",
+      "dev": true,
+      "requires": {
+        "lodash.flattendeep": "^4.4.0",
+        "nearley": "^2.7.10"
+      }
+    },
     "run-async": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
@@ -9465,6 +9716,15 @@
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true
+    },
+    "scheduler": {
+      "version": "0.13.6",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.6.tgz",
+      "integrity": "sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==",
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      }
     },
     "scriptjs": {
       "version": "2.5.9",
@@ -9966,6 +10226,17 @@
         "code-point-at": "^1.0.0",
         "is-fullwidth-code-point": "^1.0.0",
         "strip-ansi": "^3.0.0"
+      }
+    },
+    "string.prototype.trim": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
+      "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.0",
+        "function-bind": "^1.0.2"
       }
     },
     "string_decoder": {

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
     ],
     "testPathIgnorePatterns": [
       ".eslintrc.js"
-    ],
-    "setupTestFrameworkScriptFile": "../../../node_modules/jest-enzyme/lib/index.js"
+    ]
   },
   "devDependencies": {
     "babel-core": "^6.21.0",
@@ -34,7 +33,8 @@
     "babel-preset-react": "^6.16.0",
     "babel-register": "^6.22.0",
     "css-loader": "^0.26.1",
-    "enzyme": "^2.8.1",
+    "enzyme": "^3.10.0",
+    "enzyme-adapter-react-16": "^1.14.0",
     "eslint": "^4.19.1",
     "eslint-config-airbnb": "^16.1.0",
     "eslint-plugin-import": "^2.10.0",
@@ -50,8 +50,6 @@
     "jsdom": "^8.4.0",
     "json-loader": "^0.5.4",
     "node-sass": "^4.11.0",
-    "react-addons-test-utils": "^15.5.1",
-    "react-test-renderer": "^15.5.4",
     "redux-mock-store": "^1.5.1",
     "sass-loader": "^4.1.1",
     "string-replace-loader": "^1.0.5",
@@ -78,10 +76,10 @@
     "marked": "^0.3.3",
     "moment": "^2.17.1",
     "pluralize": "^7.0.0",
-    "prop-types": "^15.5.6",
+    "prop-types": "^15.7.2",
     "query-string": "^4.1.0",
-    "react": "^15.5.3",
-    "react-dom": "^15.5.3",
+    "react": "^16.8.6",
+    "react-dom": "^16.8.6",
     "react-redux": "^5.0.7",
     "redux": "^3.7.2",
     "redux-thunk": "^2.3.0",

--- a/src/encoded/static/browser.js
+++ b/src/encoded/static/browser.js
@@ -53,12 +53,10 @@ if (!window.TEST_RUNNER) {
     domready(() => {
         console.log('ready');
         // Set <html> class depending on browser features
-        const BrowserFeat = require('./components/browserfeat').BrowserFeat;
-        BrowserFeat.setHtmlFeatClass();
         const props = getRenderedProps(document);
         const serverStats = require('querystring').parse(window.stats_cookie);
         recordServerStats(serverStats, 'html');
 
-        ReactDOM.render(<App {...props} />, document);
+        ReactDOM.hydrate(<App {...props} />, document);
     });
 }

--- a/src/encoded/static/components/__tests__/cart-test.js
+++ b/src/encoded/static/components/__tests__/cart-test.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import configureStore from 'redux-mock-store';
 import { Provider } from 'react-redux';
 import { mount } from 'enzyme';
@@ -282,9 +283,9 @@ describe('Cart manager while logged in as submitter', () => {
                     fetch: () => { console.log('fetch'); },
                 },
                 childContextTypes: {
-                    session_properties: React.PropTypes.object,
-                    navigate: React.PropTypes.func,
-                    fetch: React.PropTypes.func,
+                    session_properties: PropTypes.object,
+                    navigate: PropTypes.func,
+                    fetch: PropTypes.func,
                 },
             }
         );
@@ -402,9 +403,9 @@ describe('Cart manager while logged in as admin', () => {
                     fetch: () => { console.log('fetch'); },
                 },
                 childContextTypes: {
-                    session_properties: React.PropTypes.object,
-                    navigate: React.PropTypes.func,
-                    fetch: React.PropTypes.func,
+                    session_properties: PropTypes.object,
+                    navigate: PropTypes.func,
+                    fetch: PropTypes.func,
                 },
             }
         );

--- a/src/encoded/static/components/__tests__/experiment-test.js
+++ b/src/encoded/static/components/__tests__/experiment-test.js
@@ -65,7 +65,7 @@ describe('Experiment Page', () => {
         test('has proper treatment', () => {
             const item = summary.find('[data-test="treatments"]');
             const desc = item.find('dd');
-            expect(desc.text()).toEqual('97.2 nM doxycycline hyclate (CHEBI:34730) for 6 hour [1-1]');
+            expect(desc.text()).toEqual('97.2 nM doxycycline hyclate (CHEBI:34730) for 6 hours');
         });
 
         test('has proper strand specificity', () => {
@@ -77,7 +77,7 @@ describe('Experiment Page', () => {
         test('has proper spikeins', () => {
             const item = summary.find('[data-test="spikeins"]');
             const desc = item.find('dd');
-            expect(desc.text()).toEqual('ENCSR000AJW [1-1]');
+            expect(desc.text()).toEqual('ENCSR000AJW');
         });
     });
 

--- a/src/encoded/static/components/__tests__/platform-test.js
+++ b/src/encoded/static/components/__tests__/platform-test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 
 // Import test component and data.
 import Platform from '../platform';
@@ -35,12 +35,13 @@ describe('Platform', () => {
 
         beforeAll(() => {
             defDescNode = defDescs.at(2);
-            unorderedList = defDescNode.childAt(0);
+            unorderedList = defDescNode.children().childAt(0);
             listItems = unorderedList.children();
             anchors = unorderedList.find('a');
         });
 
         test('has an unordered list with three items', () => {
+            console.log(unorderedList.debug());
             expect(defDescNode.children().exists()).toBeTruthy();
             expect(defDescNode.children()).toHaveLength(1);
             expect(unorderedList.children().exists()).toBeTruthy();

--- a/src/encoded/static/components/__tests__/platform-test.js
+++ b/src/encoded/static/components/__tests__/platform-test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { mount, shallow } from 'enzyme';
+import { mount } from 'enzyme';
 
 // Import test component and data.
 import Platform from '../platform';
@@ -41,7 +41,6 @@ describe('Platform', () => {
         });
 
         test('has an unordered list with three items', () => {
-            console.log(unorderedList.debug());
             expect(defDescNode.children().exists()).toBeTruthy();
             expect(defDescNode.children()).toHaveLength(1);
             expect(unorderedList.children().exists()).toBeTruthy();

--- a/src/encoded/static/components/__tests__/server-render-test.js
+++ b/src/encoded/static/components/__tests__/server-render-test.js
@@ -5,6 +5,10 @@ import { getRenderedProps } from '../app';
 import App from '..';
 
 
+// App calls Browserfeat to act on the DOM, so prevent that functionality as we have no DOM.
+jest.mock('../browserfeat');
+
+
 describe('Server rendering', () => {
     let document;
     const homeUrl = 'http://localhost/';
@@ -57,7 +61,7 @@ describe('Server rendering', () => {
     test('mounts the application over the rendered html', () => {
         let domNode;
         const props = getRenderedProps(document);
-        ReactDOM.render(<App {...props} domReader={(node) => { domNode = node; }} />, document);
+        ReactDOM.hydrate(<App {...props} domReader={(node) => { domNode = node; }} />, document);
         expect(domNode).toBe(document.documentElement);
     });
 });

--- a/src/encoded/static/components/antibody.js
+++ b/src/encoded/static/components/antibody.js
@@ -50,7 +50,7 @@ const LotComponent = (props, reactContext) => {
 
     // Make an array of targets with no falsy entries and no repeats
     const targets = {};
-    if (context.lot_reviews && context.lot_reviews.length) {
+    if (context.lot_reviews && context.lot_reviews.length > 0) {
         context.lot_reviews.forEach((lotReview) => {
             lotReview.targets.forEach((target) => {
                 targets[target['@id']] = target;
@@ -118,7 +118,7 @@ const LotComponent = (props, reactContext) => {
                         <AlternateAccession altAcc={context.alternate_accessions} />
                     </div>
                     <h3>
-                        {targetKeys.length ?
+                        {targetKeys.length > 0 ?
                             <span>
                                 Antibody against {Object.keys(targets).map((target, i) => {
                                     const targetObj = targets[target];
@@ -162,7 +162,7 @@ const LotComponent = (props, reactContext) => {
                             <dd>{context.lot_id}</dd>
                         </div>
 
-                        {Object.keys(targets).length ?
+                        {Object.keys(targets).length > 0 ?
                             <div data-test="targets">
                                 <dt>Characterized targets</dt>
                                 <dd>
@@ -174,7 +174,7 @@ const LotComponent = (props, reactContext) => {
                             </div>
                         : null}
 
-                        {context.lot_id_alias && context.lot_id_alias.length ?
+                        {context.lot_id_alias && context.lot_id_alias.length > 0 ?
                             <div data-test="lotidalias">
                                 <dt>Lot ID aliases</dt>
                                 <dd>{context.lot_id_alias.join(', ')}</dd>
@@ -193,7 +193,7 @@ const LotComponent = (props, reactContext) => {
                             </div>
                         : null}
 
-                        {context.purifications && context.purifications.length ?
+                        {context.purifications && context.purifications.length > 0 ?
                             <div data-test="purifications">
                                 <dt>Purification</dt>
                                 <dd className="sentence-case">{context.purifications.join(', ')}</dd>
@@ -221,14 +221,14 @@ const LotComponent = (props, reactContext) => {
                             </div>
                         : null}
 
-                        {context.aliases && context.aliases.length ?
+                        {context.aliases && context.aliases.length > 0 ?
                             <div data-test="aliases">
                                 <dt>Aliases</dt>
                                 <dd>{context.aliases.join(', ')}</dd>
                             </div>
                         : null}
 
-                        {context.dbxrefs && context.dbxrefs.length ?
+                        {context.dbxrefs && context.dbxrefs.length > 0 ?
                             <div data-test="dbxrefs">
                                 <dt>External resources</dt>
                                 <dd><DbxrefList context={context} dbxrefs={context.dbxrefs} /></dd>
@@ -356,7 +356,7 @@ const CharacterizationHeader = (props) => {
             <div className="document__header">
                 {doc.target.label} <span>{' ('}{doc.target.organism ? <i>{doc.target.organism.scientific_name}</i> : <span>{doc.target.investigated_as[0]}</span>}{')'}</span>
             </div>
-            {doc.characterization_reviews && doc.characterization_reviews.length ?
+            {doc.characterization_reviews && doc.characterization_reviews.length > 0 ?
                 <div className="document__characterization-reviews">
                     {doc.characterization_reviews.map(review => (
                         <span key={review.biosample_ontology.term_name} className="document__characterization-biosample-term">{review.biosample_ontology.term_name}</span>
@@ -489,7 +489,7 @@ const CharacterizationDetail = (props) => {
                     {download}
                 </div>
 
-                {doc.documents && doc.documents.length ?
+                {doc.documents && doc.documents.length > 0 ?
                     <div data-test="documents">
                         <dt>Documents</dt>
                         <CharacterizationDocuments docs={doc.documents} />

--- a/src/encoded/static/components/app.js
+++ b/src/encoded/static/components/app.js
@@ -8,6 +8,7 @@ import _ from 'underscore';
 import url from 'url';
 import jsonScriptEscape from '../libs/jsonScriptEscape';
 import origin from '../libs/origin';
+import { BrowserFeat } from './browserfeat';
 import cartStore, {
     cartCacheSaved,
     cartCreateAutosave,
@@ -283,6 +284,9 @@ class App extends React.Component {
             session,
         });
 
+        // Set browser features in the <html> CSS class.
+        BrowserFeat.setHtmlFeatClass();
+
         // Make a URL for the logo.
         const hrefInfo = url.parse(this.state.href);
         const logoHrefInfo = {
@@ -366,17 +370,6 @@ class App extends React.Component {
             window.onhashchange = this.onHashChange;
         }
         window.onbeforeunload = this.handleBeforeUnload;
-        (function walkmeinit() {
-            const s = document.getElementsByTagName('script')[0];
-            if (s) {
-                const walkme = document.createElement('script');
-                walkme.type = 'text/javascript';
-                walkme.async = true;
-                walkme.src = 'https://cdn.walkme.com/users/8c7ff9322d01408798869806f9f5a132/walkme_8c7ff9322d01408798869806f9f5a132_https.js';
-                s.parentNode.insertBefore(walkme, s);
-                window._walkmeConfig = { smartLoad: true };
-            }
-        }());
     }
 
     shouldComponentUpdate(nextProps, nextState) {
@@ -1101,6 +1094,7 @@ class App extends React.Component {
                     {base ? <base href={base} /> : null}
                     <link rel="canonical" href={canonical} />
                     <script async src="//www.google-analytics.com/analytics.js" />
+                    <script async src="https://cdn.walkme.com/users/8c7ff9322d01408798869806f9f5a132/walkme_8c7ff9322d01408798869806f9f5a132_https.js" />
                     {this.props.inline ? <script data-prop-name="inline" dangerouslySetInnerHTML={{ __html: this.props.inline }} /> : null}
                     {this.props.styles ? <link rel="stylesheet" href={this.props.styles} /> : null}
                     {newsHead(this.props, `${hrefUrl.protocol}//${hrefUrl.host}`)}

--- a/src/encoded/static/components/app.js
+++ b/src/encoded/static/components/app.js
@@ -317,7 +317,7 @@ class App extends React.Component {
         // Add privacy link to auth0 login modal.
         this.lock.on('signin ready', () => {
             const lockElements = document.getElementsByClassName('auth0-lock-form');
-            if (lockElements && lockElements.length) {
+            if (lockElements && lockElements.length > 0) {
                 const privacyDiv = document.createElement('div');
                 const privacyLink = document.createElement('a');
                 const privacyLinkText = document.createTextNode('Privacy policy');
@@ -826,7 +826,7 @@ class App extends React.Component {
     /* eslint no-alert: 0 */
     confirmNavigation() {
         // check for beforeunload confirmation
-        if (this.state.unsavedChanges.length) {
+        if (this.state.unsavedChanges.length > 0) {
             const res = window.confirm('You have unsaved changes. Are you sure you want to lose them?');
             if (res) {
                 this.setState({ unsavedChanges: [] });
@@ -837,7 +837,7 @@ class App extends React.Component {
     }
 
     handleBeforeUnload() {
-        if (this.state.unsavedChanges.length || cartIsUnsaved()) {
+        if (this.state.unsavedChanges.length > 0 || cartIsUnsaved()) {
             return 'You have unsaved changes.';
         }
         return undefined;

--- a/src/encoded/static/components/audit.js
+++ b/src/encoded/static/components/audit.js
@@ -243,7 +243,7 @@ AuditGroup.defaultProps = {
 export function auditsDisplayed(audits, session) {
     const loggedIn = !!(session && session['auth.userid']);
 
-    return (audits && Object.keys(audits).length) && (loggedIn || !(Object.keys(audits).length === 1 && audits.INTERNAL_ACTION));
+    return (audits && Object.keys(audits).length > 0) && (loggedIn || !(Object.keys(audits).length === 1 && audits.INTERNAL_ACTION));
 }
 
 

--- a/src/encoded/static/components/award.js
+++ b/src/encoded/static/components/award.js
@@ -26,7 +26,7 @@ function generateQuery(chosenOrganisms, searchTerm) {
     let query = '';
 
     // Add all the selected organisms, if any
-    if (chosenOrganisms.length) {
+    if (chosenOrganisms.length > 0) {
         const queryStrings = {
             HUMAN: `${searchTerm}Homo+sapiens`, // human
             MOUSE: `${searchTerm}Mus+musculus`, // mouse
@@ -51,7 +51,7 @@ function drawDonutCenter(chart) {
         ctx.clearRect(0, 0, width, height);
     } else {
         const data = chart.data.datasets[0].data;
-        if (data.length) {
+        if (data.length > 0) {
             ctx.fillStyle = '#000000';
             ctx.restore();
             const fontSize = (height / 114).toFixed(2);
@@ -312,7 +312,7 @@ export class LabChart extends React.Component {
     }
 
     componentDidMount() {
-        if (this.relevantData.length) {
+        if (this.relevantData.length > 0) {
             this.createChart(`${labChartId}-${this.props.ident}`, this.relevantData);
         }
     }
@@ -322,7 +322,7 @@ export class LabChart extends React.Component {
     }
 
     componentDidUpdate() {
-        if (this.relevantData.length) {
+        if (this.relevantData.length > 0) {
             if (this.chart) {
                 this.updateChart(this.chart, this.relevantData);
             } else {
@@ -392,7 +392,7 @@ export class LabChart extends React.Component {
                 <div className="award-charts__title">
                     Lab
                 </div>
-                {this.relevantData.length ?
+                {this.relevantData.length > 0 ?
                     <div className="award-charts__visual">
                         <div id={id} className="award-charts__canvas">
                             <canvas id={`${id}-chart`} />
@@ -433,7 +433,7 @@ export class CategoryChart extends React.Component {
     }
 
     componentDidMount() {
-        if (this.relevantData.length) {
+        if (this.relevantData.length > 0) {
             this.createChart(`${categoryChartId}-${this.props.ident}`, this.relevantData);
         }
     }
@@ -443,7 +443,7 @@ export class CategoryChart extends React.Component {
     }
 
     componentDidUpdate() {
-        if (this.relevantData.length) {
+        if (this.relevantData.length > 0) {
             if (this.chart) {
                 this.updateChart(this.chart, this.relevantData);
             } else {
@@ -516,7 +516,7 @@ export class CategoryChart extends React.Component {
                 <div className="title">
                     {title}
                 </div>
-                {this.relevantData.length ?
+                {this.relevantData.length > 0 ?
                     <div className="award-charts__visual">
                         <div id={id} className="award-charts__canvas">
                             <canvas id={`${id}-chart`} />
@@ -560,13 +560,13 @@ class AntibodyChart extends React.Component {
     }
 
     componentDidMount() {
-        if (this.relevantData.length) {
+        if (this.relevantData.length > 0) {
             this.createChart(`${categoryChartId}-${this.props.ident}`, this.relevantData);
         }
     }
 
     componentDidUpdate() {
-        if (this.relevantData.length) {
+        if (this.relevantData.length > 0) {
             if (this.chart) {
                 this.updateChart(this.chart, this.relevantData);
             } else {
@@ -637,12 +637,12 @@ class AntibodyChart extends React.Component {
         return (
             <div className="award-charts__chart">
                 <div className="award-charts__title">
-                    Antibodies {this.relevantData.length ?
+                    Antibodies {this.relevantData.length > 0 ?
                     <a className="btn btn-info btn-xs reagentsreporttitle" href={`/report/?type=AntibodyLot&${AntibodyQuery}&award=${award['@id']}&field=accession&field=lot_reviews.status&field=lot_reviews.targets.label&field=lot_reviews.targets.organism.scientific_name&field=source.title&field=product_id&field=lot_id&field=date_created`} title="View tabular report"><svg id="Table" data-name="Table" xmlns="http://www.w3.org/2000/svg" width="29" height="17" viewBox="0 0 29 17" className="svg-icon svg-icon-table"><path d="M22,0H0V17H29V0H22ZM21,4.33V8H15V4.33h6ZM15,9h6v3H15V9Zm-1,3H8V9h6v3Zm0-7.69V8H8V4.33h6Zm-13,0H7V8H1V4.33ZM1,9H7v3H1V9Zm0,7V13H7v3H1Zm7,0V13h6v3H8Zm7,0V13h6v3H15Zm13,0H22V13h6v3Zm0-4H22V9h6v3Zm0-4H22V4.33h6V8Z" /></svg></a>
                     :
                     null}
                 </div>
-                {this.relevantData.length ?
+                {this.relevantData.length > 0 ?
                     <div>
                         <div className="award-charts__visual">
                             <div id={id} className="award-charts__canvas">
@@ -681,13 +681,13 @@ class BiosampleChart extends React.Component {
     }
 
     componentDidMount() {
-        if (this.relevantData.length) {
+        if (this.relevantData.length > 0) {
             this.createChart(`${categoryChartId}-${this.props.ident}`, this.relevantData);
         }
     }
 
     componentDidUpdate() {
-        if (this.relevantData.length) {
+        if (this.relevantData.length > 0) {
             if (this.chart) {
                 this.updateChart(this.chart, this.relevantData);
             } else {
@@ -712,7 +712,6 @@ class BiosampleChart extends React.Component {
             }
         });
         const colors = labels.map((label, i) => typeSpecificColorList[i % typeSpecificColorList.length]);
-        // if (this.props.selectedOrganisms.length)
         const BiosampleQuery = generateQuery(this.props.selectedOrganisms, 'organism.scientific_name=');
         // Update chart data and redraw with the new data.
         chart.data.datasets[0].data = values;
@@ -758,11 +757,11 @@ class BiosampleChart extends React.Component {
         return (
             <div className="award-charts__chart">
                 <div className="award-charts__title">
-                    Biosamples {this.relevantData.length ?
+                    Biosamples {this.relevantData.length > 0 ?
                         <a className="btn btn-info btn-sm reagentsreporttitle" href={`/report/?type=Biosample&${BiosampleQuery}&award.name=${award.name}`} title="View tabular report"><svg id="Table" data-name="Table" xmlns="http://www.w3.org/2000/svg" width="29" height="17" viewBox="0 0 29 17" className="svg-icon svg-icon-table"><path d="M22,0H0V17H29V0H22ZM21,4.33V8H15V4.33h6ZM15,9h6v3H15V9Zm-1,3H8V9h6v3Zm0-7.69V8H8V4.33h6Zm-13,0H7V8H1V4.33ZM1,9H7v3H1V9Zm0,7V13H7v3H1Zm7,0V13h6v3H8Zm7,0V13h6v3H15Zm13,0H22V13h6v3Zm0-4H22V9h6v3Zm0-4H22V4.33h6V8Z" /></svg></a>
                     : null}
                 </div>
-                {this.relevantData.length ?
+                {this.relevantData.length > 0 ?
                     <div>
                         <div className="award-charts__visual">
                             <div id={id} className="award-charts__canvas">
@@ -819,13 +818,13 @@ function StatusData(experiments, unreplicated, isogenic, anisogenic) {
     let anisogenicDataset = [];
 
     // Find status in facets for each replicate type (unreplicated, isogenic, anisogenic) search
-    if (experiments && experiments.facets && experiments.facets.length) {
+    if (experiments && experiments.facets && experiments.facets.length > 0) {
         const unreplicatedFacet = unreplicated.facets.find(facet => facet.field === 'status');
         const isogenicFacet = isogenic.facets.find(facet => facet.field === 'status');
         const anisogenicFacet = anisogenic.facets.find(facet => facet.field === 'status');
-        unreplicatedArray = (unreplicatedFacet && unreplicatedFacet.terms && unreplicatedFacet.terms.length) ? unreplicatedFacet.terms : [];
-        isogenicArray = (isogenicFacet && isogenicFacet.terms && isogenicFacet.terms.length) ? isogenicFacet.terms : [];
-        anisogenicArray = (anisogenicFacet && anisogenicFacet.terms && anisogenicFacet.terms.length) ? anisogenicFacet.terms : [];
+        unreplicatedArray = (unreplicatedFacet && unreplicatedFacet.terms && unreplicatedFacet.terms.length > 0) ? unreplicatedFacet.terms : [];
+        isogenicArray = (isogenicFacet && isogenicFacet.terms && isogenicFacet.terms.length > 0) ? isogenicFacet.terms : [];
+        anisogenicArray = (anisogenicFacet && anisogenicFacet.terms && anisogenicFacet.terms.length > 0) ? anisogenicFacet.terms : [];
     }
     const labels = ['in progress', 'submitted', 'released', 'deleted', 'replaced', 'archived', 'revoked'];
 
@@ -834,7 +833,7 @@ function StatusData(experiments, unreplicated, isogenic, anisogenic) {
     //      so that it can be easily and accurately passed to chart.js in createBarChart
     //      First pushes anything that has a key in labels, then sorts the dataset
     //      If the array has no length, just push an array with 0 values
-    if (unreplicatedArray.length) {
+    if (unreplicatedArray.length > 0) {
         for (let j = 0; j < labels.length; j += 1) {
             for (let i = 0; i < unreplicatedArray.length; i += 1) {
                 if (unreplicatedArray[i].key === labels[j]) {
@@ -852,7 +851,7 @@ function StatusData(experiments, unreplicated, isogenic, anisogenic) {
     } else {
         unreplicatedDataset = [0, 0, 0, 0, 0, 0, 0, 0];
     }
-    if (isogenicArray.length) {
+    if (isogenicArray.length > 0) {
         for (let j = 0; j < labels.length; j += 1) {
             for (let i = 0; i < isogenicArray.length; i += 1) {
                 if (isogenicArray[i].key === labels[j]) {
@@ -870,7 +869,7 @@ function StatusData(experiments, unreplicated, isogenic, anisogenic) {
     } else {
         isogenicDataset = [0, 0, 0, 0, 0, 0, 0, 0];
     }
-    if (anisogenicArray.length) {
+    if (anisogenicArray.length > 0) {
         for (let j = 0; j < labels.length; j += 1) {
             for (let i = 0; i < anisogenicArray.length; i += 1) {
                 if (anisogenicArray[i].key === labels[j]) {
@@ -899,13 +898,13 @@ class ControlsChart extends React.Component {
     }
 
     componentDidMount() {
-        if (this.relevantData.length) {
+        if (this.relevantData.length > 0) {
             this.createChart(`${statusChartId}-${this.props.ident}-controls`, this.relevantData);
         }
     }
 
     componentDidUpdate() {
-        if (this.relevantData.length) {
+        if (this.relevantData.length > 0) {
             if (this.chart) {
                 this.updateChart(this.chart, this.relevantData);
             } else {
@@ -976,7 +975,7 @@ class ControlsChart extends React.Component {
                 <div className="award-charts__title">
                     Controls
                 </div>
-                {this.relevantData.length ?
+                {this.relevantData.length > 0 ?
                     <div className="award-charts__visual">
                         <div id={id} className="award-charts__canvas">
                             <canvas id={`${id}-chart`} />
@@ -1016,13 +1015,13 @@ class StatusExperimentChart extends React.Component {
     }
 
     componentDidMount() {
-        if (this.relevantData.length) {
+        if (this.relevantData.length > 0) {
             this.createChart(`${statusChartId}-${this.props.ident}`, this.props.statuses);
         }
     }
 
     componentDidUpdate() {
-        if (this.relevantData.length) {
+        if (this.relevantData.length > 0) {
             if (this.chart) {
                 this.updateChart(this.chart, this.relevantData);
             } else {
@@ -1103,7 +1102,7 @@ class StatusExperimentChart extends React.Component {
                 <div className="award-charts__title">
                     Status
                 </div>
-                {this.relevantData.length ?
+                {this.relevantData.length > 0?
                     <div className="award-charts__visual">
                         <div id={id} className="award-charts__canvas">
                             <canvas id={`${id}-chart`} />
@@ -1153,13 +1152,13 @@ class StatusChart extends React.Component {
     }
 
     componentDidMount() {
-        if (this.relevantData.length) {
+        if (this.relevantData.length > 0) {
             this.createChart(`${statusChartId}-${this.props.ident}`, this.relevantData);
         }
     }
 
     componentDidUpdate() {
-        if (this.relevantData.length) {
+        if (this.relevantData.length > 0) {
             if (this.chart) {
                 this.updateChart(this.chart, this.relevantData);
             } else {
@@ -1229,7 +1228,7 @@ class StatusChart extends React.Component {
                 <div className="award-charts__title">
                     Status
                 </div>
-                {this.relevantData.length ?
+                {this.relevantData.length > 0 ?
                     <div className="award-charts__visual">
                         <div id={id} className="award-charts__canvas">
                             <canvas id={`${id}-chart`} />
@@ -1264,9 +1263,9 @@ StatusChart.contextTypes = {
 // The existing species are added to the array of species
 function generateUpdatedSpeciesArray(categories, query, updatedSpeciesArray) {
     let categorySpeciesArray;
-    if (categories && categories.facets && categories.facets.length) {
+    if (categories && categories.facets && categories.facets.length > 0) {
         const genusFacet = categories.facets.find(facet => facet.field === query);
-        categorySpeciesArray = (genusFacet && genusFacet.terms && genusFacet.terms.length) ? genusFacet.terms : [];
+        categorySpeciesArray = (genusFacet && genusFacet.terms && genusFacet.terms.length > 0) ? genusFacet.terms : [];
         const categorySpeciesArrayLength = categorySpeciesArray.length;
         for (let j = 0; j < categorySpeciesArrayLength; j += 1) {
             if (categorySpeciesArray[j].doc_count !== 0) {
@@ -1371,24 +1370,24 @@ const ChartRenderer = (props) => {
     searchData.controls.data = (controls && controls.facets) || [];
 
     ['experiments', 'annotations', 'antibodies', 'biosamples', 'controls'].forEach((chartCategory) => {
-        if (searchData[chartCategory].data.length) {
+        if (searchData[chartCategory].data.length > 0) {
             // Get the array of lab data.
             const labFacet = searchData[chartCategory].data.find(facet => facet.field === 'lab.title');
-            searchData[chartCategory].labs = (labFacet && labFacet.terms && labFacet.terms.length) ? labFacet.terms.sort((a, b) => (a.key < b.key ? -1 : (a.key > b.key ? 1 : 0))) : [];
+            searchData[chartCategory].labs = (labFacet && labFacet.terms && labFacet.terms.length > 0) ? labFacet.terms.sort((a, b) => (a.key < b.key ? -1 : (a.key > b.key ? 1 : 0))) : [];
 
             // Get the array of data specific to experiments, annotations, or antibodies
             const categoryFacet = searchData[chartCategory].data.find(facet => facet.field === searchData[chartCategory].categoryFacet);
-            searchData[chartCategory].categoryData = (categoryFacet && categoryFacet.terms && categoryFacet.terms.length) ? categoryFacet.terms : [];
+            searchData[chartCategory].categoryData = (categoryFacet && categoryFacet.terms && categoryFacet.terms.length > 0) ? categoryFacet.terms : [];
 
             // Get the array of status data.
             const statusFacet = searchData[chartCategory].data.find(facet => facet.field === 'status');
-            searchData[chartCategory].statuses = (statusFacet && statusFacet.terms && statusFacet.terms.length) ? statusFacet.terms : [];
+            searchData[chartCategory].statuses = (statusFacet && statusFacet.terms && statusFacet.terms.length > 0) ? statusFacet.terms : [];
         }
     });
     // If there are experiements, then the corresponding species are added to the array of species
-    if (experiments && experiments.facets && experiments.facets.length) {
+    if (experiments && experiments.facets && experiments.facets.length > 0) {
         const genusFacet = experiments.facets.find(facet => facet.field === 'replicates.library.biosample.donor.organism.scientific_name');
-        experimentSpeciesArray = (genusFacet && genusFacet.terms && genusFacet.terms.length) ? genusFacet.terms : [];
+        experimentSpeciesArray = (genusFacet && genusFacet.terms && genusFacet.terms.length > 0) ? genusFacet.terms : [];
         const experimentSpeciesArrayLength = experimentSpeciesArray.length;
         for (let j = 0; j < experimentSpeciesArrayLength; j += 1) {
             if (experimentSpeciesArray[j].doc_count !== 0) {
@@ -1397,9 +1396,9 @@ const ChartRenderer = (props) => {
         }
     }
     // If there are annotations, then the corresponding species are added to the array of species
-    if (annotations && annotations.facets && annotations.facets.length) {
+    if (annotations && annotations.facets && annotations.facets.length > 0) {
         const genusFacet = annotations.facets.find(facet => facet.field === 'organism.scientific_name');
-        annotationSpeciesArray = (genusFacet && genusFacet.terms && genusFacet.terms.length) ? genusFacet.terms : [];
+        annotationSpeciesArray = (genusFacet && genusFacet.terms && genusFacet.terms.length > 0) ? genusFacet.terms : [];
         const annotationSpeciesArrayLength = annotationSpeciesArray.length;
         for (let j = 0; j < annotationSpeciesArrayLength; j += 1) {
             if (annotationSpeciesArray[j].doc_count !== 0) {
@@ -1408,9 +1407,9 @@ const ChartRenderer = (props) => {
         }
     }
     // If there are biosamples, then the corresponding species are iadded to the array of species
-    if (biosamples && biosamples.facets && biosamples.facets.length) {
+    if (biosamples && biosamples.facets && biosamples.facets.length > 0) {
         const genusFacet = biosamples.facets.find(facet => facet.field === 'organism.scientific_name=');
-        biosampleSpeciesArray = (genusFacet && genusFacet.terms && genusFacet.terms.length) ? genusFacet.terms : [];
+        biosampleSpeciesArray = (genusFacet && genusFacet.terms && genusFacet.terms.length > 0) ? genusFacet.terms : [];
         const biosampleSpeciesArrayLength = biosampleSpeciesArray.length;
         for (let j = 0; j < biosampleSpeciesArrayLength; j += 1) {
             if (biosampleSpeciesArray[j].doc_count !== 0) {
@@ -1419,9 +1418,9 @@ const ChartRenderer = (props) => {
         }
     }
     // If there are antibodies, then the corresponding species are added to the array of species
-    if (antibodies && antibodies.facets && antibodies.facets.length) {
+    if (antibodies && antibodies.facets && antibodies.facets.length > 0) {
         const genusFacet = antibodies.facets.find(facet => facet.field === 'targets.organism.scientific_name=');
-        antibodySpeciesArray = (genusFacet && genusFacet.terms && genusFacet.terms.length) ? genusFacet.terms : [];
+        antibodySpeciesArray = (genusFacet && genusFacet.terms && genusFacet.terms.length > 0) ? genusFacet.terms : [];
         const antibodySpeciesArrayLength = antibodySpeciesArray.length;
         for (let j = 0; j < antibodySpeciesArrayLength; j += 1) {
             if (antibodySpeciesArray[j].doc_count !== 0) {
@@ -1452,11 +1451,11 @@ const ChartRenderer = (props) => {
             <PanelBody>
                 <div className="award-chart__group-wrapper">
                     <h2>
-                        Assays {experimentsConfig.labs.length ?
+                        Assays {experimentsConfig.labs.length > 0 ?
                             <a className="btn btn-info btn-sm reporttitle" href={`/report/?type=Experiment&${ExperimentQuery}&award.name=${award.name}`} title="View tabular report"><svg id="Table" data-name="Table" xmlns="http://www.w3.org/2000/svg" width="29" height="17" viewBox="0 0 29 17" className="svg-icon svg-icon-table"><path d="M22,0H0V17H29V0H22ZM21,4.33V8H15V4.33h6ZM15,9h6v3H15V9Zm-1,3H8V9h6v3Zm0-7.69V8H8V4.33h6Zm-13,0H7V8H1V4.33ZM1,9H7v3H1V9Zm0,7V13H7v3H1Zm7,0V13h6v3H8Zm7,0V13h6v3H15Zm13,0H22V13h6v3Zm0-4H22V9h6v3Zm0-4H22V4.33h6V8Z" /></svg></a>
                         : null}
                     </h2>
-                    {experimentsConfig.labs.length ?
+                    {experimentsConfig.labs.length > 0 ?
                         <div>
                             <div className="award-chart__group">
                                 <LabChart
@@ -1496,11 +1495,11 @@ const ChartRenderer = (props) => {
                 </div>
                 <div className="award-chart__group-wrapper">
                     <h2>
-                        Annotations {annotationsConfig.labs.length ?
+                        Annotations {annotationsConfig.labs.length > 0 ?
                             <a className="btn btn-info btn-sm reporttitle" href={`/report/?type=Annotation&${AnnotationQuery}&award.name=${award.name}`} title="View tabular report"><svg id="Table" data-name="Table" xmlns="http://www.w3.org/2000/svg" width="29" height="17" viewBox="0 0 29 17" className="svg-icon svg-icon-table"><path d="M22,0H0V17H29V0H22ZM21,4.33V8H15V4.33h6ZM15,9h6v3H15V9Zm-1,3H8V9h6v3Zm0-7.69V8H8V4.33h6Zm-13,0H7V8H1V4.33ZM1,9H7v3H1V9Zm0,7V13H7v3H1Zm7,0V13h6v3H8Zm7,0V13h6v3H15Zm13,0H22V13h6v3Zm0-4H22V9h6v3Zm0-4H22V4.33h6V8Z" /></svg></a>
                         : null}
                     </h2>
-                    {annotationsConfig.labs.length ?
+                    {annotationsConfig.labs.length > 0 ?
                         <div>
                             <div className="award-chart__group">
                                 <LabChart
@@ -1537,7 +1536,7 @@ const ChartRenderer = (props) => {
                 </div>
                 <div className="award-chart__group-wrapper">
                     <h2>Reagents</h2>
-                    {antibodiesConfig.categoryData.length || biosamplesConfig.categoryData.length || experimentsConfig.statuses.length ?
+                    {antibodiesConfig.categoryData.length > 0 || biosamplesConfig.categoryData.length > 0 || experimentsConfig.statuses.length > 0 ?
                         <div className="award-chart__group">
                             <AntibodyChart
                                 award={award}
@@ -1605,7 +1604,7 @@ class GenusButtons extends React.Component {
     render() {
         const { updatedGenusArray, selectedOrganisms, handleClick } = this.props;
         // If genera exist, then the button for each specific genus is created
-        if (updatedGenusArray.length) {
+        if (updatedGenusArray.length > 0) {
             return (
                 <div className="organism-selector">
                     {updatedGenusArray.indexOf('HUMAN') !== -1 ?
@@ -1748,11 +1747,11 @@ export const ExperimentDate = (props) => {
     let deduplicatedsubmitted = {};
 
     // Search experiments for month_released and date_submitted in facets
-    if (experiments.facets && experiments.facets.length) {
+    if (experiments.facets && experiments.facets.length > 0) {
         const monthReleasedFacet = experiments.facets.find(facet => facet.field === 'month_released');
         const dateSubmittedFacet = experiments.facets.find(facet => facet.field === 'date_submitted');
-        releasedDates = (monthReleasedFacet && monthReleasedFacet.terms && monthReleasedFacet.terms.length) ? monthReleasedFacet.terms : [];
-        submittedDates = (dateSubmittedFacet && dateSubmittedFacet.terms && dateSubmittedFacet.terms.length) ? dateSubmittedFacet.terms : [];
+        releasedDates = (monthReleasedFacet && monthReleasedFacet.terms && monthReleasedFacet.terms.length > 0) ? monthReleasedFacet.terms : [];
+        submittedDates = (dateSubmittedFacet && dateSubmittedFacet.terms && dateSubmittedFacet.terms.length > 0) ? dateSubmittedFacet.terms : [];
     }
 
     // Take an array of date facet terms and return an array of terms sorted by date.
@@ -1790,15 +1789,15 @@ export const ExperimentDate = (props) => {
     let accumulatedDataReleased = [];
     let accumulatedDataSubmitted = [];
     let date = [];
-    if (releasedDates.length || submittedDates.length) {
+    if (releasedDates.length > 0 || submittedDates.length > 0) {
         const sortedreleasedTerms = consolidateSortedDates(sortTerms(releasedDates));
         const sortedsubmittedTerms = consolidateSortedDates(sortTerms(submittedDates));
 
         // Add an object with the most current date to one of the arrays.
-        if ((releasedDates && releasedDates.length) && (submittedDates && submittedDates.length)) {
-            if (sortedreleasedTerms.length && moment(sortedsubmittedTerms[sortedsubmittedTerms.length - 1].key).isAfter(sortedreleasedTerms[sortedreleasedTerms.length - 1].key, 'date')) {
+        if ((releasedDates && releasedDates.length > 0) && (submittedDates && submittedDates.length > 0)) {
+            if (sortedreleasedTerms.length > 0 && moment(sortedsubmittedTerms[sortedsubmittedTerms.length - 1].key).isAfter(sortedreleasedTerms[sortedreleasedTerms.length - 1].key, 'date')) {
                 sortedreleasedTerms.push({ key: sortedsubmittedTerms[sortedsubmittedTerms.length - 1].key, doc_count: 0 });
-            } else if (sortedsubmittedTerms.length && moment(sortedsubmittedTerms[sortedsubmittedTerms.length - 1].key).isBefore(sortedreleasedTerms[sortedreleasedTerms.length - 1].key, 'date')) {
+            } else if (sortedsubmittedTerms.length > 0 && moment(sortedsubmittedTerms[sortedsubmittedTerms.length - 1].key).isBefore(sortedreleasedTerms[sortedreleasedTerms.length - 1].key, 'date')) {
                 sortedsubmittedTerms.push({ key: sortedreleasedTerms[sortedreleasedTerms.length - 1].key, doc_count: 0 });
             }
         }
@@ -1828,7 +1827,7 @@ export const ExperimentDate = (props) => {
 
     return (
         <div>
-            {accumulatedDataReleased.length || accumulatedDataSubmitted.length ?
+            {accumulatedDataReleased.length > 0 || accumulatedDataSubmitted.length > 0 ?
                 <Panel addClasses={panelCss}>
                     <PanelHeading addClasses={panelHeadingCss}>
                         <h4>Cumulative Number of Experiments</h4>

--- a/src/encoded/static/components/biosample.js
+++ b/src/encoded/static/components/biosample.js
@@ -165,7 +165,7 @@ class BiosampleComponent extends React.Component {
                                         </div>
                                     : null}
 
-                                    {context.depleted_in_term_name && context.depleted_in_term_name.length ?
+                                    {context.depleted_in_term_name && context.depleted_in_term_name.length > 0 ?
                                         <div data-test="depletedin">
                                             <dt>Depleted in</dt>
                                             <dd>
@@ -249,7 +249,7 @@ class BiosampleComponent extends React.Component {
                                         </div>
                                     : null}
 
-                                    {context.parent_of && context.parent_of.length ?
+                                    {context.parent_of && context.parent_of.length > 0 ?
                                         <div data-test="parentof">
                                             <dt>Parent of biosamples</dt>
                                             <dd>
@@ -306,7 +306,7 @@ class BiosampleComponent extends React.Component {
                                         <dd>{context.award.project}</dd>
                                     </div>
 
-                                    {dbxrefs.length ?
+                                    {dbxrefs.length > 0 ?
                                         <div data-test="externalresources">
                                             <dt>External resources</dt>
                                             <dd><DbxrefList context={context} dbxrefs={dbxrefs} /></dd>
@@ -327,7 +327,7 @@ class BiosampleComponent extends React.Component {
                                         </div>
                                     : null}
 
-                                    {context.aliases.length ?
+                                    {context.aliases.length > 0 ?
                                         <div data-test="aliases">
                                             <dt>Aliases</dt>
                                             <dd>{aliasList}</dd>
@@ -351,7 +351,7 @@ class BiosampleComponent extends React.Component {
                             </div>
                         </div>
 
-                        {context.pooled_from && context.pooled_from.length ?
+                        {context.pooled_from && context.pooled_from.length > 0 ?
                             <section data-test="pooledfrom">
                                 <hr />
                                 <h4>Pooled from biosamples</h4>
@@ -365,7 +365,7 @@ class BiosampleComponent extends React.Component {
                             </section>
                         : null}
 
-                        {context.treatments.length ?
+                        {context.treatments.length > 0 ?
                             <section>
                                 <hr />
                                 <h4>Treatment details</h4>
@@ -375,7 +375,7 @@ class BiosampleComponent extends React.Component {
                     </PanelBody>
                 </Panel>
 
-                {context.applied_modifications && context.applied_modifications.length ?
+                {context.applied_modifications && context.applied_modifications.length > 0 ?
                     <GeneticModificationSummary geneticModifications={context.applied_modifications} />
                 : null}
 
@@ -409,7 +409,7 @@ class BiosampleComponent extends React.Component {
                     Component={BiosampleTable}
                 />
 
-                {combinedDocs.length ?
+                {combinedDocs.length > 0 ?
                     <DocumentsPanel documentSpecs={[{ documents: combinedDocs }]} />
                 : null}
             </div>
@@ -578,7 +578,7 @@ const CharacterizationDetail = (props) => {
 
     // See if we need a list of documents or not. Documents without attachments don't get
     // displayed.
-    const docs = characterization.documents && characterization.documents.length ?
+    const docs = characterization.documents && characterization.documents.length > 0 ?
         characterization.documents.filter(doc => !!(doc.attachment && doc.attachment.href && doc.attachment.download))
     : [];
 
@@ -618,7 +618,7 @@ const CharacterizationDetail = (props) => {
                     </div>
                 : null}
 
-                {docs.length ?
+                {docs.length > 0 ?
                     <div data-test="documents">
                         <dt>Documents</dt>
                         <CharacterizationDocuments docs={docs} />

--- a/src/encoded/static/components/biosample_type.js
+++ b/src/encoded/static/components/biosample_type.js
@@ -60,7 +60,7 @@ const BiosampleTypeComponenet = (props, reactContext) => {
                         </div>
                     : null}
 
-                    {context.dbxrefs && context.dbxrefs.length ?
+                    {context.dbxrefs && context.dbxrefs.length > 0 ?
                         <div data-test="externalresources">
                             <dt>External resources</dt>
                             <dd><DbxrefList context={context} dbxrefs={context.dbxrefs} /></dd>
@@ -74,7 +74,7 @@ const BiosampleTypeComponenet = (props, reactContext) => {
                         </div>
                     : null}
 
-                    {context.aliases.length ?
+                    {context.aliases.length > 0 ?
                         <div data-test="aliases">
                             <dt>Aliases</dt>
                             <dd>

--- a/src/encoded/static/components/blocks/search.js
+++ b/src/encoded/static/components/blocks/search.js
@@ -13,7 +13,7 @@ const SearchResultsLayout = (props) => {
     return (
         <div className="panel">
             <ul className="nav result-table">
-                {results.length ?
+                {results.length > 0 ?
                     results.map(result => Listing({ context: result, columns, key: result['@id'] }))
                 : null}
             </ul>

--- a/src/encoded/static/components/cart/cart.js
+++ b/src/encoded/static/components/cart/cart.js
@@ -1183,7 +1183,7 @@ class CartComponent extends React.Component {
                     </div>
                 </header>
                 <Panel addClasses="cart__result-table">
-                    {cartElements.length ?
+                    {cartElements.length > 0 ?
                         <PanelHeading addClasses="cart__header">
                             <PagerArea currentPage={this.state.currentDatasetResultsPage} totalPageCount={totalDatasetPages} updateCurrentPage={this.updateDatasetCurrentPage} />
                             <CartTools

--- a/src/encoded/static/components/collection.js
+++ b/src/encoded/static/components/collection.js
@@ -32,7 +32,7 @@ class FacetChart extends React.Component {
         // Before rendering anything into the chart, check whether we have a the chart.js module
         // loaded yet. If it hasn't loaded yet, we have nothing to do yet. Also see if we have any
         // values to render at all, and skip this if not.
-        if (Chart && this.values.length) {
+        if (Chart && this.values.length > 0) {
             // In case we don't have enough colors defined for all the values, make an array of
             // colors with enough entries to fill out the labels and values.
             const colors = this.labels.map((label, i) => collectionColorList[i % collectionColorList.length]);
@@ -126,7 +126,7 @@ class FacetChart extends React.Component {
 
         // Check whether we have usable values in one array or the other we just collected (we'll
         // just use `this;values` here) to see if we need to render a chart or not.
-        if (this.values.length) {
+        if (this.values.length > 0) {
             return (
                 <div className="collection-charts__chart">
                     <div className="collection-charts__title">{facet.title}</div>
@@ -206,7 +206,7 @@ class Collection extends React.Component {
                         </div>
                     </PanelHeading>
                     <PanelBody>
-                        {chartFacets.length ?
+                        {chartFacets.length > 0 ?
                             <div className="collection-charts">
                                 {chartFacets.map(facet =>
                                     <FacetChart

--- a/src/encoded/static/components/datacolors.js
+++ b/src/encoded/static/components/datacolors.js
@@ -205,7 +205,7 @@ export const isLight = (color) => {
 
 class DataColors {
     constructor(keys) {
-        if (keys && keys.length) {
+        if (keys && keys.length > 0) {
             this.keys = [...keys]; // Clone given array
         } else {
             this.keys = [];
@@ -221,7 +221,7 @@ class DataColors {
     //         integer -- do not pass a string with a "%" sign at the end.
     colorList(keys, options) {
         let colors = [];
-        if (keys && keys.length) {
+        if (keys && keys.length > 0) {
             // Map the given keys to colors consistently
             colors = keys.map((key) => {
                 let outColor;

--- a/src/encoded/static/components/dataset.js
+++ b/src/encoded/static/components/dataset.js
@@ -29,7 +29,7 @@ export function annotationBiosampleSummary(annotation) {
     // Build an array of strings we can join, not including empty strings
     const summaryStrings = _.compact([organismName, lifeStageString, timepointString]);
 
-    if (summaryStrings.length) {
+    if (summaryStrings.length > 0) {
         return (
             <span className="biosample-summary">
                 {summaryStrings.map((summaryString, i) =>
@@ -60,7 +60,7 @@ class AnnotationComponent extends React.Component {
         const experimentsUrl = `/search/?type=Experiment&possible_controls.accession=${context.accession}`;
 
         // Build up array of documents attached to this dataset
-        const datasetDocuments = (context.documents && context.documents.length) ? context.documents : [];
+        const datasetDocuments = (context.documents && context.documents.length > 0) ? context.documents : [];
 
         // Make a biosample summary string
         const biosampleSummary = annotationBiosampleSummary(context);
@@ -155,7 +155,7 @@ class AnnotationComponent extends React.Component {
                                         </div>
                                     : null}
 
-                                    {context.software_used && context.software_used.length ?
+                                    {context.software_used && context.software_used.length > 0 ?
                                         <div data-test="softwareused">
                                             <dt>Software used</dt>
                                             <dd>{softwareVersionList(context.software_used)}</dd>
@@ -186,7 +186,7 @@ class AnnotationComponent extends React.Component {
 
                                     <AwardRef context={context} adminUser={adminUser} />
 
-                                    {context.aliases.length ?
+                                    {context.aliases.length > 0 ?
                                         <div data-test="aliases">
                                             <dt>Aliases</dt>
                                             <dd><DbxrefList context={context} dbxrefs={context.aliases} /></dd>
@@ -196,7 +196,7 @@ class AnnotationComponent extends React.Component {
                                     <div data-test="externalresources">
                                         <dt>External resources</dt>
                                         <dd>
-                                            {context.dbxrefs && context.dbxrefs.length ?
+                                            {context.dbxrefs && context.dbxrefs.length > 0 ?
                                                 <DbxrefList context={context} dbxrefs={context.dbxrefs} />
                                             : <em>None submitted</em> }
                                         </dd>
@@ -259,7 +259,7 @@ class PublicationDataComponent extends React.Component {
         const experimentsUrl = `/search/?type=Experiment&possible_controls.accession=${context.accession}`;
 
         // Build up array of documents attached to this dataset
-        const datasetDocuments = (context.documents && context.documents.length) ? context.documents : [];
+        const datasetDocuments = (context.documents && context.documents.length > 0) ? context.documents : [];
 
         // Set up the breadcrumbs
         const datasetType = context['@type'][1];
@@ -300,7 +300,7 @@ class PublicationDataComponent extends React.Component {
                                         <dd><Status item={context} inline /></dd>
                                     </div>
 
-                                    {context.assay_term_name && context.assay_term_name.length ?
+                                    {context.assay_term_name && context.assay_term_name.length > 0 ?
                                         <div data-test="assaytermname">
                                             <dt>Assay(s)</dt>
                                             <dd>{context.assay_term_name.join(', ')}</dd>
@@ -360,7 +360,7 @@ class PublicationDataComponent extends React.Component {
                                     <div data-test="externalresources">
                                         <dt>External resources</dt>
                                         <dd>
-                                            {context.dbxrefs && context.dbxrefs.length ?
+                                            {context.dbxrefs && context.dbxrefs.length > 0 ?
                                                 <DbxrefList context={context} dbxrefs={context.dbxrefs} />
                                             : <em>None submitted</em> }
                                         </dd>
@@ -423,7 +423,7 @@ class ReferenceComponent extends React.Component {
         const experimentsUrl = `/search/?type=Experiment&possible_controls.accession=${context.accession}`;
 
         // Build up array of documents attached to this dataset
-        const datasetDocuments = (context.documents && context.documents.length) ? context.documents : [];
+        const datasetDocuments = (context.documents && context.documents.length > 0) ? context.documents : [];
 
         // Set up the breadcrumbs
         const datasetType = context['@type'][1];
@@ -490,7 +490,7 @@ class ReferenceComponent extends React.Component {
                                         </div>
                                     : null}
 
-                                    {context.software_used && context.software_used.length ?
+                                    {context.software_used && context.software_used.length > 0 ?
                                         <div data-test="softwareused">
                                             <dt>Software used</dt>
                                             <dd>{softwareVersionList(context.software_used)}</dd>
@@ -514,7 +514,7 @@ class ReferenceComponent extends React.Component {
 
                                     <AwardRef context={context} adminUser={adminUser} />
 
-                                    {context.aliases.length ?
+                                    {context.aliases.length > 0 ?
                                         <div data-test="aliases">
                                             <dt>Aliases</dt>
                                             <dd><DbxrefList context={context} dbxrefs={context.aliases} /></dd>
@@ -524,7 +524,7 @@ class ReferenceComponent extends React.Component {
                                     <div data-test="externalresources">
                                         <dt>External resources</dt>
                                         <dd>
-                                            {context.dbxrefs && context.dbxrefs.length ?
+                                            {context.dbxrefs && context.dbxrefs.length > 0 ?
                                                 <DbxrefList context={context} dbxrefs={context.dbxrefs} />
                                             : <em>None submitted</em> }
                                         </dd>
@@ -587,10 +587,10 @@ class ProjectComponent extends React.Component {
         const experimentsUrl = `/search/?type=Experiment&possible_controls.accession=${context.accession}`;
 
         // Build up array of documents attached to this dataset
-        const datasetDocuments = (context.documents && context.documents.length) ? context.documents : [];
+        const datasetDocuments = (context.documents && context.documents.length > 0) ? context.documents : [];
 
         // Collect organisms
-        const organisms = (context.organism && context.organism.length) ? _.uniq(context.organism.map(organism => organism.name)) : [];
+        const organisms = (context.organism && context.organism.length > 0) ? _.uniq(context.organism.map(organism => organism.name)) : [];
 
         // Set up the breadcrumbs
         const datasetType = context['@type'][1];
@@ -631,7 +631,7 @@ class ProjectComponent extends React.Component {
                                         <dd><Status item={context} inline /></dd>
                                     </div>
 
-                                    {context.assay_term_name && context.assay_term_name.length ?
+                                    {context.assay_term_name && context.assay_term_name.length > 0 ?
                                         <div data-test="assaytermname">
                                             <dt>Assay(s)</dt>
                                             <dd>{context.assay_term_name.join(', ')}</dd>
@@ -671,14 +671,14 @@ class ProjectComponent extends React.Component {
                                         </div>
                                     : null}
 
-                                    {organisms.length ?
+                                    {organisms.length > 0 ?
                                         <div data-test="organism">
                                             <dt>Organism</dt>
                                             <dd>{organisms.join(', ')}</dd>
                                         </div>
                                     : null}
 
-                                    {context.software_used && context.software_used.length ?
+                                    {context.software_used && context.software_used.length > 0 ?
                                         <div data-test="softwareused">
                                             <dt>Software used</dt>
                                             <dd>{softwareVersionList(context.software_used)}</dd>
@@ -702,7 +702,7 @@ class ProjectComponent extends React.Component {
 
                                     <AwardRef context={context} adminUser={adminUser} />
 
-                                    {context.aliases.length ?
+                                    {context.aliases.length > 0 ?
                                         <div data-test="aliases">
                                             <dt>Aliases</dt>
                                             <dd><DbxrefList context={context} dbxrefs={context.aliases} /></dd>
@@ -712,7 +712,7 @@ class ProjectComponent extends React.Component {
                                     <div data-test="externalresources">
                                         <dt>External resources</dt>
                                         <dd>
-                                            {context.dbxrefs && context.dbxrefs.length ?
+                                            {context.dbxrefs && context.dbxrefs.length > 0 ?
                                                 <DbxrefList context={context} dbxrefs={context.dbxrefs} />
                                             : <em>None submitted</em> }
                                         </dd>
@@ -775,10 +775,10 @@ class UcscBrowserCompositeComponent extends React.Component {
         const experimentsUrl = `/search/?type=Experiment&possible_controls.accession=${context.accession}`;
 
         // Build up array of documents attached to this dataset
-        const datasetDocuments = (context.documents && context.documents.length) ? context.documents : [];
+        const datasetDocuments = (context.documents && context.documents.length > 0) ? context.documents : [];
 
         // Collect organisms
-        const organisms = (context.organism && context.organism.length) ? _.uniq(context.organism.map(organism => organism.name)) : [];
+        const organisms = (context.organism && context.organism.length > 0) ? _.uniq(context.organism.map(organism => organism.name)) : [];
 
         // Set up the breadcrumbs
         const datasetType = context['@type'][1];
@@ -819,7 +819,7 @@ class UcscBrowserCompositeComponent extends React.Component {
                                         <dd><Status item={context} inline /></dd>
                                     </div>
 
-                                    {context.assay_term_name && context.assay_term_name.length ?
+                                    {context.assay_term_name && context.assay_term_name.length > 0 ?
                                         <div data-test="assays">
                                             <dt>Assay(s)</dt>
                                             <dd>{context.assay_term_name.join(', ')}</dd>
@@ -845,14 +845,14 @@ class UcscBrowserCompositeComponent extends React.Component {
                                         </div>
                                     : null}
 
-                                    {organisms.length ?
+                                    {organisms.length > 0 ?
                                         <div data-test="organism">
                                             <dt>Organism</dt>
                                             <dd>{organisms.join(', ')}</dd>
                                         </div>
                                     : null}
 
-                                    {context.software_used && context.software_used.length ?
+                                    {context.software_used && context.software_used.length > 0 ?
                                         <div data-test="software-used">
                                             <dt>Software used</dt>
                                             <dd>{softwareVersionList(context.software_used)}</dd>
@@ -876,7 +876,7 @@ class UcscBrowserCompositeComponent extends React.Component {
 
                                     <AwardRef context={context} adminUser={adminUser} />
 
-                                    {context.aliases.length ?
+                                    {context.aliases.length > 0 ?
                                         <div data-test="aliases">
                                             <dt>Aliases</dt>
                                             <dd><DbxrefList context={context} dbxrefs={context.aliases} /></dd>
@@ -886,7 +886,7 @@ class UcscBrowserCompositeComponent extends React.Component {
                                     <div data-test="externalresources">
                                         <dt>External resources</dt>
                                         <dd>
-                                            {context.dbxrefs && context.dbxrefs.length ?
+                                            {context.dbxrefs && context.dbxrefs.length > 0 ?
                                                 <DbxrefList context={context} dbxrefs={context.dbxrefs} />
                                             : <em>None submitted</em> }
                                         </dd>
@@ -970,7 +970,7 @@ FilePanelHeader.propTypes = {
 
 
 function displayPossibleControls(item, adminUser) {
-    if (item.possible_controls && item.possible_controls.length) {
+    if (item.possible_controls && item.possible_controls.length > 0) {
         return (
             <span>
                 {item.possible_controls.map((control, i) =>
@@ -1109,7 +1109,7 @@ const replicationTimingSeriesTableColumns = {
         display: (experiment) => {
             let phases = [];
 
-            if (experiment.replicates && experiment.replicates.length) {
+            if (experiment.replicates && experiment.replicates.length > 0) {
                 const biosamples = experiment.replicates.map(replicate => replicate.library && replicate.library.biosample);
                 phases = _.chain(biosamples.map(biosample => biosample.phase)).compact().uniq().value();
             }
@@ -1173,10 +1173,10 @@ const organismDevelopmentSeriesTableColumns = {
             let synchronizationBiosample;
             let ages;
 
-            if (experiment.replicates && experiment.replicates.length) {
+            if (experiment.replicates && experiment.replicates.length > 0) {
                 biosamples = experiment.replicates.map(replicate => replicate.library && replicate.library.biosample);
             }
-            if (biosamples && biosamples.length) {
+            if (biosamples && biosamples.length > 0) {
                 synchronizationBiosample = _(biosamples).find(biosample => biosample.synchronization);
                 if (!synchronizationBiosample) {
                     ages = _.chain(biosamples.map(biosample => biosample.age_display)).compact().uniq().value();
@@ -1187,7 +1187,7 @@ const organismDevelopmentSeriesTableColumns = {
                     {synchronizationBiosample ?
                         <span>{`${synchronizationBiosample.synchronization} + ${synchronizationBiosample.age_display}`}</span>
                     :
-                        <span>{ages && ages.length ? <span>{ages.join(', ')}</span> : null}</span>
+                        <span>{ages && ages.length > 0 ? <span>{ages.join(', ')}</span> : null}</span>
                     }
                 </span>
             );
@@ -1201,10 +1201,10 @@ const organismDevelopmentSeriesTableColumns = {
             let biosamples;
             let lifeStageBiosample;
 
-            if (experiment.replicates && experiment.replicates.length) {
+            if (experiment.replicates && experiment.replicates.length > 0) {
                 biosamples = experiment.replicates.map(replicate => replicate.library && replicate.library.biosample);
             }
-            if (biosamples && biosamples.length) {
+            if (biosamples && biosamples.length > 0) {
                 lifeStageBiosample = _(biosamples).find(biosample => biosample.life_stage);
                 return lifeStageBiosample.life_stage;
             }
@@ -1267,7 +1267,7 @@ export class SeriesComponent extends React.Component {
         experiments = _.values(experiments);
 
         // Build up array of documents attached to this dataset
-        const datasetDocuments = (context.documents && context.documents.length) ? context.documents : [];
+        const datasetDocuments = (context.documents && context.documents.length > 0) ? context.documents : [];
 
         // Set up the breadcrumbs
         const datasetType = context['@type'][1];
@@ -1289,7 +1289,7 @@ export class SeriesComponent extends React.Component {
 
         // Calculate the biosample summary
         let speciesRender = null;
-        if (context.organism && context.organism.length) {
+        if (context.organism && context.organism.length > 0) {
             const speciesList = _.uniq(context.organism.map(organism => organism.scientific_name));
             speciesRender = (
                 <span>
@@ -1357,18 +1357,18 @@ export class SeriesComponent extends React.Component {
                                         <dd>{diversity}</dd>
                                     </div>
 
-                                    {context.assay_term_name && context.assay_term_name.length ?
+                                    {context.assay_term_name && context.assay_term_name.length > 0 ?
                                         <div data-test="description">
                                             <dt>Assay</dt>
                                             <dd>{context.assay_term_name.join(', ')}</dd>
                                         </div>
                                     : null}
 
-                                    {terms.length || speciesRender ?
+                                    {terms.length > 0 || speciesRender ?
                                         <div data-test="biosamplesummary">
                                             <dt>Biosample summary</dt>
                                             <dd>
-                                                {terms.length ? <span>{terms.join(' and ')} </span> : null}
+                                                {terms.length > 0 ? <span>{terms.join(' and ')} </span> : null}
                                                 {speciesRender ? <span>({speciesRender})</span> : null}
                                             </dd>
                                         </div>
@@ -1404,7 +1404,7 @@ export class SeriesComponent extends React.Component {
                                     <div data-test="externalresources">
                                         <dt>External resources</dt>
                                         <dd>
-                                            {context.dbxrefs && context.dbxrefs.length ?
+                                            {context.dbxrefs && context.dbxrefs.length > 0 ?
                                                 <DbxrefList context={context} dbxrefs={context.dbxrefs} />
                                             : <em>None submitted</em> }
                                         </dd>

--- a/src/encoded/static/components/doc.js
+++ b/src/encoded/static/components/doc.js
@@ -36,8 +36,8 @@ const EXCERPT_LENGTH = 80; // Maximum number of characters in an excerpt
 
 export const DocumentsPanel = (props) => {
     // Filter documentSpecs to just those that have actual documents in them.
-    const documentSpecsMapped = props.documentSpecs.length && _.compact(props.documentSpecs.map(documentSpecs => (
-        documentSpecs.documents.length ? documentSpecs : null
+    const documentSpecsMapped = props.documentSpecs.length > 0 && _.compact(props.documentSpecs.map(documentSpecs => (
+        documentSpecs.documents.length > 0 ? documentSpecs : null
     )));
 
     // Concatenate all documents, and map their UUIDs to corresponding labels
@@ -53,7 +53,7 @@ export const DocumentsPanel = (props) => {
     // Sort documents by attachment download name.
     const sortedDocs = globals.sortDocs(allDocs);
 
-    if (documentSpecsMapped.length) {
+    if (documentSpecsMapped.length > 0) {
         return (
             <div>
                 <Panel addClasses="clearfix">
@@ -89,7 +89,7 @@ DocumentsPanel.defaultProps = {
 // array of matching documents.
 const DocumentsPanelRenderer = (props) => {
     const documents = props.documentSearch['@graph'];
-    if (documents && documents.length) {
+    if (documents && documents.length > 0) {
         return <DocumentsPanel documentSpecs={[{ documents }]} />;
     }
     return null;
@@ -109,7 +109,7 @@ DocumentsPanelRenderer.defaultProps = {
 export const DocumentsPanelReq = (props) => {
     const { documents } = props;
 
-    if (documents && documents.length) {
+    if (documents && documents.length > 0) {
         return (
             <FetchedData>
                 <Param name="documentSearch" url={`/search/?type=Item&${documents.map(docAtId => `@id=${docAtId}`).join('&')}`} />
@@ -457,7 +457,7 @@ export const CharacterizationDocuments = (props) => {
             {docs.map((doc) => {
                 if (doc && doc.attachment) {
                     const attachmentHref = url.resolve(doc['@id'], doc.attachment.href);
-                    const docName = (doc.aliases && doc.aliases.length) ? doc.aliases[0] :
+                    const docName = (doc.aliases && doc.aliases.length > 0) ? doc.aliases[0] :
                         ((doc.attachment && doc.attachment.download) ? doc.attachment.download : '');
                     return (
                         <div className="multi-dd dl-link" key={doc['@id']}>

--- a/src/encoded/static/components/donor.js
+++ b/src/encoded/static/components/donor.js
@@ -41,14 +41,14 @@ const HumanDonor = (props) => {
                             <dd>{biosample ? <a href={context['@id']}>{context.accession}</a> : context.accession}</dd>
                         </div>
 
-                        {context.aliases.length ?
+                        {context.aliases.length > 0 ?
                             <div data-test="aliases">
                                 <dt>Aliases</dt>
                                 <dd>{context.aliases.join(', ')}</dd>
                             </div>
                         : null}
 
-                        {context.external_ids && context.external_ids.length ?
+                        {context.external_ids && context.external_ids.length > 0 ?
                             <div data-test="externalid">
                                 <dt>Donor external identifiers</dt>
                                 <dd><DbxrefList context={context} dbxrefs={context.external_ids} /></dd>
@@ -97,7 +97,7 @@ const HumanDonor = (props) => {
                             </div>
                         : null}
 
-                        {context.dbxrefs && context.dbxrefs.length ?
+                        {context.dbxrefs && context.dbxrefs.length > 0 ?
                             <div data-test="external-resources">
                                 <dt>External resources</dt>
                                 <dd><DbxrefList context={context} dbxrefs={context.dbxrefs} /></dd>
@@ -223,14 +223,14 @@ const MouseDonor = (props) => {
                             <dd>{biosample ? <a href={context['@id']}>{context.accession}</a> : context.accession}</dd>
                         </div>
 
-                        {context.aliases.length ?
+                        {context.aliases.length > 0 ?
                             <div data-test="aliases">
                                 <dt>Aliases</dt>
                                 <dd>{context.aliases.join(', ')}</dd>
                             </div>
                         : null}
 
-                        {context.external_ids && context.external_ids.length ?
+                        {context.external_ids && context.external_ids.length > 0 ?
                             <div data-test="externalid">
                                 <dt>Donor external identifiers</dt>
                                 <dd><DbxrefList context={context} dbxrefs={context.external_ids} /></dd>
@@ -286,14 +286,14 @@ const MouseDonor = (props) => {
                             </div>
                         : null}
 
-                        {context.dbxrefs && context.dbxrefs.length ?
+                        {context.dbxrefs && context.dbxrefs.length > 0 ?
                             <div data-test="external-resources">
                                 <dt>External resources</dt>
                                 <dd><DbxrefList context={context} dbxrefs={context.dbxrefs} /></dd>
                             </div>
                         : null}
 
-                        {context.references && context.references.length ?
+                        {context.references && context.references.length > 0 ?
                             <div data-test="references">
                                 <dt>References</dt>
                                 <dd>{pubReferenceList(context.references)}</dd>
@@ -308,7 +308,7 @@ const MouseDonor = (props) => {
                         : null}
                     </dl>
 
-                    {biosample && biosample.donor.characterizations && biosample.donor.characterizations.length ?
+                    {biosample && biosample.donor.characterizations && biosample.donor.characterizations.length > 0 ?
                         <div>
                             <hr />
                             <h4>Characterizations</h4>
@@ -357,14 +357,14 @@ const FlyWormDonor = (props) => {
                             <dd>{biosample ? <a href={context['@id']}>{context.accession}</a> : context.accession}</dd>
                         </div>
 
-                        {context.aliases.length ?
+                        {context.aliases.length > 0 ?
                             <div data-test="aliases">
                                 <dt>Aliases</dt>
                                 <dd>{context.aliases.join(', ')}</dd>
                             </div>
                         : null}
 
-                        {context.external_ids && context.external_ids.length ?
+                        {context.external_ids && context.external_ids.length > 0 ?
                             <div data-test="externalid">
                                 <dt>Donor external identifiers</dt>
                                 <dd><DbxrefList context={context} dbxrefs={context.external_ids} /></dd>
@@ -420,7 +420,7 @@ const FlyWormDonor = (props) => {
                             </div>
                         : null}
 
-                        {context.dbxrefs && context.dbxrefs.length ?
+                        {context.dbxrefs && context.dbxrefs.length > 0 ?
                             <div data-test="external-resources">
                                 <dt>External resources</dt>
                                 <dd><DbxrefList context={context} dbxrefs={context.dbxrefs} /></dd>
@@ -497,8 +497,8 @@ class DonorComponent extends React.Component {
         // just arrays of human_donor @ids. This function does a database search to retrieve all
         // donor.parent and donor.children objects.
         const donor = this.props.context;
-        const parentAtids = donor.parents && donor.parents.length ? donor.parents : [];
-        const childrenAtids = donor.children && donor.children.length ? donor.children : [];
+        const parentAtids = donor.parents && donor.parents.length > 0 ? donor.parents : [];
+        const childrenAtids = donor.children && donor.children.length > 0 ? donor.children : [];
 
         // Do both the donor.parent and donor.children as a combined search, and sort the results
         // out after they get retrieved.
@@ -506,7 +506,7 @@ class DonorComponent extends React.Component {
 
         // atIds now has an array of human_donor parents and children @ids. Send a GET request to
         // perform a search.
-        if (atIds.length) {
+        if (atIds.length > 0) {
             requestObjects(atIds, '/search/?type=HumanDonor&limit=all&status!=deleted&status!=revoked&status!=replaced').then((parentChildDonors) => {
                 // Got search results with all human_donor parents and children as one search
                 // result array. Sort them into parents and children based on their locations in
@@ -544,12 +544,12 @@ class DonorComponent extends React.Component {
         let donorDocuments = [];
 
         // Collect the characterization documents.
-        if (context.characterizations && context.characterizations.length) {
+        if (context.characterizations && context.characterizations.length > 0) {
             characterizationDocuments = context.characterizations;
         }
 
         // Collect the donor documents.
-        if (context.documents && context.documents.length) {
+        if (context.documents && context.documents.length > 0) {
             donorDocuments = context.documents;
         }
 
@@ -581,7 +581,7 @@ class DonorComponent extends React.Component {
 
                 <PanelView key={context.uuid} {...this.props} />
 
-                {context.genetic_modifications && context.genetic_modifications.length ?
+                {context.genetic_modifications && context.genetic_modifications.length > 0 ?
                     <GeneticModificationSummary geneticModifications={context.genetic_modifications} />
                 : null}
 
@@ -591,11 +591,11 @@ class DonorComponent extends React.Component {
                     Component={BiosampleTable}
                 />
 
-                {context['@type'][0] === 'HumanDonor' && this.state.childDonors && this.state.childDonors.length ?
+                {context['@type'][0] === 'HumanDonor' && this.state.childDonors && this.state.childDonors.length > 0 ?
                     <DonorTable title="Children of this donor" donors={this.state.childDonors} />
                 : null}
 
-                {context['@type'][0] === 'HumanDonor' && this.state.parentDonors && this.state.parentDonors.length ?
+                {context['@type'][0] === 'HumanDonor' && this.state.parentDonors && this.state.parentDonors.length > 0 ?
                     <DonorTable title="Parents of this donor" donors={this.state.parentDonors} />
                 : null}
 
@@ -605,7 +605,7 @@ class DonorComponent extends React.Component {
                     Component={ExperimentTable}
                 />
 
-                {combinedDocuments.length ?
+                {combinedDocuments.length > 0 ?
                     <DocumentsPanel documentSpecs={[{ documents: combinedDocuments }]} />
                 : null}
             </div>
@@ -656,12 +656,12 @@ const DonorListingComponent = (props, reactContext) => {
                 <div className="accession">
                     <a href={result['@id']}>
                         <i>{result.organism.scientific_name}</i>
-                        {details.length ? ` (${details.join(', ')})` : null}
+                        {details.length > 0 ? ` (${details.join(', ')})` : null}
                     </a>
                 </div>
                 <div className="data-row">
                     {result.lab ? <div><strong>Lab: </strong>{result.lab.title}</div> : null}
-                    {result.external_ids && result.external_ids.length ?
+                    {result.external_ids && result.external_ids.length > 0 ?
                         <div>
                             <strong>External resources: </strong>
                             <DbxrefList context={result} dbxrefs={result.external_ids} />

--- a/src/encoded/static/components/experiment.js
+++ b/src/encoded/static/components/experiment.js
@@ -289,7 +289,7 @@ const ExperimentComponent = ({ context, auditIndicators, auditDetail }, reactCon
     }
 
     // Collect all documents from the experiment itself.
-    const documents = (context.documents && context.documents.length) ? context.documents : [];
+    const documents = (context.documents && context.documents.length > 0) ? context.documents : [];
 
     // Make array of all replicate biosamples, not including biosample-less replicates. Also
     // collect up library documents.
@@ -298,7 +298,7 @@ const ExperimentComponent = ({ context, auditIndicators, auditDetail }, reactCon
     if (replicates.length > 0) {
         biosamples = _.compact(replicates.map((replicate) => {
             if (replicate.library) {
-                if (replicate.library.documents && replicate.library.documents.length) {
+                if (replicate.library.documents && replicate.library.documents.length > 0) {
                     Array.prototype.push.apply(libraryDocs, replicate.library.documents);
                 }
 
@@ -330,21 +330,21 @@ const ExperimentComponent = ({ context, auditIndicators, auditDetail }, reactCon
     // Collect pipeline-related documents.
     let analysisStepDocs = [];
     let pipelineDocs = [];
-    if (context.files && context.files.length) {
+    if (context.files && context.files.length > 0) {
         context.files.forEach((file) => {
             const fileAnalysisStepVersion = file.analysis_step_version;
             if (fileAnalysisStepVersion) {
                 const fileAnalysisStep = fileAnalysisStepVersion.analysis_step;
                 if (fileAnalysisStep) {
                     // Collect analysis step docs
-                    if (fileAnalysisStep.documents && fileAnalysisStep.documents.length) {
+                    if (fileAnalysisStep.documents && fileAnalysisStep.documents.length > 0) {
                         analysisStepDocs = analysisStepDocs.concat(fileAnalysisStep.documents);
                     }
 
                     // Collect pipeline docs
-                    if (fileAnalysisStep.pipelines && fileAnalysisStep.pipelines.length) {
+                    if (fileAnalysisStep.pipelines && fileAnalysisStep.pipelines.length > 0) {
                         fileAnalysisStep.pipelines.forEach((pipeline) => {
-                            if (pipeline.documents && pipeline.documents.length) {
+                            if (pipeline.documents && pipeline.documents.length > 0) {
                                 pipelineDocs = pipelineDocs.concat(pipeline.documents);
                             }
                         });
@@ -353,8 +353,8 @@ const ExperimentComponent = ({ context, auditIndicators, auditDetail }, reactCon
             }
         });
     }
-    analysisStepDocs = analysisStepDocs.length ? _.uniq(analysisStepDocs) : [];
-    pipelineDocs = pipelineDocs.length ? _.uniq(pipelineDocs) : [];
+    analysisStepDocs = analysisStepDocs.length > 0 ? _.uniq(analysisStepDocs) : [];
+    pipelineDocs = pipelineDocs.length > 0 ? _.uniq(pipelineDocs) : [];
 
     // Determine this experiment's ENCODE version.
     const encodevers = globals.encodeVersion(context);
@@ -371,7 +371,7 @@ const ExperimentComponent = ({ context, auditIndicators, auditDetail }, reactCon
 
     // Get a list of related datasets, possibly filtering on their status.
     let seriesList = [];
-    if (context.related_series && context.related_series.length) {
+    if (context.related_series && context.related_series.length > 0) {
         seriesList = _(context.related_series).filter(dataset => loggedIn || dataset.status === 'released');
     }
 
@@ -383,8 +383,8 @@ const ExperimentComponent = ({ context, auditIndicators, auditDetail }, reactCon
     let nameQuery = '';
     let nameTip = '';
     const names = organismNames.map((organismName, i) => {
-        nameTip += (nameTip.length ? ' + ' : '') + organismName;
-        nameQuery += `${nameQuery.length ? '&' : ''}replicates.library.biosample.donor.organism.scientific_name=${organismName}`;
+        nameTip += (nameTip.length > 0 ? ' + ' : '') + organismName;
+        nameQuery += `${nameQuery.length > 0 ? '&' : ''}replicates.library.biosample.donor.organism.scientific_name=${organismName}`;
         return <span key={i}>{i > 0 ? <span> + </span> : null}<i>{organismName}</i></span>;
     });
     const biosampleTermName = context.biosample_ontology.term_name;
@@ -392,7 +392,7 @@ const ExperimentComponent = ({ context, auditIndicators, auditDetail }, reactCon
     const crumbs = [
         { id: 'Experiments' },
         { id: assayName, query: assayQuery, tip: assayName },
-        { id: names.length ? names : null, query: nameQuery, tip: nameTip },
+        { id: names.length > 0 ? names : null, query: nameQuery, tip: nameTip },
         { id: biosampleTermName, query: biosampleTermQuery, tip: biosampleTermName },
     ];
     const crumbsReleased = (context.status === 'released');
@@ -466,7 +466,7 @@ const ExperimentComponent = ({ context, auditIndicators, auditDetail }, reactCon
                                     <div data-test="biosample-summary">
                                         <dt>Biosample summary</dt>
                                         <dd>
-                                            {organismNames.length ?
+                                            {organismNames.length > 0 ?
                                                 <span>
                                                     {organismNames.map((organismName, i) =>
                                                         <span key={organismName}>
@@ -505,7 +505,7 @@ const ExperimentComponent = ({ context, auditIndicators, auditDetail }, reactCon
 
                                 <LibraryProperties replicates={replicates} />
 
-                                {Object.keys(platforms).length ?
+                                {Object.keys(platforms).length > 0 ?
                                     <div data-test="platform">
                                         <dt>Platform</dt>
                                         <dd>
@@ -519,7 +519,7 @@ const ExperimentComponent = ({ context, auditIndicators, auditDetail }, reactCon
                                     </div>
                                 : null}
 
-                                {context.possible_controls && context.possible_controls.length ?
+                                {context.possible_controls && context.possible_controls.length > 0 ?
                                     <div data-test="possible-controls">
                                         <dt>Controls</dt>
                                         <dd>
@@ -556,7 +556,7 @@ const ExperimentComponent = ({ context, auditIndicators, auditDetail }, reactCon
                                     <dd>{context.award.project}</dd>
                                 </div>
 
-                                {context.dbxrefs.length ?
+                                {context.dbxrefs.length > 0 ?
                                     <div data-test="external-resources">
                                         <dt>External resources</dt>
                                         <dd><DbxrefList context={context} dbxrefs={context.dbxrefs} /></dd>
@@ -570,7 +570,7 @@ const ExperimentComponent = ({ context, auditIndicators, auditDetail }, reactCon
                                     </div>
                                 : null}
 
-                                {context.aliases.length ?
+                                {context.aliases.length > 0 ?
                                     <div data-test="aliases">
                                         <dt>Aliases</dt>
                                         <dd>{context.aliases.join(', ')}</dd>
@@ -591,7 +591,7 @@ const ExperimentComponent = ({ context, auditIndicators, auditDetail }, reactCon
                                     </div>
                                 : null}
 
-                                {seriesList.length ?
+                                {seriesList.length > 0 ?
                                     <div data-test="relatedseries">
                                         <dt>Related datasets</dt>
                                         <dd><RelatedSeriesList seriesList={seriesList} /></dd>
@@ -628,7 +628,7 @@ const ExperimentComponent = ({ context, auditIndicators, auditDetail }, reactCon
 
             <FetchedItems context={context} url={experimentsUrl} Component={ControllingExperiments} />
 
-            {combinedDocuments.length ?
+            {combinedDocuments.length > 0 ?
                 <DocumentsPanelReq documents={combinedDocuments} />
             : null}
         </div>
@@ -717,7 +717,7 @@ const replicateTableColumns = {
         display: (condensedReplicate) => {
             const replicate = condensedReplicate[0];
             const gms = replicate.library && replicate.library.biosample && replicate.library.biosample.applied_modifications;
-            if (gms && gms.length) {
+            if (gms && gms.length > 0) {
                 return (
                     <span>
                         {gms.map((gm, i) => (
@@ -733,7 +733,7 @@ const replicateTableColumns = {
         },
         hide: list => _(list).all((condensedReplicate) => {
             const replicate = condensedReplicate[0];
-            return !(replicate.library && replicate.library.biosample && replicate.library.biosample.applied_modifications && replicate.library.biosample.applied_modifications.length);
+            return !(replicate.library && replicate.library.biosample && replicate.library.biosample.applied_modifications && replicate.library.biosample.applied_modifications.length > 0);
         }),
     },
 

--- a/src/encoded/static/components/experiment.js
+++ b/src/encoded/static/components/experiment.js
@@ -27,622 +27,613 @@ const anisogenicValues = [
 ];
 
 
-// Return an array of React components to render into the enclosing panel, given the experiment
-// object in the context parameter
-function AssayDetails(replicates, libVals, libSpecials, libComps) {
-    // Make a deep copy of libVals to avoid side effects.
-    const results = Object.assign({}, libVals);
+/**
+ * List of displayable library properties, the title to display it with, and the value to use for
+ * its data-test attribute.
+ */
+const displayedLibraryProperties = [
+    { property: 'treatments', title: 'Treatments', test: 'treatments' },
+    { property: 'nucleic_acid_term_name', title: 'Nucleic acid type', test: 'nucleicacid' },
+    { property: 'rna_integrity_number', title: 'RNA integrity number', test: 'rnaintegritynumber' },
+    { property: 'depleted_in_term_name', title: 'Depleted in', test: 'depletedin' },
+    { property: 'nucleic_acid_starting_quantity', title: 'Library starting quantity', test: 'startingquantity' },
+    { property: 'size_range', title: 'Size range', test: 'sizerange' },
+    { property: 'lysis_method', title: 'Lysis method', test: 'lysismethod' },
+    { property: 'extraction_method', title: 'Extraction method', test: 'extractionmethod' },
+    { property: 'fragmentation_methods', title: 'Fragmentation methods', test: 'fragmentationmethod' },
+    { property: 'library_size_selection_method', title: 'Size selection method', test: 'sizeselectionmethod' },
+    { property: 'strand_specificity', title: 'Strand specificity', test: 'strandspecificity' },
+    { property: 'spikeins_used', title: 'Spike-ins datasets', test: 'spikeins' },
+];
 
-    // Little utility to convert a replicate to a unique index we can use for arrays (like libraryValues below)
-    function replicateToIndex(replicate) {
-        return `${replicate.biological_replicate_number}-${replicate.technical_replicate_number}`;
-    }
 
-    // No replicates, so no assay entries
-    if (!replicates.length) {
-        return [];
-    }
+/**
+ * Specifies the property extractors for each library property that doesn't get displayed directly
+ * as text, maybe because an object represents the value or the value needs some other property to
+ * render. Each property extractor gets selected with the corresponding library property name, and
+ * each returns a one- or two-property object. All must return `libraryPropertyString` which either
+ * contains the text to display, or a string uniquely identifying that property's value between
+ * replicates, in which case `libraryPropertyComponent` gets returned which contains the JSX to
+ * render the property's value in a complex way, e.g. a link, italic text, etc. Property extractors
+ * must return an object, but they set `libraryPropertyString` to null to indicate no value to
+ * display.
+ */
+const libraryPropertyExtractors = {
+    treatments: (library) => {
+        // Collect and combine treatments from the library as well as the library's biosample.
+        let libraryTreatments = [];
 
-    // Collect library values to display from each replicate. Each key holds an array of values from each replicate's library,
-    // indexed by the replicate's biological replicate number. After this loop runs, libraryValues.values should all be filled
-    // with objects keyed by <bio rep num>-<tech rep num> and have the corresponding value or undefined if no value exists
-    // for that key. The 'value' properties of each object in libraryValues will all be undefined after this loop runs.
-    replicates.forEach((replicate) => {
-        const library = replicate.library;
-        const replicateIndex = replicateToIndex(replicate);
-
-        if (library) {
-            // Handle "normal" library properties
-            Object.keys(results).forEach((key) => {
-                let libraryValue;
-
-                // For specific library properties, preprocess non-simple values into simple ones using librarySpecials
-                if (libSpecials && libSpecials[key]) {
-                    // Preprocess complex values into simple ones
-                    libraryValue = libSpecials[key](library);
-                } else {
-                    // Simple value -- just copy it if it exists (copy undefined if it doesn't)
-                    libraryValue = library[key];
-                }
-
-                // If library property exists, add it to the values we're collecting, keyed by the biological replicate number.
-                // We'll prune it after this replicate loop.
-                results[key].values[replicateIndex] = libraryValue;
-            });
+        const treatments = library.treatments;
+        if (treatments && treatments.length > 0) {
+            libraryTreatments = libraryTreatments.concat(treatments.map(treatment => singleTreatment(treatment)));
         }
-    });
-
-    // Each property of libraryValues now has every value found in every existing library property in every replicate.
-    // Now for each library value in libraryValues, set the 'value' property if all values in the 'values' object are
-    // identical and existing. Otherwise, keep 'value' set to undefined.
-    const firstBiologicalReplicate = replicateToIndex(replicates[0]);
-    Object.keys(results).forEach((key) => {
-        // Get the first key's value to compare against the others.
-        const firstValue = results[key].values[firstBiologicalReplicate];
-
-        // See if all values in the values array are identical. Treat 'undefined' as a value
-        if (_(Object.keys(results[key].values)).all(replicateId => results[key].values[replicateId] === firstValue)) {
-            // All values for the library value are the same. Set the 'value' field with that value.
-            results[key].value = firstValue;
-
-            // If the resulting value is undefined, then all values are undefined for this key. Null out the values array.
-            if (firstValue === undefined) {
-                results[key].values = [];
-            } else if (libComps && libComps[key]) {
-                // The current key shows a rendering component, call it and save the resulting React object for later rendering.
-                results[key].component[firstBiologicalReplicate] = libComps[key](replicates[0].library);
-            }
-        } else if (libComps && libComps[key]) {
-            replicates.forEach((replicate) => {
-                // If the current key shows a rendering component, call it and save the resulting React object for later rendering.
-                results[key].component[replicateToIndex(replicate)] = libComps[key](replicate.library);
-            });
+        const biosampleTreatments = library.biosample && library.biosample.treatments;
+        if (biosampleTreatments && biosampleTreatments.length > 0) {
+            libraryTreatments = libraryTreatments.concat(biosampleTreatments.map(treatment => singleTreatment(treatment)));
         }
-    });
 
-    // Now begin the output process -- one React component per array element
-    const components = Object.keys(results).map((key) => {
-        const libraryEntry = results[key];
-        if (libraryEntry.value !== undefined || (libraryEntry.values && Object.keys(libraryEntry.values).length)) {
-            return (
-                <div key={key} data-test={libraryEntry.test}>
-                    <dt>{libraryEntry.title}</dt>
-                    <dd>
-                        {libraryEntry.value !== undefined ?
-                            <span>
-                                {(libraryEntry.component && Object.keys(libraryEntry.component).length) ?
-                                    <span>
-                                        {Object.keys(libraryEntry.component).map(componentKey => <span key={componentKey}>{libraryEntry.component[componentKey]}</span>)}
-                                    </span>
-                                :
-                                    <span>{libraryEntry.value}</span>
-                                }
-                            </span>
-                        :
-                            <span>
-                                {Object.keys(libraryEntry.values).map((replicateId) => {
-                                    const value = libraryEntry.values[replicateId];
-                                    if (libraryEntry.component && libraryEntry.component[replicateId]) {
-                                        // Display the pre-rendered component
-                                        return <span key={replicateId} className="line-item">{libraryEntry.component[replicateId]} [{replicateId}]</span>;
-                                    }
-                                    if (value) {
-                                        // Display the simple value
-                                        return <span key={replicateId} className="line-item">{value} [{replicateId}]</span>;
-                                    }
+        return { libraryPropertyString: libraryTreatments.join(', ') };
+    },
 
-                                    // No value to display; happens when at least one replicate had a value for this property, but this one doesn't
-                                    return null;
-                                })}
-                            </span>
-                        }
-                    </dd>
-                </div>
+    nucleic_acid_starting_quantity: (library) => {
+        let libraryPropertyString = null;
+        let libraryPropertyComponent = null;
+        const quantity = library.nucleic_acid_starting_quantity;
+        if (quantity) {
+            const units = library.nucleic_acid_starting_quantity_units;
+            libraryPropertyString = `${quantity}-${units}`;
+            libraryPropertyComponent = <span>{quantity}<span className="unit">{units}</span></span>;
+        }
+        return { libraryPropertyString, libraryPropertyComponent };
+    },
+
+    depleted_in_term_name: (library) => {
+        const terms = library.depleted_in_term_name;
+        let libraryPropertyString = null;
+        if (terms && terms.length > 0) {
+            libraryPropertyString = terms.sort().join(', ');
+        }
+        return { libraryPropertyString };
+    },
+
+    spikeins_used: (library) => {
+        const spikeins = library.spikeins_used;
+        let libraryPropertyString = null;
+        let libraryPropertyComponent = null;
+        if (spikeins && spikeins.length > 0) {
+            libraryPropertyString = spikeins.sort().join();
+            libraryPropertyComponent = (
+                spikeins.map((spikeinsAtId, i) => (
+                    <span key={i}>
+                        {i > 0 ? ', ' : ''}
+                        <a href={spikeinsAtId}>{globals.atIdToAccession(spikeinsAtId)}</a>
+                    </span>
+                ))
             );
         }
+        return { libraryPropertyString, libraryPropertyComponent };
+    },
 
-        // No value exists for this property in any replicate; display nothing for this property.
-        return null;
-    });
+    fragmentation_methods: (library) => {
+        const fragMethods = library.fragmentation_methods;
+        let libraryPropertyString = null;
+        if (fragMethods && fragMethods.length > 0) {
+            libraryPropertyString = fragMethods.sort().join(', ');
+        }
+        return { libraryPropertyString };
+    },
 
-    // Finally, return the array of JSX renderings of all assay details.
-    return components;
-}
+    strand_specificity: (library) => {
+        const strandSpecificity = library.strand_specificity;
+        let libraryPropertyString = null;
+
+        // A strand_specificity of "false" is still a displayable value.
+        if (strandSpecificity !== undefined) {
+            libraryPropertyString = strandSpecificity ? 'Strand-specific' : 'Non-strand-specific';
+        }
+        return { libraryPropertyString };
+    },
+};
 
 
-class ExperimentComponent extends React.Component {
-    constructor() {
-        super();
-
-        this.libraryValues = {
-            treatments: { values: {}, value: undefined, component: {}, title: 'Treatments', test: 'treatments' },
-            nucleic_acid_term_name: { values: {}, value: undefined, component: {}, title: 'Nucleic acid type', test: 'nucleicacid' },
-            rna_integrity_number: { values: {}, value: undefined, component: {}, title: 'RNA integrity number', test: 'rnaintegritynumber' },
-            depleted_in_term_name: { values: {}, value: undefined, component: {}, title: 'Depleted in', test: 'depletedin' },
-            nucleic_acid_starting_quantity: { values: {}, value: undefined, component: {}, title: 'Library starting quantity', test: 'startingquantity' },
-            size_range: { values: {}, value: undefined, component: {}, title: 'Size range', test: 'sizerange' },
-            lysis_method: { values: {}, value: undefined, component: {}, title: 'Lysis method', test: 'lysismethod' },
-            extraction_method: { values: {}, value: undefined, component: {}, title: 'Extraction method', test: 'extractionmethod' },
-            fragmentation_methods: { values: {}, value: undefined, component: {}, title: 'Fragmentation methods', test: 'fragmentationmethod' },
-            library_size_selection_method: { values: {}, value: undefined, component: {}, title: 'Size selection method', test: 'sizeselectionmethod' },
-            strand_specificity: { values: {}, value: undefined, component: {}, title: 'Strand specificity', test: 'strandspecificity' },
-            spikeins_used: { values: {}, value: undefined, component: {}, title: 'Spike-ins datasets', test: 'spikeins' },
-        };
-    }
-
-    render() {
-        let librarySpecials = {};
-        let libraryComponents = {};
-        let condensedReplicates = [];
-        let libSubmitterComments = [];
-        const context = this.props.context;
-        const loggedIn = !!(this.context.session && this.context.session['auth.userid']);
-        const adminUser = !!(this.context.session_properties && this.context.session_properties.admin);
-        const itemClass = globals.itemClass(context, 'view-item');
-        const replicates = context.replicates && context.replicates.length ? context.replicates : [];
-        if (replicates.length) {
-            const condensedReplicatesKeyed = _(replicates).groupBy(replicate => (replicate.library ? replicate.library['@id'] : replicate.uuid));
-            if (Object.keys(condensedReplicatesKeyed).length) {
-                condensedReplicates = _.toArray(condensedReplicatesKeyed);
-            }
-
-            // Collect all replicate libraries into one array of library objects.
-            const libraries = replicates.reduce((libraryAcc, replicate) => (replicate.library ? libraryAcc.concat([replicate.library]) : libraryAcc), []);
-
-            // Now create an array of React components displaying each library submitter comment
-            // as part of a definitino list.
-            if (libraries.length) {
-                libSubmitterComments = libraries.map((library) => {
-                    if (library.submitter_comment) {
-                        return (
-                            <div key={library['@id']} data-test={`submittercomment${library['@id']}`}>
-                                <dt>{library.accession} submitter comment</dt>
-                                <dd>{library.submitter_comment}</dd>
-                            </div>
-                        );
+/**
+ * Render the properties from all the libraries of a given set of replicates associated with a
+ * dataset. If all replicate libraries share the same property values, they get presented as one
+ * value. Where different replicate libraries have different values for the same property, every
+ * value gets displayed along with an indication of what biological and technical replicate each
+ * came from.
+ */
+const LibraryProperties = ({ replicates }) => {
+    if (replicates && replicates.length > 0) {
+        // First collect the values and optional components for all displayable replicate library
+        // properties. The product of this loop is `libraryPropertyDisplays` containing an object
+        // property for every displayable library property.
+        const libraryPropertyDisplays = {};
+        replicates.forEach((replicate) => {
+            if (replicate.library) {
+                // For each possible displayed library property within the current replicate,
+                // retrieve a string representing its value as well as an optional JSX component
+                // from the replicate library and add them along with the corresponding replicate
+                // numbers to `libraryPropertyDisplays`.
+                displayedLibraryProperties.forEach(({ property }) => {
+                    let libraryPropertyString = '';
+                    let libraryPropertyComponent = null;
+                    if (!libraryPropertyDisplays[property]) {
+                        libraryPropertyDisplays[property] = [];
                     }
 
-                    // No submitter comment.
-                    return null;
+                    // Some library properties have simple values you can display directly.
+                    // Others have more complex values that need a method to extract the value.
+                    // The existence of a property extractor for that property determines which
+                    // case we're dealing with.
+                    const libraryPropertyRawValue = replicate.library[property];
+                    if (libraryPropertyExtractors[property]) {
+                        // Library property has a property extractor.
+                        const extractedProperty = libraryPropertyExtractors[property](replicate.library);
+                        libraryPropertyString = extractedProperty.libraryPropertyString;
+                        libraryPropertyComponent = extractedProperty.libraryPropertyComponent;
+                    } else if (typeof libraryPropertyRawValue === 'string' || typeof libraryPropertyRawValue === 'number') {
+                        // Library property is a simple value, so just use it directly.
+                        libraryPropertyString = libraryPropertyRawValue;
+                    } // Else ignore the value; might need property extractor we haven't defined.
+
+                    // Add to the list of values and JSX components we're accumulating for the
+                    // current library property.
+                    if (libraryPropertyString) {
+                        libraryPropertyDisplays[property].push({
+                            value: libraryPropertyString,
+                            component: libraryPropertyComponent,
+                            bioRep: replicate.biological_replicate_number,
+                            techRep: replicate.technical_replicate_number,
+                        });
+                    }
                 });
             }
-        }
+        });
 
-        // Collect all documents from the experiment itself.
-        const documents = (context.documents && context.documents.length) ? context.documents : [];
-
-        // Make array of all replicate biosamples, not including biosample-less replicates. Also
-        // collect up library documents.
-        const libraryDocs = [];
-        let biosamples = [];
-        if (replicates.length) {
-            biosamples = _.compact(replicates.map((replicate) => {
-                if (replicate.library) {
-                    if (replicate.library.documents && replicate.library.documents.length) {
-                        Array.prototype.push.apply(libraryDocs, replicate.library.documents);
-                    }
-
-                    return replicate.library.biosample;
+        // Generate JSX for all the collected library property strings.
+        const renderedLibraryProperties = [];
+        displayedLibraryProperties.forEach((displayedLibraryProperty) => {
+            const libraryPropertyElements = libraryPropertyDisplays[displayedLibraryProperty.property];
+            if (libraryPropertyElements && libraryPropertyElements.length > 0) {
+                const homogeneous = !libraryPropertyElements.some(libraryProperty => libraryProperty.value !== libraryPropertyElements[0].value);
+                if (!homogeneous) {
+                    // More than one value collected for this property, and at least one had a
+                    // different value from the others. Display all values with a replicate
+                    // identifier for each one.
+                    renderedLibraryProperties.push(
+                        <div key={displayedLibraryProperty.property} data-test={displayedLibraryProperty.test}>
+                            <dt>{displayedLibraryProperty.title}</dt>
+                            <dd>
+                                {libraryPropertyElements.map((libraryPropertyElement) => {
+                                    const replicateIdentifier = `[${libraryPropertyElement.bioRep}-${libraryPropertyElement.techRep}]`;
+                                    return (
+                                        <span key={replicateIdentifier} className="line-item">
+                                            {libraryPropertyElement.component || libraryPropertyElement.value} {replicateIdentifier}
+                                        </span>
+                                    );
+                                })}
+                            </dd>
+                        </div>
+                    );
+                } else {
+                    // Only one value collected for this property, or more than one but all have
+                    // the same value, so just display the one value without a replicate
+                    // identifier.
+                    renderedLibraryProperties.push(
+                        <div key={displayedLibraryProperty.property} data-test={displayedLibraryProperty.test}>
+                            <dt>{displayedLibraryProperty.title}</dt>
+                            <dd>{libraryPropertyElements[0].component || libraryPropertyElements[0].value}</dd>
+                        </div>
+                    );
                 }
-                return null;
-            }));
-        }
-
-        // Create platforms array from file platforms; ignore duplicate platforms.
-        const platforms = {};
-        if (context.files && context.files.length) {
-            context.files.forEach((file) => {
-                if (file.platform && file.dataset === context['@id']) {
-                    platforms[file.platform['@id']] = file.platform;
-                }
-            });
-        }
-
-        // If we have replicates, handle what we used to call Assay Details -- display data about
-        // each of the replicates, breaking out details
-        // if they differ between replicates.
-        if (replicates.length) {
-            // Prepare to collect values from each replicate's library. Each key in this object
-            // refers to a property in the libraries. For any library properties that aren't simple
-            // values, put functions to process them into simple values in this object, keyed by
-            // their library property name. Returned JS undefined if no complex value exists so
-            // that we can reliably test it. We have a couple properties too complex even for this,
-            // so they'll get added separately at the end.
-            librarySpecials = {
-                treatments: (library) => {
-                    let treatments = []; // Array of treatment_term_name
-
-                    // First get the treatments in the library
-                    if (library.treatments && library.treatments.length) {
-                        treatments = library.treatments.map(treatment => singleTreatment(treatment));
-                    }
-
-                    // Now get the treatments in the biosamples
-                    if (library.biosample && library.biosample.treatments && library.biosample.treatments.length) {
-                        treatments = treatments.concat(library.biosample.treatments.map(treatment => singleTreatment(treatment)));
-                    }
-
-                    if (treatments.length) {
-                        return treatments.sort().join(', ');
-                    }
-                    return undefined;
-                },
-                nucleic_acid_starting_quantity: (library) => {
-                    const quantity = library.nucleic_acid_starting_quantity;
-                    if (quantity) {
-                        return quantity + library.nucleic_acid_starting_quantity_units;
-                    }
-                    return undefined;
-                },
-                depleted_in_term_name: (library) => {
-                    const terms = library.depleted_in_term_name;
-                    if (terms && terms.length) {
-                        return terms.sort().join(', ');
-                    }
-                    return undefined;
-                },
-                spikeins_used: (library) => {
-                    const spikeins = library.spikeins_used;
-
-                    // Just track @id for deciding if all values are the same or not. Rendering
-                    // handled in libraryComponents
-                    if (spikeins && spikeins.length) {
-                        return spikeins.sort().join();
-                    }
-                    return undefined;
-                },
-                fragmentation_methods: (library) => {
-                    const fragMethods = library.fragmentation_methods;
-                    if (fragMethods && fragMethods.length > 0) {
-                        return fragMethods.sort().join(', ');
-                    }
-                    return undefined;
-                },
-            };
-            libraryComponents = {
-                nucleic_acid_starting_quantity: (library) => {
-                    if (library && library.nucleic_acid_starting_quantity && library.nucleic_acid_starting_quantity_units) {
-                        return <span>{library.nucleic_acid_starting_quantity}<span className="unit">{library.nucleic_acid_starting_quantity_units}</span></span>;
-                    }
-                    return null;
-                },
-                strand_specificity: library => (library ? <span>{library.strand_specificity ? 'Strand-specific' : 'Non-strand-specific'}</span> : null),
-                spikeins_used: (library) => {
-                    const spikeins = library && library.spikeins_used;
-                    if (spikeins && spikeins.length) {
-                        return (
-                            <span>
-                                {spikeins.map((spikeinsAtId, i) =>
-                                    <span key={i}>
-                                        {i > 0 ? ', ' : ''}
-                                        <a href={spikeinsAtId}>{globals.atIdToAccession(spikeinsAtId)}</a>
-                                    </span>
-                                )}
-                            </span>
-                        );
-                    }
-                    return null;
-                },
-            };
-        }
-
-        // Collect biosample docs.
-        let biosampleDocs = [];
-        biosamples.forEach((biosample) => {
-            biosampleDocs = biosampleDocs.concat(CollectBiosampleDocs(biosample));
-            if (biosample.part_of) {
-                biosampleDocs = biosampleDocs.concat(CollectBiosampleDocs(biosample.part_of));
             }
         });
+        return renderedLibraryProperties;
+    }
+    return null;
+};
 
-        // Collect pipeline-related documents.
-        let analysisStepDocs = [];
-        let pipelineDocs = [];
-        if (context.files && context.files.length) {
-            context.files.forEach((file) => {
-                const fileAnalysisStepVersion = file.analysis_step_version;
-                if (fileAnalysisStepVersion) {
-                    const fileAnalysisStep = fileAnalysisStepVersion.analysis_step;
-                    if (fileAnalysisStep) {
-                        // Collect analysis step docs
-                        if (fileAnalysisStep.documents && fileAnalysisStep.documents.length) {
-                            analysisStepDocs = analysisStepDocs.concat(fileAnalysisStep.documents);
-                        }
+LibraryProperties.propTypes = {
+    /** Array of replicates whose library details need display */
+    replicates: PropTypes.array,
+};
 
-                        // Collect pipeline docs
-                        if (fileAnalysisStep.pipelines && fileAnalysisStep.pipelines.length) {
-                            fileAnalysisStep.pipelines.forEach((pipeline) => {
-                                if (pipeline.documents && pipeline.documents.length) {
-                                    pipelineDocs = pipelineDocs.concat(pipeline.documents);
-                                }
-                            });
-                        }
+LibraryProperties.defaultProps = {
+    replicates: [],
+};
+
+
+/**
+ * Display submitter comments from all libraries in all the given replicates.
+ */
+const LibrarySubmitterComments = ({ replicates }) => {
+    // Make a list of all libraries in all replicates, deduped.
+    const libraries = _.uniq(replicates.reduce((libraryAcc, replicate) => (replicate.library ? libraryAcc.concat([replicate.library]) : libraryAcc), []), library => library['@id']);
+    if (libraries.length > 0) {
+        return libraries.map((library) => {
+            if (library.submitter_comment) {
+                return (
+                    <div key={library['@id']} data-test={`submittercomment${library['@id']}`}>
+                        <dt>{library.accession} submitter comment</dt>
+                        <dd>{library.submitter_comment}</dd>
+                    </div>
+                );
+            }
+            return null;
+        });
+    }
+    return null;
+};
+
+LibrarySubmitterComments.propTypes = {
+    /** Replicates containing libraries whose comments we display */
+    replicates: PropTypes.array,
+};
+
+
+const ExperimentComponent = ({ context, auditIndicators, auditDetail }, reactContext) => {
+    let condensedReplicates = [];
+    const loggedIn = !!(reactContext.session && reactContext.session['auth.userid']);
+    const adminUser = !!(reactContext.session_properties && reactContext.session_properties.admin);
+    const itemClass = globals.itemClass(context, 'view-item');
+    const replicates = context.replicates && context.replicates.length > 0 ? context.replicates : [];
+    if (replicates.length > 0) {
+        // Make an array of arrays of replicates, called “condensed replicates" here. Each top-
+        // level array element represents a library linked to by the replicates inside that
+        // array. Only the first replicate in each library array gets displayed in the table.
+        const condensedReplicatesKeyed = _(replicates).groupBy(replicate => (replicate.library ? replicate.library['@id'] : replicate.uuid));
+        if (Object.keys(condensedReplicatesKeyed).length > 0) {
+            condensedReplicates = _.toArray(condensedReplicatesKeyed);
+        }
+    }
+
+    // Collect all documents from the experiment itself.
+    const documents = (context.documents && context.documents.length) ? context.documents : [];
+
+    // Make array of all replicate biosamples, not including biosample-less replicates. Also
+    // collect up library documents.
+    const libraryDocs = [];
+    let biosamples = [];
+    if (replicates.length > 0) {
+        biosamples = _.compact(replicates.map((replicate) => {
+            if (replicate.library) {
+                if (replicate.library.documents && replicate.library.documents.length) {
+                    Array.prototype.push.apply(libraryDocs, replicate.library.documents);
+                }
+
+                return replicate.library.biosample;
+            }
+            return null;
+        }));
+    }
+
+    // Create platforms array from file platforms; ignore duplicate platforms.
+    const platforms = {};
+    if (context.files && context.files.length > 0) {
+        context.files.forEach((file) => {
+            if (file.platform && file.dataset === context['@id']) {
+                platforms[file.platform['@id']] = file.platform;
+            }
+        });
+    }
+
+    // Collect biosample docs.
+    let biosampleDocs = [];
+    biosamples.forEach((biosample) => {
+        biosampleDocs = biosampleDocs.concat(CollectBiosampleDocs(biosample));
+        if (biosample.part_of) {
+            biosampleDocs = biosampleDocs.concat(CollectBiosampleDocs(biosample.part_of));
+        }
+    });
+
+    // Collect pipeline-related documents.
+    let analysisStepDocs = [];
+    let pipelineDocs = [];
+    if (context.files && context.files.length) {
+        context.files.forEach((file) => {
+            const fileAnalysisStepVersion = file.analysis_step_version;
+            if (fileAnalysisStepVersion) {
+                const fileAnalysisStep = fileAnalysisStepVersion.analysis_step;
+                if (fileAnalysisStep) {
+                    // Collect analysis step docs
+                    if (fileAnalysisStep.documents && fileAnalysisStep.documents.length) {
+                        analysisStepDocs = analysisStepDocs.concat(fileAnalysisStep.documents);
+                    }
+
+                    // Collect pipeline docs
+                    if (fileAnalysisStep.pipelines && fileAnalysisStep.pipelines.length) {
+                        fileAnalysisStep.pipelines.forEach((pipeline) => {
+                            if (pipeline.documents && pipeline.documents.length) {
+                                pipelineDocs = pipelineDocs.concat(pipeline.documents);
+                            }
+                        });
                     }
                 }
-            });
-        }
-        analysisStepDocs = analysisStepDocs.length ? _.uniq(analysisStepDocs) : [];
-        pipelineDocs = pipelineDocs.length ? _.uniq(pipelineDocs) : [];
-
-        // Determine this experiment's ENCODE version.
-        const encodevers = globals.encodeVersion(context);
-
-        // Make list of statuses.
-        const statuses = [{ status: context.status, title: 'Status' }];
-        if (adminUser && context.internal_status) {
-            statuses.push({ status: context.internal_status, title: 'Internal' });
-        }
-
-        // Determine whether the experiment is isogenic or anisogenic. No replication_type
-        // indicates isogenic.
-        const anisogenic = context.replication_type ? (anisogenicValues.indexOf(context.replication_type) !== -1) : false;
-
-        // Get a list of related datasets, possibly filtering on their status.
-        let seriesList = [];
-        if (context.related_series && context.related_series.length) {
-            seriesList = _(context.related_series).filter(dataset => loggedIn || dataset.status === 'released');
-        }
-
-        // Set up the breadcrumbs.
-        const assayTerm = context.assay_term_name ? 'assay_term_name' : 'assay_term_id';
-        const assayName = context[assayTerm];
-        const assayQuery = `${assayTerm}=${assayName}`;
-        const organismNames = BiosampleOrganismNames(biosamples);
-        let nameQuery = '';
-        let nameTip = '';
-        const names = organismNames.map((organismName, i) => {
-            nameTip += (nameTip.length ? ' + ' : '') + organismName;
-            nameQuery += `${nameQuery.length ? '&' : ''}replicates.library.biosample.donor.organism.scientific_name=${organismName}`;
-            return <span key={i}>{i > 0 ? <span> + </span> : null}<i>{organismName}</i></span>;
+            }
         });
-        const biosampleTermName = context.biosample_ontology.term_name;
-        const biosampleTermQuery = biosampleTermName ? `biosample_ontology.term_name=${biosampleTermName}` : '';
-        const crumbs = [
-            { id: 'Experiments' },
-            { id: assayName, query: assayQuery, tip: assayName },
-            { id: names.length ? names : null, query: nameQuery, tip: nameTip },
-            { id: biosampleTermName, query: biosampleTermQuery, tip: biosampleTermName },
-        ];
-        const crumbsReleased = (context.status === 'released');
-
-        // Compile the document list.
-        const combinedDocuments = _.uniq(documents.concat(
-            biosampleDocs,
-            libraryDocs,
-            pipelineDocs,
-            analysisStepDocs
-        ));
-
-        const experimentsUrl = `/search/?type=Experiment&possible_controls.accession=${context.accession}`;
-
-        // Make a list of reference links, if any.
-        const references = pubReferenceList(context.references);
-
-        // Render tags badges.
-
-        return (
-            <div className={itemClass}>
-                <header className="row">
-                    <div className="col-sm-12">
-                        <Breadcrumbs root="/search/?type=Experiment" crumbs={crumbs} crumbsReleased={crumbsReleased} />
-                        <h2>Experiment summary for {context.accession}</h2>
-                        <ReplacementAccessions context={context} />
-                        <div className="cart__toggle--header">
-                            <CartToggle element={context} />
-                        </div>
-                        <DisplayAsJson />
-                        {this.props.auditIndicators(context.audit, 'experiment-audit', { session: this.context.session })}
-                    </div>
-                </header>
-                {this.props.auditDetail(context.audit, 'experiment-audit', { session: this.context.session, except: context['@id'] })}
-                <Panel addClasses="data-display">
-                    <PanelBody addClasses="panel-body-with-header">
-                        <div className="flexrow">
-                            <div className="flexcol-sm-6">
-                                <div className="flexcol-heading experiment-heading">
-                                    <h4>Summary</h4>
-                                </div>
-                                <dl className="key-value">
-                                    <div data-test="status">
-                                        <dt>Status</dt>
-                                        <dd>
-                                            <Status item={context} css="dd-status" title="Experiment status" inline />
-                                            {adminUser && context.internal_status ?
-                                                <Status item={context.internal_status} title="Internal status" inline />
-                                            : null}
-                                        </dd>
-                                    </div>
-
-                                    <div data-test="assay">
-                                        <dt>Assay</dt>
-                                        <dd>
-                                            {context.assay_term_name}
-                                            {context.assay_term_name !== context.assay_title ?
-                                                <span>{` (${context.assay_title})`}</span>
-                                            : null}
-                                        </dd>
-                                    </div>
-
-                                    {context.target ?
-                                        <div data-test="target">
-                                            <dt>Target</dt>
-                                            <dd><a href={context.target['@id']}>{context.target.label}</a></dd>
-                                        </div>
-                                    : null}
-
-                                    {context.biosample_summary ?
-                                        <div data-test="biosample-summary">
-                                            <dt>Biosample summary</dt>
-                                            <dd>
-                                                {organismNames.length ?
-                                                    <span>
-                                                        {organismNames.map((organismName, i) =>
-                                                            <span key={organismName}>
-                                                                {i > 0 ? <span> and </span> : null}
-                                                                <i>{organismName}</i>
-                                                            </span>
-                                                        )}
-                                                        &nbsp;
-                                                    </span>
-                                                : null}
-                                                <span>{context.biosample_summary}</span>
-                                            </dd>
-                                        </div>
-                                    : null}
-
-                                    {context.biosample_ontology ?
-                                        <div data-test="biosample-type">
-                                            <dt>Biosample Type</dt>
-                                            <dd>{context.biosample_ontology.classification}</dd>
-                                        </div>
-                                    : null}
-
-                                    {context.replication_type ?
-                                        <div data-test="replicationtype">
-                                            <dt>Replication type</dt>
-                                            <dd>{context.replication_type}</dd>
-                                        </div>
-                                    : null}
-
-                                    {context.description ?
-                                        <div data-test="description">
-                                            <dt>Description</dt>
-                                            <dd>{context.description}</dd>
-                                        </div>
-                                    : null}
-
-                                    {AssayDetails(replicates, this.libraryValues, librarySpecials, libraryComponents)}
-
-                                    {Object.keys(platforms).length ?
-                                        <div data-test="platform">
-                                            <dt>Platform</dt>
-                                            <dd>
-                                                {Object.keys(platforms).map((platformId, i) =>
-                                                    <span key={platformId}>
-                                                        {i > 0 ? <span>, </span> : null}
-                                                        <a className="stacked-link" href={platformId}>{platforms[platformId].title}</a>
-                                                    </span>
-                                                )}
-                                            </dd>
-                                        </div>
-                                    : null}
-
-                                    {context.possible_controls && context.possible_controls.length ?
-                                        <div data-test="possible-controls">
-                                            <dt>Controls</dt>
-                                            <dd>
-                                                <ul>
-                                                    {context.possible_controls.map(control => (
-                                                        <li key={control['@id']} className="multi-comma">
-                                                            <a href={control['@id']}>
-                                                                {control.accession}
-                                                            </a>
-                                                        </li>
-                                                    ))}
-                                                </ul>
-                                            </dd>
-                                        </div>
-                                    : null}
-                                </dl>
-                            </div>
-
-                            <div className="flexcol-sm-6">
-                                <div className="flexcol-heading experiment-heading">
-                                    <h4>Attribution</h4>
-                                    <ProjectBadge award={context.award} addClasses="badge-heading" />
-                                </div>
-                                <dl className="key-value">
-                                    <div data-test="lab">
-                                        <dt>Lab</dt>
-                                        <dd>{context.lab.title}</dd>
-                                    </div>
-
-                                    <AwardRef context={context} adminUser={adminUser} />
-
-                                    <div data-test="project">
-                                        <dt>Project</dt>
-                                        <dd>{context.award.project}</dd>
-                                    </div>
-
-                                    {context.dbxrefs.length ?
-                                        <div data-test="external-resources">
-                                            <dt>External resources</dt>
-                                            <dd><DbxrefList context={context} dbxrefs={context.dbxrefs} /></dd>
-                                        </div>
-                                    : null}
-
-                                    {references ?
-                                        <div data-test="references">
-                                            <dt>References</dt>
-                                            <dd>{references}</dd>
-                                        </div>
-                                    : null}
-
-                                    {context.aliases.length ?
-                                        <div data-test="aliases">
-                                            <dt>Aliases</dt>
-                                            <dd>{context.aliases.join(', ')}</dd>
-                                        </div>
-                                    : null}
-
-                                    {context.date_submitted ?
-                                        <div data-test="date-submitted">
-                                            <dt>Date submitted</dt>
-                                            <dd>{moment(context.date_submitted).format('MMMM D, YYYY')}</dd>
-                                        </div>
-                                    : null}
-
-                                    {context.date_released ?
-                                        <div data-test="date-released">
-                                            <dt>Date released</dt>
-                                            <dd>{moment(context.date_released).format('MMMM D, YYYY')}</dd>
-                                        </div>
-                                    : null}
-
-                                    {seriesList.length ?
-                                        <div data-test="relatedseries">
-                                            <dt>Related datasets</dt>
-                                            <dd><RelatedSeriesList seriesList={seriesList} /></dd>
-                                        </div>
-                                    : null}
-
-                                    {context.submitter_comment ?
-                                        <div data-test="submittercomment">
-                                            <dt>Submitter comment</dt>
-                                            <dd>{context.submitter_comment}</dd>
-                                        </div>
-                                    : null}
-
-                                    {libSubmitterComments}
-
-                                    {context.internal_tags && context.internal_tags.length > 0 ?
-                                        <div className="tag-badges" data-test="tags">
-                                            <dt>Tags</dt>
-                                            <dd><InternalTags context={context} /></dd>
-                                        </div>
-                                    : null}
-                                </dl>
-                            </div>
-                        </div>
-                    </PanelBody>
-                </Panel>
-
-                {Object.keys(condensedReplicates).length ?
-                    <ReplicateTable condensedReplicates={condensedReplicates} replicationType={context.replication_type} />
-                : null}
-
-                {/* Display the file widget with the facet, graph, and tables */}
-                <FileGallery context={context} encodevers={encodevers} anisogenic={anisogenic} />
-
-                <FetchedItems {...this.props} url={experimentsUrl} Component={ControllingExperiments} />
-
-                {combinedDocuments.length ?
-                    <DocumentsPanelReq documents={combinedDocuments} />
-                : null}
-            </div>
-        );
     }
-}
+    analysisStepDocs = analysisStepDocs.length ? _.uniq(analysisStepDocs) : [];
+    pipelineDocs = pipelineDocs.length ? _.uniq(pipelineDocs) : [];
+
+    // Determine this experiment's ENCODE version.
+    const encodevers = globals.encodeVersion(context);
+
+    // Make list of statuses.
+    const statuses = [{ status: context.status, title: 'Status' }];
+    if (adminUser && context.internal_status) {
+        statuses.push({ status: context.internal_status, title: 'Internal' });
+    }
+
+    // Determine whether the experiment is isogenic or anisogenic. No replication_type
+    // indicates isogenic.
+    const anisogenic = context.replication_type ? (anisogenicValues.indexOf(context.replication_type) !== -1) : false;
+
+    // Get a list of related datasets, possibly filtering on their status.
+    let seriesList = [];
+    if (context.related_series && context.related_series.length) {
+        seriesList = _(context.related_series).filter(dataset => loggedIn || dataset.status === 'released');
+    }
+
+    // Set up the breadcrumbs.
+    const assayTerm = context.assay_term_name ? 'assay_term_name' : 'assay_term_id';
+    const assayName = context[assayTerm];
+    const assayQuery = `${assayTerm}=${assayName}`;
+    const organismNames = BiosampleOrganismNames(biosamples);
+    let nameQuery = '';
+    let nameTip = '';
+    const names = organismNames.map((organismName, i) => {
+        nameTip += (nameTip.length ? ' + ' : '') + organismName;
+        nameQuery += `${nameQuery.length ? '&' : ''}replicates.library.biosample.donor.organism.scientific_name=${organismName}`;
+        return <span key={i}>{i > 0 ? <span> + </span> : null}<i>{organismName}</i></span>;
+    });
+    const biosampleTermName = context.biosample_ontology.term_name;
+    const biosampleTermQuery = biosampleTermName ? `biosample_ontology.term_name=${biosampleTermName}` : '';
+    const crumbs = [
+        { id: 'Experiments' },
+        { id: assayName, query: assayQuery, tip: assayName },
+        { id: names.length ? names : null, query: nameQuery, tip: nameTip },
+        { id: biosampleTermName, query: biosampleTermQuery, tip: biosampleTermName },
+    ];
+    const crumbsReleased = (context.status === 'released');
+
+    // Compile the document list.
+    const combinedDocuments = _.uniq(documents.concat(
+        biosampleDocs,
+        libraryDocs,
+        pipelineDocs,
+        analysisStepDocs
+    ));
+
+    const experimentsUrl = `/search/?type=Experiment&possible_controls.accession=${context.accession}`;
+
+    // Make a list of reference links, if any.
+    const references = pubReferenceList(context.references);
+
+    // Render tags badges.
+
+    return (
+        <div className={itemClass}>
+            <header className="row">
+                <div className="col-sm-12">
+                    <Breadcrumbs root="/search/?type=Experiment" crumbs={crumbs} crumbsReleased={crumbsReleased} />
+                    <h2>Experiment summary for {context.accession}</h2>
+                    <ReplacementAccessions context={context} />
+                    <div className="cart__toggle--header">
+                        <CartToggle element={context} />
+                    </div>
+                    <DisplayAsJson />
+                    {auditIndicators(context.audit, 'experiment-audit', { session: reactContext.session })}
+                </div>
+            </header>
+            {auditDetail(context.audit, 'experiment-audit', { session: reactContext.session, except: context['@id'] })}
+            <Panel addClasses="data-display">
+                <PanelBody addClasses="panel-body-with-header">
+                    <div className="flexrow">
+                        <div className="flexcol-sm-6">
+                            <div className="flexcol-heading experiment-heading">
+                                <h4>Summary</h4>
+                            </div>
+                            <dl className="key-value">
+                                <div data-test="status">
+                                    <dt>Status</dt>
+                                    <dd>
+                                        <Status item={context} css="dd-status" title="Experiment status" inline />
+                                        {adminUser && context.internal_status ?
+                                            <Status item={context.internal_status} title="Internal status" inline />
+                                        : null}
+                                    </dd>
+                                </div>
+
+                                <div data-test="assay">
+                                    <dt>Assay</dt>
+                                    <dd>
+                                        {context.assay_term_name}
+                                        {context.assay_term_name !== context.assay_title ?
+                                            <span>{` (${context.assay_title})`}</span>
+                                        : null}
+                                    </dd>
+                                </div>
+
+                                {context.target ?
+                                    <div data-test="target">
+                                        <dt>Target</dt>
+                                        <dd><a href={context.target['@id']}>{context.target.label}</a></dd>
+                                    </div>
+                                : null}
+
+                                {context.biosample_summary ?
+                                    <div data-test="biosample-summary">
+                                        <dt>Biosample summary</dt>
+                                        <dd>
+                                            {organismNames.length ?
+                                                <span>
+                                                    {organismNames.map((organismName, i) =>
+                                                        <span key={organismName}>
+                                                            {i > 0 ? <span> and </span> : null}
+                                                            <i>{organismName}</i>
+                                                        </span>
+                                                    )}
+                                                    &nbsp;
+                                                </span>
+                                            : null}
+                                            <span>{context.biosample_summary}</span>
+                                        </dd>
+                                    </div>
+                                : null}
+
+                                {context.biosample_ontology ?
+                                    <div data-test="biosample-type">
+                                        <dt>Biosample Type</dt>
+                                        <dd>{context.biosample_ontology.classification}</dd>
+                                    </div>
+                                : null}
+
+                                {context.replication_type ?
+                                    <div data-test="replicationtype">
+                                        <dt>Replication type</dt>
+                                        <dd>{context.replication_type}</dd>
+                                    </div>
+                                : null}
+
+                                {context.description ?
+                                    <div data-test="description">
+                                        <dt>Description</dt>
+                                        <dd>{context.description}</dd>
+                                    </div>
+                                : null}
+
+                                <LibraryProperties replicates={replicates} />
+
+                                {Object.keys(platforms).length ?
+                                    <div data-test="platform">
+                                        <dt>Platform</dt>
+                                        <dd>
+                                            {Object.keys(platforms).map((platformId, i) =>
+                                                <span key={platformId}>
+                                                    {i > 0 ? <span>, </span> : null}
+                                                    <a className="stacked-link" href={platformId}>{platforms[platformId].title}</a>
+                                                </span>
+                                            )}
+                                        </dd>
+                                    </div>
+                                : null}
+
+                                {context.possible_controls && context.possible_controls.length ?
+                                    <div data-test="possible-controls">
+                                        <dt>Controls</dt>
+                                        <dd>
+                                            <ul>
+                                                {context.possible_controls.map(control => (
+                                                    <li key={control['@id']} className="multi-comma">
+                                                        <a href={control['@id']}>
+                                                            {control.accession}
+                                                        </a>
+                                                    </li>
+                                                ))}
+                                            </ul>
+                                        </dd>
+                                    </div>
+                                : null}
+                            </dl>
+                        </div>
+
+                        <div className="flexcol-sm-6">
+                            <div className="flexcol-heading experiment-heading">
+                                <h4>Attribution</h4>
+                                <ProjectBadge award={context.award} addClasses="badge-heading" />
+                            </div>
+                            <dl className="key-value">
+                                <div data-test="lab">
+                                    <dt>Lab</dt>
+                                    <dd>{context.lab.title}</dd>
+                                </div>
+
+                                <AwardRef context={context} adminUser={adminUser} />
+
+                                <div data-test="project">
+                                    <dt>Project</dt>
+                                    <dd>{context.award.project}</dd>
+                                </div>
+
+                                {context.dbxrefs.length ?
+                                    <div data-test="external-resources">
+                                        <dt>External resources</dt>
+                                        <dd><DbxrefList context={context} dbxrefs={context.dbxrefs} /></dd>
+                                    </div>
+                                : null}
+
+                                {references ?
+                                    <div data-test="references">
+                                        <dt>References</dt>
+                                        <dd>{references}</dd>
+                                    </div>
+                                : null}
+
+                                {context.aliases.length ?
+                                    <div data-test="aliases">
+                                        <dt>Aliases</dt>
+                                        <dd>{context.aliases.join(', ')}</dd>
+                                    </div>
+                                : null}
+
+                                {context.date_submitted ?
+                                    <div data-test="date-submitted">
+                                        <dt>Date submitted</dt>
+                                        <dd>{moment(context.date_submitted).format('MMMM D, YYYY')}</dd>
+                                    </div>
+                                : null}
+
+                                {context.date_released ?
+                                    <div data-test="date-released">
+                                        <dt>Date released</dt>
+                                        <dd>{moment(context.date_released).format('MMMM D, YYYY')}</dd>
+                                    </div>
+                                : null}
+
+                                {seriesList.length ?
+                                    <div data-test="relatedseries">
+                                        <dt>Related datasets</dt>
+                                        <dd><RelatedSeriesList seriesList={seriesList} /></dd>
+                                    </div>
+                                : null}
+
+                                {context.submitter_comment ?
+                                    <div data-test="submittercomment">
+                                        <dt>Submitter comment</dt>
+                                        <dd>{context.submitter_comment}</dd>
+                                    </div>
+                                : null}
+
+                                <LibrarySubmitterComments replicates={replicates} />
+
+                                {context.internal_tags && context.internal_tags.length > 0 ?
+                                    <div className="tag-badges" data-test="tags">
+                                        <dt>Tags</dt>
+                                        <dd><InternalTags context={context} /></dd>
+                                    </div>
+                                : null}
+                            </dl>
+                        </div>
+                    </div>
+                </PanelBody>
+            </Panel>
+
+            {Object.keys(condensedReplicates).length > 0 ?
+                <ReplicateTable condensedReplicates={condensedReplicates} replicationType={context.replication_type} />
+            : null}
+
+            {/* Display the file widget with the facet, graph, and tables */}
+            <FileGallery context={context} encodevers={encodevers} anisogenic={anisogenic} />
+
+            <FetchedItems context={context} url={experimentsUrl} Component={ControllingExperiments} />
+
+            {combinedDocuments.length ?
+                <DocumentsPanelReq documents={combinedDocuments} />
+            : null}
+        </div>
+    );
+};
 
 ExperimentComponent.propTypes = {
     context: PropTypes.object.isRequired, // Experiment object to render on this page

--- a/src/encoded/static/components/fetched.js
+++ b/src/encoded/static/components/fetched.js
@@ -169,7 +169,7 @@ export class FetchedData extends React.Component {
         }
 
         // If no <Param> components, nothing to render here
-        if (!params.length) {
+        if (params.length === 0) {
             return null;
         }
 
@@ -187,7 +187,7 @@ export class FetchedData extends React.Component {
             .filter(obj => obj && (obj['@type'] || []).indexOf('Error') > -1);
 
         // If we got an error, display the error string on the web page
-        if (errors.length) {
+        if (errors.length > 0) {
             // Render whatever error we got back from the server on the page.
             return (
                 <div className="error done">

--- a/src/encoded/static/components/file.js
+++ b/src/encoded/static/components/file.js
@@ -212,7 +212,7 @@ class DerivedFiles extends React.Component {
 }
 
 DerivedFiles.propTypes = {
-    file: React.PropTypes.object.isRequired, // Query string fragment for the search that ultimately generates the table of files
+    file: PropTypes.object.isRequired, // Query string fragment for the search that ultimately generates the table of files
 };
 
 
@@ -414,7 +414,7 @@ class FileComponent extends React.Component {
                                     {context.restriction_enzymes ?
                                         <div data-test="restrictionEnzymes">
                                             <dt>Restriction enzymes</dt>
-                                            <dd>{context.restriction_enzymes.join(", ")}</dd>
+                                            <dd>{context.restriction_enzymes.join(', ')}</dd>
                                         </div>
                                     : null}
 

--- a/src/encoded/static/components/file.js
+++ b/src/encoded/static/components/file.js
@@ -62,12 +62,12 @@ function sortProcessedPagedFiles(files) {
     // Start by sorting the accessioned files.
     let sortedAccession = [];
     let sortedExternal = [];
-    if (accessionList.accession && accessionList.accession.length) {
+    if (accessionList.accession && accessionList.accession.length > 0) {
         sortedAccession = accessionList.accession.sort((a, b) => (a.accession > b.accession ? 1 : (a.accession < b.accession ? -1 : 0)));
     }
 
     // Now sort the external_accession files
-    if (accessionList.external && accessionList.external.length) {
+    if (accessionList.external && accessionList.external.length > 0) {
         sortedExternal = accessionList.external.sort((a, b) => (a.title > b.title ? 1 : (a.title < b.title ? -1 : 0)));
     }
     return sortedAccession.concat(sortedExternal);
@@ -112,7 +112,7 @@ class DerivedFiles extends React.Component {
         requestSearch(`type=File&limit=all&field=@id&status!=deleted&status!=revoked&status!=replaced&field=accession&field=title&field=accession&derived_from=${file['@id']}`).then((result) => {
             // The server has returned search results. See if we got matching files to display
             // in the table.
-            if (Object.keys(result).length && result['@graph'] && result['@graph'].length) {
+            if (Object.keys(result).length > 0 && result['@graph'] && result['@graph'].length > 0) {
                 // Sort the files. We still get an array of search results from the server, just
                 // sorted by accessioned files, followed by external_accession files.
                 const sortedFiles = sortProcessedPagedFiles(result['@graph']);
@@ -177,7 +177,7 @@ class DerivedFiles extends React.Component {
     // @id of files that derive from the one being displayed, and this.state.currentPage to hold
     // the currently displayed page of files in the table.
     currentPageFiles() {
-        if (this.allFileIds && this.allFileIds.length) {
+        if (this.allFileIds && this.allFileIds.length > 0) {
             const start = this.state.currentPage * PagedFileTableMax;
             return this.allFileIds.slice(start, start + PagedFileTableMax);
         }
@@ -191,7 +191,7 @@ class DerivedFiles extends React.Component {
     render() {
         const { file } = this.props;
 
-        if (this.state.pageFiles.length) {
+        if (this.state.pageFiles.length > 0) {
             // If we have more than one page of files to display, render a pager component in the
             // footer.
             const pager = this.state.totalPages > 1 ? <Pager total={this.state.totalPages} current={this.state.currentPage} updateCurrentPage={this.updateCurrentPage} /> : null;
@@ -337,8 +337,8 @@ class FileComponent extends React.Component {
 
         // Retrieve an array of file @ids that this file derives from. Once this array arrives.
         // it sets the derivedFromFiles React state that causes the list to render.
-        const derivedFromFileIds = file.derived_from && file.derived_from.length ? file.derived_from : [];
-        if (derivedFromFileIds.length) {
+        const derivedFromFileIds = file.derived_from && file.derived_from.length > 0 ? file.derived_from : [];
+        if (derivedFromFileIds.length > 0) {
             requestFiles(derivedFromFileIds).then((derivedFromFiles) => {
                 this.setState({ derivedFromFiles });
             });
@@ -346,8 +346,8 @@ class FileComponent extends React.Component {
 
         // Retrieve an array of file format specification document @ids. Once the array arrives,
         // set the fileFormatSpecs React state that causes the list to render.
-        const fileFormatSpecs = file.file_format_specifications && file.file_format_specifications.length ? file.file_format_specifications : [];
-        if (fileFormatSpecs.length) {
+        const fileFormatSpecs = file.file_format_specifications && file.file_format_specifications.length > 0 ? file.file_format_specifications : [];
+        if (fileFormatSpecs.length > 0) {
             requestObjects(fileFormatSpecs, '/search/?type=Document&limit=all&status!=deleted&status!=revoked&status!=replaced').then((docs) => {
                 this.setState({ fileFormatSpecs: docs });
             });
@@ -357,14 +357,14 @@ class FileComponent extends React.Component {
     render() {
         const { context } = this.props;
         const itemClass = globals.itemClass(context, 'view-item');
-        const aliasList = (context.aliases && context.aliases.length) ? context.aliases.join(', ') : '';
+        const aliasList = (context.aliases && context.aliases.length > 0) ? context.aliases.join(', ') : '';
         const datasetAccession = globals.atIdToAccession(context.dataset);
         const loggedIn = !!(this.context.session && this.context.session['auth.userid']);
         const adminUser = !!this.context.session_properties.admin;
 
         // Collect up relevant pipelines and quality metrics.
         let pipelines = [];
-        if (context.analysis_step_version && context.analysis_step_version.analysis_step.pipelines && context.analysis_step_version.analysis_step.pipelines.length) {
+        if (context.analysis_step_version && context.analysis_step_version.analysis_step.pipelines && context.analysis_step_version.analysis_step.pipelines.length > 0) {
             pipelines = context.analysis_step_version.analysis_step.pipelines;
         }
         const qualityMetrics = context.quality_metrics.filter(qc => loggedIn || qc.status === 'released');
@@ -420,15 +420,15 @@ class FileComponent extends React.Component {
 
                                     <div data-test="bioreplicate">
                                         <dt>Biological replicate(s)</dt>
-                                        <dd>{`[${context.biological_replicates && context.biological_replicates.length ? context.biological_replicates.join(', ') : '-'}]`}</dd>
+                                        <dd>{`[${context.biological_replicates && context.biological_replicates.length > 0 ? context.biological_replicates.join(', ') : '-'}]`}</dd>
                                     </div>
 
                                     <div data-test="techreplicate">
                                         <dt>Technical replicate(s)</dt>
-                                        <dd>{`[${context.technical_replicates && context.technical_replicates.length ? context.technical_replicates.join(', ') : '-'}]`}</dd>
+                                        <dd>{`[${context.technical_replicates && context.technical_replicates.length > 0 ? context.technical_replicates.join(', ') : '-'}]`}</dd>
                                     </div>
 
-                                    {pipelines.length ?
+                                    {pipelines.length > 0 ?
                                         <div data-test="pipelines">
                                             <dt>Pipelines</dt>
                                             <dd>
@@ -527,7 +527,7 @@ class FileComponent extends React.Component {
                                         </div>
                                     : null}
 
-                                    {context.dbxrefs && context.dbxrefs.length ?
+                                    {context.dbxrefs && context.dbxrefs.length > 0 ?
                                         <div data-test="externalresources">
                                             <dt>External resources</dt>
                                             <dd><DbxrefList context={context} dbxrefs={context.dbxrefs} /></dd>
@@ -571,15 +571,15 @@ class FileComponent extends React.Component {
                     <SequenceFileInfo file={context} />
                 : null}
 
-                {this.state.derivedFromFiles && this.state.derivedFromFiles.length ? <DerivedFromFiles file={context} derivedFromFiles={this.state.derivedFromFiles} /> : null}
+                {this.state.derivedFromFiles && this.state.derivedFromFiles.length > 0 ? <DerivedFromFiles file={context} derivedFromFiles={this.state.derivedFromFiles} /> : null}
 
                 <DerivedFiles file={context} />
 
-                {this.state.fileFormatSpecs.length ?
+                {this.state.fileFormatSpecs.length > 0 ?
                     <DocumentsPanel title="File format specifications" documentSpecs={[{ documents: this.state.fileFormatSpecs }]} />
                 : null}
 
-                {qualityMetrics.length ?
+                {qualityMetrics.length > 0 ?
                     <QualityMetricsPanel qcMetrics={qualityMetrics} file={context} />
                 : null}
             </div>
@@ -625,7 +625,7 @@ class SequenceFileInfo extends React.Component {
                             </div>
                         : null}
 
-                        {file.flowcell_details && file.flowcell_details.length ?
+                        {file.flowcell_details && file.flowcell_details.length > 0 ?
                             <div data-test="flowcelldetails">
                                 <dt>Flowcell</dt>
                                 <dd>
@@ -642,7 +642,7 @@ class SequenceFileInfo extends React.Component {
                             </div>
                         : null}
 
-                        {file.fastq_signature && file.fastq_signature.length ?
+                        {file.fastq_signature && file.fastq_signature.length > 0 ?
                             <div data-test="fastqsignature">
                                 <dt>Fastq flowcell signature</dt>
                                 <dd>{file.fastq_signature.join(', ')}</dd>
@@ -669,7 +669,7 @@ class SequenceFileInfo extends React.Component {
                             </div>
                         : null}
 
-                        {file.controlled_by && file.controlled_by.length ?
+                        {file.controlled_by && file.controlled_by.length > 0 ?
                             <div data-test="controlledby">
                                 <dt>Controlled by</dt>
                                 <dd>

--- a/src/encoded/static/components/filegallery.js
+++ b/src/encoded/static/components/filegallery.js
@@ -1839,8 +1839,8 @@ class FileGalleryRendererComponent extends React.Component {
         }
     }
 
-    componentDidUpdate(prevProps, prevState, prevContext) {
-        this.updateFiles(!!(prevContext.session && prevContext.session['auth.userid']));
+    componentDidUpdate(prevProps) {
+        this.updateFiles(!!(prevProps.session && prevProps.session['auth.userid']));
     }
 
     // Called from child components when the selected node changes.
@@ -2152,14 +2152,24 @@ FileGalleryRendererComponent.inclusionStatuses = [
 ];
 
 FileGalleryRendererComponent.propTypes = {
-    context: PropTypes.object.isRequired, // Dataset whose files we're rendering
-    data: PropTypes.object, // File data retrieved from search request
-    schemas: PropTypes.object, // Schemas for the entire system; used for QC property titles
-    hideGraph: PropTypes.bool, // T to hide graph display
-    altFilterDefault: PropTypes.bool, // T to default to All Assemblies and Annotations
-    auditIndicators: PropTypes.func.isRequired, // Inherited from auditDecor HOC
-    auditDetail: PropTypes.func.isRequired, // Inherited from auditDecor HOC
-    showReplicateNumber: PropTypes.bool, // True to show replicate number
+    /** Dataset whose files we're rendering */
+    context: PropTypes.object.isRequired,
+    /** File data retrieved from search request */
+    data: PropTypes.object,
+    /** Schemas for the entire system; used for QC property titles */
+    schemas: PropTypes.object,
+    /** True to hide graph display */
+    hideGraph: PropTypes.bool,
+    /** True to default to All Assemblies and Annotations */
+    altFilterDefault: PropTypes.bool,
+    /** Inherited from auditDecor HOC */
+    auditIndicators: PropTypes.func.isRequired,
+    /** Inherited from auditDecor HOC */
+    auditDetail: PropTypes.func.isRequired,
+    /** True to show replicate number */
+    showReplicateNumber: PropTypes.bool,
+    /** ENCODE session object from <App> */
+    session: PropTypes.object.isRequired,
 };
 
 FileGalleryRendererComponent.defaultProps = {
@@ -2171,7 +2181,6 @@ FileGalleryRendererComponent.defaultProps = {
 };
 
 FileGalleryRendererComponent.contextTypes = {
-    session: PropTypes.object,
     session_properties: PropTypes.object,
     location_href: PropTypes.string,
     navigate: PropTypes.func,

--- a/src/encoded/static/components/filegallery.js
+++ b/src/encoded/static/components/filegallery.js
@@ -145,7 +145,7 @@ export class FileTable extends React.Component {
             selectedAnnotation = filterOptions[selectedFilterValue].annotation;
         }
 
-        let datasetFiles = _((items && items.length) ? items : []).uniq(file => file['@id']);
+        let datasetFiles = _((items && items.length > 0) ? items : []).uniq(file => file['@id']);
         if (datasetFiles.length > 0) {
             const unfilteredCount = datasetFiles.length;
 
@@ -460,8 +460,8 @@ const sortBioReps = (a, b) => {
     // Sorting function for biological replicates of the given files.
     let result; // Ends sorting loop once it has a value
     let i = 0;
-    let repA = (a.biological_replicates && a.biological_replicates.length) ? a.biological_replicates[i] : undefined;
-    let repB = (b.biological_replicates && b.biological_replicates.length) ? b.biological_replicates[i] : undefined;
+    let repA = (a.biological_replicates && a.biological_replicates.length > 0) ? a.biological_replicates[i] : undefined;
+    let repB = (b.biological_replicates && b.biological_replicates.length > 0) ? b.biological_replicates[i] : undefined;
 
     while (result === undefined) {
         if (repA !== undefined && repB !== undefined) {
@@ -509,7 +509,7 @@ class RawSequencingTable extends React.Component {
         const { files, meta, showReplicateNumber } = this.props;
         const { loggedIn, adminUser } = meta;
 
-        if (files && files.length) {
+        if (files && files.length > 0) {
             // Make object keyed by all files' @ids to make searching easy. Each key's value
             // points to the corresponding file object.
             const filesKeyed = {};
@@ -568,7 +568,7 @@ class RawSequencingTable extends React.Component {
             // so that they'll sort at the end.
             let pairedRepGroups = {};
             let pairedRepKeys = [];
-            if (pairedFiles.length) {
+            if (pairedFiles.length > 0) {
                 pairedRepGroups = _(pairedFiles).groupBy(file => (
                     (file.biological_replicates && file.biological_replicates.length === 1) ?
                         globals.zeroFill(file.biological_replicates[0]) + ((file.replicate && file.replicate.library) ? file.replicate.library.accession : '')
@@ -663,7 +663,7 @@ class RawSequencingTable extends React.Component {
                                     runType = 'PE';
                                 }
                                 const rowClasses = [
-                                    pairedRepKeys.length && i === 0 ? 'table-raw-separator' : null,
+                                    pairedRepKeys.length > 0 && i === 0 ? 'table-raw-separator' : null,
                                 ];
 
                                 // Determine if accession should be a button or not.
@@ -672,7 +672,7 @@ class RawSequencingTable extends React.Component {
                                 return (
                                     <tr key={file['@id']} className={rowClasses.join(' ')}>
                                         {showReplicateNumber ?
-                                            <td className="table-raw-biorep">{file.biological_replicates && file.biological_replicates.length ? file.biological_replicates.sort((a, b) => a - b).join(', ') : 'N/A'}</td> :
+                                            <td className="table-raw-biorep">{file.biological_replicates && file.biological_replicates.length > 0 ? file.biological_replicates.sort((a, b) => a - b).join(', ') : 'N/A'}</td> :
                                         null}
                                         <td>{(file.replicate && file.replicate.library) ? file.replicate.library.accession : 'N/A'}</td>
                                         <td>
@@ -740,7 +740,7 @@ class RawFileTable extends React.Component {
         const { files, meta, showReplicateNumber } = this.props;
         const { loggedIn, adminUser } = meta;
 
-        if (files && files.length) {
+        if (files && files.length > 0) {
             // Group all files by their library accessions. Any files without replicates or
             // libraries get grouped under library 'Z' so they get sorted at the end.
             const libGroups = _(files).groupBy((file) => {
@@ -811,7 +811,7 @@ class RawFileTable extends React.Component {
                                         <tr key={file['@id']}>
                                             {showReplicateNumber && i === 0 ?
                                                 <td rowSpan={groupFiles.length} className={`${bottomClass} merge-right table-raw-merged table-raw-biorep`}>
-                                                    {groupFiles[0].biological_replicates.length ? <span>{groupFiles[0].biological_replicates[0]}</span> : <i>N/A</i>}
+                                                    {groupFiles[0].biological_replicates.length > 0 ? <span>{groupFiles[0].biological_replicates[0]}</span> : <i>N/A</i>}
                                                 </td>
                                             : null}
                                             {i === 0 ?
@@ -837,7 +837,7 @@ class RawFileTable extends React.Component {
                             {nonGrouped.sort(sortBioReps).map((file, i) => {
                                 // Prepare for run_type display
                                 const rowClasses = [
-                                    groupKeys.length && i === 0 ? 'table-raw-separator' : null,
+                                    groupKeys.length > 0 && i === 0 ? 'table-raw-separator' : null,
                                 ];
 
                                 // Determine if accession should be a button or not.
@@ -846,7 +846,7 @@ class RawFileTable extends React.Component {
                                 return (
                                     <tr key={file['@id']} className={rowClasses.join(' ')}>
                                         {showReplicateNumber ?
-                                            <td className="table-raw-biorep">{(file.biological_replicates && file.biological_replicates.length) ? file.biological_replicates.sort((a, b) => a - b).join(', ') : 'N/A'}</td> :
+                                            <td className="table-raw-biorep">{(file.biological_replicates && file.biological_replicates.length > 0) ? file.biological_replicates.sort((a, b) => a - b).join(', ') : 'N/A'}</td> :
                                         null}
                                         <td>{(file.replicate && file.replicate.library) ? file.replicate.library.accession : 'N/A'}</td>
                                         <td>
@@ -897,8 +897,8 @@ RawFileTable.defaultProps = {
 export const DatasetFiles = (props) => {
     const { items } = props;
 
-    const files = _.uniq((items && items.length) ? items : []);
-    if (files.length) {
+    const files = _.uniq((items && items.length > 0) ? items : []);
+    if (files.length > 0) {
         return <FileTable {...props} items={files} />;
     }
     return null;
@@ -970,7 +970,7 @@ function collectAssembliesAnnotations(files) {
     // Eliminate duplicate entries in filterOptions. Duplicates are detected by combining the
     // assembly and annotation into a long string. Use the '!' separator so that highly unlikely
     // anomalies don't pass undetected (e.g. hg19!V19 and hg1!9V19 -- again, highly unlikely).
-    filterOptions = filterOptions.length ? _(filterOptions).uniq(option => `${option.assembly}!${option.annotation ? option.annotation : ''}`) : [];
+    filterOptions = filterOptions.length > 0 ? _(filterOptions).uniq(option => `${option.assembly}!${option.annotation ? option.annotation : ''}`) : [];
 
     // Now begin a two-stage sort, with the primary key being the assembly in a specific priority
     // order specified by the assemblyPriority array, and the secondary key being the annotation
@@ -1224,7 +1224,7 @@ function collectDerivedFroms(file, fileDataset, selectedAssembly, selectedAnnota
     // going up the chain once we get to a file not in the current dataset, which might be a
     // processed file that doesn't belong in the graph, or a contributing file. Note that we have a
     // risk of infinite recursion if the file data incluees a derived_from loop, which isn't valid.
-    if (file.derived_from && file.derived_from.length && file.dataset === fileDataset['@id']) {
+    if (file.derived_from && file.derived_from.length > 0 && file.dataset === fileDataset['@id']) {
         // File is the product of at least one derived_from chain, so for any files this file
         // derives from (parent files), go up the chain continuing to collect the files involved
         // in the current branch of the chain.
@@ -1296,7 +1296,7 @@ const fileCssClassGen = (file, active, colorizeNode, addClasses) => {
 export function assembleGraph(files, dataset, options, loggedIn = false) {
     // Calculate a step ID from a file's derived_from array.
     function rDerivedFileIds(file) {
-        if (file.derived_from && file.derived_from.length) {
+        if (file.derived_from && file.derived_from.length > 0) {
             return file.derived_from.sort().join();
         }
         return '';
@@ -1327,14 +1327,14 @@ export function assembleGraph(files, dataset, options, loggedIn = false) {
         if ((file.assembly === selectedAssembly) && ((!file.genome_annotation && !selectedAnnotation) || (file.genome_annotation === selectedAnnotation))) {
             // Note whether any files have an analysis step
             const fileAnalysisStep = file.analysis_step_version && file.analysis_step_version.analysis_step;
-            if (!fileAnalysisStep || (file.derived_from && file.derived_from.length)) {
+            if (!fileAnalysisStep || (file.derived_from && file.derived_from.length > 0)) {
                 // File has no analysis step or derives from other files, so it can be included in
                 // the graph.
                 matchingFiles[file['@id']] = file;
 
                 // Collect any QC info that applies to this file and make it searchable by file
                 // @id.
-                if (file.quality_metrics && file.quality_metrics.length) {
+                if (file.quality_metrics && file.quality_metrics.length > 0) {
                     fileQcMetrics[file['@id']] = file.quality_metrics.filter(qc => loggedIn || qc.status === 'released');
                 }
 
@@ -1416,7 +1416,7 @@ export function assembleGraph(files, dataset, options, loggedIn = false) {
         const noIslandFiles = {};
         Object.keys(matchingFiles).forEach((matchingFileId) => {
             const matchingFile = matchingFiles[matchingFileId];
-            const hasDerivedFroms = matchingFile && matchingFile.derived_from && matchingFile.derived_from.length &&
+            const hasDerivedFroms = matchingFile && matchingFile.derived_from && matchingFile.derived_from.length > 0 &&
                 matchingFile.derived_from.some(derivedFileAtId => derivedFileAtId in derivedFromList);
             if (hasDerivedFroms || allDerivedFroms[matchingFileId]) {
                 // This file either has derived_from set, or other files derive from it. Copy it to
@@ -1448,7 +1448,7 @@ export function assembleGraph(files, dataset, options, loggedIn = false) {
 
     // Make a list of contributing files that matchingFiles files derive from.
     const usedContributingFiles = {};
-    if (dataset.contributing_files && dataset.contributing_files.length) {
+    if (dataset.contributing_files && dataset.contributing_files.length > 0) {
         dataset.contributing_files.forEach((contributingFileAtId) => {
             if (contributingFileAtId in allDerivedFroms) {
                 usedContributingFiles[contributingFileAtId] = allDerivedFroms[contributingFileAtId];
@@ -1460,7 +1460,7 @@ export function assembleGraph(files, dataset, options, loggedIn = false) {
     // derive from it. We'll need that for coalescing contributing files.
     const allCoalesced = {};
     let coalescingGroups = {};
-    if (Object.keys(usedContributingFiles).length) {
+    if (Object.keys(usedContributingFiles).length > 0) {
         // Now use the derivedFiles property of every contributing file to group them into potential
         // coalescing nodes. `coalescingGroups` gets assigned an object keyed by dataset file ids
         // hashed to a stringified 32-bit integer, and mapped to an array of contributing files they
@@ -1473,7 +1473,7 @@ export function assembleGraph(files, dataset, options, loggedIn = false) {
         // Set a `coalescingGroup` property in each contributing file with its coalescing group's hash
         // value. That'll be important when we add step nodes.
         const coalescingGroupKeys = Object.keys(coalescingGroups);
-        if (coalescingGroupKeys && coalescingGroupKeys.length) {
+        if (coalescingGroupKeys && coalescingGroupKeys.length > 0) {
             coalescingGroupKeys.forEach((groupHash) => {
                 const group = coalescingGroups[groupHash];
                 if (group.length >= MINIMUM_COALESCE_COUNT) {
@@ -1520,7 +1520,7 @@ export function assembleGraph(files, dataset, options, loggedIn = false) {
 
     // Create nodes for the replicates.
     Object.keys(allReplicates).forEach((replicateNum) => {
-        if (allReplicates[replicateNum] && allReplicates[replicateNum].length) {
+        if (allReplicates[replicateNum] && allReplicates[replicateNum].length > 0) {
             jsonGraph.addNode(`rep:${replicateNum}`, `Replicate ${replicateNum}`, {
                 cssClass: 'pipeline-replicate',
                 type: 'Rep',
@@ -1559,7 +1559,7 @@ export function assembleGraph(files, dataset, options, loggedIn = false) {
             let metricsInfo;
 
             // Add QC metrics info from the file to the list to generate the nodes later.
-            if (fileQcMetrics[fileId] && fileQcMetrics[fileId].length) {
+            if (fileQcMetrics[fileId] && fileQcMetrics[fileId].length > 0) {
                 const sortedMetrics = fileQcMetrics[fileId].sort((a, b) => (a['@type'][0] > b['@type'][0] ? 1 : (a['@type'][0] < b['@type'][0] ? -1 : 0)));
                 metricsInfo = sortedMetrics.map((metric) => {
                     const qcId = genQcId(metric, file);
@@ -1665,7 +1665,7 @@ export function assembleGraph(files, dataset, options, loggedIn = false) {
     // Now add coalesced nodes to the graph.
     Object.keys(coalescingGroups).forEach((groupHash) => {
         const coalescingGroup = coalescingGroups[groupHash];
-        if (coalescingGroup.length) {
+        if (coalescingGroup.length > 0) {
             const fileNodeId = `coalesced:${groupHash}`;
             const fileCssClass = `pipeline-node-file contributing${infoNode === fileNodeId ? ' active' : ''}`;
             jsonGraph.addNode(fileNodeId, `${coalescingGroup.length} contributing files`, {
@@ -1703,7 +1703,7 @@ const FileGraph = (props) => {
 
     // Build node graph of the files and analysis steps with this experiment
     let graph;
-    if (files.length) {
+    if (files.length > 0) {
         try {
             graph = assembleGraph(
                 files,
@@ -2283,7 +2283,7 @@ const FileDetailView = function FileDetailView(node, qcClick, auditIndicators, a
     const loggedIn = !!(session && session['auth.userid']);
     const adminUser = !!(sessionProperties && sessionProperties.admin);
 
-    if (selectedFile && Object.keys(selectedFile).length) {
+    if (selectedFile && Object.keys(selectedFile).length > 0) {
         let contributingAccession;
 
         if (node.metadata.contributing) {
@@ -2321,14 +2321,14 @@ const FileDetailView = function FileDetailView(node, qcClick, auditIndicators, a
                         </div>
                     : null}
 
-                    {selectedFile.biological_replicates && selectedFile.biological_replicates.length ?
+                    {selectedFile.biological_replicates && selectedFile.biological_replicates.length > 0 ?
                         <div data-test="bioreplicate">
                             <dt>Biological replicate(s)</dt>
                             <dd>{`[${selectedFile.biological_replicates.join(',')}]`}</dd>
                         </div>
                     : null}
 
-                    {selectedFile.biological_replicates && selectedFile.biological_replicates.length ?
+                    {selectedFile.biological_replicates && selectedFile.biological_replicates.length > 0 ?
                         <div data-test="techreplicate">
                             <dt>Technical replicate(s)</dt>
                             <dd>{`[${selectedFile.technical_replicates.join(',')}]`}</dd>
@@ -2370,7 +2370,7 @@ const FileDetailView = function FileDetailView(node, qcClick, auditIndicators, a
                         </div>
                     : null}
 
-                    {selectedFile.analysis_step_version && selectedFile.analysis_step_version.software_versions && selectedFile.analysis_step_version.software_versions.length ?
+                    {selectedFile.analysis_step_version && selectedFile.analysis_step_version.software_versions && selectedFile.analysis_step_version.software_versions.length > 0 ?
                         <div data-test="software">
                             <dt>Software</dt>
                             <dd>{softwareVersionList(selectedFile.analysis_step_version.software_versions)}</dd>
@@ -2463,7 +2463,7 @@ export const CoalescedDetailsView = function CoalescedDetailsView(node) {
     let header;
     let body;
 
-    if (node.metadata.coalescedFiles && node.metadata.coalescedFiles.length) {
+    if (node.metadata.coalescedFiles && node.metadata.coalescedFiles.length > 0) {
         // Configuration for reference file table
         const coalescedFileColumns = {
             accession: {

--- a/src/encoded/static/components/form.js
+++ b/src/encoded/static/components/form.js
@@ -99,7 +99,7 @@ const defaultValue = function defaultValue(schema) {
                 }
             }
         });
-        return (Object.keys(value).length ? value : undefined);
+        return (Object.keys(value).length > 0 ? value : undefined);
     }
     return schema.default || undefined;
 };
@@ -949,7 +949,7 @@ export class Form extends React.Component {
         let error;
         if (data.errors !== undefined) {
             data.errors.forEach((err) => {
-                let path = `instance${err.name.length ? `.${err.name.join('.')}` : ''}`;
+                let path = `instance${err.name.length > 0 ? `.${err.name.join('.')}` : ''}`;
                 // Missing values for required properties are reported
                 // on the parent property (the one that specifies `required`)
                 // so we have to add the property that is actually missing here.

--- a/src/encoded/static/components/gene.js
+++ b/src/encoded/static/components/gene.js
@@ -77,7 +77,7 @@ const Gene = (props) => {
                     <div data-test="external">
                         <dt>External resources</dt>
                         <dd>
-                            {context.dbxrefs.length ?
+                            {context.dbxrefs.length > 0 ?
                                 <DbxrefList context={context} dbxrefs={context.dbxrefs} />
                             : <em>None submitted</em> }
                         </dd>
@@ -132,7 +132,7 @@ const ListingComponent = (props, reactContext) => {
                 </div>
                 <div className="data-row">
                     <strong>External resources: </strong>
-                    {result.dbxrefs && result.dbxrefs.length ?
+                    {result.dbxrefs && result.dbxrefs.length > 0 ?
                         <DbxrefList context={result} dbxrefs={result.dbxrefs} />
                     : <em>None submitted</em> }
                 </div>

--- a/src/encoded/static/components/genetic_modification.js
+++ b/src/encoded/static/components/genetic_modification.js
@@ -22,7 +22,7 @@ import { BiosampleTable, DonorTable } from './typeutils';
 const IntroducedTags = (props) => {
     const { geneticModification } = props;
 
-    if (geneticModification.introduced_tags && geneticModification.introduced_tags.length) {
+    if (geneticModification.introduced_tags && geneticModification.introduced_tags.length > 0) {
         // Generate an array of React components, each containing one epitope_tags display from
         // the array of epitope_tags in the given genetic modification object. At least one
         // property of each epitope tag element must be present, or else an empty <li></li> will
@@ -173,7 +173,7 @@ const ModificationMethod = (props) => {
     // Make an array of treatment text summaries within <li> elements that can get inserted
     // directly into a <ul> element.
     let treatments = [];
-    if (geneticModification.treatments && geneticModification.treatments.length) {
+    if (geneticModification.treatments && geneticModification.treatments.length > 0) {
         treatments = geneticModification.treatments.map(treatment => <li key={treatment.uuid}>{singleTreatment(treatment)}</li>);
     }
 
@@ -187,7 +187,7 @@ const ModificationMethod = (props) => {
                     <dd>{geneticModification.method}</dd>
                 </div>
 
-                {treatments.length ?
+                {treatments.length > 0 ?
                     <div data-test="treatments">
                         <dt>Treatments</dt>
                         <dd>
@@ -198,7 +198,7 @@ const ModificationMethod = (props) => {
                     </div>
                 : null}
 
-                {geneticModification.rnai_sequences && geneticModification.rnai_sequences.length ?
+                {geneticModification.rnai_sequences && geneticModification.rnai_sequences.length > 0 ?
                     <div data-test="rnai">
                         <dt>RNAi sequences</dt>
                         <dd>
@@ -209,7 +209,7 @@ const ModificationMethod = (props) => {
                     </div>
                 : null}
 
-                {geneticModification.guide_rna_sequences && geneticModification.guide_rna_sequences.length ?
+                {geneticModification.guide_rna_sequences && geneticModification.guide_rna_sequences.length > 0 ?
                     <div data-test="guiderna">
                         <dt>Guide RNAs</dt>
                         <dd>
@@ -218,7 +218,7 @@ const ModificationMethod = (props) => {
                     </div>
                 : null}
 
-                {geneticModification.RVD_sequence_pairs && geneticModification.RVD_sequence_pairs.length ?
+                {geneticModification.RVD_sequence_pairs && geneticModification.RVD_sequence_pairs.length > 0 ?
                     <div data-test="rvdseq">
                         <dt>RVD sequence pairs</dt>
                         <dd>
@@ -231,7 +231,7 @@ const ModificationMethod = (props) => {
                     </div>
                 : null}
 
-                {geneticModification.reagents && geneticModification.reagents.length ?
+                {geneticModification.reagents && geneticModification.reagents.length > 0 ?
                     <div data-test="reagent">
                         <dt>Reagents</dt>
                         <dd>
@@ -289,7 +289,7 @@ const AttributionRenderer = (props) => {
                     <dd>{award.project}</dd>
                 </div>
 
-                {geneticModification.aliases && geneticModification.aliases.length ?
+                {geneticModification.aliases && geneticModification.aliases.length > 0 ?
                     <div data-test="aliases">
                         <dt>Aliases</dt>
                         <dd>{geneticModification.aliases.join(', ')}</dd>
@@ -342,7 +342,7 @@ Attribution.propTypes = {
 const DocumentsRenderer = ({ characterizations, modificationDocuments, characterizationDocuments }) => {
     // Don't need to check for characterizationDocuments.length because these only get displayed
     // within characterization panels.
-    if (characterizations.length || modificationDocuments.length) {
+    if (characterizations.length > 0 || modificationDocuments.length > 0) {
         // Make a mapping of characterization document @ids to characterization documents
         // to make searching in the next step easier.
         const characterizationDocumentMap = {};
@@ -386,9 +386,9 @@ DocumentsRenderer.propTypes = {
  */
 const collectCharacterizationAtIds = (characterizations) => {
     const characterizationDocumentAtIds = [];
-    if (characterizations && characterizations.length) {
+    if (characterizations && characterizations.length > 0) {
         characterizations.forEach((characterization) => {
-            if (characterization.documents && characterization.documents.length) {
+            if (characterization.documents && characterization.documents.length > 0) {
                 characterizationDocumentAtIds.push(...characterization.documents);
             }
         });
@@ -466,14 +466,14 @@ class GeneticModificationComponent extends React.Component {
 
         // Collect GM document @ids and combine with characterization document @ids so we can do
         // one GET request for both.
-        const modificationCharacterizationDocumentsAtIds = _.uniq((context.documents && context.documents.length ? context.documents : []).concat(characterizationDocumentAtIds));
+        const modificationCharacterizationDocumentsAtIds = _.uniq((context.documents && context.documents.length > 0 ? context.documents : []).concat(characterizationDocumentAtIds));
 
         // Convert the array of document @ids into a query string and do the GET request for their
         // objects.
         const modificationDocuments = [];
         const characterizationDocuments = [];
         let searchPromise = null;
-        const modificationCharacterizationDocumentsQuery = modificationCharacterizationDocumentsAtIds.length ? modificationCharacterizationDocumentsAtIds.reduce((acc, document) => `${acc}&${globals.encodedURIComponent(`@id=${document}`)}`, '') : null;
+        const modificationCharacterizationDocumentsQuery = modificationCharacterizationDocumentsAtIds.length > 0 ? modificationCharacterizationDocumentsAtIds.reduce((acc, document) => `${acc}&${globals.encodedURIComponent(`@id=${document}`)}`, '') : null;
         if (modificationCharacterizationDocumentsQuery) {
             searchPromise = requestSearch(`type=Document${modificationCharacterizationDocumentsQuery}`);
         } else {
@@ -484,7 +484,7 @@ class GeneticModificationComponent extends React.Component {
         searchPromise.then(
             (results) => {
                 // `results` is the search results object, or {} if it 404ed.
-                if (results['@graph'] && results['@graph'].length) {
+                if (results['@graph'] && results['@graph'].length > 0) {
                     // Split the results into arrays of modification and characterization
                     // document objects.
                     results['@graph'].forEach((document) => {
@@ -784,7 +784,7 @@ const CharacterizationDocuments = (props) => {
             {docs.map((doc, i) => {
                 if (doc && doc.attachment) {
                     const attachmentHref = url.resolve(doc['@id'], doc.attachment.href);
-                    const docName = (doc.aliases && doc.aliases.length) ? doc.aliases[0] :
+                    const docName = (doc.aliases && doc.aliases.length > 0) ? doc.aliases[0] :
                         ((doc.attachment && doc.attachment.download) ? doc.attachment.download : '');
                     return (
                         <div className="multi-dd dl-link" key={doc['@id']}>
@@ -847,7 +847,7 @@ const CharacterizationDetail = (props) => {
                     </div>
                 : null}
 
-                {doc.documents && doc.documents.length ?
+                {doc.documents && doc.documents.length > 0 ?
                     <div data-test="documents">
                         <dt>Documents</dt>
                         <CharacterizationDocuments docs={doc.documents} />

--- a/src/encoded/static/components/genetic_modification.js
+++ b/src/encoded/static/components/genetic_modification.js
@@ -238,7 +238,7 @@ const ModificationMethod = (props) => {
                             <ul className="multi-value-line">
                                 {geneticModification.reagents.map((reagent, i) => {
                                     // Although reagents specify source, we want to use the source prefix from the identifier for best consistency
-                                    const parsedIdentifier = reagent.identifier.split(":")
+                                    const parsedIdentifier = reagent.identifier.split(':');
                                     const reagentId = <span>{parsedIdentifier[0]} &mdash; {parsedIdentifier[1]}</span>;
                                     if (reagent.url) {
                                         return <li key={i}><a href={reagent.url}>{reagentId}</a></li>;
@@ -415,16 +415,16 @@ class GeneticModificationComponent extends React.Component {
         this.requestDocuments();
     }
 
-    componentDidUpdate(previousProperties, previousState, previousContext) {
-        if (this.conditionsChanged(previousProperties, previousState, previousContext)) {
+    componentDidUpdate(previousProperties) {
+        if (this.conditionsChanged(previousProperties)) {
             this.requestDocuments();
         }
     }
 
-    conditionsChanged(previousProperties, previousState, previousContext) {
+    conditionsChanged(previousProperties) {
         // Logged-in state has changed.
-        const previousLoggedIn = !!(previousContext.session && previousContext.session['auth.userid']);
-        const currentLoggedIn = !!(this.context.session && this.context.session['auth.userid']);
+        const previousLoggedIn = !!(previousProperties.session && previousProperties.session['auth.userid']);
+        const currentLoggedIn = !!(this.props.session && this.props.session['auth.userid']);
         if (previousLoggedIn !== currentLoggedIn) {
             return true;
         }
@@ -642,13 +642,28 @@ GeneticModificationComponent.propTypes = {
     context: PropTypes.object.isRequired, // GM object being displayed
     auditIndicators: PropTypes.func.isRequired, // Audit HOC function to display audit indicators
     auditDetail: PropTypes.func.isRequired, // Audit HOC function to display audit details
-};
-
-GeneticModificationComponent.contextTypes = {
     session: PropTypes.object, // Login information from <App>
 };
 
-const GeneticModification = auditDecor(GeneticModificationComponent);
+GeneticModificationComponent.defaultProps = {
+    session: null,
+};
+
+const GeneticModificationInternal = (props, reactContext) => (
+    <GeneticModificationComponent {...props} session={reactContext.session} />
+);
+
+GeneticModificationInternal.propTypes = {
+    context: PropTypes.object.isRequired, // GM object being displayed
+    auditIndicators: PropTypes.func.isRequired, // Audit HOC function to display audit indicators
+    auditDetail: PropTypes.func.isRequired, // Audit HOC function to display audit details
+};
+
+GeneticModificationInternal.contextTypes = {
+    session: PropTypes.object, // Login information from <App>
+};
+
+const GeneticModification = auditDecor(GeneticModificationInternal);
 
 globals.contentViews.register(GeneticModification, 'GeneticModification');
 

--- a/src/encoded/static/components/genome_browser.js
+++ b/src/encoded/static/components/genome_browser.js
@@ -435,7 +435,7 @@ class GenomeBrowser extends React.Component {
                 });
             }
         });
-        if (this.browserFiles.length) {
+        if (this.browserFiles.length > 0) {
             browserCfg.sources = browserCfg.sources.concat(this.browserFiles);
         }
 
@@ -466,7 +466,7 @@ class GenomeBrowser extends React.Component {
 
     componentDidUpdate() {
         // Remove old tiers
-        if (this.browser && this.browserFiles && this.browserFiles.length) {
+        if (this.browser && this.browserFiles && this.browserFiles.length > 0) {
             this.browserFiles.forEach((fileSource) => {
                 this.browser.removeTier({
                     name: fileSource.name,
@@ -477,7 +477,7 @@ class GenomeBrowser extends React.Component {
         }
 
         const files = !this.context.localInstance ? this.props.files.slice(0, maxFilesBrowsed - 1) : dummyFiles;
-        if (this.browser && files && files.length) {
+        if (this.browser && files && files.length > 0) {
             let domain = `${window.location.protocol}//${window.location.hostname}`;
             if (domain.includes('localhost')) {
                 domain = domainName;
@@ -529,6 +529,7 @@ class GenomeBrowser extends React.Component {
     }
 
     makeTrackLabel(file) {
+        console.log('FILE %o', file);
         const datasetAccession = file.dataset.split('/')[2];
         // Unreleased files are not in visBlob so get default labels
         const trackLabels = {

--- a/src/encoded/static/components/genome_browser.js
+++ b/src/encoded/static/components/genome_browser.js
@@ -529,7 +529,6 @@ class GenomeBrowser extends React.Component {
     }
 
     makeTrackLabel(file) {
-        console.log('FILE %o', file);
         const datasetAccession = file.dataset.split('/')[2];
         // Unreleased files are not in visBlob so get default labels
         const trackLabels = {

--- a/src/encoded/static/components/graph.js
+++ b/src/encoded/static/components/graph.js
@@ -83,13 +83,13 @@ export class JsonGraph {
             if (nodes[i].id === id) {
                 return nodes[i];
             }
-            if (nodes[i].nodes.length) {
+            if (nodes[i].nodes.length > 0) {
                 const matching = this.getNode(id, nodes[i]);
                 if (matching) {
                     return matching;
                 }
             }
-            if (nodes[i].subnodes && nodes[i].subnodes.length) {
+            if (nodes[i].subnodes && nodes[i].subnodes.length > 0) {
                 const matching = nodes[i].subnodes.find(subnode => id === subnode.id);
                 if (matching) {
                     return matching;
@@ -104,13 +104,13 @@ export class JsonGraph {
 
         for (let i = 0; i < nodes.length; i += 1) {
             const node = nodes[i];
-            if (node.subnodes && node.subnodes.length) {
+            if (node.subnodes && node.subnodes.length > 0) {
                 for (let j = 0; j < node.subnodes.length; j += 1) {
                     if (node.subnodes[j].id === id) {
                         return node.subnodes[j];
                     }
                 }
-            } else if (nodes[i].nodes.length) {
+            } else if (nodes[i].nodes.length > 0) {
                 const matching = this.getSubnode(id, nodes[i]);
                 if (matching) {
                     return matching;
@@ -121,7 +121,7 @@ export class JsonGraph {
     }
 
     getEdge(source, target) {
-        if (this.edges && this.edges.length) {
+        if (this.edges && this.edges.length > 0) {
             const matching = _(this.edges).find(edge =>
                 (source === edge.source) && (target === edge.target)
             );
@@ -143,7 +143,7 @@ export class JsonGraph {
             returnArray.push(fn.call(context, node));
 
             // If the node has its own nodes, recurse
-            if (node.nodes && node.nodes.length) {
+            if (node.nodes && node.nodes.length > 0) {
                 returnArray = returnArray.concat(this.map(fn, context, node.nodes));
             }
         }
@@ -216,7 +216,7 @@ export class Graph extends React.Component {
                 if (!parent.root) {
                     subgraph.setParent(node.id, parent.id);
                 }
-                if (node.nodes.length) {
+                if (node.nodes.length > 0) {
                     convertGraphInner(subgraph, node);
                 }
             });
@@ -542,7 +542,7 @@ export class Graph extends React.Component {
                             if (typeof (rule.style) !== 'undefined' && rule.selectorText && rule.selectorText.substring(0, 2) === 'g.') {
                                 // If any elements use this style, add the style's CSS text to our style text accumulator.
                                 const elems = el.querySelectorAll(rule.selectorText);
-                                if (elems.length) {
+                                if (elems.length > 0) {
                                     stylesText += `${rule.selectorText} { ${rule.style.cssText} }\n`;
                                 }
                             }

--- a/src/encoded/static/components/home.js
+++ b/src/encoded/static/components/home.js
@@ -22,7 +22,7 @@ function generateQuery(selectedOrganisms, selectedAssayCategory) {
     }
 
     // Add all the selected organisms, if any
-    if (selectedOrganisms.length) {
+    if (selectedOrganisms.length > 0) {
         const organismSpec = selectedAssayCategory === 'COMPPRED' ? 'organism.scientific_name=' : 'replicates.library.biosample.donor.organism.scientific_name=';
         const queryStrings = {
             HUMAN: `${organismSpec}Homo+sapiens`, // human
@@ -279,7 +279,7 @@ class InputSuggest extends React.Component {
     render() {
         const { items, inputId, placeholder } = this.props;
         const controlId = `${inputId}-list`;
-        const activeDescendant = (this.props.items.length && this.state.selectedItemIndex > -1) ? this.props.items[this.state.selectedItemIndex] : '';
+        const activeDescendant = (this.props.items.length > 0 && this.state.selectedItemIndex > -1) ? this.props.items[this.state.selectedItemIndex] : '';
         return (
             <div className="site-search__input-field" role="combobox" aria-haspopup="listbox" aria-expanded={items.length > 0} aria-controls={controlId} aria-owns={controlId}>
                 <input
@@ -953,7 +953,7 @@ class HomepageChart extends React.Component {
         if (this.myPieChart) {
             // Existing data updated
             this.updateChart(this.myPieChart, this.facetData);
-        } else if (this.facetData.length) {
+        } else if (this.facetData.length > 0) {
             // Chart existed but was destroyed for lack of data. Rebuild the chart.
             this.createChart(this.facetData);
         }
@@ -1079,8 +1079,8 @@ class HomepageChart extends React.Component {
         if (facets) {
             const projectFacet = facets.find(facet => facet.field === 'award.project');
             this.facetData = projectFacet ? projectFacet.terms : [];
-            const docCounts = this.facetData.length ? this.facetData.map(data => data.doc_count) : [];
-            total = docCounts.length ? docCounts.reduce((prev, curr) => prev + curr) : 0;
+            const docCounts = this.facetData.length > 0 ? this.facetData.map(data => data.doc_count) : [];
+            total = docCounts.length > 0 ? docCounts.reduce((prev, curr) => prev + curr) : 0;
 
             // No data with the current selection, but we used to? Destroy the existing chart so we can
             // display a no-data message instead.
@@ -1102,7 +1102,7 @@ class HomepageChart extends React.Component {
                     Project
                     <center><hr width="80%" color="blue" /></center>
                 </div>
-                {this.facetData.length && total ?
+                {this.facetData.length > 0 && total ?
                     <div id="chart-wrapper-1" className="chart-wrapper">
                         <div className="chart-container">
                             <canvas id="myChart" />
@@ -1151,7 +1151,7 @@ class HomepageChart2 extends React.Component {
         if (this.myPieChart) {
             // Existing data updated
             this.updateChart(this.myPieChart, this.facetData);
-        } else if (this.facetData.length) {
+        } else if (this.facetData.length > 0) {
             // Chart existed but was destroyed for lack of data. Rebuild the chart.
             this.createChart(this.facetData);
         }
@@ -1281,8 +1281,8 @@ class HomepageChart2 extends React.Component {
             this.computationalPredictions = this.props.assayCategory === 'COMPPRED';
             const assayFacet = facets.find(facet => facet.field === 'biosample_ontology.classification');
             this.facetData = assayFacet ? assayFacet.terms : [];
-            const docCounts = this.facetData.length ? this.facetData.map(data => data.doc_count) : [];
-            total = docCounts.length ? docCounts.reduce((prev, curr) => prev + curr) : 0;
+            const docCounts = this.facetData.length > 0 ? this.facetData.map(data => data.doc_count) : [];
+            total = docCounts.length > 0 ? docCounts.reduce((prev, curr) => prev + curr) : 0;
 
             // No data with the current selection, but we used to destroy the existing chart so we can
             // display a no-data message instead.
@@ -1304,7 +1304,7 @@ class HomepageChart2 extends React.Component {
                     Biosample Type
                     <center><hr width="80%" color="blue" /></center>
                 </div>
-                {this.facetData.length && total ?
+                {this.facetData.length > 0 && total ?
                     <div id="chart-wrapper-2" className="chart-wrapper">
                         <div className="chart-container">
                             <canvas id="myChart2" />
@@ -1381,7 +1381,7 @@ class HomepageChart3 extends React.Component {
         if (this.myPieChart) {
             // Existing data updated
             this.updateChart(this.myPieChart, this.facetData);
-        } else if (this.facetData.length) {
+        } else if (this.facetData.length > 0) {
             // Chart existed but was destroyed for lack of data. Rebuild the chart.
             this.createChart(this.facetData);
         }
@@ -1501,8 +1501,8 @@ class HomepageChart3 extends React.Component {
         if (facets) {
             const projectFacet = facets.find(facet => facet.field === 'assay_slims');
             this.facetData = projectFacet ? projectFacet.terms : [];
-            const docCounts = this.facetData.length ? this.facetData.map(data => data.doc_count) : [];
-            total = docCounts.length ? docCounts.reduce((prev, curr) => prev + curr) : 0;
+            const docCounts = this.facetData.length > 0 ? this.facetData.map(data => data.doc_count) : [];
+            total = docCounts.length > 0 ? docCounts.reduce((prev, curr) => prev + curr) : 0;
 
             // No data with the current selection, but we used to? Destroy the existing chart so we can
             // display a no-data message instead.
@@ -1524,7 +1524,7 @@ class HomepageChart3 extends React.Component {
                     Assay Categories
                     <center><hr width="80%" color="blue" /></center>
                 </div>
-                {this.facetData.length && total ?
+                {this.facetData.length > 0 && total ?
                     <div id="chart-wrapper-3" className="chart-wrapper">
                         <div className="chart-container-assaycat">
                             <canvas id="myChart3" />

--- a/src/encoded/static/components/item.js
+++ b/src/encoded/static/components/item.js
@@ -195,7 +195,7 @@ const FetchedRelatedItems = (props) => {
     const { Component, context, title, itemUrl } = props;
     if (context === undefined) return null;
     const items = context['@graph'];
-    if (!items || !items.length) return null;
+    if (!items || !items.length > 0) return null;
 
     return (
         <Component {...props} title={title} context={context} total={context.total} items={items} url={itemUrl} showControls={false} />

--- a/src/encoded/static/components/layout.js
+++ b/src/encoded/static/components/layout.js
@@ -693,7 +693,7 @@ export default class Layout extends React.Component {
         }
         // eslint-disable-next-line react/no-find-dom-node
         const targetNode = (target || this).domNode;
-        if (!targetNode.childNodes.length) return;
+        if (targetNode.childNodes.length === 0) return;
         const targetOffset = offset(targetNode);
         const x = e.pageX - targetOffset.left;
         const y = e.pageY - targetOffset.top;

--- a/src/encoded/static/components/matrix.js
+++ b/src/encoded/static/components/matrix.js
@@ -634,7 +634,7 @@ class Matrix extends React.Component {
 }
 
 Matrix.propTypes = {
-    context: React.PropTypes.object.isRequired,
+    context: PropTypes.object.isRequired,
 };
 
 Matrix.contextTypes = {
@@ -796,7 +796,7 @@ class AuditMatrix extends React.Component {
 }
 
 AuditMatrix.propTypes = {
-    context: React.PropTypes.object.isRequired,
+    context: PropTypes.object.isRequired,
 };
 
 AuditMatrix.contextTypes = {

--- a/src/encoded/static/components/navigation.js
+++ b/src/encoded/static/components/navigation.js
@@ -66,7 +66,7 @@ export default class Navigation extends React.Component {
         // If collection with .sticky-header on page, jiggle scroll position
         // to force the sticky header to jump to the top of the page.
         const hdrs = document.getElementsByClassName('sticky-header');
-        if (hdrs.length) {
+        if (hdrs.length > 0) {
             window.scrollBy(0, -1);
             window.scrollBy(0, 1);
         }
@@ -298,7 +298,7 @@ export const Breadcrumbs = (props) => {
 
                 // Build up tooltip if not specified completely
                 if (!crumb.wholeTip) {
-                    accretingTip += crumb.tip ? (accretingTip.length ? ' and ' : '') + crumb.tip : '';
+                    accretingTip += crumb.tip ? (accretingTip.length > 0 ? ' and ' : '') + crumb.tip : '';
                 }
 
                 // Append released tag to link and link title if the object is released itself

--- a/src/encoded/static/components/objectutils.js
+++ b/src/encoded/static/components/objectutils.js
@@ -139,7 +139,7 @@ export function requestObjects(atIds, uri, filteringObjects) {
     let filteredObjectIds = {}; // @ids of files we need to retrieve
 
     // Make a searchable object of file IDs for files to filter out of our list.
-    if (filteringObjects && filteringObjects.length) {
+    if (filteringObjects && filteringObjects.length > 0) {
         filteringObjects.forEach((filteringObject) => {
             filteringFileIds[filteringObject['@id']] = filteringObject;
         });
@@ -181,8 +181,8 @@ export function requestObjects(atIds, uri, filteringObjects) {
         // All search chunks have resolved or errored. We get an array of search results in
         // `chunks` -- one per chunk. Now collect their files from their @graphs into one array of
         // files and return them as the promise result.
-        if (chunks && chunks.length) {
-            return chunks.reduce((objects, chunk) => (chunk && chunk['@graph'].length ? objects.concat(chunk['@graph']) : objects), []);
+        if (chunks && chunks.length > 0) {
+            return chunks.reduce((objects, chunk) => (chunk && chunk['@graph'].length > 0 ? objects.concat(chunk['@graph']) : objects), []);
         }
 
         // Didn't get any good chucks back, so just return no results.
@@ -213,17 +213,17 @@ export function requestFiles(fileIds, filteringFiles) {
 export function donorDiversity(dataset) {
     let diversity = 'none';
 
-    if (dataset.related_datasets && dataset.related_datasets.length) {
+    if (dataset.related_datasets && dataset.related_datasets.length > 0) {
         // Get all non-deleted related experiments; empty array if none.
         const experiments = dataset.related_datasets.filter(experiment => experiment.status !== 'deleted');
 
         // From list list of non-deleted experiments, get all non-deleted replicates into one
         // array.
-        if (experiments.length) {
+        if (experiments.length > 0) {
             // Make an array of replicate arrays, one replicate array per experiment. Only include
             // non-deleted replicates.
             const replicatesByExperiment = experiments.map(experiment => (
-                (experiment.replicates && experiment.replicates.length) ?
+                (experiment.replicates && experiment.replicates.length > 0) ?
                     experiment.replicates.filter(replicate => replicate.status !== 'deleted')
                 : [])
             );
@@ -234,7 +234,7 @@ export function donorDiversity(dataset) {
             // Look at the donors in each replicate's biosample. If we see at least two different
             // donors, we know we have a composite. If only one unique donor after examining all
             // donors, we have a single. "None" if no donors found in all replicates.
-            if (replicates.length) {
+            if (replicates.length > 0) {
                 const donorAtIdCollection = [];
                 replicates.every((replicate) => {
                     if (replicate.library && replicate.library.status !== 'deleted' &&
@@ -637,7 +637,7 @@ export function PanelLookup(properties) {
 export const AlternateAccession = (props) => {
     const { altAcc } = props;
 
-    if (altAcc && altAcc.length) {
+    if (altAcc && altAcc.length > 0) {
         return (
             <h4 className="replacement-accessions__alternate">
                 {altAcc.length === 1 ?

--- a/src/encoded/static/components/objectutils.js
+++ b/src/encoded/static/components/objectutils.js
@@ -66,7 +66,11 @@ export function singleTreatment(treatment) {
     }
     treatmentText += `${treatment.treatment_term_name}${treatment.treatment_term_id ? ` (${treatment.treatment_term_id})` : ''} `;
     if (treatment.duration) {
-        treatmentText += `for ${treatment.duration} ${treatment.duration_units ? treatment.duration_units : ''}`;
+        let units = '';
+        if (treatment.duration_units) {
+            units = `${treatment.duration_units}${treatment.duration !== 1 ? 's' : ''}`;
+        }
+        treatmentText += `for ${treatment.duration}${units ? ` ${units}` : ''}`;
     }
     return treatmentText;
 }

--- a/src/encoded/static/components/page.js
+++ b/src/encoded/static/components/page.js
@@ -71,7 +71,7 @@ globals.listingViews.register(Listing, 'Page');
 // Display a list of keywords for the news article in the `post` prop.
 const NewsKeywordList = (props) => {
     const post = props.post;
-    if (post.news_keywords && post.news_keywords.length) {
+    if (post.news_keywords && post.news_keywords.length > 0) {
         return (
             <div className="news-keyword-list">
                 <p>View news matching these terms, or all recent news</p>

--- a/src/encoded/static/components/pipeline.js
+++ b/src/encoded/static/components/pipeline.js
@@ -35,7 +35,7 @@ function AnalysisStep(step, node) {
             // Get the analysis_step_version array from the step for pipeline graph display.
             stepVersions = step.versions && _(step.versions).sortBy(version => version.minor_version);
             swStepVersions = _.compact(stepVersions.map((version) => {
-                if (version.software_versions && version.software_versions.length) {
+                if (version.software_versions && version.software_versions.length > 0) {
                     return (
                         <span className="sw-step-versions" key={version.uuid}><strong>Version {step.major_version}.{version.minor_version}</strong>: {softwareVersionList(version.software_versions)}<br /></span>
                     );
@@ -47,7 +47,7 @@ function AnalysisStep(step, node) {
         header = (
             <div className="details-view-info">
                 <h4>
-                    {swVersions && swVersions.length ?
+                    {swVersions && swVersions.length > 0 ?
                         <span>{`${step.title} — Version ${node.metadata.ref.major_version}.${node.metadata.stepVersion.minor_version}`}</span>
                     :
                         <span>{step.title} — Version {node.metadata.ref.major_version}</span>
@@ -58,28 +58,28 @@ function AnalysisStep(step, node) {
         body = (
             <div>
                 <dl className="key-value">
-                    {(step.analysis_step_types && step.analysis_step_types.length) ?
+                    {(step.analysis_step_types && step.analysis_step_types.length > 0) ?
                         <div data-test="steptype">
                             <dt>Step type</dt>
                             <dd>{step.analysis_step_types.join(', ')}</dd>
                         </div>
                     : null}
 
-                    {step.aliases && step.aliases.length ?
+                    {step.aliases && step.aliases.length > 0 ?
                         <div data-test="stepname">
                             <dt>Step aliases</dt>
                             <dd>{step.aliases.join(', ')}</dd>
                         </div>
                     : null}
 
-                    {step.input_file_types && step.input_file_types.length ?
+                    {step.input_file_types && step.input_file_types.length > 0 ?
                         <div data-test="inputtypes">
                             <dt>Input</dt>
                             <dd>{step.input_file_types.join(', ')}</dd>
                         </div>
                     : null}
 
-                    {step.output_file_types && step.output_file_types.length ?
+                    {step.output_file_types && step.output_file_types.length > 0 ?
                         <div data-test="outputtypes">
                             <dt>Output</dt>
                             <dd>
@@ -93,7 +93,7 @@ function AnalysisStep(step, node) {
                         </div>
                     : null}
 
-                    {node && node.metadata.pipelines && node.metadata.pipelines.length ?
+                    {node && node.metadata.pipelines && node.metadata.pipelines.length > 0 ?
                         <div data-test="pipeline">
                             <dt>Pipeline</dt>
                             <dd>
@@ -107,7 +107,7 @@ function AnalysisStep(step, node) {
                         </div>
                     : null}
 
-                    {step.qa_stats_generated && step.qa_stats_generated.length ?
+                    {step.qa_stats_generated && step.qa_stats_generated.length > 0 ?
                         <div data-test="qastats">
                             <dt>QA statistics</dt>
                             <dd>
@@ -126,14 +126,14 @@ function AnalysisStep(step, node) {
                             <dt>Software</dt>
                             <dd>{softwareVersionList(swVersions)}</dd>
                         </div>
-                    : stepVersions && stepVersions.length ?
+                    : stepVersions && stepVersions.length > 0 ?
                         <div data-test="swstepversions">
                             <dt>Software</dt>
                             <dd>{swStepVersions}</dd>
                         </div>
                     : null}
 
-                    {step.documents && step.documents.length ?
+                    {step.documents && step.documents.length > 0 ?
                         <div data-test="documents">
                             <dt>Documents</dt>
                             <dd>
@@ -200,7 +200,7 @@ class PipelineComponent extends React.Component {
         let jsonGraph;
 
         // Only produce a graph if there's at least one analysis step.
-        if (analysisSteps && analysisSteps.length) {
+        if (analysisSteps && analysisSteps.length > 0) {
             // Make an object with all step UUIDs in the pipeline.
             const allSteps = {};
             analysisSteps.forEach((step) => {
@@ -218,14 +218,14 @@ class PipelineComponent extends React.Component {
                 let label;
 
                 // Collect software version titles.
-                if (step.current_version && step.current_version.software_versions && step.current_version.software_versions.length) {
+                if (step.current_version && step.current_version.software_versions && step.current_version.software_versions.length > 0) {
                     const softwareVersions = step.current_version.software_versions;
                     swVersionList = softwareVersions.map(version => version.software.title);
                 }
 
                 // Build the node label; both step types and sw version titles if available.
-                const stepTypes = (step.analysis_step_types && step.analysis_step_types.length) ? step.analysis_step_types.join(', ') : '';
-                if (swVersionList.length) {
+                const stepTypes = (step.analysis_step_types && step.analysis_step_types.length > 0) ? step.analysis_step_types.join(', ') : '';
+                if (swVersionList.length > 0) {
                     label = [stepTypes, swVersionList.join(', ')];
                 } else {
                     label = stepTypes;
@@ -242,7 +242,7 @@ class PipelineComponent extends React.Component {
 
                 // Add this step's `output_file_types` nodes to the graph, and connect edges from
                 // them to the current step.
-                if (step.output_file_types && step.output_file_types.length) {
+                if (step.output_file_types && step.output_file_types.length > 0) {
                     step.output_file_types.forEach((outputFile) => {
                         // Get the unique ID for the file type node. We can have repeats of the
                         // same output_file_type all over the graph, so we have to include the step
@@ -266,18 +266,18 @@ class PipelineComponent extends React.Component {
                 // output_file_types nodes. `parentlessInputs` tracks input file types that *don't*
                 // overlap with the parents' output file types.
                 let parentlessInputs = step.input_file_types || [];
-                if (step.parents && step.parents.length) {
+                if (step.parents && step.parents.length > 0) {
                     step.parents.forEach((parent) => {
                         // Get this step's parent object so we can look at its output_file_types array.
                         const parentId = PipelineComponent.genStepId(parent);
                         const parentStep = allSteps[parentId];
                         if (parentStep) {
-                            if (parentStep.output_file_types && parentStep.output_file_types.length) {
+                            if (parentStep.output_file_types && parentStep.output_file_types.length > 0) {
                                 // We have the parent analysis_step object and it has output_file_types.
                                 // Compare that array with this step's input_file_types elements.
                                 // Draw an edge to any that overlap.
                                 const overlaps = _.intersection(parentStep.output_file_types, step.input_file_types);
-                                if (overlaps.length) {
+                                if (overlaps.length > 0) {
                                     overlaps.forEach((overlappingFile) => {
                                         const overlappingFileId = PipelineComponent.genFileId(parentStep, overlappingFile);
                                         jsonGraph.addEdge(overlappingFileId, stepId);
@@ -306,7 +306,7 @@ class PipelineComponent extends React.Component {
                 // Render input file types not shared by a parent step. `parentlessInputs` is an
                 // array holding all the input file types for the current step that aren't shared
                 // with a parent's output file types.
-                if (parentlessInputs.length) {
+                if (parentlessInputs.length > 0) {
                     // The step doesn't have parents but it has input_file_types. Draw nodes for
                     // all its input_file_types.
                     parentlessInputs.forEach((fileType) => {
@@ -357,7 +357,7 @@ class PipelineComponent extends React.Component {
         const itemClass = globals.itemClass(context, 'view-item');
 
         let crumbs;
-        const assayName = (context.assay_term_names && context.assay_term_names.length) ? context.assay_term_names.join(' + ') : null;
+        const assayName = (context.assay_term_names && context.assay_term_names.length > 0) ? context.assay_term_names.join(' + ') : null;
         if (assayName) {
             const query = context.assay_term_names.map(name => `assay_term_names=${name}`).join('&');
             crumbs = [
@@ -414,7 +414,7 @@ class PipelineComponent extends React.Component {
                                 <dd>{context.title}</dd>
                             </div>
 
-                            {context.assay_term_names && context.assay_term_names.length ?
+                            {context.assay_term_names && context.assay_term_names.length > 0 ?
                                 <div data-test="assay">
                                     <dt>Assays</dt>
                                     <dd>{context.assay_term_names.join(', ')}</dd>
@@ -473,7 +473,7 @@ class PipelineComponent extends React.Component {
                     </Panel>
                 : null}
 
-                {context.documents && context.documents.length ?
+                {context.documents && context.documents.length > 0 ?
                     <DocumentsPanel documentSpecs={[{ documents: context.documents }]} />
                 : null}
 
@@ -536,16 +536,16 @@ class ListingComponent extends React.Component {
         let swTitle = [];
 
         // Collect up an array of published-by and software titles for all steps in this pipeline
-        if (result.analysis_steps && result.analysis_steps.length) {
+        if (result.analysis_steps && result.analysis_steps.length > 0) {
             result.analysis_steps.forEach((step) => {
-                if (step.versions && step.versions.length) {
+                if (step.versions && step.versions.length > 0) {
                     step.versions.forEach((version) => {
-                        if (version.software_versions && version.software_versions.length) {
+                        if (version.software_versions && version.software_versions.length > 0) {
                             version.software_versions.forEach((softwareVersion) => {
                                 swTitle.push(softwareVersion.software.title);
-                                if (softwareVersion.software.references && softwareVersion.software.references.length) {
+                                if (softwareVersion.software.references && softwareVersion.software.references.length > 0) {
                                     softwareVersion.software.references.forEach((reference) => {
-                                        if (reference.published_by && reference.published_by.length) {
+                                        if (reference.published_by && reference.published_by.length > 0) {
                                             publishedBy.push(...reference.published_by);
                                         }
                                     });
@@ -573,15 +573,15 @@ class ListingComponent extends React.Component {
                         <a href={result['@id']}>{result.title}</a>
                     </div>
                     <div className="data-row">
-                        {result.assay_term_names && result.assay_term_names.length ?
+                        {result.assay_term_names && result.assay_term_names.length > 0 ?
                             <div><strong>Assays: </strong>{result.assay_term_names.join(', ')}</div>
                         : null}
 
-                        {swTitle.length ?
+                        {swTitle.length > 0 ?
                             <div><strong>Software: </strong>{swTitle.join(', ')}</div>
                         : null}
 
-                        {publishedBy.length ?
+                        {publishedBy.length > 0 ?
                             <div><strong>References: </strong>{publishedBy.join(', ')}</div>
                         : null}
                     </div>

--- a/src/encoded/static/components/platform.js
+++ b/src/encoded/static/components/platform.js
@@ -22,7 +22,7 @@ const Platform = (props) => {
                 <div data-test="externalresources">
                     <dt>External resources</dt>
                     <dd>
-                        {context.dbxrefs.length ?
+                        {context.dbxrefs.length > 0 ?
                             <DbxrefList context={context} dbxrefs={context.dbxrefs} />
                         : <em>None submitted</em> }
                     </dd>

--- a/src/encoded/static/components/publication.js
+++ b/src/encoded/static/components/publication.js
@@ -91,7 +91,7 @@ const PublicationComponent = (props, reactContext) => {
                 </div>
             : null}
 
-            {context.datasets && context.datasets.length ?
+            {context.datasets && context.datasets.length > 0 ?
                     <SortTablePanel title="Datasets">
                         <FetchedData>
                             <Param name="datasets" url={datasetsUrl} allowMultipleRequest />
@@ -100,7 +100,7 @@ const PublicationComponent = (props, reactContext) => {
                     </SortTablePanel>
             : null }
 
-            {context.supplementary_data && context.supplementary_data.length ?
+            {context.supplementary_data && context.supplementary_data.length > 0 ?
                 <div>
                     <h3>Related data</h3>
                     <div className="panel view-detail" data-test="supplementarydata">
@@ -162,7 +162,7 @@ const Abstract = (props) => {
                 </div>
             : null}
 
-            {context.identifiers && context.identifiers.length ?
+            {context.identifiers && context.identifiers.length > 0 ?
                 <div data-test="references">
                     <dt>References</dt>
                     <dd><DbxrefList context={context} dbxrefs={context.identifiers} addClasses="multi-value" /></dd>
@@ -305,7 +305,7 @@ SupplementaryDataListing.defaultProps = {
 
 const ListingComponent = (props, context) => {
     const result = props.context;
-    const authorList = result.authors && result.authors.length ? result.authors.split(', ', 4) : [];
+    const authorList = result.authors && result.authors.length > 0 ? result.authors.split(', ', 4) : [];
     const authors = authorList.length === 4 ? `${authorList.splice(0, 3).join(', ')}, et al` : result.authors;
 
     return (
@@ -321,8 +321,8 @@ const ListingComponent = (props, context) => {
                 <div className="data-row">
                     {authors ? <p className="list-author">{authors}.</p> : null}
                     <p className="list-citation"><Citation {...props} /></p>
-                    {result.identifiers && result.identifiers.length ? <DbxrefList context={result} dbxrefs={result.identifiers} addClasses="list-reference" /> : '' }
-                    {result.supplementary_data && result.supplementary_data.length ?
+                    {result.identifiers && result.identifiers.length > 0 ? <DbxrefList context={result} dbxrefs={result.identifiers} addClasses="list-reference" /> : '' }
+                    {result.supplementary_data && result.supplementary_data.length > 0 ?
                         <div>
                             {result.supplementary_data.map((data, i) =>
                                 <SupplementaryDataListing data={data} id={result['@id']} index={i} key={i} />

--- a/src/encoded/static/components/quality_metric.js
+++ b/src/encoded/static/components/quality_metric.js
@@ -41,7 +41,7 @@ export function qcModalContent(qc, file, qcSchema, genericQCSchema) {
     // quality_metric_of is an array of @ids because they're not embedded, and we're trying
     // to avoid embedding where not absolutely needed. So use a regex to extract the files'
     // accessions from the @ids. After generating the array, filter out empty entries.
-    if (qc.quality_metric_of && qc.quality_metric_of.length) {
+    if (qc.quality_metric_of && qc.quality_metric_of.length > 0) {
         filesOfMetric = qc.quality_metric_of.map((metricId) => {
             // Extract the file's accession from the @id
             const match = globals.atIdToAccession(metricId);
@@ -90,7 +90,7 @@ export function qcModalContent(qc, file, qcSchema, genericQCSchema) {
     const header = (
         <div className="details-view-info">
             <h4>{qcName} of {file.title}</h4>
-            {filesOfMetric.length ? <h5>Shared with {filesOfMetric.join(', ')}</h5> : null}
+            {filesOfMetric.length > 0 ? <h5>Shared with {filesOfMetric.join(', ')}</h5> : null}
         </div>
     );
     const body = (
@@ -100,7 +100,7 @@ export function qcModalContent(qc, file, qcSchema, genericQCSchema) {
                     <QCDataDisplay qcMetric={qc} qcSchema={qcSchema} genericQCSchema={genericQCSchema} />
                 </div>
 
-                {(qcPanels && qcPanels.length) || qc.attachment ?
+                {(qcPanels && qcPanels.length > 0) || qc.attachment ?
                     <div className="col-md-8 col-sm-12 quality-metrics-attachments">
                         <div className="row">
                             <h5>Quality metric attachments</h5>
@@ -400,7 +400,7 @@ const QCDetailView = function QCDetailView(node) {
     const selectedQc = node.ref;
     let modalContent = {};
 
-    if (selectedQc && Object.keys(selectedQc).length) {
+    if (selectedQc && Object.keys(selectedQc).length > 0) {
         const schemas = node.schemas;
         const genericQCSchema = schemas.GenericQualityMetric;
         const qcSchema = schemas[selectedQc['@type'][0]];

--- a/src/encoded/static/components/reference.js
+++ b/src/encoded/static/components/reference.js
@@ -4,7 +4,7 @@ import _ from 'underscore';
 
 export default function pubReferenceList(values) {
     // Render each of the links, with null for each value without an identifier property
-    if (values && values.length) {
+    if (values && values.length > 0) {
         const links = _.compact(values.map((value) => {
             if (value.identifiers) {
                 return value.identifiers.map((identifier, index) =>
@@ -17,7 +17,7 @@ export default function pubReferenceList(values) {
         }));
 
         // Render any links into a ul. Just return null if no links to render.
-        if (links.length) {
+        if (links.length > 0) {
             return (
                 <ul>{links}</ul>
             );

--- a/src/encoded/static/components/region_search.js
+++ b/src/encoded/static/components/region_search.js
@@ -21,7 +21,7 @@ const AutocompleteBox = (props) => {
     const handleClick = props.handleClick;
     const userTerm = props.userTerm && props.userTerm.toLowerCase(); // Term user entered
 
-    if (!props.hide && userTerm && userTerm.length && terms && terms.length) {
+    if (!props.hide && userTerm && userTerm.length > 0 && terms && terms.length > 0) {
         return (
             <ul className="adv-search-autocomplete">
                 {terms.map((term) => {
@@ -293,7 +293,7 @@ class RegionSearch extends React.Component {
 
         // Get a sorted list of batch hubs keys with case-insensitive sort
         let visualizeKeys = [];
-        if (context.visualize_batch && Object.keys(context.visualize_batch).length) {
+        if (context.visualize_batch && Object.keys(context.visualize_batch).length > 0) {
             visualizeKeys = Object.keys(context.visualize_batch).sort((a, b) => {
                 const aLower = a.toLowerCase();
                 const bLower = b.toLowerCase();

--- a/src/encoded/static/components/report.js
+++ b/src/encoded/static/components/report.js
@@ -103,7 +103,7 @@ function lookupColumn(result, column) {
         }
     }
 
-    for (let i = 0, len = names.length; i < len && nodes.length; i += 1) {
+    for (let i = 0, len = names.length; i < len && nodes.length > 0; i += 1) {
         let nextnodes = [];
         _.each(nodes.map(node => node[names[i]]), (v) => {
             if (v === undefined) return;
@@ -124,12 +124,12 @@ function lookupColumn(result, column) {
         }
     }
     // if we ended with an embedded object, show the @id
-    if (nodes.length && nodes[0]['@id'] !== undefined) {
+    if (nodes.length > 0 && nodes[0]['@id'] !== undefined) {
         nodes = nodes.map(node => node['@id']);
     }
 
     // Stringify any nodes that are objects or arrays. Objects and arrays have typeof `object`.
-    if (nodes.length) {
+    if (nodes.length > 0) {
         nodes = nodes.map(item => (typeof item === 'object' ? JSON.stringify(item) : item));
     }
 

--- a/src/encoded/static/components/schema.js
+++ b/src/encoded/static/components/schema.js
@@ -99,7 +99,7 @@ function createJsonDisplay(elementId, term) {
  */
 function schemaIdToName(schemaId) {
     const pathMatch = schemaId.match(/\/profiles\/(.*).json/);
-    return pathMatch && pathMatch.length ? pathMatch[1] : null;
+    return pathMatch && pathMatch.length > 0 ? pathMatch[1] : null;
 }
 
 
@@ -185,16 +185,16 @@ const SchemaTermLinksSection = (props) => {
     // Collect all the linkTo and linkFrom @types from schemaProp.
     const collectedLinks = collectLinks(schemaProp);
 
-    if (collectedLinks.linkTo.length || collectedLinks.linkFrom.length) {
+    if (collectedLinks.linkTo.length > 0 || collectedLinks.linkFrom.length > 0) {
         return (
             <div className="schema-term-links">
-                {collectedLinks.linkTo.length ?
+                {collectedLinks.linkTo.length > 0 ?
                     <div>
                         <span className="schema-term-links__title">References: </span>
                         <SchemaTermLinks schemaNames={collectedLinks.linkTo} profilesMap={profilesMap} />
                     </div>
                 : null}
-                {collectedLinks.linkFrom.length ?
+                {collectedLinks.linkFrom.length > 0 ?
                     <div>
                         <span className="schema-term-links__title">Referenced by: </span>
                         <SchemaTermLinks schemaNames={collectedLinks.linkFrom} profilesMap={profilesMap} />
@@ -347,7 +347,7 @@ const TermDisplay = (props) => {
             // array (at this time, I don't think any schema array values have non-simple types)
             // and sort the results.
             const simpleTermValues = termSchema.filter(item => !!simpleTypeDisplay[typeof item]).sort();
-            if (simpleTermValues.length) {
+            if (simpleTermValues.length > 0) {
                 return (
                     <div>
                         {simpleTermValues.map((item, i) => (
@@ -635,7 +635,7 @@ const AllSchemasPage = (props, reactContext) => {
     // out those without any `identifyingProperties` because the user can't add objects of that
     // type, nor display their schemas.
     const objectNames = Object.keys(context).sort().filter(objectName => (
-        !!(context[objectName].identifyingProperties && context[objectName].identifyingProperties.length)
+        context[objectName].identifyingProperties && context[objectName].identifyingProperties.length > 0
     ));
 
     return (

--- a/src/encoded/static/components/search.js
+++ b/src/encoded/static/components/search.js
@@ -100,7 +100,7 @@ export function Listing(reactProps) {
 /* eslint-disable react/prefer-stateless-function */
 export class PickerActions extends React.Component {
     render() {
-        if (this.context.actions && this.context.actions.length) {
+        if (this.context.actions && this.context.actions.length > 0) {
             return (
                 <div className="pull-right">
                     {this.context.actions.map(action => React.cloneElement(action, { key: this.props.context.name, id: this.props.context['@id'] }))}
@@ -176,13 +176,13 @@ class BiosampleComponent extends React.Component {
         const age = (result.age && result.age !== 'unknown') ? ` ${result.age}` : '';
         const ageUnits = (result.age_units && result.age_units !== 'unknown' && age) ? ` ${result.age_units}` : '';
         const separator = (lifeStage || age) ? ',' : '';
-        const treatment = (result.treatments && result.treatments.length) ? result.treatments[0].treatment_term_name : '';
+        const treatment = (result.treatments && result.treatments.length > 0) ? result.treatments[0].treatment_term_name : '';
 
         // Calculate genetic modification properties for display.
         const rnais = [];
         const constructs = [];
         const mutatedGenes = [];
-        if (result.applied_modifications && result.applied_modifications.length) {
+        if (result.applied_modifications && result.applied_modifications.length > 0) {
             result.applied_modifications.forEach((am) => {
                 // Collect RNAi GM methods.
                 if (am.method === 'RNAi' && am.modified_site_by_target_id && am.modified_site_by_target_id.name) {
@@ -230,10 +230,10 @@ class BiosampleComponent extends React.Component {
                     <div className="data-row">
                         <div><strong>Type: </strong>{result.biosample_ontology.classification}</div>
                         {result.summary ? <div><strong>Summary: </strong>{BiosampleSummaryString(result)}</div> : null}
-                        {rnais.length ? <div><strong>RNAi targets: </strong>{rnais.join(', ')}</div> : null}
-                        {constructs.length ? <div><strong>Constructs: </strong>{constructs.join(', ')}</div> : null}
+                        {rnais.length > 0 ? <div><strong>RNAi targets: </strong>{rnais.join(', ')}</div> : null}
+                        {constructs.length > 0 ? <div><strong>Constructs: </strong>{constructs.join(', ')}</div> : null}
                         {treatment ? <div><strong>Treatment: </strong>{treatment}</div> : null}
-                        {mutatedGenes.length ? <div><strong>Mutated genes: </strong>{mutatedGenes.join(', ')}</div> : null}
+                        {mutatedGenes.length > 0 ? <div><strong>Mutated genes: </strong>{mutatedGenes.join(', ')}</div> : null}
                         {result.culture_harvest_date ? <div><strong>Culture harvest date: </strong>{result.culture_harvest_date}</div> : null}
                         {result.date_obtained ? <div><strong>Date obtained: </strong>{result.date_obtained}</div> : null}
                         {synchText ? <div><strong>Synchronization timepoint: </strong>{synchText}</div> : null}
@@ -270,16 +270,16 @@ const ExperimentComponent = (props, reactContext) => {
     // Collect all biosamples associated with the experiment. This array can contain duplicate
     // biosamples, but no null entries.
     let biosamples = [];
-    if (result.replicates && result.replicates.length) {
+    if (result.replicates && result.replicates.length > 0) {
         biosamples = _.compact(result.replicates.map(replicate => replicate.library && replicate.library.biosample));
     }
 
     // Get all biosample organism names
-    const organismNames = biosamples.length ? BiosampleOrganismNames(biosamples) : [];
+    const organismNames = biosamples.length > 0 ? BiosampleOrganismNames(biosamples) : [];
 
     // Bek: Forrest should review the change for correctness
     // Collect synchronizations
-    if (result.replicates && result.replicates.length) {
+    if (result.replicates && result.replicates.length > 0) {
         synchronizations = _.uniq(result.replicates.filter(replicate =>
             replicate.library && replicate.library.biosample && replicate.library.biosample.synchronization
         ).map((replicate) => {
@@ -314,7 +314,7 @@ const ExperimentComponent = (props, reactContext) => {
                     </div>
                     {result.biosample_summary ?
                         <div className="highlight-row">
-                            {organismNames.length ?
+                            {organismNames.length > 0 ?
                                 <span>
                                     {organismNames.map((organism, i) =>
                                         <span key={organism}>
@@ -332,7 +332,7 @@ const ExperimentComponent = (props, reactContext) => {
                             <div><strong>Target: </strong>{result.target.label}</div>
                         : null}
 
-                        {synchronizations && synchronizations.length ?
+                        {synchronizations && synchronizations.length > 0 ?
                             <div><strong>Synchronization timepoint: </strong>{synchronizations.join(', ')}</div>
                         : null}
 
@@ -386,15 +386,15 @@ const DatasetComponent = (props, reactContext) => {
     // Get the biosample info for Series types if any. Can be string or array. If array, only use iff 1 term name exists
     if (seriesDataset) {
         biosampleTerm = (result.biosample_ontology && Array.isArray(result.biosample_ontology) && result.biosample_ontology.length === 1 && result.biosample_ontology[0].term_name) ? result.biosample_ontology[0].term_name : ((result.biosample_ontology && result.biosample_ontology.term_name) ? result.biosample_ontology.term_name : '');
-        const organisms = (result.organism && result.organism.length) ? _.uniq(result.organism.map(resultOrganism => resultOrganism.scientific_name)) : [];
+        const organisms = (result.organism && result.organism.length > 0) ? _.uniq(result.organism.map(resultOrganism => resultOrganism.scientific_name)) : [];
         if (organisms.length === 1) {
             organism = organisms[0];
         }
 
         // Dig through the biosample life stages and ages
-        if (result.related_datasets && result.related_datasets.length) {
+        if (result.related_datasets && result.related_datasets.length > 0) {
             result.related_datasets.forEach((dataset) => {
-                if (dataset.replicates && dataset.replicates.length) {
+                if (dataset.replicates && dataset.replicates.length > 0) {
                     dataset.replicates.forEach((replicate) => {
                         if (replicate.library && replicate.library.biosample) {
                             const biosample = replicate.library.biosample;
@@ -453,7 +453,7 @@ const DatasetComponent = (props, reactContext) => {
                     </div>
                     <div className="data-row">
                         {result.dataset_type ? <div><strong>Dataset type: </strong>{result.dataset_type}</div> : null}
-                        {targets && targets.length ? <div><strong>Targets: </strong>{targets.join(', ')}</div> : null}
+                        {targets && targets.length > 0 ? <div><strong>Targets: </strong>{targets.join(', ')}</div> : null}
                         <div><strong>Lab: </strong>{result.lab.title}</div>
                         <div><strong>Project: </strong>{result.award.project}</div>
                     </div>
@@ -498,7 +498,7 @@ class TargetComponent extends React.Component {
                     </div>
                     <div className="data-row">
                         <strong>External resources: </strong>
-                        {result.dbxref && result.dbxref.length ?
+                        {result.dbxref && result.dbxref.length > 0 ?
                             <DbxrefList context={result} dbxrefs={result.dbxref} />
                         : <em>None submitted</em> }
                     </div>
@@ -1322,7 +1322,7 @@ export class TextFilter extends React.Component {
 
     getValue() {
         const filter = this.props.filters.filter(f => f.field === 'searchTerm');
-        return filter.length ? filter[0].term : '';
+        return filter.length > 0 ? filter[0].term : '';
     }
 
     /**
@@ -1387,7 +1387,7 @@ export class FacetList extends React.Component {
         const normalFacets = facets.filter(facet => facet.field.substring(0, 6) !== 'audit.');
 
         let width = 'inherit';
-        if (!facets.length && mode !== 'picker') return <div />;
+        if (facets.length === 0 && mode !== 'picker') return <div />;
         let hideTypes;
         if (mode === 'picker') {
             // The edit forms item picker (search results in an edit item) shows the Types facet.
@@ -1652,7 +1652,7 @@ export const SearchControls = ({ context, visualizeDisabledTitle, showResultsTog
 
     // Get a sorted list of batch hubs keys with case-insensitive sort.
     let visualizeKeys = [];
-    if (context.visualize_batch && Object.keys(context.visualize_batch).length) {
+    if (context.visualize_batch && Object.keys(context.visualize_batch).length > 0) {
         visualizeKeys = Object.keys(context.visualize_batch).sort((a, b) => {
             const aLower = a.toLowerCase();
             const bLower = b.toLowerCase();
@@ -1754,8 +1754,8 @@ export class ResultTable extends React.Component {
         // Make an array of all assemblies found in all files in the search results.
         let assemblies = [];
         const results = this.props.context['@graph'];
-        const files = results.length ? results.filter(result => result['@type'][0] === 'File') : [];
-        if (files.length) {
+        const files = results.length > 0 ? results.filter(result => result['@type'][0] === 'File') : [];
+        if (files.length > 0) {
             // Reduce all found file assemblies so we don't have duplicates in the 'assemblies' array.
             assemblies = files.reduce((assembliesAcc, file) => ((!file.assembly || assembliesAcc.indexOf(file.assembly) > -1) ? assembliesAcc : assembliesAcc.concat(file.assembly)), []);
         }
@@ -1763,7 +1763,7 @@ export class ResultTable extends React.Component {
         // Set React component state.
         this.state = {
             assemblies,
-            browserAssembly: assemblies.length && assemblies[0], // Currently selected assembly for the browser
+            browserAssembly: assemblies.length > 0 && assemblies[0], // Currently selected assembly for the browser
             selectedTab: '',
         };
 
@@ -1833,7 +1833,7 @@ export class ResultTable extends React.Component {
 
         // See if a specific result type was requested ('type=x')
         // Satisfied iff exactly one type is in the search
-        if (results.length) {
+        if (results.length > 0) {
             let specificFilter;
             filters.forEach((filter) => {
                 if (filter.field === 'type') {
@@ -1909,7 +1909,7 @@ export class ResultTable extends React.Component {
         return (
             <div>
                 <div className="row">
-                    {facets.length ?
+                    {facets.length > 0 ?
                         <div className="col-sm-5 col-md-4 col-lg-3">
                             <FacetList
                                 {...this.props}
@@ -1986,7 +1986,7 @@ const BrowserTabQuickView = function BrowserTabQuickView() {
 // Display the list of search results.
 export const ResultTableList = ({ results, columns, tabbed, cartControls }) => (
     <ul className={`nav result-table${tabbed ? ' result-table-tabbed' : ''}`} id="result-table">
-        {results.length ?
+        {results.length > 0 ?
             results.map(result => Listing({ context: result, columns, key: result['@id'], cartControls }))
         : null}
     </ul>

--- a/src/encoded/static/components/search.js
+++ b/src/encoded/static/components/search.js
@@ -2128,8 +2128,8 @@ Search.contextTypes = {
 
 // optionally make a persistent region
 Search.lastRegion = {
-    assembly: React.PropTypes.string,
-    region: React.PropTypes.string,
+    assembly: PropTypes.string,
+    region: PropTypes.string,
 };
 
 globals.contentViews.register(Search, 'Search');

--- a/src/encoded/static/components/software.js
+++ b/src/encoded/static/components/software.js
@@ -33,7 +33,7 @@ class SoftwareComponent extends React.Component {
         // See if there’s a version number to highlight
         let highlightVersion;
         const queryParsed = this.context.location_href && url.parse(this.context.location_href, true).query;
-        if (queryParsed && Object.keys(queryParsed).length) {
+        if (queryParsed && Object.keys(queryParsed).length > 0) {
             // Find the first 'version' query string item, if any
             const versionKey = _(Object.keys(queryParsed)).find(key => key === 'version');
             if (versionKey) {
@@ -79,14 +79,14 @@ class SoftwareComponent extends React.Component {
                             <dd>{context.description}</dd>
                         </div>
 
-                        {context.software_type && context.software_type.length ?
+                        {context.software_type && context.software_type.length > 0 ?
                             <div data-test="type">
                                 <dt>Software type</dt>
                                 <dd>{context.software_type.join(', ')}</dd>
                             </div>
                         : null}
 
-                        {context.purpose && context.purpose.length ?
+                        {context.purpose && context.purpose.length > 0 ?
                             <div data-test="purpose">
                                 <dt>Used for</dt>
                                 <dd>{context.purpose.join(', ')}</dd>
@@ -102,7 +102,7 @@ class SoftwareComponent extends React.Component {
                     </dl>
                 </div>
 
-                {context.versions && context.versions.length ?
+                {context.versions && context.versions.length > 0 ?
                     <div>
                         <h3>Software Versions</h3>
                         <SoftwareVersionTable items={context.versions} highlightVersion={highlightVersion} />
@@ -194,7 +194,7 @@ class ListingComponent extends React.Component {
                     </div>
                     <div className="data-row">
                         <div>{result.description}</div>
-                        {result.software_type && result.software_type.length ?
+                        {result.software_type && result.software_type.length > 0 ?
                             <div>
                                 <strong>Software type: </strong>
                                 {result.software_type.join(', ')}

--- a/src/encoded/static/components/sorttable.js
+++ b/src/encoded/static/components/sorttable.js
@@ -281,7 +281,7 @@ export class SortTable extends React.Component {
         const colCount = columnIds.length - hiddenCount;
 
         // Now display the table, but only if we were passed a non-empty list
-        if (list && list.length) {
+        if (list && list.length > 0) {
             // Sort the list according to the requested sorting column. Only do this *after* this
             // component has mounted (ENCD-3459).
             const sortedList = this.state.mounted ? list.sort(this.sortColumn) : list;

--- a/src/encoded/static/components/summary.js
+++ b/src/encoded/static/components/summary.js
@@ -55,7 +55,7 @@ function generateStatusData(buckets, labels) {
     const statusData = Array.from({ length: labels.length }, (() => 0));
 
     // Convert statusData to a form createBarChart understands.
-    if (buckets && buckets.length) {
+    if (buckets && buckets.length > 0) {
         buckets.forEach((bucketItem) => {
             const statusIndex = labels.indexOf(bucketItem.key);
             if (statusIndex !== -1) {
@@ -347,14 +347,14 @@ class SummaryData extends React.Component {
 
         // Filter the assay list if any assay facets have been selected so that the assay graph will be
         // filtered accordingly. Find assay_title filters. Same applies to the lab filters.
-        if (context.filters && context.filters.length) {
+        if (context.filters && context.filters.length > 0) {
             const assayTitleFilters = context.filters.filter(filter => filter.field === 'assay_title');
-            if (assayTitleFilters.length) {
+            if (assayTitleFilters.length > 0) {
                 const assayTitleFilterTerms = assayTitleFilters.map(filter => filter.term);
                 assays = assays.filter(assayItem => assayTitleFilterTerms.indexOf(assayItem.key) !== -1);
             }
             const labFilters = context.filters.filter(filter => filter.field === 'lab.title');
-            if (labFilters.length) {
+            if (labFilters.length > 0) {
                 const labFilterTerms = labFilters.map(filter => filter.term);
                 labs = labs.filter(labItem => labFilterTerms.indexOf(labItem.key) !== -1);
             }
@@ -370,7 +370,7 @@ class SummaryData extends React.Component {
 
         // Collect selected facet terms to add to the base linkUri.
         let searchQuery = '';
-        if (context.filters && context.filters.length) {
+        if (context.filters && context.filters.length > 0) {
             searchQuery = context.filters.reduce((queryAcc, filter) => `${queryAcc}&${filter.field}=${globals.encodedURIComponent(filter.term)}`, '');
         }
         const linkUri = `/matrix/?type=Experiment${searchQuery}`;

--- a/src/encoded/static/components/target.js
+++ b/src/encoded/static/components/target.js
@@ -65,7 +65,7 @@ class Target extends React.Component {
                         <div data-test="external">
                             <dt>External resources</dt>
                             <dd>
-                                {context.dbxref.length ?
+                                {context.dbxref.length > 0 ?
                                     <DbxrefList context={context} dbxrefs={context.dbxref} />
                                 : <em>None submitted</em> }
                             </dd>

--- a/src/encoded/static/components/typeutils.js
+++ b/src/encoded/static/components/typeutils.js
@@ -31,26 +31,26 @@ export function BiosampleOrganismNames(biosamples) {
 export function CollectBiosampleDocs(biosample) {
     // Collect up the various biosample documents
     let protocolDocuments = [];
-    if (biosample.documents && biosample.documents.length) {
+    if (biosample.documents && biosample.documents.length > 0) {
         protocolDocuments = _.uniq(biosample.documents);
     }
     let characterizations = [];
-    if (biosample.characterizations && biosample.characterizations.length) {
+    if (biosample.characterizations && biosample.characterizations.length > 0) {
         characterizations = _.uniq(biosample.characterizations);
     }
     let donorDocuments = [];
     let donorCharacterizations = [];
     if (biosample.donor) {
-        if (biosample.donor.characterizations && biosample.donor.characterizations.length) {
+        if (biosample.donor.characterizations && biosample.donor.characterizations.length > 0) {
             donorCharacterizations = biosample.donor.characterizations;
         }
-        if (biosample.donor.documents && biosample.donor.documents.length) {
+        if (biosample.donor.documents && biosample.donor.documents.length > 0) {
             donorDocuments = biosample.donor.documents;
         }
     }
     let treatmentDocuments = [];
-    if (biosample.treatments && biosample.treatments.length) {
-        treatmentDocuments = biosample.treatments.reduce((allDocs, treatment) => ((treatment.documents && treatment.documents.length) ? allDocs.concat(treatment.documents) : allDocs), []);
+    if (biosample.treatments && biosample.treatments.length > 0) {
+        treatmentDocuments = biosample.treatments.reduce((allDocs, treatment) => ((treatment.documents && treatment.documents.length > 0) ? allDocs.concat(treatment.documents) : allDocs), []);
     }
 
     // Put together the document list for rendering

--- a/src/encoded/static/components/user.js
+++ b/src/encoded/static/components/user.js
@@ -122,7 +122,7 @@ class AccessKeyTable extends React.Component {
         return (
             <div>
                 <button className="btn btn-success" onClick={this.create}>Add Access Key</button>
-                {this.state.access_keys.length ?
+                {this.state.access_keys.length > 0 ?
                     <table className="table">
                         <thead>
                             <tr>


### PR DESCRIPTION
* environment.js sets up the React/jest environment. With the new AirBnB/React adapter module, this is highly simplified.
* I rebuilt package-lock.json from scratch, so we have minor updates of several packages, and major updates of ones directly related to the React upgrade.
* I wanted to redo one section of existing code to take advantage of something new in React 16, so I chose the library renderer for experiment pages because the old way to have a component write directly into a `<dl>` section was so complicated. It’s still not trivial, but now takes advantage of being able to have a React component return an array of components instead of just one. It was and is designed to make it easy to add/subtract replicate library values to display in the experiment summary panel.
    * The old `libraryValues` configuration object that I mutated before using it for display is now non-mutated and simpler, now called `displayedLibraryProperties`.
    * I now use the term “property extractor” which are functions to extract a value for display from an experiment replicate llibrary, when that value isn’t simple text.
* `componentDidMount` used to take the old React context as the third parameter. React no longer does this, so FileGalleryRendererComponent now uses a previously little used prop to take its place.
* Took this opportunity to change the walkme code from injecting a `<script>` tag to just having the script tag statically — something I suspected was possible originally, but was afraid to at the time with all the debugging Khine was doing with the walkme support people.
* The BrowserFeat call really belonged in a componentDidMount, so that’s where it lives now.