### PR TITLE
ENCD-4699 Fix Javascript crash display series file tables

### DIFF
--- a/src/encoded/static/components/filegallery.js
+++ b/src/encoded/static/components/filegallery.js
@@ -179,6 +179,7 @@ export class FileTable extends React.Component {
             // TODO: (1)Move .hide to FileTable.procTableColumns declaration
             // (2) move showReplicateNumber to meta
             FileTable.procTableColumns.biological_replicates.hide = () => !showReplicateNumber;
+            FileTable.procTableColumns.visualize.hide = () => browserOptions.browserFileSelectHandler === null;
 
             return (
                 <div>
@@ -281,7 +282,7 @@ FileTable.propTypes = {
         /** Currently selected genome browser */
         currentBrowser: PropTypes.string,
         /** Called when user selects a browser */
-        browserFileSelectHandler: PropTypes.func.isRequired,
+        browserFileSelectHandler: PropTypes.func,
         /** Files selected for browsing */
         selectedBrowserFiles: PropTypes.array,
     }),
@@ -316,6 +317,7 @@ FileTable.defaultProps = {
     showFileCount: false,
     browserOptions: {
         currentBrowser: '',
+        browserFileSelectHandler: null,
         selectedBrowserFiles: [],
     },
     setInfoNodeId: null,


### PR DESCRIPTION
FileTable can be called from FileGalleryRenderer for experiments and annotations, but it can also be called from DatasetFiles where visualizations aren’t relevant to objects using DatasetFiles so it passes nothing for the required browserOptions.browserFileSelectHandler, and it fails prop validation. This change removes this property as a _requirement_, and checks whether it exists, and hides the Visualize column from the table if it doesn’t.