### PR TITLE
ENCD-4692 Add mechanism for audit details to include links

### DIFF
--- a/src/encoded/audit/biosample.py
+++ b/src/encoded/audit/biosample.py
@@ -2,6 +2,7 @@ from snovault import (
     AuditFailure,
     audit_checker,
 )
+from .formatter import audit_link
 
 
 # flag biosamples that contain GM that is different from the GM in donor. It could be legitimate case, but we would like to see it.
@@ -91,7 +92,7 @@ def audit_biosample_donor(value, system):
         return
 
     if 'donor' not in value:
-        detail = 'Biosample {} is not associated with any donor.'.format(value['@id'])
+        detail = 'Biosample {} is not associated with any donor.'.format(audit_link(value['accession'], value['@id']))
         if 'award' in value and 'rfa' in value['award'] and \
            value['award']['rfa'] == 'GGR':
             yield AuditFailure('missing donor', detail, level='INTERNAL_ACTION')

--- a/src/encoded/audit/experiment.py
+++ b/src/encoded/audit/experiment.py
@@ -2,6 +2,10 @@ from snovault import (
     AuditFailure,
     audit_checker,
 )
+from .formatter import (
+    audit_link,
+    path_to_text,
+)
 from .gtex_data import gtexDonorsList
 from .standards_data import pipelines_with_read_depth, minimal_read_depth_requirements
 
@@ -1344,13 +1348,13 @@ def check_replicate_metric_dual_threshold(
                 level = 'NOT_COMPLIANT'
                 standards_severity = 'requirements'
                 audit_name_severity = 'insufficient'
-            file_names_fmt = str(files).replace('\'', ' ')
+            file_names_links = [audit_link(path_to_text(file), file) for file in files]
             detail = (
                 'Files {} have {} of {}, which is below ENCODE {}. According to '
                 'ENCODE standards, a number for this property in a replicate of > {:,} '
                 'is required, and > {:,} is recommended.'
             ).format(
-                file_names_fmt,
+                ', '.join(file_names_links),
                 metric_description,
                 metric_value,
                 standards_severity,
@@ -2719,7 +2723,7 @@ def audit_experiment_documents(value, system, excluded_types):
 
     # If there are no library documents anywhere, then we say something
     if lib_docs == 0:
-        detail = 'Experiment {} has no attached documents'.format(value['@id'])
+        detail = 'Experiment {} has no attached documents'.format(audit_link(value['accession'], value['@id']))
         yield AuditFailure('missing documents', detail, level='NOT_COMPLIANT')
     return
 

--- a/src/encoded/audit/formatter.py
+++ b/src/encoded/audit/formatter.py
@@ -1,0 +1,10 @@
+import re
+
+def audit_link(linkText, uri):
+    """Generate link "markdown" from URI."""
+    return '{{{}|{}}}'.format(linkText, uri)
+
+def path_to_text(path):
+    """Convert object path to the text portion."""
+    accession = re.match('\/.*\/(.*)\/', path)
+    return accession.group(1) if accession else None

--- a/src/encoded/static/components/antibody.js
+++ b/src/encoded/static/components/antibody.js
@@ -133,7 +133,7 @@ const LotComponent = (props, reactContext) => {
                     <DisplayAsJson />
                 </div>
             </header>
-            {props.auditDetail(context.audit, 'antibody-audit', { except: context['@id'], session: reactContext.session })}
+            {props.auditDetail(context.audit, 'antibody-audit', { session: reactContext.session })}
 
             <div className="antibody-statuses">
                 {antibodyStatuses}
@@ -682,7 +682,7 @@ const ListingComponent = (props, reactContext) => {
                     <div><strong>Product ID / Lot ID: </strong>{result.product_id} / {result.lot_id}</div>
                 </div>
             </div>
-            {props.auditDetail(result.audit, result['@id'], { session: reactContext.session, except: result['@id'], forcedEditLink: true })}
+            {props.auditDetail(result.audit, result['@id'], { session: reactContext.session })}
         </li>
     );
 };

--- a/src/encoded/static/components/biosample.js
+++ b/src/encoded/static/components/biosample.js
@@ -76,7 +76,7 @@ class BiosampleComponent extends React.Component {
                         <DisplayAsJson />
                     </div>
                 </header>
-                {this.props.auditDetail(context.audit, 'biosample-audit', { session: this.context.session, except: context['@id'] })}
+                {this.props.auditDetail(context.audit, 'biosample-audit', { session: this.context.session })}
                 <Panel addClasses="data-display">
                     <PanelBody addClasses="panel-body-with-header">
                         <div className="flexrow">

--- a/src/encoded/static/components/biosample_type.js
+++ b/src/encoded/static/components/biosample_type.js
@@ -40,7 +40,7 @@ const BiosampleTypeComponenet = (props, reactContext) => {
                     <DisplayAsJson />
                 </div>
             </header>
-            {props.auditDetail(context.audit, 'biosample-type-audit', { session: reactContext.session, except: context['@id'] })}
+            {props.auditDetail(context.audit, 'biosample-type-audit', { session: reactContext.session })}
             <div className="panel">
                 <dl className="key-value">
                     <div data-test="term-name">
@@ -128,7 +128,7 @@ const ListingComponent = (props, reactContext) => {
                     <strong>Ontology ID: </strong><BiosampleTermId termId={result.term_id} />
                 </div>
             </div>
-            {props.auditDetail(result.audit, result['@id'], { session: reactContext.session, except: result['@id'], forcedEditLink: true })}
+            {props.auditDetail(result.audit, result['@id'], { session: reactContext.session })}
         </li>
     );
 };

--- a/src/encoded/static/components/dataset.js
+++ b/src/encoded/static/components/dataset.js
@@ -93,7 +93,7 @@ class AnnotationComponent extends React.Component {
                         <DisplayAsJson />
                     </div>
                 </header>
-                {this.props.auditDetail(context.audit, 'annotation-audit', { session: this.context.session, except: context['@id'] })}
+                {this.props.auditDetail(context.audit, 'annotation-audit', { session: this.context.session })}
                 <Panel addClasses="data-display">
                     <PanelBody addClasses="panel-body-with-header">
                         <div className="flexrow">
@@ -288,7 +288,7 @@ class PublicationDataComponent extends React.Component {
                         <DisplayAsJson />
                     </div>
                 </header>
-                {this.props.auditDetail(context.audit, 'publicationdata-audit', { session: this.context.session, except: context['@id'] })}
+                {this.props.auditDetail(context.audit, 'publicationdata-audit', { session: this.context.session })}
                 <Panel addClasses="data-display">
                     <PanelBody addClasses="panel-body-with-header">
                         <div className="flexrow">
@@ -452,7 +452,7 @@ class ReferenceComponent extends React.Component {
                         <DisplayAsJson />
                     </div>
                 </header>
-                {this.props.auditDetail(context.audit, 'reference-audit', { session: this.context.session, except: context['@id'] })}
+                {this.props.auditDetail(context.audit, 'reference-audit', { session: this.context.session })}
                 <Panel addClasses="data-display">
                     <PanelBody addClasses="panel-body-with-header">
                         <div className="flexrow">
@@ -619,7 +619,7 @@ class ProjectComponent extends React.Component {
                         <DisplayAsJson />
                     </div>
                 </header>
-                {this.props.auditDetail(context.audit, 'project-audit', { session: this.context.session, except: context['@id'] })}
+                {this.props.auditDetail(context.audit, 'project-audit', { session: this.context.session })}
                 <Panel addClasses="data-display">
                     <PanelBody addClasses="panel-body-with-header">
                         <div className="flexrow">
@@ -807,7 +807,7 @@ class UcscBrowserCompositeComponent extends React.Component {
                         <DisplayAsJson />
                     </div>
                 </header>
-                {this.props.auditDetail(context.audit, 'ucscbrowsercomposite-audit', { session: this.context.session, except: context['@id'] })}
+                {this.props.auditDetail(context.audit, 'ucscbrowsercomposite-audit', { session: this.context.session })}
                 <Panel addClasses="data-display">
                     <PanelBody addClasses="panel-body-with-header">
                         <div className="flexrow">
@@ -1333,7 +1333,7 @@ export class SeriesComponent extends React.Component {
                         <DisplayAsJson />
                     </div>
                 </header>
-                {this.props.auditDetail(context.audit, 'series-audit', { session: this.context.session, except: context['@id'] })}
+                {this.props.auditDetail(context.audit, 'series-audit', { session: this.context.session })}
                 <Panel addClasses="data-display">
                     <PanelBody addClasses="panel-body-with-header">
                         <div className="flexrow">

--- a/src/encoded/static/components/donor.js
+++ b/src/encoded/static/components/donor.js
@@ -574,7 +574,7 @@ class DonorComponent extends React.Component {
                             <AlternateAccession altAcc={context.alternate_accessions} />
                         </div>
                         {this.props.auditIndicators(context.audit, 'donor-audit', { session: this.context.session })}
-                        {this.props.auditDetail(context.audit, 'donor-audit', { session: this.context.session, except: context['@id'] })}
+                        {this.props.auditDetail(context.audit, 'donor-audit', { session: this.context.session })}
                         <DisplayAsJson />
                     </div>
                 </header>
@@ -669,7 +669,7 @@ const DonorListingComponent = (props, reactContext) => {
                     : null}
                 </div>
             </div>
-            {props.auditDetail(result.audit, result['@id'], { session: reactContext.session, except: result['@id'], forcedEditLink: true })}
+            {props.auditDetail(result.audit, result['@id'], { session: reactContext.session })}
         </li>
     );
 };

--- a/src/encoded/static/components/experiment.js
+++ b/src/encoded/static/components/experiment.js
@@ -426,7 +426,7 @@ const ExperimentComponent = ({ context, auditIndicators, auditDetail }, reactCon
                     {auditIndicators(context.audit, 'experiment-audit', { session: reactContext.session })}
                 </div>
             </header>
-            {auditDetail(context.audit, 'experiment-audit', { session: reactContext.session, except: context['@id'] })}
+            {auditDetail(context.audit, 'experiment-audit', { session: reactContext.session })}
             <Panel addClasses="data-display">
                 <PanelBody addClasses="panel-body-with-header">
                     <div className="flexrow">

--- a/src/encoded/static/components/experiment_series.js
+++ b/src/encoded/static/components/experiment_series.js
@@ -143,7 +143,7 @@ const ExperimentSeriesComponent = (props, reactContext) => {
                     <DisplayAsJson />
                 </div>
             </header>
-            {props.auditDetail(context.audit, 'series-audit', { session: reactContext.session, except: context['@id'] })}
+            {props.auditDetail(context.audit, 'series-audit', { session: reactContext.session })}
             <Panel addClasses="data-display">
                 <PanelBody addClasses="panel-body-with-header">
                     <div className="flexrow">
@@ -363,7 +363,7 @@ const ListingComponent = (props, reactContext) => {
                     </div>
                 </div>
             </div>
-            {props.auditDetail(result.audit, result['@id'], { session: reactContext.session, except: result['@id'], forcedEditLink: true })}
+            {props.auditDetail(result.audit, result['@id'], { session: reactContext.session })}
         </li>
     );
 };

--- a/src/encoded/static/components/file.js
+++ b/src/encoded/static/components/file.js
@@ -381,7 +381,7 @@ class FileComponent extends React.Component {
                         : null}
                         <ReplacementAccessions context={context} />
                         {this.props.auditIndicators(context.audit, 'file-audit', { session: this.context.session })}
-                        {this.props.auditDetail(context.audit, 'file-audit', { session: this.context.session, except: context['@id'] })}
+                        {this.props.auditDetail(context.audit, 'file-audit', { session: this.context.session })}
                         <DisplayAsJson />
                     </div>
                 </header>
@@ -722,7 +722,7 @@ class ListingComponent extends React.Component {
                         </div>
                     </div>
                 </div>
-                {this.props.auditDetail(result.audit, result['@id'], { session: this.context.session, except: result['@id'], forcedEditLink: true })}
+                {this.props.auditDetail(result.audit, result['@id'], { session: this.context.session })}
             </li>
         );
     }

--- a/src/encoded/static/components/filegallery.js
+++ b/src/encoded/static/components/filegallery.js
@@ -2444,7 +2444,7 @@ const FileDetailView = function FileDetailView(node, qcClick, auditIndicators, a
                         <div className="col-xs-12">
                             <h5>File audits:</h5>
                             {auditIndicators ? auditIndicators(selectedFile.audit, 'file-audit', { session }) : null}
-                            {auditDetail ? auditDetail(selectedFile.audit, 'file-audit', { session, except: selectedFile['@id'] }) : null}
+                            {auditDetail ? auditDetail(selectedFile.audit, 'file-audit', { session }) : null}
                         </div>
                     </div>
                 : null}

--- a/src/encoded/static/components/gene.js
+++ b/src/encoded/static/components/gene.js
@@ -137,7 +137,7 @@ const ListingComponent = (props, reactContext) => {
                     : <em>None submitted</em> }
                 </div>
             </div>
-            {props.auditDetail(result.audit, result['@id'], { session: reactContext.session, except: result['@id'], forcedEditLink: true })}
+            {props.auditDetail(result.audit, result['@id'], { session: reactContext.session })}
         </li>
     );
 };

--- a/src/encoded/static/components/genetic_modification.js
+++ b/src/encoded/static/components/genetic_modification.js
@@ -544,7 +544,7 @@ class GeneticModificationComponent extends React.Component {
                         <DisplayAsJson />
                     </div>
                 </header>
-                {this.props.auditDetail(context.audit, 'genetic-modification-audit', { session: this.context.session, except: context['@id'] })}
+                {this.props.auditDetail(context.audit, 'genetic-modification-audit', { session: this.context.session })}
                 <Panel addClasses="data-display">
                     <PanelBody addClasses="panel-body-with-header">
                         <div className="flexrow">
@@ -687,7 +687,7 @@ const ListingComponent = (props, reactContext) => {
                     {result.lab ? <div><strong>Lab: </strong>{result.lab.title}</div> : null}
                 </div>
             </div>
-            {props.auditDetail(result.audit, result['@id'], { session: reactContext.session, except: result['@id'], forcedEditLink: true })}
+            {props.auditDetail(result.audit, result['@id'], { session: reactContext.session })}
         </li>
     );
 };

--- a/src/encoded/static/components/pipeline.js
+++ b/src/encoded/static/components/pipeline.js
@@ -400,7 +400,7 @@ class PipelineComponent extends React.Component {
                         <DisplayAsJson />
                     </div>
                 </header>
-                {this.props.auditDetail(context.audit, 'pipeline-audit', { session: this.context.session, except: context['@id'] })}
+                {this.props.auditDetail(context.audit, 'pipeline-audit', { session: this.context.session })}
                 <Panel addClasses="data-display">
                     <PanelBody>
                         <dl className="key-value">

--- a/src/encoded/static/components/publication.js
+++ b/src/encoded/static/components/publication.js
@@ -78,7 +78,7 @@ const PublicationComponent = (props, reactContext) => {
             <Breadcrumbs root="/search/?type=Publication" crumbs={crumbs} crumbsReleased={crumbsReleased} />
             <h2>{context.title}</h2>
             {props.auditIndicators(context.audit, 'publication-audit', { session: reactContext.session })}
-            {props.auditDetail(context.audit, 'publication-audit', { session: reactContext.session, except: context['@id'] })}
+            {props.auditDetail(context.audit, 'publication-audit', { session: reactContext.session })}
             {context.authors ? <div className="authors">{context.authors}.</div> : null}
             <DisplayAsJson />
             <div className="journal">

--- a/src/encoded/static/components/search.js
+++ b/src/encoded/static/components/search.js
@@ -146,7 +146,7 @@ class ItemComponent extends React.Component {
                         {result.description}
                     </div>
                 </div>
-                {this.props.auditDetail(result.audit, result['@id'], { session: this.context.session, except: result['@id'], forcedEditLink: true })}
+                {this.props.auditDetail(result.audit, result['@id'], { session: this.context.session })}
             </li>
         );
     }
@@ -240,7 +240,7 @@ class BiosampleComponent extends React.Component {
                         <div><strong>Source: </strong>{result.source.title}</div>
                     </div>
                 </div>
-                {this.props.auditDetail(result.audit, result['@id'], { session: this.context.session, except: result['@id'], forcedEditLink: true })}
+                {this.props.auditDetail(result.audit, result['@id'], { session: this.context.session })}
             </li>
         );
     }
@@ -346,7 +346,7 @@ const ExperimentComponent = (props, reactContext) => {
                     </div>
                 : null}
             </div>
-            {props.auditDetail(result.audit, result['@id'], { session: reactContext.session, except: result['@id'], forcedEditLink: true })}
+            {props.auditDetail(result.audit, result['@id'], { session: reactContext.session })}
         </li>
     );
 };
@@ -459,7 +459,7 @@ const DatasetComponent = (props, reactContext) => {
                     </div>
                 </div>
             </div>
-            {props.auditDetail(result.audit, result['@id'], { session: reactContext.session, except: result['@id'], forcedEditLink: true })}
+            {props.auditDetail(result.audit, result['@id'], { session: reactContext.session })}
         </li>
     );
 };
@@ -503,7 +503,7 @@ class TargetComponent extends React.Component {
                         : <em>None submitted</em> }
                     </div>
                 </div>
-                {this.props.auditDetail(result.audit, result['@id'], { session: this.context.session, except: result['@id'], forcedEditLink: true })}
+                {this.props.auditDetail(result.audit, result['@id'], { session: this.context.session })}
             </li>
         );
     }

--- a/src/encoded/static/components/software.js
+++ b/src/encoded/static/components/software.js
@@ -57,7 +57,7 @@ class SoftwareComponent extends React.Component {
                         <DisplayAsJson />
                     </div>
                 </header>
-                {this.props.auditDetail(context.audit, 'software-audit', { session: this.context.session, except: context['@id'] })}
+                {this.props.auditDetail(context.audit, 'software-audit', { session: this.context.session })}
 
                 <div className="panel">
                     <dl className="key-value">
@@ -202,7 +202,7 @@ class ListingComponent extends React.Component {
                         : null}
                     </div>
                 </div>
-                {this.props.auditDetail(result.audit, result['@id'], { session: this.context.session, except: result['@id'], forcedEditLink: true })}
+                {this.props.auditDetail(result.audit, result['@id'], { session: this.context.session })}
             </li>
         );
     }

--- a/src/encoded/tests/test_audit_experiment.py
+++ b/src/encoded/tests/test_audit_experiment.py
@@ -1,4 +1,4 @@
-import pytest
+import pytest, re
 
 RED_DOT = """data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUA
 AAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO
@@ -1143,6 +1143,14 @@ def test_audit_experiment_documents_excluded(testapp, base_experiment,
     testapp.patch_json(award['@id'], {'rfa': 'modENCODE'})
     res = testapp.get(base_experiment['@id'] + '@@index-data')
     assert any(error['category'] != 'missing documents'
+               for error in collect_audit_errors(res))
+
+def test_audit_experiment_links_included(testapp, base_experiment,
+                                             base_library, award, base_replicate):
+    testapp.patch_json(base_replicate['@id'], {'library': base_library['@id']})
+    testapp.patch_json(award['@id'], {'rfa': 'modENCODE'})
+    res = testapp.get(base_experiment['@id'] + '@@index-data')
+    assert any(re.search(r'{.+?\|.+?}', error['detail'])
                for error in collect_audit_errors(res))
 
 


### PR DESCRIPTION
The main addition is the formatter.py file to the “audit” directory that includes two functions to help generate strings with inks for audit details. I used this new mechanism in two places as models for modifying all relevant audit detail messages, one in a complicated experiment.py case, and one in a simple biosample.py case for use in a new audit test.

The new functions generate a sort of markdown-like string that the front end interprets and converts to links. The existing mechanism where things that looks like paths get converted to links still works, but we should remove that from the front end code once all audit details get converted to this new mechanism.