### PR TITLE
ENCD-4771 Gene locations for mouse incorrectly padded

### DIFF
--- a/src/encoded/static/components/genome_browser.js
+++ b/src/encoded/static/components/genome_browser.js
@@ -425,10 +425,10 @@ class GenomeBrowser extends React.Component {
             const annotation = annotations[annotationIndex];
 
             // Compute gene location information from the annotation
-            const annotationLength = annotation.end - annotation.start;
+            const annotationLength = +annotation.end - +annotation.start;
             const contig = `chr${annotation.chromosome}`;
-            const xStart = annotation.start - (annotationLength / 2);
-            const xEnd = annotation.end + (annotationLength / 2);
+            const xStart = +annotation.start - (annotationLength / 2);
+            const xEnd = +annotation.end + (annotationLength / 2);
             console.log(annotation);
             const printStatement = `Success: found gene location for ${this.state.searchTerm}`;
             console.log(printStatement);


### PR DESCRIPTION
If you navigate to the genome browser for mm10 and search for a gene, the chromosome start location is correct but the chromosome end location is incorrect. The end location appears to be a string concatenation rather than a computed location. (Oddly, there seems to be no issue for human gene look-ups.)