### PR TITLE
ENCD-4779 fix default tracks

### DIFF
--- a/src/encoded/static/components/genome_browser.js
+++ b/src/encoded/static/components/genome_browser.js
@@ -192,8 +192,13 @@ class GenomeBrowser extends React.Component {
         if (assembly === 'GRCh38') {
             pinnedFiles = [
                 {
+                    file_format: 'vdna-dir',
+                    href: 'https://encoded-build.s3.amazonaws.com/browser/GRCh38/GRCh38.vdna-dir',
+                },
+                {
                     file_format: 'vgenes-dir',
                     href: 'https://encoded-build.s3.amazonaws.com/browser/GRCh38/GRCh38.vgenes-dir',
+                    title: 'GENCODE V29',
                 },
             ];
             contig = 'chr1';
@@ -202,8 +207,13 @@ class GenomeBrowser extends React.Component {
         } else if (assembly === 'hg19' || assembly === 'GRCh37') {
             pinnedFiles = [
                 {
+                    file_format: 'vdna-dir',
+                    href: 'https://encoded-build.s3.amazonaws.com/browser/hg19/hg19.vdna-dir',
+                },
+                {
                     file_format: 'vgenes-dir',
                     href: 'https://encoded-build.s3.amazonaws.com/browser/hg19/hg19.vgenes-dir',
+                    title: 'GENCODE V29',
                 },
             ];
             contig = 'chr21';
@@ -212,8 +222,13 @@ class GenomeBrowser extends React.Component {
         } else if (assembly === 'mm10' || assembly === 'mm10-minimal' || assembly === 'GRCm38') {
             pinnedFiles = [
                 {
+                    file_format: 'vdna-dir',
+                    href: 'https://encoded-build.s3.amazonaws.com/browser/mm10/mm10.vdna-dir',
+                },
+                {
                     file_format: 'vgenes-dir',
                     href: 'https://encoded-build.s3.amazonaws.com/browser/mm10/mm10.vgenes-dir',
+                    title: 'GENCODE M21',
                 },
             ];
             contig = 'chr12';
@@ -340,14 +355,14 @@ class GenomeBrowser extends React.Component {
                 return trackObj;
             } else if (file.file_format === 'vdna-dir') {
                 const trackObj = {};
-                trackObj.name = 'Genome';
+                trackObj.name = this.props.assembly.split(' ')[0];
                 trackObj.type = 'sequence';
                 trackObj.path = file.href;
                 trackObj.heightPx = 40;
                 return trackObj;
             } else if (file.file_format === 'vgenes-dir') {
                 const trackObj = {};
-                trackObj.name = this.props.assembly;
+                trackObj.name = file.title;
                 trackObj.type = 'annotation';
                 trackObj.path = file.href;
                 trackObj.heightPx = 120;
@@ -455,7 +470,7 @@ class GenomeBrowser extends React.Component {
     render() {
         return (
             <React.Fragment>
-                {(this.state.trackList.length > 1 && this.state.genome !== null && !(this.state.disableBrowserForIE)) ?
+                {(this.state.trackList.length > 0 && this.state.genome !== null && !(this.state.disableBrowserForIE)) ?
                     <React.Fragment>
                         { (this.state.genome.indexOf('GRC') !== -1) ?
                             <div className="gene-search">

--- a/src/encoded/static/components/genome_browser.js
+++ b/src/encoded/static/components/genome_browser.js
@@ -301,7 +301,7 @@ class GenomeBrowser extends React.Component {
         genomePromise.then(() => {
             const domain = `${window.location.protocol}//${window.location.hostname}`;
             const files = this.compileFiles(domain);
-            if (files.length > 1) {
+            if (files.length > 0) {
                 const tracks = this.filesToTracks(files, domain);
                 this.setState({ trackList: tracks }, () => {
                     this.drawTracks(this.chartdisplay);
@@ -332,7 +332,9 @@ class GenomeBrowser extends React.Component {
                     return +obj.biological_replicates * 1000;
                 })
                 .value();
-            newFiles = [...this.state.pinnedFiles, ...files];
+            if (files.length > 0) {
+                newFiles = [...this.state.pinnedFiles, ...files];
+            }
         }
         return newFiles;
     }


### PR DESCRIPTION
This branch fixes several issues with the genome browser:
- The browser does not display for cases where the file list is filtered down to one result.
- We were not displaying all available DNA and gene tracks.
- We renamed the genome and gene tracks:
     --  genome track should be "GRCh38" or "mm10" etc
     -- genes should be "GENCODE V29" for GRCh38 and hg19 and should be "GENCODE M21" on mm10