### PR TITLE
ENCD-4791 remove Quick View

### DIFF
--- a/src/encoded/static/components/objectutils.js
+++ b/src/encoded/static/components/objectutils.js
@@ -573,7 +573,6 @@ export class BrowserSelector extends React.Component {
                                                         <div key={browser} className="browser-selector__browser">
                                                             <a href={assemblyBrowsers[browser]} onClick={this.handleClick} rel="noopener noreferrer" target="_blank">
                                                                 {browser}
-                                                                {browser === 'Quick View' ? <span className="beta-badge">BETA</span> : null}
                                                             </a>
                                                         </div>
                                                     )}

--- a/src/encoded/static/components/vis_defines.js
+++ b/src/encoded/static/components/vis_defines.js
@@ -70,7 +70,6 @@ const ASSEMBLY_DETAILS = {
  */
 const browserFileTypes = {
     UCSC: [],
-    'Quick View': ['bigWig', 'bigBed'],
     Ensembl: ['bigWig', 'bigBed'],
     hic: ['hic'],
 };
@@ -80,7 +79,7 @@ const browserFileTypes = {
  * Open a browser visualization in a new tab. If called from a React component, that component must
  * be mounted.
  * @param {object} dataset Dataset object whose files we're visualizing
- * @param {string} browser Specifies browser to use: UCSC, Quick View, Ensembl, hic currently
+ * @param {string} browser Specifies browser to use: UCSC, Ensembl, hic currently
  *                         acceptable
  * @param {string} assembly Assembly to use with visualizer
  * @param {array} files Array of files to visualize if applicable
@@ -93,11 +92,6 @@ export const visOpenBrowser = (dataset, browser, assembly, files, datasetUrl) =>
         // UCSC does not use `files` under any circumstances.
         const ucscAssembly = ASSEMBLY_DETAILS[assembly].ucsc_assembly;
         href = `http://genome.ucsc.edu/cgi-bin/hgTracks?hubClear=${datasetUrl}@@hub/hub.txt&db=${ucscAssembly}`;
-        break;
-    }
-    case 'Quick View': {
-        const fileQueries = files.map(file => `accession=${globals.atIdToAccession(file['@id'])}`);
-        href = `/search/?type=File&assembly=${assembly}&dataset=${dataset['@id']}&${fileQueries.join('&')}#browser`;
         break;
     }
     case 'hic': {
@@ -165,9 +159,6 @@ export const visFileSelectable = (file, selectedFiles, browser) => {
     case 'UCSC':
         // Always not selectable.
         break;
-    case 'Quick View':
-        selectable = browserFileTypes[browser].indexOf(file.file_format) !== -1;
-        break;
     case 'hic':
         selectable = (browserFileTypes[browser].indexOf(file.file_format) !== -1) && (selectedFiles.length < MAX_HIC_FILES_SELECTED);
         break;
@@ -187,7 +178,6 @@ export const visFileSelectable = (file, selectedFiles, browser) => {
  */
 const browserOrder = [
     'UCSC',
-    'Quick View',
     'hic',
     'Ensembl',
 ];

--- a/src/encoded/tests/features/test_trackhubs.py
+++ b/src/encoded/tests/features/test_trackhubs.py
@@ -141,11 +141,9 @@ def test_visualize(submitter_testapp, workbook):
     expected = {
         'GRCh38': [
             "Ensembl",
-            "Quick View",
             "UCSC",
         ],
         'hg19': [
-            "Quick View",
             "UCSC"
         ]
     }

--- a/src/encoded/vis_defines.py
+++ b/src/encoded/vis_defines.py
@@ -1544,13 +1544,13 @@ def browsers_available(
     if "Dataset" not in types:
         return []
     if item_type is None:
-        visualizabe_types = set(VISIBLE_DATASET_TYPES)
-        if visualizabe_types.isdisjoint(types):
+        visualizable_types = set(VISIBLE_DATASET_TYPES)
+        if visualizable_types.isdisjoint(types):
             return []
     elif item_type not in VISIBLE_DATASET_TYPES_LC:
             return []
     browsers = set()
-    full_set = {'ucsc', 'ensembl', 'quickview', 'hic'}
+    full_set = {'ucsc', 'ensembl', 'hic'}
     file_assemblies = None
     file_types = None
     if request is not None:
@@ -1582,16 +1582,6 @@ def browsers_available(
                 and not BROWSER_FILE_TYPES['ensembl'].isdisjoint(file_types)):
             if vis_blob or files is None or assembly in file_assemblies:
                 browsers.add('Ensembl')
-        if ('quickview' not in browsers
-                and 'quickview' in mapped_assembly.keys()
-                and not BROWSER_FILE_TYPES['quickview'].isdisjoint(file_types)):
-            # NOTE: quickview may not have vis_blob as 'in progress'
-            #   files can also be displayed
-            #       Ideally we would also look at files' statuses and formats.
-            #   However, the (calculated)files property only contains
-            #   'released' files so it doesn't really help for quickview!
-            if vis_blob is not None or status not in QUICKVIEW_STATUSES_BLOCKED:
-                browsers.add('Quick View')
         if ('hic' not in browsers
                 and 'hic' in mapped_assembly.keys()
                 and not BROWSER_FILE_TYPES['hic'].isdisjoint(file_types)):


### PR DESCRIPTION
Now that we have an embedded quick view browser (Valis), there is no need for a link to a browser in a new page.