### PR TITLE
ENCD-4797 Add new file FCC output_type elements reference

### DIFF
--- a/src/encoded/schemas/file.json
+++ b/src/encoded/schemas/file.json
@@ -1096,6 +1096,7 @@
                         "DHS peaks",
                         "differential expression quantifications",
                         "differential splicing quantifications",
+                        "elements reference",
                         "enhancer validation",
                         "enrichment",
                         "exon quantifications",


### PR DESCRIPTION
Added new output_type, "elements reference" for FCE experiments in file.json 