### PR TITLE
ENCD-4817 Restore file table audit column

### DIFF
--- a/src/encoded/static/components/audit.js
+++ b/src/encoded/static/components/audit.js
@@ -147,7 +147,7 @@ ObjectAuditIcon.propTypes = {
 };
 
 ObjectAuditIcon.defaultProps = {
-    audit: null,
+    audit: undefined,
     loggedIn: false,
 };
 


### PR DESCRIPTION
New component to display these audits used "null" to suppress display, but unfortunately I set the default value of null. Change the default to "undefined" so that the component would get the needed data from the passed object.

Planned for production hot fix.