### PR TITLE
ENCD-4832 remove border on empty results

### DIFF
--- a/src/encoded/static/scss/encoded/modules/_genome_browser.scss
+++ b/src/encoded/static/scss/encoded/modules/_genome_browser.scss
@@ -145,7 +145,6 @@
             bottom: 0;
             right: 0;
             left: 0;
-            border: 1px solid #bdbdbd;
             background: white;
             z-index: 99999;
         }
@@ -154,6 +153,7 @@
             top: 0;
             background: white;
             color: black;
+            margin-top: 0;
         }
         
     }


### PR DESCRIPTION
This branch should remove an empty border around the "done" div and also remove unnecessary margin at the top of the dropdown containing gene lookup results.