### PR TITLE
ENCD-4856 break up test suite for circle-ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,19 +50,39 @@ commands:
             buildout bootstrap
             bin/buildout
 jobs:
-  npm-non-bdd-tests:
+  npm-non-indexing-tests:
     executor: encoded-executor
     # indexing tests fail using default medium resource_class
-    resource_class: large
+    resource_class: medium
     parallelism: 2
     steps:
       - buildout
       - run:
-          name: NPM and non BDD tests
+          name: NPM and non ES indexing tests
           command: |
             mkdir test-results
             npm run circleci-test
-            bin/test -m "not bdd" --collect-only -qq |
+            bin/test -k "not bdd and not indexing" --collect-only -qq |
+              while read test; do
+                [ -z "$test" ] && break
+                echo ${test%:*}
+              done | sort | circleci tests split | xargs -n 1 -I {} -t bin/test -v -v --timeout=400 --junitxml=test-results/{}_junit.xml -k {}
+          environment:
+            JEST_JUNIT_OUTPUT: "~/encoded/test-results/js-test-results.xml"
+      - store_test_results:
+          path: test-results
+  indexing-tests:
+    executor: encoded-executor
+    # indexing tests fail using default medium resource_class
+    resource_class: xlarge
+    steps:
+      - buildout
+      - run:
+          name: Indexing tests
+          command: |
+            mkdir test-results
+            npm run circleci-test
+            bin/test -m indexing --collect-only -qq |
               while read test; do
                 [ -z "$test" ] && break
                 echo ${test%:*}
@@ -97,4 +117,5 @@ workflows:
   encoded-tests:
     jobs:
       - bdd-tests
-      - npm-non-bdd-tests
+      - npm-non-indexing-tests
+      - indexing-tests


### PR DESCRIPTION
This just edits .circleci/config.yml to run the indexing tests separately.