### PR TITLE
ENCD-4846 Fix microRNA raw data table headers

### DIFF
--- a/src/encoded/static/components/filegallery.js
+++ b/src/encoded/static/components/filegallery.js
@@ -740,7 +740,7 @@ class RawFileTable extends React.Component {
             const groupKeys = Object.keys(grouped).sort();
 
             return (
-                <table className="table table-sortable table-raw">
+                <table className="table table__sortable table-raw">
                     <thead>
                         <tr className="table-section">
                             <th colSpan="11">


### PR DESCRIPTION
Was using an obsolete CSS class for Raw Data table column headers.