### PR TITLE
ENCD-4863 Remove JS code to process paths in audit descriptions

### DIFF
--- a/src/encoded/static/components/audit.js
+++ b/src/encoded/static/components/audit.js
@@ -156,7 +156,11 @@ ObjectAuditIcon.defaultProps = {
 const markdownRegex = /{(.+?)\|(.+?)}/g;
 
 
-// Display details text with embedded links. This gets displayed in each row of the audit details.
+/**
+ * Display details text with embedded links. This gets displayed in each row of the audit details.
+ * Links, if they exist in the `detail` text, must be formatted in this form:
+ * {link text|URI}
+ */
 const DetailEmbeddedLink = ({ detail }) => {
     let linkMatches = markdownRegex.exec(detail);
     if (linkMatches) {
@@ -178,36 +182,11 @@ const DetailEmbeddedLink = ({ detail }) => {
         const postText = detail.substring(segmentIndex, detail.length);
         return renderedDetail.concat(postText ? <span key={segmentIndex}>{postText}</span> : null);
     }
-
-    // TODO: Remove this segment of code once no audits include bare paths.
-    const matches = detail.match(/([^a-z0-9]|^)(\/.*?\/.*?\/)(?=[\t \n,.]|$)/gmi);
-    if (matches) {
-        // Build React object of text followed by path for all paths in detail string
-        let lastStart = 0;
-        const result = matches.map((match) => {
-            let preMatchedChar = '';
-            const linkStart = detail.indexOf(match, lastStart);
-            const preText = detail.slice(lastStart, linkStart);
-            lastStart = linkStart + match.length;
-            const linkText = detail.slice(linkStart, lastStart);
-            if (linkText[0] !== '/') {
-                preMatchedChar = linkText[0];
-            }
-            return <span key={linkStart}>{preText}{preMatchedChar}<a href={linkText}>{linkText}</a></span>;
-        });
-
-        // Pick up any trailing text after the last path, if any
-        const postText = detail.slice(lastStart);
-
-        // Render all text and paths, plus the trailing text
-        return <span>{result}{postText}</span>;
-    }
-
     return detail;
 };
 
 DetailEmbeddedLink.propTypes = {
-    /** Audit detail text, possibly containing @ids or marks to turn into links */
+    /** Audit detail text containing formatted links */
     detail: PropTypes.string.isRequired,
 };
 


### PR DESCRIPTION
ENCD-4692 introduced a new way to embed links in audit detail text. Before this, we had an unreliable and inflexible method of looking for /text/text/ strings in audit detail text and converting those to links. Now, links within the text are a kind of mini-variant of markdown that looks like {link text|link URI}.

To let us gradually convert over, I temporarily had the new audit details parser look for both the old and new patterns. With ENCD-4753, all audit details use the new pattern, so the Javascript to parse the old pattern is no longer needed. This branch removes that code.