### PR TITLE
ENCD-4866 fix sorttable comment

### DIFF
--- a/src/encoded/static/components/sorttable.js
+++ b/src/encoded/static/components/sorttable.js
@@ -30,7 +30,8 @@
 //     display -- (function): If the property to display has a more complicated display than just a single
 //                            value, this function returns JSX to display the property in any way it needs to.
 //                            It receives one parameter that's the single object of `list` being displayed in
-//                            a cell. If `display` is specified, the following `getValue` doesn't get called.
+//                            a cell. If `display` is specified, the following `getValue` doesn't get called
+//                            for displaying the value (however `getValue` can be called for sorting).
 //
 //     getValue -- (function): If the property to display can't be retrieved directly through item[columns.key],
 //                             this function retrieves and returns the value to be displayed in the cell. It


### PR DESCRIPTION
From the ticket:
The comment in sorttable.js for the "display" property ends with “If `display` is specified, the following `getValue` doesn't get called.” This is true for displaying the value, but it’s misleading in that `getValue` still gets called for sorting the values. 