### PR TITLE
ENCD-4855 Extra-wide search facets

### DIFF
--- a/src/encoded/static/components/auditmatrix.js
+++ b/src/encoded/static/components/auditmatrix.js
@@ -15,6 +15,12 @@ import { FacetList, TextFilter, ClearFilters, SearchControls } from './search';
 /** Number of subcategory items to show when subcategory isn't expanded. */
 const SUB_CATEGORY_SHORT_SIZE = 5;
 
+/**
+ * Maximum number of selected items that can be visualized.
+ * @constant
+ */
+const VISUALIZE_LIMIT = 500;
+
 /** Audit matrix rowCategory colors. */
 const auditColors = ['#e0e000', '#ff8000', '#cc0700', '#a0a0a0'];
 
@@ -360,6 +366,8 @@ const convertAuditToDataTable = (context, expandedRowCategories, expanderClickHa
  * Render the title panel and list of experiment internal tags.
  */
 const MatrixHeader = ({ context }) => {
+    const visualizeDisabledTitle = context.total > VISUALIZE_LIMIT ? `Filter to ${VISUALIZE_LIMIT} to visualize` : '';
+
     // Compose a type title for the page if only one type is included in the query string.
     // Currently, only one type is allowed in the query string or the server returns a 400, so this
     // code exists in case more than one type is allowed in future.
@@ -393,7 +401,7 @@ const MatrixHeader = ({ context }) => {
                 </div>
                 <div className="matrix-header__search-controls">
                     <h4>Showing {context.total} results</h4>
-                    <SearchControls context={context} />
+                    <SearchControls context={context} visualizeDisabledTitle={visualizeDisabledTitle} />
                 </div>
             </div>
         </div>

--- a/src/encoded/static/components/matrix.js
+++ b/src/encoded/static/components/matrix.js
@@ -384,10 +384,21 @@ const MatrixHeader = ({ context }) => {
         clearButton = nonPersistentTerms && terms.type;
     }
 
+    // Compose a type title for the page if only one type is included in the query string.
+    // Currently, only one type is allowed in the query string or the server returns a 400, so this
+    // code exists in case more than one type is allowed in future.
+    let type = '';
+    if (context.filters && context.filters.length > 0) {
+        const typeFilters = context.filters.filter(filter => filter.field === 'type');
+        if (typeFilters.length === 1) {
+            type = typeFilters[0].term;
+        }
+    }
+
     return (
         <div className="matrix-header">
             <div className="matrix-header__title">
-                <h1>{context.title}</h1>
+                <h1>{type ? `${type} ` : ''}{context.title}</h1>
                 <div className="matrix-tags">
                     <MatrixInternalTags context={context} />
                 </div>

--- a/src/encoded/static/components/matrix.js
+++ b/src/encoded/static/components/matrix.js
@@ -14,7 +14,7 @@ import { svgIcon } from '../libs/svg-icons';
 import { tintColor, isLight } from './datacolors';
 import DataTable from './datatable';
 import * as globals from './globals';
-import { ImageWithFallback } from './objectutils';
+import { MatrixInternalTags } from './objectutils';
 import { FacetList, TextFilter, ClearFilters, SearchControls } from './search';
 
 
@@ -369,29 +369,10 @@ const convertExperimentToDataTable = (context, getRowCategories, getRowSubCatego
 
 
 /**
- * Display internal tag badges from search results.
- */
-const MatrixInternalTags = ({ context }) => {
-    // Collect filters that are internal_tags.
-    const internalTags = _.uniq(context.filters.filter(filter => (
-        filter.field === 'internal_tags' && filter.term !== '*'
-    )).map(filter => filter.term));
-    return internalTags.map(tag => (
-        <ImageWithFallback imageUrl={`/static/img/tag-${tag}.png`} imageAlt={`${tag} collection logo`} key={tag} />
-    ));
-};
-
-MatrixInternalTags.propTypes = {
-    /** encode search-results object being displayed */
-    context: PropTypes.object.isRequired,
-};
-
-
-/**
  * Render the area above the facets and matrix content.
  */
 const MatrixHeader = ({ context }) => {
-    const visualizeDisabledTitle = context.matrix.doc_count > VISUALIZE_LIMIT ? `Filter to ${VISUALIZE_LIMIT} to visualize` : '';
+    const visualizeDisabledTitle = context.total > VISUALIZE_LIMIT ? `Filter to ${VISUALIZE_LIMIT} to visualize` : '';
 
     let clearButton;
     const searchQuery = url.parse(context['@id']).search;

--- a/src/encoded/static/components/matrix.js
+++ b/src/encoded/static/components/matrix.js
@@ -14,7 +14,7 @@ import { svgIcon } from '../libs/svg-icons';
 import { tintColor, isLight } from './datacolors';
 import DataTable from './datatable';
 import * as globals from './globals';
-import { MatrixInternalTags } from './objectutils';
+import { ImageWithFallback } from './objectutils';
 import { FacetList, TextFilter, ClearFilters, SearchControls } from './search';
 
 
@@ -369,24 +369,58 @@ const convertExperimentToDataTable = (context, getRowCategories, getRowSubCatego
 
 
 /**
- * Render the title panel and list of experiment internal tags.
+ * Display internal tag badges from search results.
+ */
+const MatrixInternalTags = ({ context }) => {
+    // Collect filters that are internal_tags.
+    const internalTags = _.uniq(context.filters.filter(filter => (
+        filter.field === 'internal_tags' && filter.term !== '*'
+    )).map(filter => filter.term));
+    return internalTags.map(tag => (
+        <ImageWithFallback imageUrl={`/static/img/tag-${tag}.png`} imageAlt={`${tag} collection logo`} key={tag} />
+    ));
+};
+
+MatrixInternalTags.propTypes = {
+    /** encode search-results object being displayed */
+    context: PropTypes.object.isRequired,
+};
+
+
+/**
+ * Render the area above the facets and matrix content.
  */
 const MatrixHeader = ({ context }) => {
-    // Compose a type title for the page if only one type is included in the query string.
-    // Currently, only one type is allowed in the query string or the server returns a 400, so this
-    // code exists in case more than one type is allowed in future.
-    let type = '';
-    if (context.filters && context.filters.length > 0) {
-        const typeFilters = context.filters.filter(filter => filter.field === 'type');
-        if (typeFilters.length === 1) {
-            type = typeFilters[0].term;
-        }
+    const visualizeDisabledTitle = context.matrix.doc_count > VISUALIZE_LIMIT ? `Filter to ${VISUALIZE_LIMIT} to visualize` : '';
+
+    let clearButton;
+    const searchQuery = url.parse(context['@id']).search;
+    if (searchQuery) {
+        // If we have a 'type' query string term along with others terms, we need a Clear Filters
+        // button.
+        const terms = queryString.parse(searchQuery);
+        const nonPersistentTerms = _(Object.keys(terms)).any(term => term !== 'type');
+        clearButton = nonPersistentTerms && terms.type;
     }
 
     return (
-        <div className="matrix__header">
-            <h1>{type ? `${type} ` : ''}{context.title}</h1>
-            <MatrixInternalTags context={context} />
+        <div className="matrix-header">
+            <div className="matrix-header__title">
+                <h1>{context.title}</h1>
+                <div className="matrix-tags">
+                    <MatrixInternalTags context={context} />
+                </div>
+            </div>
+            <div className="matrix-header__controls">
+                <div className="matrix-header__filter-controls">
+                    <ClearFilters searchUri={context.clear_filters} enableDisplay={!!clearButton} />
+                    <SearchFilter context={context} />
+                </div>
+                <div className="matrix-header__search-controls">
+                    <h4>Showing {context.total} results</h4>
+                    <SearchControls context={context} visualizeDisabledTitle={visualizeDisabledTitle} />
+                </div>
+            </div>
         </div>
     );
 };
@@ -400,56 +434,14 @@ MatrixHeader.propTypes = {
 /**
  * Render the vertical facets.
  */
-class MatrixVerticalFacets extends React.Component {
-    constructor() {
-        super();
-        this.onFilter = this.onFilter.bind(this);
-    }
-
-    /**
-     * Called when the user filters the data using a facet. Navigate to the URL of the clicked
-     * facet term.
-     * @param {object} e React synthetic event containing the filtering URL.
-     */
-    onFilter(e) {
-        const search = e.currentTarget.getAttribute('href');
-        this.context.navigate(search);
-        e.stopPropagation();
-        e.preventDefault();
-    }
-
-    render() {
-        const { context } = this.props;
-
-        // Calculate the searchBase, which is the current search query string fragment that can
-        // have terms added to it.
-        const searchBase = `${url.parse(this.context.location_href).search}&` || '?';
-
-        let clearButton;
-        const searchQuery = url.parse(context['@id']).search;
-        if (searchQuery) {
-            // If we have a 'type' query string term along with others terms, we need a Clear Filters
-            // button.
-            const terms = queryString.parse(searchQuery);
-            const nonPersistentTerms = _(Object.keys(terms)).any(term => term !== 'type');
-            clearButton = nonPersistentTerms && terms.type;
-        }
-
-        return (
-            <div className="matrix__facets-vertical">
-                <ClearFilters searchUri={context.clear_filters} enableDisplay={!!clearButton} />
-                <SearchFilter context={context} />
-                <FacetList
-                    facets={context.facets}
-                    filters={context.filters}
-                    searchBase={searchBase}
-                    onFilter={this.onFilter}
-                    addClasses="matrix-facets"
-                />
-            </div>
-        );
-    }
-}
+const MatrixVerticalFacets = ({ context }, reactContext) => (
+    <FacetList
+        facets={context.facets}
+        filters={context.filters}
+        searchBase={`${url.parse(reactContext.location_href).search}&` || '?'}
+        addClasses="matrix-facets"
+    />
+);
 
 MatrixVerticalFacets.propTypes = {
     /** Matrix search result object */
@@ -551,7 +543,6 @@ class MatrixPresentation extends React.Component {
     render() {
         const { context, rowCategoryGetter, rowSubCategoryGetter, mapRowCategoryQueries, mapSubCategoryQueries } = this.props;
         const { scrolledRight } = this.state;
-        const visualizeDisabledTitle = context.total > VISUALIZE_LIMIT ? `Filter to ${VISUALIZE_LIMIT} to visualize` : '';
 
         // Convert encode matrix data to a DataTable object.
         const { dataTable, rowKeys } = convertExperimentToDataTable(context, rowCategoryGetter, rowSubCategoryGetter, mapRowCategoryQueries, mapSubCategoryQueries, this.state.expandedRowCategories, this.expanderClickHandler);
@@ -563,8 +554,6 @@ class MatrixPresentation extends React.Component {
 
         return (
             <div className="matrix__presentation">
-                <h4>Showing {context.total} results</h4>
-                <SearchControls context={context} visualizeDisabledTitle={visualizeDisabledTitle} />
                 <div className={`matrix__label matrix__label--horz${!scrolledRight ? ' horz-scroll' : ''}`}>
                     <span>{context.matrix.x.label}</span>
                     {svgIcon('largeArrow')}

--- a/src/encoded/static/components/objectutils.js
+++ b/src/encoded/static/components/objectutils.js
@@ -640,27 +640,6 @@ ImageWithFallback.propTypes = {
     imageAlt: PropTypes.string.isRequired,
 };
 
-/**
- * Display internal tag badges for collection pages
- */
-export const MatrixInternalTags = ({ context }) => {
-    // Collect internal tags that are filters
-    const internalTags = [];
-    context.filters.forEach((filter) => {
-        if (filter.field === 'internal_tags') {
-            if ((filter.term !== '*') && !internalTags.includes(filter.term)) {
-                internalTags.push(filter.term);
-            }
-        }
-    });
-    const tagBadges = internalTags.map(tag => (<ImageWithFallback imageUrl={`/static/img/tag-${tag}.png`} imageAlt={`${tag} collection logo`} key={tag} />));
-    return <div className="matrix-tag">{tagBadges}</div>;
-};
-
-MatrixInternalTags.propTypes = {
-    /** encode object being displayed */
-    context: PropTypes.object.isRequired,
-};
 
 /**
  * Given a search results object, extract the type of object that was requested in the query

--- a/src/encoded/static/components/objectutils.js
+++ b/src/encoded/static/components/objectutils.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import _ from 'underscore';
 import url from 'url';
 import { CartToggle } from './cart';
 import * as globals from './globals';
@@ -638,6 +639,25 @@ export class ImageWithFallback extends React.Component {
 ImageWithFallback.propTypes = {
     imageUrl: PropTypes.string.isRequired,
     imageAlt: PropTypes.string.isRequired,
+};
+
+
+/**
+ * Display internal tag badges from search results.
+ */
+export const MatrixInternalTags = ({ context }) => {
+    // Collect filters that are internal_tags.
+    const internalTags = _.uniq(context.filters.filter(filter => (
+        filter.field === 'internal_tags' && filter.term !== '*'
+    )).map(filter => filter.term));
+    return internalTags.map(tag => (
+        <ImageWithFallback imageUrl={`/static/img/tag-${tag}.png`} imageAlt={`${tag} collection logo`} key={tag} />
+    ));
+};
+
+MatrixInternalTags.propTypes = {
+    /** encode search-results object being displayed */
+    context: PropTypes.object.isRequired,
 };
 
 

--- a/src/encoded/static/components/search.js
+++ b/src/encoded/static/components/search.js
@@ -1474,7 +1474,9 @@ export const FacetList = (props, reactContext) => {
                     {(context || clearButton) ?
                         <div className="search-header-control">
                             {context ? <DocTypeTitle searchResults={context} wrapper={children => <h1>{children} {docTypeTitleSuffix}</h1>} /> : null}
-                            <ClearFilters searchUri={context.clear_filters} enableDisplay={!!clearButton} />
+                            {context.clear_filters ?
+                                <ClearFilters searchUri={context.clear_filters} enableDisplay={!!clearButton} />
+                            : null}
                         </div>
                     : null}
                     {mode === 'picker' && !hideTextFilter ? <TextFilter {...props} filters={filters} /> : ''}

--- a/src/encoded/static/components/search.js
+++ b/src/encoded/static/components/search.js
@@ -1468,48 +1468,48 @@ export const FacetList = (props, reactContext) => {
     const negationFilters = filters.filter(filter => filter.field.charAt(filter.field.length - 1) === '!');
 
     return (
-        <div className={`box facets${addClasses ? ` ${addClasses}` : ''}`}>
-            <div className={`orientation${orientation === 'horizontal' ? ' horizontal' : ''}`}>
-                {(context || clearButton) ?
-                    <div className="search-header-control">
-                        {context ? <DocTypeTitle searchResults={context} wrapper={children => <h1>{children} {docTypeTitleSuffix}</h1>} /> : null}
-                        {context.clear_filters ?
+        <div className="search-results__facets">
+            <div className={`box facets${addClasses ? ` ${addClasses}` : ''}`}>
+                <div className={`orientation${orientation === 'horizontal' ? ' horizontal' : ''}`}>
+                    {(context || clearButton) ?
+                        <div className="search-header-control">
+                            {context ? <DocTypeTitle searchResults={context} wrapper={children => <h1>{children} {docTypeTitleSuffix}</h1>} /> : null}
                             <ClearFilters searchUri={context.clear_filters} enableDisplay={!!clearButton} />
-                        : null}
-                    </div>
-                : null}
-                {mode === 'picker' && !hideTextFilter ? <TextFilter {...props} filters={filters} /> : ''}
-                {facets.map((facet) => {
-                    if (hideTypes && facet.field === 'type') {
-                        return <span key={facet.field} />;
-                    }
-                    if (facet.field === 'date_released') {
+                        </div>
+                    : null}
+                    {mode === 'picker' && !hideTextFilter ? <TextFilter {...props} filters={filters} /> : ''}
+                    {facets.map((facet) => {
+                        if (hideTypes && facet.field === 'type') {
+                            return <span key={facet.field} />;
+                        }
+                        if (facet.field === 'date_released') {
+                            return (
+                                <DateSelectorFacet
+                                    {...props}
+                                    key={facet.field}
+                                    facet={facet}
+                                    filters={filters}
+                                    width={width}
+                                    negationFilters={negationFilters}
+                                    facets={facets}
+                                />
+                            );
+                        }
+                        if (facet.field === 'date_submitted' || isFacetHidden(facet, reactContext.session, reactContext.session_properties)) {
+                            return null;
+                        }
                         return (
-                            <DateSelectorFacet
+                            <Facet
                                 {...props}
                                 key={facet.field}
                                 facet={facet}
                                 filters={filters}
                                 width={width}
                                 negationFilters={negationFilters}
-                                facets={facets}
                             />
                         );
-                    }
-                    if (facet.field === 'date_submitted' || isFacetHidden(facet, reactContext.session, reactContext.session_properties)) {
-                        return null;
-                    }
-                    return (
-                        <Facet
-                            {...props}
-                            key={facet.field}
-                            facet={facet}
-                            filters={filters}
-                            width={width}
-                            negationFilters={negationFilters}
-                        />
-                    );
-                })}
+                    })}
+                </div>
             </div>
         </div>
     );

--- a/src/encoded/static/components/summary.js
+++ b/src/encoded/static/components/summary.js
@@ -197,101 +197,24 @@ SummaryStatusChart.contextTypes = {
 };
 
 
-// Render the horizontal facets.
-class SummaryHorizontalFacets extends React.Component {
-    constructor() {
-        super();
-
-        // Bind `this` to non-React methods
-        this.onFilter = this.onFilter.bind(this);
-    }
-
-    onFilter(e) {
-        const search = e.currentTarget.getAttribute('href');
-        this.context.navigate(search);
-        e.stopPropagation();
-        e.preventDefault();
-    }
-
-    render() {
-        const { context } = this.props;
-        const allFacets = context.facets;
-
-        // Get the array of facet field values to display in the horizontal facet area.
-        const horzFacetFields = context.summary.x.facets;
-
-        // Extract the horizontal facets from the list of all facets. We use the array of horizontal
-        // facet field values of facets that should appear in the horizontal facets.
-        const horzFacets = allFacets.filter(facet => horzFacetFields.indexOf(facet.field) >= 0);
-
-        // Calculate the searchBase, which is the current search query string fragment that can have
-        // terms added to it.`
-        const searchBase = `${url.parse(this.context.location_href).search}&` || '?';
-
-        return (
-            <div className="summary-header__facets-horizontal">
-                <FacetList
-                    facets={horzFacets}
-                    filters={context.filters}
-                    orientation="horizontal"
-                    searchBase={searchBase}
-                    onFilter={this.onFilter}
-                    addClasses="summary-facets"
-                />
-            </div>
-        );
-    }
-}
-
-SummaryHorizontalFacets.propTypes = {
-    context: PropTypes.object.isRequired, // Summary search result object
-};
-
-SummaryHorizontalFacets.contextTypes = {
-    location_href: PropTypes.string, // Current URL
-    navigate: PropTypes.func, // encoded navigation
-};
-
-
 // Render the vertical facets.
-class SummaryVerticalFacets extends React.Component {
-    constructor() {
-        super();
+const SummaryVerticalFacets = ({ context }, reactContext) => {
+    // All facets are vertical facets.
+    const vertFacets = context.facets;
 
-        // Bind `this` to non-React methods.
-        this.onFilter = this.onFilter.bind(this);
-    }
+    // Calculate the searchBase, which is the current search query string fragment that can have
+    // terms added to it.
+    const searchBase = `${url.parse(reactContext.location_href).search}&` || '?';
 
-    onFilter(e) {
-        const search = e.currentTarget.getAttribute('href');
-        this.context.navigate(search);
-        e.stopPropagation();
-        e.preventDefault();
-    }
-
-    render() {
-        const { context } = this.props;
-
-        // All facets are vertical facets
-        const vertFacets = context.facets;
-
-        // Calculate the searchBase, which is the current search query string fragment that can have
-        // terms added to it.`
-        const searchBase = `${url.parse(this.context.location_href).search}&` || '?';
-
-        return (
-            <div className="summary-content__facets-vertical">
-                <FacetList
-                    facets={vertFacets}
-                    filters={context.filters}
-                    searchBase={searchBase}
-                    onFilter={this.onFilter}
-                    addClasses="summary-facets"
-                />
-            </div>
-        );
-    }
-}
+    return (
+        <FacetList
+            facets={vertFacets}
+            filters={context.filters}
+            searchBase={searchBase}
+            addClasses="summary-facets"
+        />
+    );
+};
 
 SummaryVerticalFacets.propTypes = {
     context: PropTypes.object.isRequired, // Summary search result object

--- a/src/encoded/static/scss/encoded/modules/_matrix.scss
+++ b/src/encoded/static/scss/encoded/modules/_matrix.scss
@@ -22,10 +22,6 @@ $row-data-header-width: 200px;
     max-width: none;
     border-spacing: 0;
 	
-    @at-root #{&}__header {
-        border-bottom: 1px solid #eeeeee;
-    }
-
     // Holds vertical facets and matrix itself.
     @at-root #{&}__content {
         display: block;
@@ -48,7 +44,7 @@ $row-data-header-width: 200px;
         overflow: hidden;
 
         @media screen and (min-width: $screen-md-min) {
-            flex: 0 1 80%;
+            flex: 0 1 75%;
             padding-left: 10px;
         }
 
@@ -370,6 +366,58 @@ $row-data-header-width: 200px;
 }
 
 
+.matrix-header {
+    padding-bottom: 10px;
+    margin-bottom: 10px;
+    border-bottom: 1px solid #ccc;
+
+    @at-root #{&}__title {
+        display: flex;
+        justify-content: space-between;
+
+        h1 {
+            flex: 0 1 auto;
+            margin: 0;
+            font-size: 1.5rem;
+        }
+
+        .matrix-tags {
+            flex: 0 1 auto;
+
+            img {
+                display: inline-block;
+                margin-left: 5px;
+                height: 22px;
+            }
+        }
+    }
+
+    @at-root #{&}__controls {
+        @media screen and (min-width: $screen-md-min) {
+            display: flex;
+            align-items: flex-end;
+        }
+    }
+
+    @at-root #{&}__filter-controls {
+        @media screen and (min-width: $screen-md-min) {
+            flex: 0 1 25%;
+            padding-right: 20px;
+        }
+    }
+
+    @at-root #{&}__search-controls {
+        @media screen and (min-width: $screen-md-min) {
+            flex: 0 1 75%;
+        }
+
+        .results-table-control {
+            margin-bottom: 0;
+        }
+    }
+}
+
+
 @keyframes arrow-pulse {
     0% {
         opacity: 1;
@@ -435,34 +483,8 @@ table.matrix th.group-all-groups-cell {
 }
 
 .matrix-general-search {
-    margin-top: 10px;
-    margin-bottom: 10px;
-}
-
-.matrix__header {
-    display: flex;
-    align-items: flex-end;
-    border-bottom: 1px solid #ccc;
-    h1 {
-        margin-top: 0;
-        margin-bottom: 5px;
-        padding-bottom: 5px;
-        font-size: 1.5rem;
-        flex: 0 1 30%;
-        border-bottom: 0;
-    }
-    .matrix-tag {
-        flex: 0 1 70%;
-        text-align: right;
-    }
-}
-
-.matrix-tag {
-    float: right;
-    img {
-        height: 22px;
-        vertical-align: top;
-        padding-left: 10px;
-        margin-bottom: 5px;
+    .general-search-entry {
+        margin-bottom: 0;
+        padding-bottom: 0;
     }
 }

--- a/src/encoded/static/scss/encoded/modules/_search.scss
+++ b/src/encoded/static/scss/encoded/modules/_search.scss
@@ -3,6 +3,12 @@ $form-bg: #f3f3f3;
 
 // Contains all search result elements.
 .search-results {
+    @at-root #{&}__facets {
+        @media screen and (min-width: $screen-md-min) {
+            flex: 0 1 25%;
+        }
+    }
+
     display: block;
 
     h4 {
@@ -15,13 +21,15 @@ $form-bg: #f3f3f3;
 
     .box.facets {
         @media screen and (min-width: $screen-md-min) {
-            flex: 0 1 25%;
             margin-right: 10px;
         }
     }
 
     @at-root #{&}__result-list {
+        margin-top: 20px;
+
         @media screen and (min-width: $screen-md-min) {
+            margin-top: 0;
             flex: 0 1 75%;
             display: flex;
             flex-direction: column;


### PR DESCRIPTION
I rearranged the matrix views (experiment and audit) so that all views that include facets follow a pattern of a wrapper div with display:flex, and then exactly two child divs: one with the facets taking up a horizontal portion and one with the main content of the page taking the rest. The matrix views now split the search terms input field off from the facets, and the view buttons off the main matrix view, and combines them both into the header div. That leaves just the facets and header content to share horizontal space, matching other pages that have facets.

The cart view display does have facets, and does follow this pattern, but uses different CSS classes and values for a different look, so it doesn’t _quite_ follow the pattern of the others.

I moved `<MatrixInternalTags>` from objectutils.js to matrix.js since it’s a matrix-specific component, and rewrote it to take advantage of React 16’s ability to render arrays of components.

I removed the onFilter function properties passed to FacetList as they aren’t used, and the functions passed to them did nothing beyond what a regular link does — navigate to the href. I believe the use of onFilter can be removed from search.js as well, as it only served the tabbed biodalliance view we don’t have anymore, but I didn’t do that in this ticket.