### PR TITLE
ENCD-4892 region search refresh

### DIFF
--- a/src/encoded/static/components/region_search.js
+++ b/src/encoded/static/components/region_search.js
@@ -186,7 +186,6 @@ class AdvSearch extends React.Component {
 
     handleOnFocus() {
         this.setState({ showAutoSuggest: false });
-        this.context.navigate(this.context.location_href);
     }
 
     tick() {

--- a/src/encoded/static/components/region_search.js
+++ b/src/encoded/static/components/region_search.js
@@ -254,7 +254,6 @@ AdvSearch.contextTypes = {
     autocompleteHidden: PropTypes.bool,
     onAutocompleteHiddenChange: PropTypes.func,
     location_href: PropTypes.string,
-    navigate: PropTypes.func,
 };
 
 
@@ -364,7 +363,6 @@ RegionSearch.defaultProps = {
 
 RegionSearch.contextTypes = {
     location_href: PropTypes.string,
-    navigate: PropTypes.func,
 };
 
 export default AutocompleteBox;


### PR DESCRIPTION
An extra call to "navigate" was reversing user updates to a region search. A new search would load new results correctly and then revert to an original search (incorrectly). This update prevents the page from reverting to an original search.