### PR TITLE
ENCD-4885 add entry for functional characterization assays

### DIFF
--- a/src/encoded/static/components/app.js
+++ b/src/encoded/static/components/app.js
@@ -40,8 +40,8 @@ const portal = {
             title: 'Data',
             children: [
                 { id: 'assaymatrix', title: 'Experiment matrix', url: '/matrix/?type=Experiment&status=released' },
-                { id: 'assaysearch', title: 'Search', url: '/search/?type=Experiment&status=released' },
-                { id: 'assaysummary', title: 'Summary', url: '/summary/?type=Experiment&status=released' },
+                { id: 'assaysearch', title: 'Experiment search', url: '/search/?type=Experiment&status=released' },
+                { id: 'functional-char-assays', title: 'Functional characterization search', url: '/search/?type=FunctionalCharacterizationExperiment' },
                 { id: 'sep-mm-1' },
                 { id: 'cloud', title: 'Cloud Resources' },
                 { id: 'aws-link', title: 'AWS Open Data', url: 'https://registry.opendata.aws/encode-project/', tag: 'cloud' },


### PR DESCRIPTION
Rearranging the drop-down menu to include link to functional characterization experiments. (Note: link should be https://www.encodeproject.org/search/?type=FunctionalCharacterizationExperiment without status=released because no experiments are released at this time).

Top section should be:
"Experiment matrix"
"Experiment search"
"Functional characterization search"

And "Summary" should be entirely removed.