### PR TITLE
ENCD-4912-update-matching-md5-audit

### DIFF
--- a/src/encoded/audit/file.py
+++ b/src/encoded/audit/file.py
@@ -465,7 +465,7 @@ def audit_file_matching_md5sum(value, system):
                     audit_link(path_to_text(value['@id']), value['@id'])
                 )
             )
-            yield AuditFailure('Incorrect matching_md5sum', detail, level='ERROR')
+            yield AuditFailure('incorrect matching_md5sum', detail, level='ERROR')
         elif file.get('status') in checked_statuses:
             matching_files.append(file['@id'])
             matching_files_links = [audit_link(path_to_text(file), file) for file in matching_files]
@@ -486,7 +486,7 @@ def audit_file_matching_md5sum(value, system):
             matching_files_joined
         )
     )
-    yield AuditFailure('Matching md5 sums', detail, level='WARNING')
+    yield AuditFailure('matching md5 sums', detail, level='WARNING')
 
     return
 

--- a/src/encoded/tests/test_audit_file.py
+++ b/src/encoded/tests/test_audit_file.py
@@ -1058,7 +1058,7 @@ def test_audit_matching_md5sum(testapp, file7, file6):
     errors_list = []
     for error_type in errors:
         errors_list.extend(errors[error_type])
-    assert any(error['category'] == 'Incorrect matching_md5sum'
+    assert any(error['category'] == 'incorrect matching_md5sum'
                for error in errors_list)
 
     testapp.patch_json(
@@ -1073,5 +1073,5 @@ def test_audit_matching_md5sum(testapp, file7, file6):
     errors_list = []
     for error_type in errors:
         errors_list.extend(errors[error_type])
-    assert any(error['category'] == 'Matching md5 sums'
+    assert any(error['category'] == 'matching md5 sums'
                for error in errors_list)


### PR DESCRIPTION
in file.py,  "def audit_file_matching_md5sum(value, system):" the AuditFailure categories were changed to all lower case to match other AuditFailure(s):
'Incorrect matching_md5sum' was changed to 'incorrect matching_md5sum'
'Matching md5 sums' was changed to 'matching md5 sums'