### PR TITLE
ENCD-4958 Group PR of 5 backend changes

### DIFF
--- a/cloud-config/config-build-files/cc-parts/CC_RUNCMD_DEMO.yml
+++ b/cloud-config/config-build-files/cc-parts/CC_RUNCMD_DEMO.yml
@@ -1,13 +1,13 @@
 runcmd:
 - sudo -u ubuntu git clone %(GIT_REPO)s /home/ubuntu/encoded
-- sudo -u ubuntu git -C /home/ubuntu/encoded checkout -b %(GIT_BRANCH)s origin/%(GIT_BRANCH)s
+- sudo -u ubuntu git -C /home/ubuntu/encoded checkout -b %(GIT_BRANCH)s %(GIT_REMOTE)s/%(GIT_BRANCH)s
 - sudo -u ubuntu %(CC_DIR)s/post-boot-install.sh %(S3_AUTH_KEYS)s
 - sudo -u ubuntu %(CC_DIR)s/java11-oracle-install.sh
 - %(CC_DIR)s/redis-install.sh %(REDIS_PORT)s
 - %(CC_DIR)s/es-install.sh NONE %(JVM_GIGS)s %(ES_OPT_FILENAME)s
 - %(CC_DIR)s/cloudwatchmon-install.sh
 - %(CC_DIR)s/pg-install.sh off %(ROLE)s %(WALE_S3_PREFIX)s %(PG_VERSION)s
-- %(CC_DIR)s/encd-install.sh %(GIT_REPO)s %(GIT_BRANCH)s %(ROLE)s %(ES_IP)s %(ES_PORT)s %(REGION_INDEX)s %(APP_WORKERS)s
+- %(CC_DIR)s/encd-install.sh %(GIT_REPO)s %(GIT_REMOTE)s %(GIT_BRANCH)s %(ROLE)s %(ES_IP)s %(ES_PORT)s %(REGION_INDEX)s %(APP_WORKERS)s
 - %(CC_DIR)s/a2en-run.sh
 - if test "%(ROLE)s" = "demo"
 - then

--- a/cloud-config/config-build-files/cc-parts/CC_RUNCMD_ES.yml
+++ b/cloud-config/config-build-files/cc-parts/CC_RUNCMD_ES.yml
@@ -1,6 +1,6 @@
 runcmd:
 - sudo -u ubuntu git clone %(GIT_REPO)s /home/ubuntu/encoded
-- sudo -u ubuntu git -C /home/ubuntu/encoded checkout -b %(GIT_BRANCH)s origin/%(GIT_BRANCH)s
+- sudo -u ubuntu git -C /home/ubuntu/encoded checkout -b %(GIT_BRANCH)s %(GIT_REMOTE)s/%(GIT_BRANCH)s
 - sudo -u ubuntu %(CC_DIR)s/post-boot-install.sh %(S3_AUTH_KEYS)s
 - sudo -u ubuntu %(CC_DIR)s/java11-oracle-install.sh
 - %(CC_DIR)s/es-install.sh %(CLUSTER_NAME)s %(JVM_GIGS)s %(ES_OPT_FILENAME)s

--- a/cloud-config/config-build-files/cc-parts/CC_RUNCMD_FRONTEND.yml
+++ b/cloud-config/config-build-files/cc-parts/CC_RUNCMD_FRONTEND.yml
@@ -1,6 +1,6 @@
 runcmd:
 - sudo -u ubuntu git clone %(GIT_REPO)s /home/ubuntu/encoded
-- sudo -u ubuntu git -C /home/ubuntu/encoded checkout -b %(GIT_BRANCH)s origin/%(GIT_BRANCH)s
+- sudo -u ubuntu git -C /home/ubuntu/encoded checkout -b %(GIT_BRANCH)s %(GIT_REMOTE)s/%(GIT_BRANCH)s
 - sudo -u ubuntu %(CC_DIR)s/post-boot-install.sh %(S3_AUTH_KEYS)s
 - sudo -u ubuntu %(CC_DIR)s/java11-oracle-install.sh
 - %(CC_DIR)s/redis-install.sh %(REDIS_PORT)s
@@ -11,7 +11,7 @@ runcmd:
 - else
 -   %(CC_DIR)s/pg-install.sh on %(ROLE)s %(WALE_S3_PREFIX)s %(PG_VERSION)s
 - fi
-- %(CC_DIR)s/encd-install.sh %(GIT_REPO)s %(GIT_BRANCH)s %(ROLE)s %(ES_IP)s %(ES_PORT)s %(REGION_INDEX)s %(APP_WORKERS)s
+- %(CC_DIR)s/encd-install.sh %(GIT_REPO)s %(GIT_REMOTE)s %(GIT_BRANCH)s %(ROLE)s %(ES_IP)s %(ES_PORT)s %(REGION_INDEX)s %(APP_WORKERS)s
 - %(CC_DIR)s/a2en-run.sh
 - if test "%(ROLE)s" = "demo"
 - then

--- a/cloud-config/deploy-run-scripts/a2en-run.sh
+++ b/cloud-config/deploy-run-scripts/a2en-run.sh
@@ -7,6 +7,7 @@ a2enmod headers
 a2enmod proxy_http
 a2enmod rewrite
 a2enmod ssl
+a2enmod log_forensic
 a2ensite encoded.conf
 a2dissite 000-default
 a2enconf logging

--- a/cloud-config/deploy-run-scripts/conf-apache/encoded.conf
+++ b/cloud-config/deploy-run-scripts/conf-apache/encoded.conf
@@ -49,8 +49,8 @@ WSGIScriptAlias / /srv/encoded/parts/production/wsgi process-group=encoded appli
     <IfModule access_compat_module>
         Require all granted
     </IfModule>
-    # Limit upload size to 500 MB (375MB before base64 encoding)
-    LimitRequestBody 524288000
+    # Limit upload size to 500000 MB (375000MB before base64 encoding)
+    LimitRequestBody 524288000000
     # Apache adds -gzip to outgoing ETag in mod_deflate, remove inbound.
     # https://issues.apache.org/bugzilla/show_bug.cgi?id=39727
     RequestHeader edit If-Match    -gzip\"$    \"

--- a/cloud-config/deploy-run-scripts/conf-apache/some-vars.conf
+++ b/cloud-config/deploy-run-scripts/conf-apache/some-vars.conf
@@ -2,5 +2,5 @@
 # https://github.com/GrahamDumpleton/mod_wsgi/issues/2
 SetEnvIf Request_Method HEAD X_REQUEST_METHOD=HEAD
 
-LogFormat "%v:%p %h %l %u %t \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\" %{X-Stats}o&server_time=%D" vhost_combined_stats
-
+ForensicLog ${APACHE_LOG_DIR}/forensic_log.log
+LogFormat "%{forensic-id}n %v:%p %h %l %u %t \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\" %{X-Stats}o&server_time=%D" vhost_combined_stats

--- a/cloud-config/deploy-run-scripts/conf-apache/the-rest.conf
+++ b/cloud-config/deploy-run-scripts/conf-apache/the-rest.conf
@@ -8,8 +8,8 @@ WSGIScriptAlias / /srv/encoded/parts/production/wsgi process-group=encoded appli
     <IfModule access_compat_module>
         Require all granted
     </IfModule>
-    # Limit upload size to 500 MB (375MB before base64 encoding)
-    LimitRequestBody 524288000
+    # Limit upload size to 500000 MB (375000MB before base64 encoding)
+    LimitRequestBody 524288000000
     # Apache adds -gzip to outgoing ETag in mod_deflate, remove inbound.
     # https://issues.apache.org/bugzilla/show_bug.cgi?id=39727
     RequestHeader edit If-Match    -gzip\"$    \"

--- a/cloud-config/deploy-run-scripts/conf-es/es-cluster-elect.yml
+++ b/cloud-config/deploy-run-scripts/conf-es/es-cluster-elect.yml
@@ -17,6 +17,10 @@ indices.query.bool.max_clause_count: 8192
 # Self elect master node
 node.master: true
 node.data: true
+
+# We can only use 4 or 5 node clusters
+#  since this is hard coded to 3.
+# N/2+1 formula.
 discovery.zen.minimum_master_nodes: 3
 
 # Cluster name is appened on deploy

--- a/cloud-config/deploy-run-scripts/encd-install.sh
+++ b/cloud-config/deploy-run-scripts/encd-install.sh
@@ -4,19 +4,22 @@
 # apt deps:
 
 GIT_REPO="$1"
-GIT_BRANCH="$2"
-ROLE="$3"
-ES_IP="$4"
-ES_PORT="$5"
-REGION_INDEX="$6"
-APP_WORKERS="$7"
+GIT_REMOTE="$2"
+GIT_BRANCH="$3"
+ROLE="$4"
+ES_IP="$5"
+ES_PORT="$6"
+REGION_INDEX="$7"
+APP_WORKERS="$8"
+
+git_uri="$GIT_REMOTE/$GIT_BRANCH"
 
 encd_home='/srv/encoded'
 mkdir "$encd_home"
 chown encoded:encoded "$encd_home"
 cd "$encd_home"
 sudo -u encoded git clone "$GIT_REPO" .
-sudo -u encoded git checkout -b "$GIT_BRANCH" origin/"$GIT_BRANCH"
+sudo -u encoded git checkout -b "$GIT_BRANCH" "$git_uri"
 sudo pip3 install -U zc.buildout setuptools redis
 sudo -u encoded buildout bootstrap
 sudo -u encoded LANG=en_US.UTF-8 bin/buildout -c "$ROLE".cfg buildout:es-ip="$ES_IP" buildout:es-port="$ES_PORT"

--- a/src/encoded/memlimit.py
+++ b/src/encoded/memlimit.py
@@ -47,7 +47,7 @@ def rss_checker(rss_limit=None):
         if rss_limit and rss > rss_limit:
             msg = "Restarting process. Memory usage exceeds limit of %d: %d"
             log.error(msg, rss_limit, rss)
-            process.kill()
+            process.terminate()
 
     return callback
 


### PR DESCRIPTION
A bunch of isolated backend changes.  Some are not really testable(4908/4939) so as long as the machine doesn't fall over on deployment or usage.  We'll want to load test this and check logs(4938) . QA machine should be a cluster so we can add a new node(4937).  QA Cluster should be deployed from a fake tag(4947).  4911 can be tested directly by bonita/idan as with v91x0.

4947: Deployment bug fix that only impact bin/deploy where -b arg is a tag.
4911:  Makes upload limit 5gb.  This was already running in v91x0-test and v91x0 prod.
4937: Rare occasion we'll need to add one node to an already existing cluster.  This was used to add a new node to v91x0.
4938: There should be a new log /var/log/apache/forensic_log.log.  And a key in the current access.log to reference the incoming request in forensic_log
4939: Not really testable, process that hit memlimit will die more gracefully.

***
MOVED to https://github.com/ENCODE-DCC/encoded/pull/3037
4908: Not really testable, but was turned on in v91x0 as part of troubleshooting issues during that release period.