### PR TITLE
ENCD-4944 remove oneOf from target schema

### DIFF
--- a/src/encoded/static/components/schema.js
+++ b/src/encoded/static/components/schema.js
@@ -36,6 +36,7 @@ const excludedTerms = [
     'file_format_file_extension',
     'sort_by',
     'anyOf',
+    'oneOf',
 ];
 
 


### PR DESCRIPTION
Currently the "oneOf" property in the target schema is an expandable button with an empty expandable section: https://www.encodeproject.org/profiles/target. We will omit the "oneOf" property from this section.