### PR TITLE
ENCD-4848 Display Juicebox for hic visualizations

### DIFF
--- a/src/encoded/static/components/filegallery.js
+++ b/src/encoded/static/components/filegallery.js
@@ -16,7 +16,7 @@ import { qcIdToDisplay } from './quality_metric';
 import { softwareVersionList } from './software';
 import { SortTablePanel, SortTable } from './sorttable';
 import Status from './status';
-import { visOpenBrowser, visFilterBrowserFiles, visFileSelectable, visSortBrowsers } from './vis_defines';
+import { visOpenBrowser, visFilterBrowserFiles, visFileSelectable, visSortBrowsers, visMapBrowserName } from './vis_defines';
 
 
 const MINIMUM_COALESCE_COUNT = 5; // Minimum number of files in a coalescing group
@@ -1019,7 +1019,7 @@ class VisualizationControls extends React.Component {
                 {browsers.length > 0 ?
                     <select className="form-control--select" value={currentBrowser} onChange={this.handleBrowserChange}>
                         {browsers.map(browser => (
-                            <option key={browser} value={browser}>{browser}</option>
+                            <option key={browser} value={browser}>{visMapBrowserName(browser)}</option>
                         ))}
                     </select>
                 : null}

--- a/src/encoded/static/components/vis_defines.js
+++ b/src/encoded/static/components/vis_defines.js
@@ -205,6 +205,23 @@ export const visSortBrowsers = browsers => (
 
 
 /**
+ * Map of browser to display name.
+ */
+const browserNameMap = {
+    UCSC: 'UCSC',
+    hic: 'Juicebox',
+    Ensembl: 'Ensembl',
+};
+
+
+/**
+ * Map a browser to its display name.
+ * @param {string} browser Browser whose display name is desired
+ */
+export const visMapBrowserName = browser => browserNameMap[browser];
+
+
+/**
  * Batch visualization section.
  **************************************************************************************************
  */


### PR DESCRIPTION
I added a mapping of browser name from the back end to a display name. This mostly maps from something to the exact same thing, but allows us to add new mappings in the future.

Indexed demo: ~https://encd-4848-juicebox-name-57715a626-fytanaka.demo.encodedcc.org/~