### PR TITLE
ENCD-4970 Make reference-epignome cells render on IE11

### DIFF
--- a/src/encoded/static/components/matrix_reference_epigenome.js
+++ b/src/encoded/static/components/matrix_reference_epigenome.js
@@ -132,18 +132,6 @@ const generateColMap = (context) => {
 
 
 /**
- * Display a disabled cell in the matrix. Used to reduce a bit of code per cell when matrices can
- * be very large.
- */
-const DisabledCell = () => (
-    <React.Fragment>
-        <div className="matrix__disabled-cell" />
-        &nbsp;
-    </React.Fragment>
-);
-
-
-/**
  * Takes matrix data from JSON and generates an object that <DataTable> can use to generate the JSX
  * for the matrix. This is a shim between the incoming matrix data and the object <DataTable>
  * needs.
@@ -252,12 +240,13 @@ const convertReferenceEpigenomeToDataTable = (context, expandedRowCategories, ex
                             cells[colIndex] = {
                                 content: (
                                     <React.Fragment>
-                                        <a href={`${context.search_base}&${rowCategoryQuery}&${subCategoryQuery}&${colMap[colMapKey].query}`} style={{ backgroundColor: rowSubcategoryColor }}>
+                                        <a href={`${context.search_base}&${rowCategoryQuery}&${subCategoryQuery}&${colMap[colMapKey].query}`}>
                                             <span className="sr-only">Search {rowCategoryBucket.key}, {rowSubcategoryBucket.key} for {rowSubcategoryColCategoryBucket.key}, {cellData.key}</span>
                                         </a>
                                         &nbsp;
                                     </React.Fragment>
                                 ),
+                                style: { backgroundColor: rowSubcategoryColor },
                             };
                         });
                     } else {
@@ -267,12 +256,13 @@ const convertReferenceEpigenomeToDataTable = (context, expandedRowCategories, ex
                         cells[colIndex] = {
                             content: (
                                 <React.Fragment>
-                                    <a href={`${context.search_base}&${rowCategoryQuery}&${subCategoryQuery}&${colMap[rowSubcategoryColCategoryBucket.key].query}`} style={{ backgroundColor: rowSubcategoryColor }}>
+                                    <a href={`${context.search_base}&${rowCategoryQuery}&${subCategoryQuery}&${colMap[rowSubcategoryColCategoryBucket.key].query}`}>
                                         <span className="sr-only">Search {rowCategoryBucket.key}, {rowSubcategoryBucket.key} for {rowSubcategoryColCategoryBucket.key}</span>
                                     </a>
                                     &nbsp;
                                 </React.Fragment>
                             ),
+                            style: { backgroundColor: rowSubcategoryColor },
                         };
                     }
                 }
@@ -281,7 +271,7 @@ const convertReferenceEpigenomeToDataTable = (context, expandedRowCategories, ex
             // Show assay columns as disabled (i.e. nothing to see here) if those columns have
             // target columns.
             colCategoriesWithSubcategories.forEach((colCategoryName) => {
-                cells[colMap[colCategoryName].col] = { content: <DisabledCell /> };
+                cells[colMap[colCategoryName].col] = { css: 'matrix__disabled-cell' };
             });
 
             // Add a single term-name row's data and left header to the matrix.

--- a/src/encoded/static/components/matrix_reference_epigenome.js
+++ b/src/encoded/static/components/matrix_reference_epigenome.js
@@ -135,7 +135,12 @@ const generateColMap = (context) => {
  * Display a disabled cell in the matrix. Used to reduce a bit of code per cell when matrices can
  * be very large.
  */
-const DisabledCell = () => <div className="matrix__disabled-cell" />;
+const DisabledCell = () => (
+    <React.Fragment>
+        <div className="matrix__disabled-cell" />
+        &nbsp;
+    </React.Fragment>
+);
 
 
 /**
@@ -246,9 +251,12 @@ const convertReferenceEpigenomeToDataTable = (context, expandedRowCategories, ex
                             const colIndex = colMap[colMapKey].col;
                             cells[colIndex] = {
                                 content: (
-                                    <a href={`${context.search_base}&${rowCategoryQuery}&${subCategoryQuery}&${colMap[colMapKey].query}`} style={{ backgroundColor: rowSubcategoryColor }}>
-                                        <span className="sr-only">Search {rowCategoryBucket.key}, {rowSubcategoryBucket.key} for {rowSubcategoryColCategoryBucket.key}, {cellData.key}</span>
-                                    </a>
+                                    <React.Fragment>
+                                        <a href={`${context.search_base}&${rowCategoryQuery}&${subCategoryQuery}&${colMap[colMapKey].query}`} style={{ backgroundColor: rowSubcategoryColor }}>
+                                            <span className="sr-only">Search {rowCategoryBucket.key}, {rowSubcategoryBucket.key} for {rowSubcategoryColCategoryBucket.key}, {cellData.key}</span>
+                                        </a>
+                                        &nbsp;
+                                    </React.Fragment>
                                 ),
                             };
                         });
@@ -258,9 +266,12 @@ const convertReferenceEpigenomeToDataTable = (context, expandedRowCategories, ex
                         const colIndex = colMap[rowSubcategoryColCategoryBucket.key].col;
                         cells[colIndex] = {
                             content: (
-                                <a href={`${context.search_base}&${rowCategoryQuery}&${subCategoryQuery}&${colMap[rowSubcategoryColCategoryBucket.key].query}`} style={{ backgroundColor: rowSubcategoryColor }}>
-                                    <span className="sr-only">Search {rowCategoryBucket.key}, {rowSubcategoryBucket.key} for {rowSubcategoryColCategoryBucket.key}</span>
-                                </a>
+                                <React.Fragment>
+                                    <a href={`${context.search_base}&${rowCategoryQuery}&${subCategoryQuery}&${colMap[rowSubcategoryColCategoryBucket.key].query}`} style={{ backgroundColor: rowSubcategoryColor }}>
+                                        <span className="sr-only">Search {rowCategoryBucket.key}, {rowSubcategoryBucket.key} for {rowSubcategoryColCategoryBucket.key}</span>
+                                    </a>
+                                    &nbsp;
+                                </React.Fragment>
                             ),
                         };
                     }

--- a/src/encoded/static/components/matrix_reference_epigenome.js
+++ b/src/encoded/static/components/matrix_reference_epigenome.js
@@ -239,12 +239,9 @@ const convertReferenceEpigenomeToDataTable = (context, expandedRowCategories, ex
                             const colIndex = colMap[colMapKey].col;
                             cells[colIndex] = {
                                 content: (
-                                    <React.Fragment>
-                                        <a href={`${context.search_base}&${rowCategoryQuery}&${subCategoryQuery}&${colMap[colMapKey].query}`}>
-                                            <span className="sr-only">Search {rowCategoryBucket.key}, {rowSubcategoryBucket.key} for {rowSubcategoryColCategoryBucket.key}, {cellData.key}</span>
-                                        </a>
-                                        &nbsp;
-                                    </React.Fragment>
+                                    <a href={`${context.search_base}&${rowCategoryQuery}&${subCategoryQuery}&${colMap[colMapKey].query}`}>
+                                        <span className="sr-only">Search {rowCategoryBucket.key}, {rowSubcategoryBucket.key} for {rowSubcategoryColCategoryBucket.key}, {cellData.key}</span>
+                                    </a>
                                 ),
                                 style: { backgroundColor: rowSubcategoryColor },
                             };
@@ -255,12 +252,9 @@ const convertReferenceEpigenomeToDataTable = (context, expandedRowCategories, ex
                         const colIndex = colMap[rowSubcategoryColCategoryBucket.key].col;
                         cells[colIndex] = {
                             content: (
-                                <React.Fragment>
-                                    <a href={`${context.search_base}&${rowCategoryQuery}&${subCategoryQuery}&${colMap[rowSubcategoryColCategoryBucket.key].query}`}>
-                                        <span className="sr-only">Search {rowCategoryBucket.key}, {rowSubcategoryBucket.key} for {rowSubcategoryColCategoryBucket.key}</span>
-                                    </a>
-                                    &nbsp;
-                                </React.Fragment>
+                                <a href={`${context.search_base}&${rowCategoryQuery}&${subCategoryQuery}&${colMap[rowSubcategoryColCategoryBucket.key].query}`}>
+                                    <span className="sr-only">Search {rowCategoryBucket.key}, {rowSubcategoryBucket.key} for {rowSubcategoryColCategoryBucket.key}</span>
+                                </a>
                             ),
                             style: { backgroundColor: rowSubcategoryColor },
                         };

--- a/src/encoded/static/components/matrix_reference_epigenome.js
+++ b/src/encoded/static/components/matrix_reference_epigenome.js
@@ -239,9 +239,12 @@ const convertReferenceEpigenomeToDataTable = (context, expandedRowCategories, ex
                             const colIndex = colMap[colMapKey].col;
                             cells[colIndex] = {
                                 content: (
-                                    <a href={`${context.search_base}&${rowCategoryQuery}&${subCategoryQuery}&${colMap[colMapKey].query}`}>
-                                        <span className="sr-only">Search {rowCategoryBucket.key}, {rowSubcategoryBucket.key} for {rowSubcategoryColCategoryBucket.key}, {cellData.key}</span>
-                                    </a>
+                                    <React.Fragment>
+                                        <a href={`${context.search_base}&${rowCategoryQuery}&${subCategoryQuery}&${colMap[colMapKey].query}`}>
+                                            <span className="sr-only">Search {rowCategoryBucket.key}, {rowSubcategoryBucket.key} for {rowSubcategoryColCategoryBucket.key}, {cellData.key}</span>
+                                            &nbsp;
+                                        </a>
+                                    </React.Fragment>
                                 ),
                                 style: { backgroundColor: rowSubcategoryColor },
                             };
@@ -252,9 +255,12 @@ const convertReferenceEpigenomeToDataTable = (context, expandedRowCategories, ex
                         const colIndex = colMap[rowSubcategoryColCategoryBucket.key].col;
                         cells[colIndex] = {
                             content: (
-                                <a href={`${context.search_base}&${rowCategoryQuery}&${subCategoryQuery}&${colMap[rowSubcategoryColCategoryBucket.key].query}`}>
-                                    <span className="sr-only">Search {rowCategoryBucket.key}, {rowSubcategoryBucket.key} for {rowSubcategoryColCategoryBucket.key}</span>
-                                </a>
+                                <React.Fragment>
+                                    <a href={`${context.search_base}&${rowCategoryQuery}&${subCategoryQuery}&${colMap[rowSubcategoryColCategoryBucket.key].query}`}>
+                                        <span className="sr-only">Search {rowCategoryBucket.key}, {rowSubcategoryBucket.key} for {rowSubcategoryColCategoryBucket.key}</span>
+                                        &nbsp;
+                                    </a>
+                                </React.Fragment>
                             ),
                             style: { backgroundColor: rowSubcategoryColor },
                         };


### PR DESCRIPTION
This involved adding a non-breaking space to the relevant cells. Because the colors and striped SVG backgrounds are absolutely positioned, this has no visual effect otherwise. Without the non-breaking space, the height of the colored cells is zero on IE11.