### PR TITLE
ENCD-4222 Implement ENTEx matrix

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,6 +3,9 @@ module.exports = {
     env: {
         browser: true,
     },
+    plugins: [
+        'react-hooks',
+    ],
     parserOptions: {
         ecmaVersion: 6,
         ecmaFeatures: {
@@ -43,6 +46,8 @@ module.exports = {
         }],
         'prefer-destructuring': 0, // FF
         'react/forbid-prop-types': 0,
+        'react-hooks/rules-of-hooks': 'error',
+        'react-hooks/exhaustive-deps': 'warn',
         'react/jsx-filename-extension': 0,
         'react/jsx-indent': 0,
         'react/jsx-indent-props': [2, 4],

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -61,7 +61,7 @@ webtest = git https://github.com/Pylons/webtest.git
 WSGIProxy2 = git https://github.com/lrowe/WSGIProxy2.git
 zope.sqlalchemy = git https://github.com/zopefoundation/zope.sqlalchemy.git
 pytest-bdd = git https://github.com/lrowe/pytest-bdd.git branch=allow-any-step-order
-snovault = git https://github.com/ENCODE-DCC/snovault.git rev=1.0.38
+snovault = git https://github.com/ENCODE-DCC/snovault.git branch=SNO-126-allow-default-value-for-missing-aggregation-field
 
 [versions]
 # Hand set versions

--- a/package-lock.json
+++ b/package-lock.json
@@ -5936,6 +5936,12 @@
         }
       }
     },
+    "eslint-plugin-react-hooks": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-2.3.0.tgz",
+      "integrity": "sha512-gLKCa52G4ee7uXzdLiorca7JIQZPPXRAQDXV83J4bUEeUuc5pIEyZYAZ45Xnxe5IuupxEqHS+hUhSLIimK1EMw==",
+      "dev": true
+    },
     "eslint-restricted-globals": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/eslint-restricted-globals/-/eslint-restricted-globals-0.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-react": "^7.14.3",
+    "eslint-plugin-react-hooks": "^2.3.0",
     "espree": "^3.3.2",
     "fancy-log": "^1.3.3",
     "file-loader": "^0.9.0",

--- a/src/encoded/search_views.py
+++ b/src/encoded/search_views.py
@@ -9,6 +9,7 @@ from snovault.elasticsearch.searches.interfaces import SUMMARY_TITLE
 from snovault.elasticsearch.searches.fields import AuditMatrixWithFacetsResponseField
 from snovault.elasticsearch.searches.fields import AllResponseField
 from snovault.elasticsearch.searches.fields import BasicMatrixWithFacetsResponseField
+from snovault.elasticsearch.searches.fields import MissingMatrixWithFacetsResponseField
 from snovault.elasticsearch.searches.fields import BasicSearchResponseField
 from snovault.elasticsearch.searches.fields import BasicSearchWithFacetsResponseField
 from snovault.elasticsearch.searches.fields import BasicReportWithFacetsResponseField
@@ -39,6 +40,7 @@ def includeme(config):
     config.add_route('matrixv2_raw', '/matrixv2_raw{slash:/?}')
     config.add_route('matrix', '/matrix{slash:/?}')
     config.add_route('reference-epigenome-matrix', '/reference-epigenome-matrix{slash:/?}')
+    config.add_route('entex-matrix', '/entex-matrix{slash:/?}')
     config.add_route('summary', '/summary{slash:/?}')
     config.add_route('audit', '/audit{slash:/?}')
     config.scan(__name__)
@@ -216,6 +218,35 @@ def reference_epigenome_matrix(context, request):
             BasicMatrixWithFacetsResponseField(
                 default_item_types=DEFAULT_ITEM_TYPES,
                 matrix_definition_name='reference_epigenome'
+            ),
+            NotificationResponseField(),
+            FiltersResponseField(),
+            TypeOnlyClearFiltersResponseField(),
+            DebugQueryResponseField()
+        ]
+    )
+    return fr.render()
+
+
+@view_config(route_name='entex-matrix', request_method='GET', permission='search')
+def entex_matrix(context, request):
+    fr = FieldedResponse(
+        _meta={
+            'params_parser': ParamsParser(request)
+        },
+        response_fields=[
+            TitleResponseField(
+                title='ENTEx Matrix'
+            ),
+            TypeResponseField(
+                at_type=['EntexMatrix']
+            ),
+            IDResponseField(),
+            SearchBaseResponseField(),
+            ContextResponseField(),
+            MissingMatrixWithFacetsResponseField(
+                default_item_types=DEFAULT_ITEM_TYPES,
+                matrix_definition_name='entex'
             ),
             NotificationResponseField(),
             FiltersResponseField(),

--- a/src/encoded/static/components/app.js
+++ b/src/encoded/static/components/app.js
@@ -48,7 +48,7 @@ const portal = {
                 { id: 'sep-mm-2' },
                 { id: 'collections', title: 'Collections' },
                 { id: 'encore', title: 'ENCORE', url: '/matrix/?type=Experiment&status=released&internal_tags=ENCORE', tag: 'collection' },
-                { id: 'entex', title: 'ENTEx', url: '/matrix/?type=Experiment&status=released&internal_tags=ENTEx', tag: 'collection' },
+                { id: 'entex', title: 'ENTEx', url: '/entex-matrix/?type=Experiment&status=released&internal_tags=ENTEx', tag: 'collection' },
                 { id: 'sescc', title: 'SE Stem Cell Consortium', url: '/matrix/?type=Experiment&status=released&internal_tags=SESCC', tag: 'collection' },
                 { id: 'reference-epigenomes-human', title: 'Human reference epigenomes', url: '/reference-epigenome-matrix/?type=Experiment&related_series.@type=ReferenceEpigenome&replicates.library.biosample.donor.organism.scientific_name=Homo+sapiens', tag: 'collection' },
                 { id: 'reference-epigenomes-mouse', title: 'Mouse reference epigenomes', url: '/reference-epigenome-matrix/?type=Experiment&related_series.@type=ReferenceEpigenome&replicates.library.biosample.donor.organism.scientific_name=Mus+musculus', tag: 'collection' },

--- a/src/encoded/static/components/index.js
+++ b/src/encoded/static/components/index.js
@@ -26,6 +26,7 @@ require('./platform');
 require('./search');
 require('./report');
 require('./matrix_audit');
+require('./matrix_entex');
 require('./matrix_experiment');
 require('./matrix_reference_epigenome');
 require('./target');

--- a/src/encoded/static/components/matrix.js
+++ b/src/encoded/static/components/matrix.js
@@ -7,6 +7,35 @@ import { TextFilter } from './search';
 
 
 /**
+ * Maximum number of selected items that can be visualized.
+ * @constant
+ */
+export const MATRIX_VISUALIZE_LIMIT = 500;
+
+
+/**
+ * Order in which assay_titles should appear along the horizontal axis of the matrix. Anything not
+ * included gets sorted after these.
+ */
+export const matrixAssaySortOrder = [
+    'polyA plus RNA-seq',
+    'total RNA-seq',
+    'small RNA-seq',
+    'microRNA-seq',
+    'microRNA counts',
+    'RNA microarray',
+    'DNase-seq',
+    'ATAC-seq',
+    'WGBS',
+    'RRBS',
+    'MeDIP-seq',
+    'MRE-seq',
+    'TF ChIP-seq',
+    'Histone ChIP-seq',
+];
+
+
+/**
  * Render the expander button for a row category, and react to clicks by calling the parent to
  * render the expansion change.
  */

--- a/src/encoded/static/components/matrix_audit.js
+++ b/src/encoded/static/components/matrix_audit.js
@@ -9,18 +9,12 @@ import { svgIcon } from '../libs/svg-icons';
 import { tintColor, isLight } from './datacolors';
 import DataTable from './datatable';
 import * as globals from './globals';
-import { RowCategoryExpander, SearchFilter } from './matrix';
+import { RowCategoryExpander, SearchFilter, MATRIX_VISUALIZE_LIMIT } from './matrix';
 import { FacetList, ClearFilters, SearchControls } from './search';
 
 
 /** Number of subcategory items to show when subcategory isn't expanded. */
 const SUB_CATEGORY_SHORT_SIZE = 5;
-
-/**
- * Maximum number of selected items that can be visualized.
- * @constant
- */
-const VISUALIZE_LIMIT = 500;
 
 /** Audit matrix rowCategory colors. */
 const auditColors = ['#e0e000', '#ff8000', '#cc0700', '#a0a0a0'];
@@ -251,7 +245,7 @@ const convertAuditToDataTable = (context, expandedRowCategories, expanderClickHa
  * Render the title panel and list of experiment internal tags.
  */
 const MatrixHeader = ({ context }) => {
-    const visualizeDisabledTitle = context.total > VISUALIZE_LIMIT ? `Filter to ${VISUALIZE_LIMIT} to visualize` : '';
+    const visualizeDisabledTitle = context.total > MATRIX_VISUALIZE_LIMIT ? `Filter to ${MATRIX_VISUALIZE_LIMIT} to visualize` : '';
 
     // Compose a type title for the page if only one type is included in the query string.
     // Currently, only one type is allowed in the query string or the server returns a 400, so this

--- a/src/encoded/static/components/matrix_entex.js
+++ b/src/encoded/static/components/matrix_entex.js
@@ -1,0 +1,522 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import _ from 'underscore';
+import * as encoding from '../libs/query_encoding';
+import { svgIcon } from '../libs/svg-icons';
+import { Panel, PanelBody } from '../libs/ui/panel';
+import DataTable from './datatable';
+import * as globals from './globals';
+import { matrixAssaySortOrder, MATRIX_VISUALIZE_LIMIT, SearchFilter } from './matrix';
+import { MatrixInternalTags } from './objectutils';
+import { SearchControls } from './search';
+
+
+/**
+ * All assay columns not included in matrix.
+ */
+const excludedAssays = [
+    'Control ChIP-seq',
+    'Control eCLIP',
+];
+
+/**
+ * All assays that have targets but we don't display the target columns, and instead show that data
+ * combined in the assay column.
+ */
+const collapsedAssays = [
+    'MeDIP-seq',
+];
+
+/**
+ * Defines the accessions and other associated display information for each of the four ENTEx
+ * donors. The [top-left, top-right, bottom-left, bottom-right] cell render order dictates the
+ * order in this array. The properties mean:
+ *   accession: Accession of donor
+ *   cssSuffix: Suffix to use on all associated CSS style names
+ *   voice: Text for a screen reader to speak
+ *   legendText: Text to display in legend; UNICODE male/female symbols
+ */
+const entexDonors = [
+    {
+        accession: 'ENCDO845WKR',
+        cssSuffix: 'male1',
+        voice: 'Male 1',
+        legendText: '\u2642 1',
+    },
+    {
+        accession: 'ENCDO793LXB',
+        cssSuffix: 'female3',
+        voice: 'Female 3',
+        legendText: '\u2640 3',
+    },
+    {
+        accession: 'ENCDO451RUA',
+        cssSuffix: 'male2',
+        voice: 'Male 2',
+        legendText: '\u2642 2',
+    },
+    {
+        accession: 'ENCDO271OUW',
+        cssSuffix: 'female4',
+        voice: 'Female 4',
+        legendText: '\u2640 4',
+    },
+];
+
+
+/**
+ * Displays one row of the donor legend. Each pie slice not specified in `entexDonor` gets its
+ * CSS style overridden by "blank" which makes it gray colored. The pie slices otherwise get
+ * rendered the same way they do in the actual table.
+ */
+const DonorLegendRow = ({ entexDonor }) => (
+    <div className="donor-legend-row">
+        <div className="donor-cell">
+            {entexDonors.map(donorQuadrant => (
+                <div key={donorQuadrant.accession} className={`donor-quadrant donor-quadrant--${donorQuadrant.cssSuffix}${donorQuadrant.accession !== entexDonor.accession ? ' blank' : ''}`} />
+            ))}
+        </div>
+        <div className="donor-legend-row__label">
+            <div className={`donor-legend-row__short-string donor-legend-row__short-string--${entexDonor.cssSuffix}`}>{entexDonor.legendText}</div>
+            <a href={`/human-donors/${entexDonor.accession}`} aria-label={`Go to donor page for ${entexDonor.voice} ${entexDonor.accession}`}>{entexDonor.accession}</a>
+        </div>
+    </div>
+);
+
+DonorLegendRow.propTypes = {
+    /** Element of `entexDonors` to render */
+    entexDonor: PropTypes.object.isRequired,
+};
+
+
+/**
+ * Draw a legend of what the quadrants in each matrix cell means.
+ */
+const DonorLegend = () => (
+    <div className="donor-legend">
+        {entexDonors.map(entexDonor => (
+            <DonorLegendRow key={entexDonor.accession} entexDonor={entexDonor} />
+        ))}
+    </div>
+);
+
+
+/**
+ * Generate an assay:column map that maps from a combined assay and target name to a column index
+ * in the matrix. Any determination of column order or inclusion/exclusion happens in this
+ * function. Do not rely on the order of the keys. The resulting object has the form:
+ * {
+ *   'cat1': {col: 0, category: 'cat1', hasSubcategories: true},
+ *   'cat1|subcat1': {col: 1, category: 'cat1', subcategory: 'subcat1'},
+ *   'cat1|subcat2': {col: 2, category: 'cat1', subcategory: 'subcat2'},
+ *   'cat3': {col: 5, category: 'cat3', hasSubcategories: false},
+ *   'cat2': {col: 3, category: 'cat2', hasSubcategories: true},
+ *   'cat2|subcat3': {col: 4, category: 'cat2', subcategory: 'subcat3'},
+ *   ...
+ * }
+ * TODO: Convert the reference-epigenome matrix to use the same no_targets method we use in the
+ * ENTEx matrix, allowing us to share this function between the two matrix implementations.
+ * @param {object} context ENTEx matrix data
+ *
+ * @return {object} Keyed column header information
+ */
+const generateColMap = (context) => {
+    const colCategory = context.matrix.x.group_by[0];
+    const colSubcategory = context.matrix.x.group_by[1][0];
+    const colMap = {};
+    let colIndex = 0;
+
+    // Sort column categories according to a specified order, with any items not specified sorted
+    // at the end in order of occurrence.
+    const colCategoryBuckets = context.matrix.x[colCategory].buckets;
+    const sortedColCategoryBuckets = _(colCategoryBuckets).sortBy((colCategoryBucket) => {
+        const sortIndex = matrixAssaySortOrder.indexOf(colCategoryBucket.key);
+        return sortIndex >= 0 ? sortIndex : colCategoryBuckets.length;
+    });
+
+    // Loop to construct the `colMap object.
+    sortedColCategoryBuckets.forEach((colCategoryBucket) => {
+        if (!excludedAssays.includes(colCategoryBucket.key)) {
+            const colSubcategoryBuckets = colCategoryBucket[colSubcategory].buckets;
+
+            // Add the mapping of "assay" key string to column index.
+            colMap[colCategoryBucket.key] = {
+                col: colIndex,
+                category: colCategoryBucket.key,
+                hasSubcategories: colSubcategoryBuckets.length > 0 && colSubcategoryBuckets[0].key !== 'no_target',
+            };
+            colIndex += 1;
+
+            // Add the mapping of "assay|target" key string to column index for those assays that
+            // have targets and don't collapse their targets. A target of "no_target" means the
+            // assay has no targets.
+            if (!collapsedAssays.includes(colCategoryBucket.key)) {
+                colSubcategoryBuckets.forEach((colSubcategoryBucket) => {
+                    if (colSubcategoryBucket.key !== 'no_target') {
+                        colMap[`${colCategoryBucket.key}|${colSubcategoryBucket.key}`] = {
+                            col: colIndex,
+                            category: colCategoryBucket.key,
+                            subcategory: colSubcategoryBucket.key,
+                        };
+                        colIndex += 1;
+                    }
+                });
+            }
+        }
+    });
+    return colMap;
+};
+
+
+/**
+ * Display a disabled cell in the matrix. Used to reduce a bit of code per cell when matrices can
+ * be very large.
+ */
+const DisabledCell = () => <div className="matrix__disabled-cell" />;
+
+
+/**
+ * Render a single cell within the table that contains up to four donors, with each quadrant of the
+ * cell devoted to a consistent donor throughout the table.
+ */
+const DonorCell = ({ donorDatum, rowCategory, rowSubcategory, colCategory, colSubcategory }) => {
+    // Construct the screen-reader string with all provided accessions, comma separated.
+    const relevantDonors = entexDonors.filter(entexDonor => donorDatum.includes(entexDonor.accession));
+    const donorVoice = relevantDonors.map(relevantDonor => relevantDonor.voice).join(', ');
+
+    return (
+        <div className="donor-cell">
+            {entexDonors.map((entexDonor) => {
+                const quadrantStyle = `donor-quadrant donor-quadrant--${donorDatum.includes(entexDonor.accession) ? entexDonor.cssSuffix : 'none'}`;
+                return <div key={entexDonor.accession} className={quadrantStyle} />;
+            })}
+            <div className="sr-only">{donorDatum.length} {donorDatum.length > 1 ? 'donors' : 'donor'}, {donorVoice}.</div>
+            <div className="sr-only">Search {rowCategory}, {rowSubcategory} for {colCategory}, {colSubcategory === 'no_target' ? '' : colSubcategory}</div>
+        </div>
+    );
+};
+
+DonorCell.propTypes = {
+    /** Donor accessions in cell in no defined order */
+    donorDatum: PropTypes.array.isRequired,
+    /** Row category text for screen readers */
+    rowCategory: PropTypes.string.isRequired,
+    /** Row subcategory text for screen readers */
+    rowSubcategory: PropTypes.string.isRequired,
+    /** Column category text for screen readers */
+    colCategory: PropTypes.string.isRequired,
+    /** Column subcategory text for screen readers */
+    colSubcategory: PropTypes.string.isRequired,
+};
+
+
+/**
+ * Takes matrix data from JSON and generates an object that <DataTable> can use to generate the JSX
+ * for the matrix. This is a shim between the incoming matrix data and the object <DataTable>
+ * needs.
+ * @param {object} context Matrix JSON for the page
+ *
+ * @return {object} Generated object suitable for passing to <DataTable>
+ */
+const convertContextToDataTable = (context) => {
+    // Retrieve the bucket property names for the different levels of the hierarchical matrix data.
+    const colCategory = context.matrix.x.group_by[0];
+    const colSubcategory = context.matrix.x.group_by[1][0];
+    const cellCategory = context.matrix.x.group_by[2];
+    const cellSubcategory = context.matrix.x.group_by[3];
+    const rowCategory = context.matrix.y.group_by[0];
+    const rowSubcategory = context.matrix.y.group_by[1];
+
+    // Generate the mapping of column categories and subcategories.
+    const colMap = generateColMap(context);
+    const colCount = Object.keys(colMap).length;
+
+    // Convert column map to an array of column map values sorted by column number for displaying
+    // in the matrix header.
+    const sortedCols = Object.keys(colMap).map(assayColKey => colMap[assayColKey]).sort((colInfoA, colInfoB) => colInfoA.col - colInfoB.col);
+
+    // Generate array of names of assays that have targets and don't collapse their targets, for
+    // rendering those columns as disabled.
+    const colCategoriesWithSubcategories = Object.keys(colMap).filter(colCategoryName => colMap[colCategoryName].hasSubcategories && !collapsedAssays.includes(colCategoryName));
+
+    // Generate the hierarchical top-row sideways header label cells. The first cell has the
+    // legend for the cell data. At the end of this loop, rendering `{header}` shows this header
+    // row. The `sortedCols` array gets mutated in this loop, acquiring a `query` property in each
+    // of its objects that gets used later to generate cell hrefs.
+    const header = [
+        { content: <DonorLegend />, css: 'matrix__entex-corner' },
+    ].concat(sortedCols.map((colInfo) => {
+        const categoryQuery = `${colCategory}=${encoding.encodedURIComponent(colInfo.category)}`;
+        if (!colInfo.subcategory) {
+            // Add the category column links.
+            colInfo.query = categoryQuery;
+            return { header: <a href={`${context.search_base}&${categoryQuery}`}>{colInfo.category} <div className="sr-only">{context.matrix.x.label}</div></a> };
+        }
+
+        // Add the subcategory column links.
+        const subCategoryQuery = `${colSubcategory}=${encoding.encodedURIComponent(colInfo.subcategory)}`;
+        colInfo.query = `${categoryQuery}&${subCategoryQuery}`;
+        return { header: <a className="sub" href={`${context.search_base}&${categoryQuery}&${subCategoryQuery}`}>{colInfo.subcategory} <div className="sr-only">target for {colInfo.category} {context.matrix.x.label} </div></a> };
+    }));
+
+    // Generate the main table content including the data hierarchy, where the upper level of the
+    // hierarchy gets referred to here as "rowCategory" and the lower level gets referred to as
+    // "rowSubcategory." Both these types of rows get collected into `dataTable` which gets passed
+    // to <DataTable>. Also generate an array of React keys to use with <DataTable>.
+    const rowKeys = ['column-categories'];
+    const rowCategoryBuckets = context.matrix.y[rowCategory].buckets;
+
+    const dataTable = rowCategoryBuckets.reduce((accumulatingTable, rowCategoryBucket, rowCategoryIndex) => {
+        // Each loop iteration generates all the rows of the row subcategories (biosample term names)
+        // under it.
+        const rowSubcategoryBuckets = rowCategoryBucket[rowSubcategory].buckets;
+        const rowCategoryQuery = `${rowCategory}=${encoding.encodedURIComponent(rowCategoryBucket.key)}`;
+        rowKeys[rowCategoryIndex + 1] = rowCategoryBucket.key;
+
+        const cells = Array(colCount);
+        const subcategoryRows = rowSubcategoryBuckets.map((rowSubcategoryBucket, rowSubcategoryIndex) => {
+            const subCategoryQuery = `${rowSubcategory}=${encoding.encodedURIComponent(rowSubcategoryBucket.key)}`;
+
+            // Each biosample term name's row reuses the same `cells` array of cell components.
+            cells.fill(null);
+            rowSubcategoryBucket[colCategory].buckets.forEach((rowSubcategoryColCategoryBucket) => {
+                // Skip any excluded assay columns.
+                if (!excludedAssays.includes(rowSubcategoryColCategoryBucket.key)) {
+                    // Loop to generate each cell in one biosample term name row.
+                    rowSubcategoryColCategoryBucket[colSubcategory].buckets.forEach((rowSubcategoryColSubcategoryBucket) => {
+                        // Make an array of all the donor accessions relevant to one biosample
+                        // term name and assay/target.
+                        const donorData = [];
+                        rowSubcategoryColSubcategoryBucket[cellCategory].buckets.forEach((cellCategoryBucket) => {
+                            cellCategoryBucket[cellSubcategory].buckets.forEach((cellSubcategoryBucket) => {
+                                donorData.push(cellSubcategoryBucket.key);
+                            });
+                        });
+
+                        if (rowSubcategoryColSubcategoryBucket.key === 'no_target' || collapsedAssays.includes(rowSubcategoryColCategoryBucket.key)) {
+                            // The assay does not have targets, or it does but collapses them, so just
+                            // add a donor cell for the column category.
+                            const colIndex = colMap[rowSubcategoryColCategoryBucket.key].col;
+                            cells[colIndex] = {
+                                content: (
+                                    <a href={`${context.search_base}&${rowCategoryQuery}&${subCategoryQuery}&${colMap[rowSubcategoryColCategoryBucket.key].query}`}>
+                                        <DonorCell
+                                            donorDatum={donorData}
+                                            rowCategory={rowCategoryBucket.key}
+                                            rowSubcategory={rowSubcategoryBucket.key}
+                                            colCategory={rowSubcategoryColCategoryBucket.key}
+                                            colSubcategory={rowSubcategoryColSubcategoryBucket.key}
+                                        />
+                                    </a>
+                                ),
+                            };
+                        } else {
+                            // Assay has non-collapsed targets, so render the donor cell for the
+                            // current target.
+                            const colMapKey = `${rowSubcategoryColCategoryBucket.key}|${rowSubcategoryColSubcategoryBucket.key}`;
+                            const colIndex = colMap[colMapKey].col;
+                            cells[colIndex] = {
+                                content: (
+                                    <a href={`${context.search_base}&${rowCategoryQuery}&${subCategoryQuery}&${colMap[colMapKey].query}`}>
+                                        <DonorCell
+                                            donorDatum={donorData}
+                                            rowCategory={rowCategoryBucket.key}
+                                            rowSubcategory={rowSubcategoryBucket.key}
+                                            colCategory={rowSubcategoryColCategoryBucket.key}
+                                            colSubcategory={rowSubcategoryColSubcategoryBucket.key}
+                                        />
+                                    </a>
+                                ),
+                            };
+                        }
+                    });
+                }
+            });
+
+            // Show assay columns as disabled (i.e. nothing to see here) if those columns have
+            // target columns.
+            colCategoriesWithSubcategories.forEach((colCategoryName) => {
+                cells[colMap[colCategoryName].col] = { content: <DisabledCell /> };
+            });
+
+            // Add a single term-name row's data and left header to the matrix.
+            rowKeys[rowCategoryIndex + 1] = `${rowCategoryBucket.key}|${rowSubcategoryBucket.key}`;
+            return {
+                rowContent: [
+                    {
+                        header: (
+                            <a href={`${context.search_base}&${rowCategoryQuery}&${subCategoryQuery}`}>
+                                <div className="subcategory-row-text">{rowSubcategoryBucket.key} <div className="sr-only">{context.matrix.y.label}</div></div>
+                            </a>
+                        ),
+                    },
+                ].concat(cells),
+                css: `matrix__row-data${rowSubcategoryIndex === 0 ? ' matrix__row-data--first' : ''}`,
+            };
+        });
+
+        // Continue adding rendered rows to the matrix.
+        return accumulatingTable.concat(subcategoryRows);
+    }, [{ rowContent: header, css: 'matrix__col-category-header' }]);
+    return { dataTable, rowKeys };
+};
+
+
+/**
+ * Render the area above the matrix itself, including the page title.
+ */
+const MatrixHeader = ({ context }) => {
+    const visualizeDisabledTitle = context.total > MATRIX_VISUALIZE_LIMIT ? `Filter to ${MATRIX_VISUALIZE_LIMIT} to visualize` : '';
+
+    return (
+        <div className="matrix-header">
+            <div className="matrix-header__title">
+                <h1>{context.title}</h1>
+                <div className="matrix-tags">
+                    <MatrixInternalTags context={context} />
+                </div>
+            </div>
+            <div className="matrix-header__controls">
+                <div className="matrix-header__filter-controls">
+                    <SearchFilter context={context} />
+                </div>
+                <div className="matrix-header__search-controls">
+                    <h4>Showing {context.total} results</h4>
+                    <SearchControls context={context} visualizeDisabledTitle={visualizeDisabledTitle} hideBrowserSelector />
+                </div>
+            </div>
+        </div>
+    );
+};
+
+MatrixHeader.propTypes = {
+    /** Matrix search result object */
+    context: PropTypes.object.isRequired,
+};
+
+
+/**
+ * Display the matrix and associated controls above them.
+ */
+const MatrixPresentation = ({ context }) => {
+    const [scrolledRight, setScrolledRight] = React.useState(false);
+    const ref = React.useRef(null);
+
+    // Memoized (prevents function creation on every render -- function only gets recreated when
+    // `scrolledRight` value changes) callback to calculate whether the ASSAY arrow needs to flash
+    // (`scrolledRight` === false) or not (`scrolledRight` === true). Called in response to both
+    // "scroll" and "resize" events.
+    const handleScroll = React.useCallback((target) => {
+        // Have to use a "roughly equal to" test because of an MS Edge bug mentioned here:
+        // https://stackoverflow.com/questions/30900154/workaround-for-issue-with-ie-scrollwidth
+        const scrollDiff = Math.abs((target.scrollWidth - target.scrollLeft) - target.clientWidth);
+        if (scrollDiff < 2 && !scrolledRight) {
+            // Right edge of matrix scrolled into view.
+            setScrolledRight(true);
+        } else if (scrollDiff >= 2 && scrolledRight) {
+            // Right edge of matrix scrolled out of view.
+            setScrolledRight(false);
+        }
+    }, [scrolledRight]);
+
+    // Callback called after component mounts to add the "scroll" and "resize" event listeners.
+    // Both events can cause a recalculation of `scrolledRight`. People seem to prefer using the
+    // "scroll" event listener with hooks as opposed to the onScroll property, but I don't yet know
+    // why.
+    React.useEffect(() => {
+        // Direct callbacks not memoized because of their small size.
+        const handleScrollEvent = event => handleScroll(event.target);
+        const handleResizeEvent = () => handleScroll(ref.current);
+
+        // Cache the reference to the scrollable matrix <div> so that we can remove the "scroll"
+        // event handler on unmount, when ref.current might no longer point at this <div>.
+        const matrixNode = ref.current;
+
+        // Attach the scroll- and resize- event handlers, then force the initial calculation of
+        // `scrolledRight`.
+        ref.current.addEventListener('scroll', handleScrollEvent);
+        window.addEventListener('resize', handleResizeEvent);
+        handleScroll(ref.current);
+
+        // Callback called when unmounting component.
+        return () => {
+            matrixNode.removeEventListener('scroll', handleScrollEvent);
+            window.removeEventListener('resize', handleResizeEvent);
+        };
+    }, [handleScroll]);
+
+    // Convert ENTEx matrix data to a DataTable object. I'd like to memoize this but determining if
+    // the incoming, deeply nested matrix data has changed would be very complicated.
+    const { dataTable, rowKeys } = convertContextToDataTable(context);
+    const matrixConfig = {
+        rows: dataTable,
+        rowKeys,
+        tableCss: 'matrix',
+    };
+
+    return (
+        <div className="matrix__presentation">
+            <div className={`matrix__label matrix__label--horz${!scrolledRight ? ' horz-scroll' : ''}`}>
+                <span>{context.matrix.x.label}</span>
+                {svgIcon('largeArrow')}
+            </div>
+            <div className="matrix__presentation-content">
+                <div className="matrix__label matrix__label--vert"><div>{svgIcon('largeArrow')}{context.matrix.y.label}</div></div>
+                <div className="matrix__data" ref={ref}>
+                    <DataTable tableData={matrixConfig} />
+                </div>
+            </div>
+        </div>
+    );
+};
+
+MatrixPresentation.propTypes = {
+    /** ENTEx matrix object */
+    context: PropTypes.object.isRequired,
+};
+
+
+/**
+ * Render the area containing the matrix.
+ */
+const MatrixContent = ({ context }) => (
+    <div className="matrix__content matrix__content--entex">
+        <MatrixPresentation context={context} />
+    </div>
+);
+
+MatrixContent.propTypes = {
+    /** ENTEx matrix object */
+    context: PropTypes.object.isRequired,
+};
+
+
+/**
+ * View component for the ENTEx matrix page.
+ */
+const EntexMatrix = ({ context }) => {
+    const itemClass = globals.itemClass(context, 'view-item');
+
+    if (context.total > 0) {
+        return (
+            <Panel addClasses={itemClass}>
+                <PanelBody>
+                    <MatrixHeader context={context} />
+                    <MatrixContent context={context} />
+                </PanelBody>
+            </Panel>
+        );
+    }
+    return <h4>No results found</h4>;
+};
+
+EntexMatrix.propTypes = {
+    /** ENTEx matrix object */
+    context: PropTypes.object.isRequired,
+};
+
+EntexMatrix.contextTypes = {
+    location_href: PropTypes.string,
+};
+
+globals.contentViews.register(EntexMatrix, 'EntexMatrix');

--- a/src/encoded/static/components/matrix_experiment.js
+++ b/src/encoded/static/components/matrix_experiment.js
@@ -9,7 +9,7 @@ import { svgIcon } from '../libs/svg-icons';
 import { tintColor, isLight } from './datacolors';
 import DataTable from './datatable';
 import * as globals from './globals';
-import { RowCategoryExpander, SearchFilter } from './matrix';
+import { RowCategoryExpander, SearchFilter, MATRIX_VISUALIZE_LIMIT } from './matrix';
 import { MatrixInternalTags } from './objectutils';
 import { FacetList, ClearFilters, SearchControls } from './search';
 
@@ -19,13 +19,6 @@ import { FacetList, ClearFilters, SearchControls } from './search';
  * @constant
  */
 const SUB_CATEGORY_SHORT_SIZE = 5;
-
-
-/**
- * Maximum number of selected items that can be visualized.
- * @constant
- */
-const VISUALIZE_LIMIT = 500;
 
 
 /**
@@ -259,7 +252,7 @@ const convertExperimentToDataTable = (context, getRowCategories, getRowSubCatego
  * Render the area above the facets and matrix content.
  */
 const MatrixHeader = ({ context }) => {
-    const visualizeDisabledTitle = context.total > VISUALIZE_LIMIT ? `Filter to ${VISUALIZE_LIMIT} to visualize` : '';
+    const visualizeDisabledTitle = context.total > MATRIX_VISUALIZE_LIMIT ? `Filter to ${MATRIX_VISUALIZE_LIMIT} to visualize` : '';
 
     let clearButton;
     const parsedUrl = url.parse(context['@id'], true);

--- a/src/encoded/static/components/matrix_reference_epigenome.js
+++ b/src/encoded/static/components/matrix_reference_epigenome.js
@@ -10,7 +10,7 @@ import { Panel, PanelBody, TabPanel } from '../libs/ui/panel';
 import { tintColor, isLight } from './datacolors';
 import DataTable from './datatable';
 import * as globals from './globals';
-import { RowCategoryExpander, SearchFilter } from './matrix';
+import { matrixAssaySortOrder, MATRIX_VISUALIZE_LIMIT, RowCategoryExpander, SearchFilter } from './matrix';
 import { MatrixInternalTags } from './objectutils';
 import { SearchControls } from './search';
 
@@ -22,40 +22,12 @@ import { SearchControls } from './search';
 const SUB_CATEGORY_SHORT_SIZE = 10;
 
 
-/**
- * Maximum number of selected items that can be visualized.
- * @constant
- */
-const VISUALIZE_LIMIT = 500;
-
-
 // Reference epigenome category properties we use.
 const ROW_CATEGORY = 'biosample_ontology.classification';
 const ROW_SUBCATEGORY = 'biosample_ontology.term_name';
 const COL_CATEGORY = 'assay_title';
 const COL_SUBCATEGORY = 'target.label';
 
-
-/**
- * Order in which assay_titles should appear along the horizontal axis of the matrix. Anything not
- * included gets sorted after these.
- */
-const assaySortOrder = [
-    'polyA plus RNA-seq',
-    'total RNA-seq',
-    'small RNA-seq',
-    'microRNA-seq',
-    'microRNA counts',
-    'RNA microarray',
-    'DNase-seq',
-    'ATAC-seq',
-    'WGBS',
-    'RRBS',
-    'MeDIP-seq',
-    'MRE-seq',
-    'TF ChIP-seq',
-    'Histone ChIP-seq',
-];
 
 /**
  * All assay columns to not include in matrix.
@@ -100,7 +72,7 @@ const generateColMap = (context) => {
     // at the end in order of occurrence.
     const colCategoryBuckets = context.matrix.x[colCategory].buckets;
     const sortedColCategoryBuckets = _(colCategoryBuckets).sortBy((colCategoryBucket) => {
-        const sortIndex = assaySortOrder.indexOf(colCategoryBucket.key);
+        const sortIndex = matrixAssaySortOrder.indexOf(colCategoryBucket.key);
         return sortIndex >= 0 ? sortIndex : colCategoryBuckets.length;
     });
 
@@ -358,7 +330,7 @@ const convertReferenceEpigenomeToDataTable = (context, expandedRowCategories, ex
  * Render the area above the matrix itself, including the page title.
  */
 const MatrixHeader = ({ context }) => {
-    const visualizeDisabledTitle = context.total > VISUALIZE_LIMIT ? `Filter to ${VISUALIZE_LIMIT} to visualize` : '';
+    const visualizeDisabledTitle = context.total > MATRIX_VISUALIZE_LIMIT ? `Filter to ${MATRIX_VISUALIZE_LIMIT} to visualize` : '';
 
     return (
         <div className="matrix-header">

--- a/src/encoded/static/scss/encoded/modules/_matrix.scss
+++ b/src/encoded/static/scss/encoded/modules/_matrix.scss
@@ -161,6 +161,7 @@ $row-data-header-width: 200px;
         }
 
         > td {
+            position: relative;
             width: $data-cell-width;
             padding: 0 !important;
             text-align: center;
@@ -392,6 +393,7 @@ $row-data-header-width: 200px;
 
     // Link to clear selected classifications (filters)
     @at-root #{&}__clear-classifications {
+        text-align: center;
         font-weight: normal;
     }
 }
@@ -520,6 +522,10 @@ table.matrix th.group-all-groups-cell {
     }
 }
 
+
+/**
+ * Styles specific to the reference-epigenome matrix.
+ */
 .matrix__content--reference-epigenome {
     display: block;
 
@@ -548,6 +554,10 @@ table.matrix th.group-all-groups-cell {
                     font-weight: normal;
                 }
             }
+        }
+
+        > td {
+            vertical-align: bottom;
         }
     }
 
@@ -585,6 +595,173 @@ table.matrix th.group-all-groups-cell {
         .btn {
             flex: 0 1 auto;
             margin: 0 2px;
+        }
+    }
+}
+
+
+/**
+ * Styles specific to the ENTEx matrix.
+ */
+$donor-cell-width: 30px;
+$donor-cell-height: 30px;
+$border-color: #e0e0e0;
+$donor-legend-short-string-width: 33px;
+
+/**
+ * Style info for each donor with format:
+ * css-suffix donor-color donor-text-color curve-direction
+ */
+$donor-styles:
+    male1 #e4bc52 #000 top-left,
+    female3 #879acd #fff top-right,
+    male2 #eed78c #000 bottom-left,
+    female4 #354b77 #fff bottom-right;
+
+
+.matrix__content--entex {
+    display: block;
+
+    .matrix__col-category-header {
+        > th {
+            width: $donor-cell-width - 1;
+            padding: 0;
+
+            > a {
+                width: $donor-cell-width;
+                line-height: $donor-cell-width;
+                font-weight: bold;
+
+                // Column subcategory links
+                &.sub {
+                    padding-top: 20px;
+                    font-weight: normal;
+                }
+            }
+        }
+    }
+
+    .matrix__row-data {
+        > th {
+            width: $donor-cell-width;
+            padding: 0;
+            border-left: none;
+
+            > a {
+                height: $donor-cell-height;
+                line-height: $donor-cell-height;
+            }
+
+            .subcategory-row-text {
+                white-space: nowrap;
+            }
+        }
+
+        > td {
+            width: $donor-cell-width - 1;
+            border-bottom: 1px solid $border-color;
+            border-left: 1px solid $border-color;
+
+            > a {
+                width: $donor-cell-width;
+                height: $donor-cell-height;
+            }
+
+            &:last-of-type {
+                border-right: 1px solid $border-color;
+            }
+        }
+
+        @at-root #{&}--first {
+            > th {
+                border-top: 1px solid $border-color;
+            }
+
+            > td {
+                border-top: 1px solid $border-color;
+            }
+        }
+    }
+
+    // Displays donor-quadrant in the matrix itself.
+    .donor-cell {
+        display: flex;
+        flex-wrap: wrap;
+        width: $donor-cell-width;
+        height: $donor-cell-height;
+
+        .donor-quadrant {
+            flex: 0 0 50%;
+            height: 50%;
+        }
+    }
+
+    .matrix__entex-corner {
+        vertical-align: middle;
+    }
+
+    .donor-legend-row {
+        display: flex;
+        margin: 5px 10px;
+
+        @at-root #{&}__label {
+            flex: 1 0 auto;
+            margin-left: 5px;
+            line-height: $donor-cell-height;
+            white-space: nowrap;
+
+            > a {
+                display: inline-block;
+                width: calc(100% - #{$donor-legend-short-string-width});
+                padding-left: 10px;
+                padding-right: 10px;
+                line-height: $donor-cell-height;
+                text-align: center;
+                background-color: #f0f0f0;
+                border-top: 1px solid #e0e0e0;
+                border-right: 1px solid #e0e0e0;
+                border-bottom: 1px solid #e0e0e0;
+                border-top-right-radius: 3px;
+                border-bottom-right-radius: 3px;
+            }
+        }
+
+        @at-root #{&}__short-string {
+            display: inline-block;
+            width: $donor-legend-short-string-width;
+            text-align: center;
+            line-height: $donor-cell-height;
+            border-top-left-radius: 3px;
+            border-bottom-left-radius: 3px;
+            border-top: 1px solid #e0e0e0;
+            border-bottom: 1px solid #e0e0e0;
+            border-left: 1px solid #e0e0e0;
+
+            @each $donor, $color, $textcolor, $curve in $donor-styles {
+                @at-root #{&}--#{$donor} {
+                    color: $textcolor;
+                    background-color: $color;
+                }
+            }
+        }
+
+        .donor-cell {
+            flex: 0 0 $donor-cell-width;
+            width: $donor-cell-width;
+        }
+    }
+
+    // Each quadrant of a donor cell, both in the matrix and the legend.
+    .donor-quadrant {
+        @each $donor, $color, $textcolor, $curve in $donor-styles {
+            &.donor-quadrant--#{$donor} {
+                border-#{$curve}-radius: $donor-cell-height / 2;
+                background-color: $color;
+
+                &.blank {
+                    background-color: #f0f0f0;
+                }
+            }
         }
     }
 }

--- a/src/encoded/tests/data/inserts/biosample.json
+++ b/src/encoded/tests/data/inserts/biosample.json
@@ -955,5 +955,88 @@
         "status": "released",
         "submitted_by": "/users/627eedbc-7cb3-4de3-9743-a86266e435a6",
         "uuid": "693c82ee-70f1-11e9-a923-1681be663d3e"
+    },
+    {
+        "_test": "For ENTEx matrix testing",
+        "accession": "ENCBS376EJL",
+        "aliases": [
+            "gtex:ENC-1LVAN-061-SM-IP2F3"
+        ],
+        "award": "UM1HG009390",
+        "biosample_ontology": "tissue_UBERON_0001891",
+        "donor": "ENCDO271OUW",
+        "internal_tags": [
+            "ENTEx"
+        ],
+        "lab": "encode2-project",
+        "nih_institutional_certification": "NIC00019",
+        "organism": "human",
+        "source": "michael-snyder",
+        "status": "released",
+        "submitted_by": "elementum.mus@dictumst.nostra",
+        "uuid": "e6440a82-d112-43a3-b892-a9763bdce7cf"
+    },
+    {
+        "_test": "For ENTEx matrix testing",
+        "accession": "ENCBS009WOO",
+        "aliases": [
+            "john-stamatoyannopoulos:TC9599",
+            "gtex:ENC-1LGRB-010-CR89G"
+        ],
+        "award": "UM1HG009390",
+        "biosample_ontology": "tissue_UBERON_0001891",
+        "donor": "ENCDO793LXB",
+        "internal_tags": [
+            "ENTEx"
+        ],
+        "lab": "encode2-project",
+        "nih_institutional_certification": "NIC00019",
+        "organism": "human",
+        "source": "michael-snyder",
+        "status": "released",
+        "submitted_by": "elementum.mus@dictumst.nostra",
+        "uuid": "0e6c7ee8-9400-4bb8-ae2e-966ca5bb09fb"
+    },
+    {
+        "_test": "For ENTEx matrix testing",
+        "accession": "ENCBS061XGD",
+        "aliases": [
+            "gtex:ENC-1JKYN-031-SM-9JLPD-1"
+        ],
+        "award": "UM1HG009390",
+        "biosample_ontology": "tissue_UBERON_0001891",
+        "description": "RNA Evaluation human tissue adrenal gland 1-2 microRNA-seq from Mortazavi",
+        "donor": "ENCDO845WKR",
+        "internal_tags": [
+            "ENTEx"
+        ],
+        "lab": "encode2-project",
+        "nih_institutional_certification": "NIC00022",
+        "organism": "human",
+        "source": "michael-snyder",
+        "status": "released",
+        "submitted_by": "elementum.mus@dictumst.nostra",
+        "uuid": "49b698f0-02ed-4e83-b04b-15642053c78d"
+    },
+    {
+        "_test": "For ENTEx matrix testing",
+        "accession": "ENCBS204NZH",
+        "aliases": [
+            "john-stamatoyannopoulos:TC9581",
+            "gtex:ENC-1K2DA-026-IP2FC"
+        ],
+        "award": "UM1HG009390",
+        "biosample_ontology": "tissue_UBERON_0001891",
+        "donor": "ENCDO451RUA",
+        "internal_tags": [
+            "ENTEx"
+        ],
+        "lab": "encode2-project",
+        "nih_institutional_certification": "NIC00019",
+        "organism": "human",
+        "source": "michael-snyder",
+        "status": "released",
+        "submitted_by": "elementum.mus@dictumst.nostra",
+        "uuid": "17790c53-a3f4-4e9e-86a6-227689f757cb"
     }
 ]

--- a/src/encoded/tests/data/inserts/experiment.json
+++ b/src/encoded/tests/data/inserts/experiment.json
@@ -10,7 +10,7 @@
         "status": "released",
         "date_submitted": "2015-01-20",
         "date_released": "2016-01-01",
-        "internal_tags":["DREAM", "ENTEx", "ENCORE"],
+        "internal_tags":["DREAM", "ENCORE"],
         "submitted_by": "dignissim.euismod@amet.habitant",
         "uuid": "5a6d5a57-e62d-44b9-a1bd-5d1815247348"
     },
@@ -765,5 +765,73 @@
         "date_released": "2019-05-09",
         "accession": "ENCSR808QCJ",
         "uuid": "1b85ee28-66f1-49ad-940d-ba22acf85e08"
+    },
+    {
+        "_test": "For ENTEx matrix testing",
+        "accession": "ENCSR458AOS",
+        "assay_term_name": "DNase-seq",
+        "award": "UM1HG009390",
+        "biosample_ontology": "tissue_UBERON_0001891",
+        "date_released": "2019-11-08",
+        "date_submitted": "2019-07-31",
+        "internal_status": "pipeline completed",
+        "internal_tags": [
+            "ENTEx"
+        ],
+        "lab": "encode2-project",
+        "status": "released",
+        "submitted_by": "elementum.mus@dictumst.nostra",
+        "uuid": "8b39716c-b810-4a7a-81ea-6e5f41b3c103"
+    },
+    {
+        "_test": "For ENTEx matrix testing",
+        "accession": "ENCSR459AOS",
+        "assay_term_name": "DNase-seq",
+        "award": "UM1HG009390",
+        "biosample_ontology": "tissue_UBERON_0001891",
+        "date_released": "2019-11-08",
+        "date_submitted": "2019-07-31",
+        "internal_status": "pipeline completed",
+        "internal_tags": [
+            "ENTEx"
+        ],
+        "lab": "encode2-project",
+        "status": "released",
+        "submitted_by": "elementum.mus@dictumst.nostra",
+        "uuid": "d7ed67c8-85ea-403a-b295-32d1278411cd"
+    },
+    {
+        "_test": "For ENTEx matrix testing",
+        "accession": "ENCSR460AOS",
+        "assay_term_name": "DNase-seq",
+        "award": "UM1HG009390",
+        "biosample_ontology": "tissue_UBERON_0001891",
+        "date_released": "2019-11-08",
+        "date_submitted": "2019-07-31",
+        "internal_status": "pipeline completed",
+        "internal_tags": [
+            "ENTEx"
+        ],
+        "lab": "encode2-project",
+        "status": "released",
+        "submitted_by": "elementum.mus@dictumst.nostra",
+        "uuid": "db57b7e6-7366-41b6-b50d-b8c944342c34"
+    },
+    {
+        "_test": "For ENTEx matrix testing",
+        "accession": "ENCSR856XLJ",
+        "assay_term_name": "DNase-seq",
+        "award": "UM1HG009390",
+        "biosample_ontology": "tissue_UBERON_0001891",
+        "date_released": "2019-11-08",
+        "date_submitted": "2019-07-31",
+        "internal_status": "pipeline completed",
+        "internal_tags": [
+            "ENTEx"
+        ],
+        "lab": "encode2-project",
+        "status": "released",
+        "submitted_by": "elementum.mus@dictumst.nostra",
+        "uuid": "1425296d-10bc-4d50-b071-2c019a711bfb"
     }
 ]

--- a/src/encoded/tests/data/inserts/human_donor.json
+++ b/src/encoded/tests/data/inserts/human_donor.json
@@ -124,6 +124,7 @@
         "uuid": "ba1e3e4f-7ca1-4546-86c3-42df0134d627"
     },
     {
+        "_test": "For ENTEx matrix testing, female 4",
         "accession": "ENCDO271OUW",
         "age": "51",
         "age_units": "year",
@@ -143,8 +144,84 @@
         ],
         "lab": "encode2-project",
         "life_stage": "adult",
-        "organism": "/organisms/human/",
+        "organism": "human",
         "sex": "female",
-        "status": "released"
+        "status": "released",
+        "uuid": "ed01347d-b5cc-4a63-bf4c-40aebdab5cd1"
+    },
+    {
+        "_test": "For ENTEx matrix testing, female 3",
+        "accession": "ENCDO793LXB",
+        "age": "53",
+        "age_units": "year",
+        "aliases": [
+            "gtex:ENC-MAC",
+            "gtex:ENC-003",
+            "gtex:PT-1LGRB",
+            "bradley-bernstein:Donor GTEX-1LGRB"
+        ],
+        "award": "ENCODE2",
+        "external_ids": [
+            "GEO:SAMN05897794"
+        ],
+        "internal_tags": [
+            "ENTEx"
+        ],
+        "lab": "encode2-project",
+        "life_stage": "adult",
+        "organism": "human",
+        "sex": "female",
+        "status": "released",
+        "uuid": "28e5135a-6529-4f7a-8dad-41e0a216f46e"
+    },
+    {
+        "_test": "For ENTEx matrix testing, male 2",
+        "accession": "ENCDO451RUA",
+        "age": "54",
+        "age_units": "year",
+        "aliases": [
+            "gtex:PT-1K2DA",
+            "gtex:ENC-LQT",
+            "gtex:ENC-002",
+            "bradley-bernstein:Donor GTEX-1K2DA"
+        ],
+        "award": "ENCODE2",
+        "external_ids": [
+            "GEO:SAMN05897789"
+        ],
+        "internal_tags": [
+            "ENTEx"
+        ],
+        "lab": "encode2-project",
+        "life_stage": "adult",
+        "organism": "human",
+        "sex": "male",
+        "status": "released",
+        "uuid": "d370683e-81e7-473f-8475-7716d027849b"
+    },
+    {
+        "_test": "For ENTEx matrix testing, male 1",
+        "accession": "ENCDO845WKR",
+        "age": "37",
+        "age_units": "year",
+        "aliases": [
+            "gtex:ENC-QWZ",
+            "gtex:ENC-001",
+            "gtex:PT-1JKYN",
+            "bradley-bernstein:Donor GTEX-1JKYN"
+        ],
+        "award": "ENCODE2",
+        "external_ids": [
+            "GEO:SAMN05897796"
+        ],
+        "internal_tags": [
+            "ENTEx"
+        ],
+        "lab": "encode2-project",
+        "life_stage": "adult",
+        "organism": "human",
+        "sex": "male",
+        "status": "released",
+        "uuid": "845eda3c-7503-43e8-a65b-0d08e8d4674d"
     }
 ]

--- a/src/encoded/tests/data/inserts/library.json
+++ b/src/encoded/tests/data/inserts/library.json
@@ -873,5 +873,65 @@
               "file": "ENCFF379BCO"
             }
         ]
+    },
+    {
+        "_test": "For ENTEx matrix testing",
+        "accession": "ENCLB826TVQ",
+        "aliases": [
+            "john-stamatoyannopoulos:56768A"
+        ],
+        "award": "UM1HG009390",
+        "biosample": "ENCBS204NZH",
+        "lab": "encode2-project",
+        "nucleic_acid_term_name": "DNA",
+        "status": "released",
+        "strand_specificity": false,
+        "submitted_by": "elementum.mus@dictumst.nostra",
+        "uuid": "dfc344a1-e3dc-4c58-9249-23aa8e6dd2a5"
+    },
+    {
+        "_test": "For ENTEx matrix testing",
+        "accession": "ENCLB827TVQ",
+        "aliases": [
+            "john-stamatoyannopoulos:58768A"
+        ],
+        "award": "UM1HG009390",
+        "biosample": "ENCBS061XGD",
+        "lab": "encode2-project",
+        "nucleic_acid_term_name": "DNA",
+        "status": "released",
+        "strand_specificity": false,
+        "submitted_by": "elementum.mus@dictumst.nostra",
+        "uuid": "e7bd9164-9646-4352-b6e3-3acb74fa3416"
+    },
+    {
+        "_test": "For ENTEx matrix testing",
+        "accession": "ENCLB828TVQ",
+        "aliases": [
+            "john-stamatoyannopoulos:58288A"
+        ],
+        "award": "UM1HG009390",
+        "biosample": "ENCBS009WOO",
+        "lab": "encode2-project",
+        "nucleic_acid_term_name": "DNA",
+        "status": "released",
+        "strand_specificity": false,
+        "submitted_by": "elementum.mus@dictumst.nostra",
+        "uuid": "5faff51d-e5e0-4012-8263-364adf49edfa"
+    },
+    {
+        "_test": "For ENTEx matrix testing",
+        "accession": "ENCLB646BFR",
+        "aliases": [
+            "john-stamatoyannopoulos:57126A"
+        ],
+        "award": "UM1HG009390",
+        "biosample": "ENCBS376EJL",
+        "lab": "encode2-project",
+        "nucleic_acid_term_name": "DNA",
+        "status": "released",
+        "strand_specificity": false,
+        "submitted_by": "elementum.mus@dictumst.nostra",
+        "uuid": "1ab49d81-c1e2-459e-ac43-a96ee33e476c"
     }
 ]

--- a/src/encoded/tests/data/inserts/replicate.json
+++ b/src/encoded/tests/data/inserts/replicate.json
@@ -676,5 +676,57 @@
         "submitted_by": "/users/76091563-a959-4a9c-929c-9acfa1a0a078/",
         "library": "ENCLB209APR",
         "uuid": "0311d1e6-a141-4be4-a165-6abc6d320f05"
+    },
+    {
+        "_test": "For ENTEx matrix testing",
+        "aliases": [
+            "john-stamatoyannopoulos:ENCSR458AOS-1-1"
+        ],
+        "biological_replicate_number": 1,
+        "experiment": "ENCSR458AOS",
+        "library": "ENCLB826TVQ",
+        "status": "released",
+        "submitted_by": "elementum.mus@dictumst.nostra",
+        "technical_replicate_number": 1,
+        "uuid": "caf8ab68-89ba-47c6-aa44-c097da909098"
+    },
+    {
+        "_test": "For ENTEx matrix testing",
+        "aliases": [
+            "john-stamatoyannopoulos:ENCSR459AOS-1-1"
+        ],
+        "biological_replicate_number": 1,
+        "experiment": "ENCSR459AOS",
+        "library": "ENCLB827TVQ",
+        "status": "released",
+        "submitted_by": "elementum.mus@dictumst.nostra",
+        "technical_replicate_number": 1,
+        "uuid": "4db846d5-54e0-4ac9-a1cf-b46d56ac6f63"
+    },
+    {
+        "_test": "For ENTEx matrix testing",
+        "aliases": [
+            "john-stamatoyannopoulos:ENCSR460AOS-1-1"
+        ],
+        "biological_replicate_number": 1,
+        "experiment": "ENCSR460AOS",
+        "library": "ENCLB828TVQ",
+        "status": "released",
+        "submitted_by": "elementum.mus@dictumst.nostra",
+        "technical_replicate_number": 1,
+        "uuid": "f259b9e0-b720-4139-8a1a-058fbdc1f3ae"
+    },
+    {
+        "_test": "For ENTEx matrix testing",
+        "aliases": [
+            "john-stamatoyannopoulos:ENCSR856XLJ-1-1"
+        ],
+        "biological_replicate_number": 1,
+        "experiment": "ENCSR856XLJ",
+        "library": "ENCLB646BFR",
+        "status": "released",
+        "submitted_by": "elementum.mus@dictumst.nostra",
+        "technical_replicate_number": 1,
+        "uuid": "6af49008-9208-43bb-b000-80aeddf4b9a6"
     }
 ]

--- a/src/encoded/tests/features/biosamples.feature
+++ b/src/encoded/tests/features/biosamples.feature
@@ -16,7 +16,7 @@ Feature: Biosamples
         And I wait for the content to load
         When I click the link to "/search/?type=Biosample&organism.scientific_name=Homo+sapiens"
         Then I should see an element with the css selector "div.search-results"
-        And I should see "Showing 25 of 31 results"
+        And I should see "Showing 25 of 35 results"
 
         When I go back
         And I wait for the content to load

--- a/src/encoded/tests/features/matrix_entex.feature
+++ b/src/encoded/tests/features/matrix_entex.feature
@@ -1,0 +1,15 @@
+@matrix @usefixtures(workbook)
+Feature: Matrix
+    Scenario: Matrix ENTEx
+        When I visit "/"
+        And I wait for the content to load
+        Then the title should contain the text "ENCODE"
+
+        When I press "Data"
+        And I click the link with text that contains "ENTEx"
+        And I wait for the content to load
+        Then the title should contain the text "ENTEx Matrix – ENCODE"
+        And I should see at least 2 elements with the css selector "tbody > tr"
+        And I should see at least 2 elements with the css selector "tr > th"
+        And I should see at least 4 elements with the css selector ".donor-cell .donor-quadrant"
+        And I should see at least 4 elements with the css selector ".donor-legend .donor-legend-row"

--- a/src/encoded/tests/features/test_matrix.py
+++ b/src/encoded/tests/features/test_matrix.py
@@ -9,6 +9,7 @@ pytestmark = [
 ]
 
 scenarios(
+    'matrix_entex.feature',
     'matrix_experiment.feature',
     'matrix_reference_epigenome.feature'
 )

--- a/src/encoded/tests/features/views.feature
+++ b/src/encoded/tests/features/views.feature
@@ -20,7 +20,7 @@ Feature: Views
         And I should see exactly one element with the css selector "[data-test='summary']"
 
         When I click the link to "/matrix/?type=Experiment"
-        Then I should see "Showing 48 results"
+        Then I should see "Showing 52 results"
 
         When I click the link to "/report/?type=Experiment"
         Then I should see "Experiment report"

--- a/src/encoded/tests/test_batch_download.py
+++ b/src/encoded/tests/test_batch_download.py
@@ -355,7 +355,7 @@ def test_batch_download_report_download(testapp, workbook):
         b'Post-synchronization time', b'Post-synchronization time units',
         b'Replicates',
     ]
-    assert len(lines) == 50
+    assert len(lines) == 54
 
 
 def test_batch_download_matched_set_report_download(testapp, workbook):

--- a/src/encoded/tests/test_search_views.py
+++ b/src/encoded/tests/test_search_views.py
@@ -547,3 +547,43 @@ def test_search_views_reference_epigenome_matrix_response(workbook, testapp):
     assert len(
         r.json['matrix']['y']['biosample_ontology.classification']['buckets'][0]['biosample_ontology.term_name']['buckets']
     ) > 0
+
+
+def test_search_views_entex_matrix_response(workbook, testapp):
+    r = testapp.get(
+        '/entex-matrix/'
+        '?type=Experiment&status=released&internal_tags=ENTEx'
+    )
+    assert 'aggregations' not in r.json
+    assert 'facets' in r.json
+    assert 'total' in r.json
+    assert r.json['title'] == 'ENTEx Matrix'
+    assert r.json['@type'] == ['EntexMatrix']
+    assert r.json['@id'] == (
+        '/entex-matrix/'
+        '?type=Experiment&status=released&internal_tags=ENTEx'
+    )
+    assert r.json['@context'] == '/terms/'
+    assert r.json['notification'] == 'Success'
+    assert r.json['title'] == 'ENTEx Matrix'
+    assert r.json['total'] >= 4
+    assert 'filters' in r.json
+    assert 'matrix' in r.json
+    assert r.json['matrix']['x']['group_by'] == ['assay_title', ['target.label', 'no_target'], 'replicates.library.biosample.donor.sex', 'replicates.library.biosample.donor.accession']
+    assert r.json['matrix']['x']['label'] == 'Assay'
+    assert r.json['matrix']['y']['group_by'] == [
+        'biosample_ontology.classification',
+        'biosample_ontology.term_name'
+    ]
+    assert r.json['matrix']['y']['label'] == 'Biosample'
+    assert 'buckets' in r.json['matrix']['y']['biosample_ontology.classification']
+    assert 'key' in r.json['matrix']['y']['biosample_ontology.classification']['buckets'][0]
+    assert 'biosample_ontology.term_name' in r.json['matrix']['y']['biosample_ontology.classification']['buckets'][0]
+    assert 'search_base' in r.json
+    assert r.json['search_base'] == '/search/?type=Experiment&status=released&internal_tags=ENTEx'
+    assert len(
+        r.json['matrix']['y']['biosample_ontology.classification']['buckets']
+    ) > 0
+    assert len(
+        r.json['matrix']['y']['biosample_ontology.classification']['buckets'][0]['biosample_ontology.term_name']['buckets']
+    ) > 0

--- a/src/encoded/types/experiment.py
+++ b/src/encoded/types/experiment.py
@@ -207,6 +207,17 @@ class Experiment(Dataset,
         },
     }
 
+    entex = {
+        'y': {
+            'group_by': ['biosample_ontology.classification', 'biosample_ontology.term_name'],
+            'label': 'Biosample',
+        },
+        'x': {
+            'group_by': ['assay_title', ('target.label', 'no_target'), 'replicates.library.biosample.donor.sex', 'replicates.library.biosample.donor.accession'],
+            'label': 'Assay',
+        },
+    }
+
     audit = {
         'audit.ERROR.category': {
             'group_by': 'audit.ERROR.category',


### PR DESCRIPTION
* The SNO-126-allow-default-value-for-missing-aggregation-field branch that this branch relies on is merged into snovault dev, but it’s not yet tagged for release so buildout.cfg still points to this branch, whatever that means for merging this branch to dev.
* The new local test data allows for _one_ cell to display in the ENTEx matrix. This also caused changes in the counts for some BDD and non-BDD tests. See bottom note for a warning about this.
* Changes to package.json, package-lock.json, and .eslintrc.js are for a new ESLint verifier for React hooks.
* Using React hooks in MatrixPresentation to handle the flashing arrow state (no expandable sections with this matrix, so the flashing arrow state is the only state on this page). I commented the code liberally because none of us know React hooks, so I tried to reduce the amount of research you have to do, and the amount I’d have to re-research when I look at this code the next time. We won’t need to comment hooks as much as we get used to them.
* Note that biosamples.feature has a cheat. Locally, I get “Showing 25 of 36 results” for a biosample search for Homo sapiens. With CircleCI, I get “Showing 25 of 35 results.” I don’t know why, and haven’t been able to explain this. For now, I just went with the CircleCI version for the sake of the test. I’m still trying to figure out why this is happening.