### PR TITLE
ENCD-5007 Home page SVG alignment in Chrome

### DIFF
--- a/src/encoded/static/scss/encoded/modules/_home.scss
+++ b/src/encoded/static/scss/encoded/modules/_home.scss
@@ -56,8 +56,16 @@
     }
 
     img {
-        height: auto;
+        position: absolute;
         max-width: 100%;
+        z-index: 1;
+    }
+
+    .uaTrident & {
+        img {
+            position: static;
+            z-index: auto;
+        }
     }
 }
 
@@ -93,15 +101,21 @@
 
 // Positions rectangles for classic pic
 .classic-svg {
-    position: absolute;
     visibility: visible;
     display: block;
+    position: relative;
     padding-bottom: 0px;
     max-width: 100%;
-    top: 0;
-    left: 0;
-    bottom: 0;
-    right: 0;
+    z-index: 2;
+
+    .uaTrident & {
+        position: absolute;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
+        z-index: auto;
+    }
 }
 
 // Adds blue outline to rectangles 


### PR DESCRIPTION
The Chrome v79 bug seems to involve not scaling absolutely positioned SVGs. To fix this I’ve made the svg a regular DOM element, but made the image behind it absolutely positioned. This works on Safari, Firefox, and Edge as well, though it breaks IE11. To fix that, I’m using the "uaTrident" CSS class so I can use the older CSS styles for IE11, where the SVG is absolutely positioned and the image is normal.

PR demo: https://encd-5007-home-svg-pr1-fytanaka.demo.encodedcc.org/

Not indexed as I type this, but it doesn’t need to be.