### PR TITLE
ENCD-5023 fix advanced query search BDD test

### DIFF
--- a/src/encoded/tests/features/advanced_query_search.feature
+++ b/src/encoded/tests/features/advanced_query_search.feature
@@ -16,6 +16,6 @@ Feature: Search
 
 
     Scenario: Test advanced query search date search
-    When I visit "/search/?advancedQuery=@type:Experiment date_created:[2015-01-01 TO 2019-12-31]"
+    When I visit "/search/?advancedQuery=@type:Experiment date_submitted:[2015-01-01 TO 2019-12-31]"
     And I wait for the content to load
     Then I should see at least 25 elements with the css selector "ul.result-table > li"


### PR DESCRIPTION
Changed test to test "date_submitted" query in order to circumvent year roll-over problem.