### PR TITLE
ENCD-5014-new-FCE-property-target-expression-percentile

### DIFF
--- a/src/encoded/schemas/changelogs/functional_characterization_experiment.md
+++ b/src/encoded/schemas/changelogs/functional_characterization_experiment.md
@@ -3,3 +3,4 @@
 ### Minor changes since schema version 1
 * Added *control_type*
 * Removed *month_released* calculated property.
+* Added *target_expression_percentile* property.

--- a/src/encoded/schemas/functional_characterization_experiment.json
+++ b/src/encoded/schemas/functional_characterization_experiment.json
@@ -59,6 +59,14 @@
         "target_expression_range_maximum": {
             "comment": "Only functional characterization assays with target can specify target expression range.",
             "required": ["target", "target_expression_range_minimum"]
+        },
+        "target_expression_percentile": {
+            "comment": "Only functional characterization assays with target can specify target expression percentile.",
+            "required": ["target"],
+            "not": {
+                "required": ["target_expression_range_minimum", "target_expression_range_maximum"]
+            }
+
         }
     },
     "properties": {
@@ -101,6 +109,13 @@
         "target_expression_range_maximum": {
             "title": "Target expression range maximum",
             "description": "Target expression read-out range maximum percentage value",
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 100
+        },
+            "target_expression_percentile": {
+            "title": "Target expression percentile",
+            "description": "Target expression read-out expressed as a percentile",
             "type": "integer",
             "minimum": 0,
             "maximum": 100

--- a/src/encoded/static/components/experiment.js
+++ b/src/encoded/static/components/experiment.js
@@ -510,6 +510,21 @@ const ExperimentComponent = ({ context, auditIndicators, auditDetail }, reactCon
                                 </React.Fragment>
                             : null}
 
+                            {context.target ?
+                                <React.Fragment>
+                                    <div data-test="target">
+                                        <dt>Target</dt>
+                                        <dd><a href={context.target['@id']}>{context.target.label}</a></dd>
+                                    </div>
+                                    {context.target_expression_percentile !== undefined ?
+                                        <div data-test="target-perc">
+                                            <dt>Target expression percentile</dt>
+                                            <dd>{context.target_expression_percentile}th</dd>
+                                        </div>
+                                    : null}
+                                </React.Fragment>
+                            : null}
+
                             {context.control_type ?
                                 <div data-test="control_type">
                                     <dt>Control type</dt>

--- a/src/encoded/static/components/experiment.js
+++ b/src/encoded/static/components/experiment.js
@@ -510,21 +510,6 @@ const ExperimentComponent = ({ context, auditIndicators, auditDetail }, reactCon
                                 </React.Fragment>
                             : null}
 
-                            {context.target ?
-                                <React.Fragment>
-                                    <div data-test="target">
-                                        <dt>Target</dt>
-                                        <dd><a href={context.target['@id']}>{context.target.label}</a></dd>
-                                    </div>
-                                    {context.target_expression_percentile !== undefined ?
-                                        <div data-test="target-perc">
-                                            <dt>Target expression percentile</dt>
-                                            <dd>{context.target_expression_percentile}th</dd>
-                                        </div>
-                                    : null}
-                                </React.Fragment>
-                            : null}
-
                             {context.control_type ?
                                 <div data-test="control_type">
                                     <dt>Control type</dt>

--- a/src/encoded/tests/test_schema_functional_characterization_experiment.py
+++ b/src/encoded/tests/test_schema_functional_characterization_experiment.py
@@ -40,6 +40,18 @@ def functional_characterization_experiment(testapp, lab, award, cell_free):
     return testapp.post_json('/functional_characterization_experiment', item).json['@graph'][0]
 
 
+@pytest.fixture
+def functional_characterization_experiment_4(testapp, lab, award):
+    item = {
+        'lab': lab['@id'],
+        'award': award['@id'],
+        'assay_term_name': 'CRISPR screen',
+        'status': 'in progress',
+        'target_expression_percentile': 70
+    }
+    return item
+
+
 def test_valid_functional_characterization_experiment(testapp, functional_characterization_experiment_item):
     testapp.post_json('/functional_characterization_experiment', functional_characterization_experiment_item, status=201)
 
@@ -92,3 +104,13 @@ def test_functional_characterization_experiment_possible_controls(testapp, funct
         functional_characterization_experiment['@id'],
         {'possible_controls': [experiment['@id']]},
         status=200)
+
+
+def test_functional_characterization_experiment_target_expression_dependency(testapp, functional_characterization_experiment_4, target):
+    # the property target_expression_percentile can't be specified without target
+    testapp.post_json('/functional_characterization_experiment', functional_characterization_experiment_4, status=422)
+    functional_characterization_experiment_4.update({'target': target['uuid']})
+    testapp.post_json('/functional_characterization_experiment', functional_characterization_experiment_4, status=201)
+    # the property also may not coexist with target_expression_range_maximum
+    functional_characterization_experiment_4.update({'target_expression_range_maximum': 90})
+    testapp.post_json('/functional_characterization_experiment', functional_characterization_experiment_4, status=422)


### PR DESCRIPTION
2nd commit is adjustments to code in experiment.js to get the property to render, 3rd commit is reverting those changes. Visualization won't be included in this branch/ticket.