### PR TITLE
ENCD-5037-valis-library-update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4682,7 +4682,7 @@
       "requires": {
         "d3": "^3.3.8",
         "dagre": "^0.8.4",
-        "graphlib": "git+https://github.com/ENCODE-DCC/graphlib.git#v1.0.8",
+        "graphlib": "git+https://github.com/ENCODE-DCC/graphlib.git#df17f0dc51178d5a49f4a0cc638dcebcf9746b2d",
         "lodash": "^4.17.15"
       },
       "dependencies": {
@@ -5161,7 +5161,7 @@
       "version": "github:VALIS-software/Engine#edef83c9b3507fb037443343bd06a97dae5f8ca7",
       "from": "github:VALIS-software/Engine",
       "requires": {
-        "gputext": "github:VALIS-software/GPUText"
+        "gputext": "github:VALIS-software/GPUText#0e82871954fa8fe4af82517cbeb1841dd1100fbf"
       }
     },
     "enhanced-resolve": {
@@ -7289,16 +7289,16 @@
       }
     },
     "genome-visualizer": {
-      "version": "github:VALIS-software/valis-hpgv#d6f29c8a911054709cd14abd6c54b65e9e9cc6bd",
-      "from": "github:VALIS-software/valis-hpgv",
+      "version": "git+https://github.com/ENCODE-DCC/valis-hpgv.git#19aa28d9761a69b7d3b34623f35f693fe1c72850",
+      "from": "git+https://github.com/ENCODE-DCC/valis-hpgv.git#REG-161-add-marked-location",
       "requires": {
         "@material-ui/core": "^3.1.0",
         "@material-ui/icons": "^3.0.1",
         "axios": "^0.18.0",
         "bigwig-reader": "^1.0.9",
-        "engine": "github:VALIS-software/Engine",
+        "engine": "github:VALIS-software/Engine#edef83c9b3507fb037443343bd06a97dae5f8ca7",
         "fast-deep-equal": "^2.0.1",
-        "genomics-formats": "github:VALIS-software/Genomics-Formats",
+        "genomics-formats": "github:VALIS-software/Genomics-Formats#f1e2a3f6afb4bf3b848ba4f4a48e8e595b6f7cbe",
         "mkdirp": "^0.5.1",
         "react": "16.x",
         "react-dom": "16.x",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7289,8 +7289,8 @@
       }
     },
     "genome-visualizer": {
-      "version": "git+https://github.com/ENCODE-DCC/valis-hpgv.git#19aa28d9761a69b7d3b34623f35f693fe1c72850",
-      "from": "git+https://github.com/ENCODE-DCC/valis-hpgv.git#REG-161-add-marked-location",
+      "version": "git+https://github.com/ENCODE-DCC/valis-hpgv.git#60055f432ebc1ceb7a5c0a04957d7e8f3d8ded76",
+      "from": "git+https://github.com/ENCODE-DCC/valis-hpgv.git",
       "requires": {
         "@material-ui/core": "^3.1.0",
         "@material-ui/icons": "^3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4682,10 +4682,16 @@
       "requires": {
         "d3": "^3.3.8",
         "dagre": "^0.8.4",
-        "graphlib": "git+https://github.com/ENCODE-DCC/graphlib.git#df17f0dc51178d5a49f4a0cc638dcebcf9746b2d",
         "lodash": "^4.17.15"
       },
       "dependencies": {
+        "graphlib": {
+          "version": "git+https://github.com/ENCODE-DCC/graphlib.git#df17f0dc51178d5a49f4a0cc638dcebcf9746b2d",
+          "from": "git+https://github.com/ENCODE-DCC/graphlib.git#df17f0dc51178d5a49f4a0cc638dcebcf9746b2d",
+          "requires": {
+            "lodash": "^4.17.15"
+          }
+        },
         "lodash": {
           "version": "4.17.15",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
@@ -5155,13 +5161,6 @@
       "dev": true,
       "requires": {
         "once": "^1.4.0"
-      }
-    },
-    "engine": {
-      "version": "github:VALIS-software/Engine#edef83c9b3507fb037443343bd06a97dae5f8ca7",
-      "from": "github:VALIS-software/Engine",
-      "requires": {
-        "gputext": "github:VALIS-software/GPUText#0e82871954fa8fe4af82517cbeb1841dd1100fbf"
       }
     },
     "enhanced-resolve": {
@@ -7296,18 +7295,25 @@
         "@material-ui/icons": "^3.0.1",
         "axios": "^0.18.0",
         "bigwig-reader": "^1.0.9",
-        "engine": "github:VALIS-software/Engine#edef83c9b3507fb037443343bd06a97dae5f8ca7",
         "fast-deep-equal": "^2.0.1",
-        "genomics-formats": "github:VALIS-software/Genomics-Formats#f1e2a3f6afb4bf3b848ba4f4a48e8e595b6f7cbe",
         "mkdirp": "^0.5.1",
         "react": "16.x",
         "react-dom": "16.x",
         "string-split-by": "^1.0.0"
+      },
+      "dependencies": {
+        "engine": {
+          "version": "github:VALIS-software/Engine#edef83c9b3507fb037443343bd06a97dae5f8ca7",
+          "from": "github:VALIS-software/Engine#edef83c9b3507fb037443343bd06a97dae5f8ca7",
+          "requires": {
+            "gputext": "github:VALIS-software/GPUText#0e82871954fa8fe4af82517cbeb1841dd1100fbf"
+          }
+        },
+        "genomics-formats": {
+          "version": "github:VALIS-software/Genomics-Formats#f1e2a3f6afb4bf3b848ba4f4a48e8e595b6f7cbe",
+          "from": "github:VALIS-software/Genomics-Formats#f1e2a3f6afb4bf3b848ba4f4a48e8e595b6f7cbe"
+        }
       }
-    },
-    "genomics-formats": {
-      "version": "github:VALIS-software/Genomics-Formats#f1e2a3f6afb4bf3b848ba4f4a48e8e595b6f7cbe",
-      "from": "github:VALIS-software/Genomics-Formats"
     },
     "get-caller-file": {
       "version": "1.0.3",
@@ -7537,28 +7543,10 @@
         "node-forge": "^0.9.0"
       }
     },
-    "gputext": {
-      "version": "github:VALIS-software/GPUText#0e82871954fa8fe4af82517cbeb1841dd1100fbf",
-      "from": "github:VALIS-software/GPUText"
-    },
     "graceful-fs": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
       "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q=="
-    },
-    "graphlib": {
-      "version": "git+https://github.com/ENCODE-DCC/graphlib.git#df17f0dc51178d5a49f4a0cc638dcebcf9746b2d",
-      "from": "git+https://github.com/ENCODE-DCC/graphlib.git#v1.0.8",
-      "requires": {
-        "lodash": "^4.17.15"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.15",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
-        }
-      }
     },
     "growly": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "dayjs": "^1.8.16",
     "domready": "^1.0.8",
     "form-serialize": "^0.6.0",
-    "genome-visualizer": "github:VALIS-software/valis-hpgv",
+    "genome-visualizer": "git+https://github.com/ENCODE-DCC/valis-hpgv.git#REG-161-add-marked-location",
     "google-analytics": "file:node_shims/google-analytics",
     "immutable": "^3.7.5",
     "install": "^0.13.0",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "dayjs": "^1.8.16",
     "domready": "^1.0.8",
     "form-serialize": "^0.6.0",
-    "genome-visualizer": "git+https://github.com/ENCODE-DCC/valis-hpgv.git#REG-161-add-marked-location",
+    "genome-visualizer": "git+https://github.com/ENCODE-DCC/valis-hpgv.git",
     "google-analytics": "file:node_shims/google-analytics",
     "immutable": "^3.7.5",
     "install": "^0.13.0",


### PR DESCRIPTION
We've added an update to the Valis library which allows it to display a highlight location. This helps the user not lose track of the initial position of the browser. Currently this feature is not useful for Encode. However, we want Encode to point to the Valis update which enables this configuration.