### PR TITLE
ENCD-5022-ENTEx-updates

### DIFF
--- a/src/encoded/static/components/matrix.js
+++ b/src/encoded/static/components/matrix.js
@@ -14,28 +14,6 @@ export const MATRIX_VISUALIZE_LIMIT = 500;
 
 
 /**
- * Order in which assay_titles should appear along the horizontal axis of the matrix. Anything not
- * included gets sorted after these.
- */
-export const matrixAssaySortOrder = [
-    'polyA plus RNA-seq',
-    'total RNA-seq',
-    'small RNA-seq',
-    'microRNA-seq',
-    'microRNA counts',
-    'RNA microarray',
-    'DNase-seq',
-    'ATAC-seq',
-    'WGBS',
-    'RRBS',
-    'MeDIP-seq',
-    'MRE-seq',
-    'TF ChIP-seq',
-    'Histone ChIP-seq',
-];
-
-
-/**
  * Render the expander button for a row category, and react to clicks by calling the parent to
  * render the expansion change.
  */

--- a/src/encoded/static/components/matrix_entex.js
+++ b/src/encoded/static/components/matrix_entex.js
@@ -286,9 +286,8 @@ const convertContextToDataTable = (context) => {
 
     // Generate the matrix header row labels for the assays with targets. Need a max-width inline
     // style so that wide labels don't make the target columns expand.
-    let targetAssayHeader;
     if (targetAssays.length > 0) {
-        targetAssayHeader = [{ css: 'matrix__col-category-targetassay-corner' }].concat(targetAssays.map(((targetAssayElement) => {
+        const targetAssayHeader = [{ css: 'matrix__col-category-targetassay-corner' }].concat(targetAssays.map(((targetAssayElement) => {
             if (targetAssayElement) {
                 // Add cell with assay title and span for the number of targets it has.
                 const categoryQuery = `${colCategory}=${encoding.encodedURIComponent(targetAssayElement.category)}`;

--- a/src/encoded/static/components/matrix_reference_epigenome.js
+++ b/src/encoded/static/components/matrix_reference_epigenome.js
@@ -10,7 +10,7 @@ import { Panel, PanelBody, TabPanel } from '../libs/ui/panel';
 import { tintColor, isLight } from './datacolors';
 import DataTable from './datatable';
 import * as globals from './globals';
-import { matrixAssaySortOrder, MATRIX_VISUALIZE_LIMIT, RowCategoryExpander, SearchFilter } from './matrix';
+import { MATRIX_VISUALIZE_LIMIT, RowCategoryExpander, SearchFilter } from './matrix';
 import { MatrixInternalTags } from './objectutils';
 import { SearchControls } from './search';
 
@@ -27,6 +27,24 @@ const ROW_CATEGORY = 'biosample_ontology.classification';
 const ROW_SUBCATEGORY = 'biosample_ontology.term_name';
 const COL_CATEGORY = 'assay_title';
 const COL_SUBCATEGORY = 'target.label';
+
+
+const matrixAssaySortOrder = [
+    'polyA plus RNA-seq',
+    'total RNA-seq',
+    'small RNA-seq',
+    'microRNA-seq',
+    'microRNA counts',
+    'RNA microarray',
+    'DNase-seq',
+    'ATAC-seq',
+    'WGBS',
+    'RRBS',
+    'MeDIP-seq',
+    'MRE-seq',
+    'TF ChIP-seq',
+    'Histone ChIP-seq',
+];
 
 
 /**

--- a/src/encoded/static/scss/encoded/modules/_matrix.scss
+++ b/src/encoded/static/scss/encoded/modules/_matrix.scss
@@ -16,6 +16,20 @@ $row-data-header-width: 200px;
 }
 
 
+// Reusable styles for the left-most non-scrolling column.
+%sticky-column {
+    position: -webkit-sticky;
+    position: sticky;
+    left: 0;
+    background-color: #fff;
+    border-radius: 0;
+    z-index: 1;
+
+    &:after {
+        @include matrix-freeze-shadow;
+    }
+}
+
 // Applied to all matrix <table>
 .matrix {
     border-collapse: separate;
@@ -114,16 +128,7 @@ $row-data-header-width: 200px;
         }
 
         > td {
-            position: -webkit-sticky;
-            position: sticky;
-            left: 0;
-            background-color: #fff;
-            border-radius: 0;
-            z-index: 1;
-
-            &:after {
-                @include matrix-freeze-shadow;
-            }
+            @extend %sticky-column;
         }
     }
 
@@ -134,13 +139,9 @@ $row-data-header-width: 200px;
             width: $row-data-header-width;
             text-align: right;
             border-left: 1px solid #f0f0f0;
-            background-color: #fff;
-            z-index: 1;
-            position: -webkit-sticky;
-            position: sticky;
-            left: 0;
             font-size: 1rem;
             border-bottom: 1px solid #fff;
+            @extend %sticky-column;
 
             &:after {
                 @include matrix-freeze-shadow;
@@ -199,14 +200,7 @@ $row-data-header-width: 200px;
             }
 
             &:first-child {
-                position: -webkit-sticky;
-                position: sticky;
-                left: 0;
-                z-index: 1; // For focus outline
-
-                &:after {
-                    @include matrix-freeze-shadow;
-                }
+                @extend %sticky-column;
 
                 button {
                     margin-left: 5px;
@@ -238,17 +232,9 @@ $row-data-header-width: 200px;
     @at-root #{&}__row-category {
         > th {
             white-space: nowrap;
-            position: -webkit-sticky;
-            position: sticky;
-            left: 0;
-            background-color: #fff;
-            z-index: 1;
+            @extend %sticky-column;
             text-align: left;
             font-size: 1.1rem;
-
-            &:after {
-                @include matrix-freeze-shadow();
-            }
 
             > div {
                 display: flex;
@@ -620,13 +606,14 @@ $donor-styles:
     male2 #eed78c #000 bottom-left,
     female4 #354b77 #fff bottom-right;
 
+$divider-color: #000; // Color of dividers between assays with targets
 
 .matrix__content--entex {
     display: block;
 
     .matrix__col-category-header {
         > th {
-            width: $donor-cell-width - 1;
+            width: $donor-cell-width;
             padding: 0;
 
             > a {
@@ -636,10 +623,36 @@ $donor-styles:
 
                 // Column subcategory links
                 &.sub {
-                    padding-top: 20px;
                     font-weight: normal;
                 }
+
+                &:hover {
+                    background-color: transparent;
+                }
             }
+
+            // Base of labels for assays with targets in header
+            &.category-base {
+                border-top: 3px solid $divider-color;
+            }
+
+            &:hover {
+                background-color: #e0e0e0;
+            }
+        }
+    }
+
+    // Header containing titles for assays with targets
+    .matrix__col-category-targetassay-header {
+        > th.matrix__col-category-targetassay {
+            text-overflow: ellipsis;
+            overflow: hidden;
+            vertical-align: bottom;
+        }
+
+        // Left-most non-scrolling column
+        > td.matrix__col-category-targetassay-corner {
+            @extend %sticky-column;
         }
     }
 
@@ -671,6 +684,11 @@ $donor-styles:
 
             &:last-of-type {
                 border-right: 1px solid $border-color;
+            }
+
+            // Cells on the left-most target under a parent assay
+            &.cell-divider {
+                border-left-color: $divider-color;
             }
         }
 
@@ -738,6 +756,8 @@ $donor-styles:
             border-top: 1px solid #e0e0e0;
             border-bottom: 1px solid #e0e0e0;
             border-left: 1px solid #e0e0e0;
+            font-family: Menlo, Courier, sans-serif;
+            letter-spacing: 0.2rem;
 
             @each $donor, $color, $textcolor, $curve in $donor-styles {
                 @at-root #{&}--#{$donor} {
@@ -765,5 +785,22 @@ $donor-styles:
                 }
             }
         }
+    }
+}
+
+
+// Dividers for assay/target header and table cells.
+.matrix__row-data > td,
+.matrix__row-data > td:last-of-type,
+.matrix__col-category-header > th {
+    // Dividers on left edge of targets with assays in header.
+    &.divider--start {
+        border-left: 1px solid $divider-color;
+    }
+
+    // Dividers on right edge of targets with assays in header. Only needed for targets
+    // at right edge of matrix, or before an assay column without targets.
+    &.divider--end {
+        border-right: 1px solid $divider-color;
     }
 }


### PR DESCRIPTION
* The issue with the Mars/Venus symbols was that Helvetica didn’t have those symbols defined so it fell back to a default font (not sure which) that has them shaped wrong. I now use Menlo which should appear on macOS, and Courier for Windows.
* matrixAssaySortOrder determines the sort order of the assays across the x-axis and was shared between the ENTEx and Reference Epignome matrices, but Idan wanted them to have their own sorting orders, so this array moved out of matrix.js and each matrix now has its own copy.
* The `legendText` properties of `entexDonors` might look odd, but I was surprised it still separates the digit from the unicode digits. I use letter-spacing to space them as the space I used to have between them had gotten very large with the new font.
* We have a new concept of “dividers” — the dark lines defining the edges of a group of targets combined into an assay.