### PR TITLE
ENCD-5069 fix error in gene search

### DIFF
--- a/src/encoded/static/components/genome_browser.js
+++ b/src/encoded/static/components/genome_browser.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'underscore';
+import url from 'url';
 import { FetchedData, Param } from './fetched';
 import { BrowserFeat } from './browserfeat';
 import AutocompleteBox from './region_search';
@@ -445,8 +446,8 @@ class GenomeBrowser extends React.Component {
 
     handleOnFocus() {
         this.setState({ showAutoSuggest: false });
-        const pageType = this.context.location_href.indexOf('/experiments') > -1 ? 'experiments' : 'annotations';
-        const coordinateHref = `${this.context.location_href.split(`/${pageType}/`)[0]}/suggest/?genome=${this.state.genome}&q=${this.state.searchTerm}`;
+        const urlComponents = url.parse(this.context.location_href);
+        const coordinateHref = `${urlComponents.protocol}//${urlComponents.host}/suggest/?genome=${this.state.genome}&q=${this.state.searchTerm}`;
         getCoordinateData(coordinateHref, this.context.fetch).then((response) => {
             // Find the response line that matches the search
             const responseIndex = response['@graph'].findIndex(responseLine => responseLine.text === this.state.searchTerm);

--- a/src/encoded/static/components/genome_browser.js
+++ b/src/encoded/static/components/genome_browser.js
@@ -445,7 +445,13 @@ class GenomeBrowser extends React.Component {
 
     handleOnFocus() {
         this.setState({ showAutoSuggest: false });
-        getCoordinateData(`${this.context.location_href.split('/experiments/')[0]}/suggest/?genome=${this.state.genome}&q=${this.state.searchTerm}`, this.context.fetch).then((response) => {
+        let coordinateHref = '';
+        if (this.context.location_href.indexOf('/experiments') > -1) {
+            coordinateHref = `${this.context.location_href.split('/experiments/')[0]}/suggest/?genome=${this.state.genome}&q=${this.state.searchTerm}`;
+        } else if (this.context.location_href.indexOf('/annotations') > -1) {
+            coordinateHref = `${this.context.location_href.split('/annotations/')[0]}/suggest/?genome=${this.state.genome}&q=${this.state.searchTerm}`;
+        }
+        getCoordinateData(coordinateHref, this.context.fetch).then((response) => {
             // Find the response line that matches the search
             const responseIndex = response['@graph'].findIndex(responseLine => responseLine.text === this.state.searchTerm);
 

--- a/src/encoded/static/components/genome_browser.js
+++ b/src/encoded/static/components/genome_browser.js
@@ -445,12 +445,8 @@ class GenomeBrowser extends React.Component {
 
     handleOnFocus() {
         this.setState({ showAutoSuggest: false });
-        let coordinateHref = '';
-        if (this.context.location_href.indexOf('/experiments') > -1) {
-            coordinateHref = `${this.context.location_href.split('/experiments/')[0]}/suggest/?genome=${this.state.genome}&q=${this.state.searchTerm}`;
-        } else if (this.context.location_href.indexOf('/annotations') > -1) {
-            coordinateHref = `${this.context.location_href.split('/annotations/')[0]}/suggest/?genome=${this.state.genome}&q=${this.state.searchTerm}`;
-        }
+        const pageType = this.context.location_href.indexOf('/experiments') > -1 ? 'experiments' : 'annotations';
+        const coordinateHref = `${this.context.location_href.split(`/${pageType}/`)[0]}/suggest/?genome=${this.state.genome}&q=${this.state.searchTerm}`;
         getCoordinateData(coordinateHref, this.context.fetch).then((response) => {
             // Find the response line that matches the search
             const responseIndex = response['@graph'].findIndex(responseLine => responseLine.text === this.state.searchTerm);

--- a/src/encoded/static/components/genome_browser.js
+++ b/src/encoded/static/components/genome_browser.js
@@ -446,8 +446,7 @@ class GenomeBrowser extends React.Component {
 
     handleOnFocus() {
         this.setState({ showAutoSuggest: false });
-        const urlComponents = url.parse(this.context.location_href);
-        const coordinateHref = `${urlComponents.protocol}//${urlComponents.host}/suggest/?genome=${this.state.genome}&q=${this.state.searchTerm}`;
+        const coordinateHref = `/suggest/?genome=${this.state.genome}&q=${this.state.searchTerm}`;
         getCoordinateData(coordinateHref, this.context.fetch).then((response) => {
             // Find the response line that matches the search
             const responseIndex = response['@graph'].findIndex(responseLine => responseLine.text === this.state.searchTerm);


### PR DESCRIPTION
Gene searches were failing for annotations because urls were configured incorrectly (urls were only configured for experiments). This update configures urls properly for either case.