### PR TITLE
ENCD-5082 File table pagination

### DIFF
--- a/src/encoded/static/components/sorttable.js
+++ b/src/encoded/static/components/sorttable.js
@@ -66,7 +66,7 @@ import { Panel, PanelHeading } from '../libs/ui/panel';
 // Required sortable table wrapper component. Takes no parameters but puts the table in a Bootstrap panel
 // and makes it responsive. You can place multiple <SortTable />s as children of this component.
 export const SortTablePanel = (props) => {
-    const { title, header, css, noDefaultClasses } = props;
+    const { title, header, subheader, css, noDefaultClasses } = props;
 
     return (
         <Panel addClasses={`table-sort${noDefaultClasses ? '' : ' table-panel'}${css ? ` ${css}` : ''}`} noDefaultClasses={noDefaultClasses}>
@@ -77,6 +77,8 @@ export const SortTablePanel = (props) => {
             : (header ?
                 <PanelHeading key="heading">{props.header}</PanelHeading>
             : null)}
+
+            {subheader ? <>{subheader}</> : null}
 
             <div className="table__scrollarea" key="table">
                 {props.children}
@@ -89,13 +91,15 @@ SortTablePanel.propTypes = {
     /** Title to display in tabel panel header. `title` overrides `header` */
     title: PropTypes.oneOfType([
         PropTypes.string, // When title is a simple string
-        PropTypes.object, // When title is JSX
+        PropTypes.element, // When title is JSX
     ]),
     /** CSS class string to add to <Panel> classes */
     css: PropTypes.string,
     /** React component to render inside header */
-    header: PropTypes.object,
-    /** T to skip default <Panel> classes */
+    header: PropTypes.element,
+    /** React component to render above the table below the header */
+    subheader: PropTypes.element,
+    /** React component to render below the table inside the panel */
     noDefaultClasses: PropTypes.bool,
     /** Table components within a SortTablePanel */
     children: PropTypes.node,
@@ -105,6 +109,7 @@ SortTablePanel.defaultProps = {
     title: '',
     css: '',
     header: null,
+    subheader: null,
     noDefaultClasses: false,
     children: null,
 };

--- a/src/encoded/static/scss/encoded/modules/_panels.scss
+++ b/src/encoded/static/scss/encoded/modules/_panels.scss
@@ -755,3 +755,10 @@ $nav-tab-border-radius: 4px;
     border-radius: 5px;
     font-size: 0.8rem;
 }
+
+.file-table-paged {
+    @at-root #{&}__count {
+        @extend .file-gallery-counts;
+        border-top: 1px solid #a0a0a0;
+    }
+}


### PR DESCRIPTION
* The main addition in this branch is a new component, `FileTablePaged`, that shows a non-sortable table of files which. If more than 50 files exist in the table, a pager appears which lets the user page between the pages of files. The table displays either an array of file objects or an array of file `@id`s — `FileTablePaged` does a fetch of the file objects displayed on the current page in the latter case. The most local 10 pages get cached in memory, kicking out farther pages from the current if the cache overflows.
* The change to `DerivedFiles` in file.js is because it contained all the functionality I needed for this ticket, though not generically enough. `DerivedFiles` now calls the new `FileTablePaged`.
