### PR TITLE
ENCD-5168-allow-apache-status-monitoring

### DIFF
--- a/cloud-config/config-build-files/cc-parts/CC_U18_PACKAGES_DEMO.yml
+++ b/cloud-config/config-build-files/cc-parts/CC_U18_PACKAGES_DEMO.yml
@@ -8,6 +8,7 @@ packages:
 - apache2-utils
 - ssl-cert
 - libapache2-mod-wsgi-py3
+- w3m
 # cloudwatchmon
 # encoded app install
 ## ckeditor

--- a/cloud-config/config-build-files/cc-parts/CC_U18_PACKAGES_FRONTEND.yml
+++ b/cloud-config/config-build-files/cc-parts/CC_U18_PACKAGES_FRONTEND.yml
@@ -8,6 +8,7 @@ packages:
 - apache2-utils
 - ssl-cert
 - libapache2-mod-wsgi-py3
+- w3m
 # cloudwatchmon
 # encoded app install
 ## ckeditor

--- a/src/encoded/commands/deploy.py
+++ b/src/encoded/commands/deploy.py
@@ -900,8 +900,8 @@ def _parse_args():
 
         # Private AMIs: Add comments to each build
 
-        # encdami-demo build on 2020-02-27 17:12:38.684857: encdami-demo-2020-02-27_171238
-        'demo': 'ami-03a18bee9b42de1ff',
+        # encdami-demo build on 2020-03-20 12:38:54.016879: encdami-demo-2020-03-20_123854
+        'demo': 'ami-08daa6a7c89fce16a',
         # encdami-es-wait-head build on 2020-02-27 17:12:49.808527: encdami-es-wait-head-2020-02-27_171249
         'es-wait-head': 'ami-0dcd11e4701f5f45c',
         # encdami-es-wait-node build on 2020-02-27 17:13:29.261061: encdami-es-wait-node-2020-02-27_171329


### PR DESCRIPTION
Allows running  apachtctl status

Such as, $ watch -n 5 apachectl status