### PR TITLE
REG-5166 change organoid color

### DIFF
--- a/src/encoded/static/components/__tests__/datacolor-test.js
+++ b/src/encoded/static/components/__tests__/datacolor-test.js
@@ -12,13 +12,14 @@ describe('DataColor Module', () => {
             'in vitro differentiated cells',
             'induced pluripotent stem cell line',
             'secondary cell',
+            'organoid',
         ];
         const dataColorsInstance = new DataColors(testKeys);
 
         it('Returns correct colors for small array', () => {
             const testColors = dataColorsInstance.colorList(['stem cell', 'primary cell']);
             expect(testColors[0]).toEqual('#9b009b');
-            expect(testColors[1]).toEqual('#ff9a00');
+            expect(testColors[1]).toEqual('#FF9000');
         });
 
         it('Returns medium gray for a non-existent key', () => {
@@ -28,12 +29,12 @@ describe('DataColor Module', () => {
 
         it('Wraps around the used color if more keys than colors', () => {
             const testColors = dataColorsInstance.colorList(['secondary cell']);
-            expect(testColors[0]).toEqual('#2f62cf');
+            expect(testColors[0]).toEqual('#124E78');
         });
 
         it('Wraps around the used color if more keys than colors', () => {
             const testColors = dataColorsInstance.colorList(['primary cell'], { tint: 0.1 });
-            expect(testColors[0]).toEqual('#ffa419');
+            expect(testColors[0]).toEqual('#ff9b19');
         });
 
         it('Merry-go-round if unseen key and merry-go-round in enabled', () => {

--- a/src/encoded/static/components/datacolors.js
+++ b/src/encoded/static/components/datacolors.js
@@ -16,11 +16,13 @@ import _ from 'underscore';
 const rootColorList = [
     '#2f62cf',
     '#de3700',
-    '#ff9a00',
+    '#FF9000',
     '#009802',
     '#9b009b',
     '#0098c8',
     '#df4076',
+    '#124E78',
+    '#FFC300',
 ];
 
 


### PR DESCRIPTION
Added another two colors so that "Organoid" and "Cell line" colors would not be the same on the matrix page.