### PR TITLE
ENCD-5197-return-paths-from-libraries-calculated-property

### DIFF
--- a/src/encoded/types/experiment.py
+++ b/src/encoded/types/experiment.py
@@ -456,7 +456,7 @@ class Replicate(Item):
             "linkTo": "Library"
         }
     })
-    def libraries(self, status, biological_replicate_number,
+    def libraries(self, request, status, biological_replicate_number,
                   technical_replicate_number):
         if status == 'deleted':
             return []
@@ -483,4 +483,4 @@ class Replicate(Item):
                 libraries.add(rep_props['library'])
         # This is the "first" techinical replicate within the isogenic
         # replciate. Therefore, libraries should be calculated.
-        return list(libraries)
+        return [request.resource_path(root.get_by_uuid(lib)) for lib in libraries]


### PR DESCRIPTION
The uuid is escaping into the object frame of this replicate when you request it with frame=object.