### PR TITLE
ENCD-5111-cleanup-deploy-output

### DIFF
--- a/src/encoded/commands/deploy.py
+++ b/src/encoded/commands/deploy.py
@@ -709,7 +709,7 @@ def main():
                         )
                     )
                 print('Run the following command to view this es node deployment log.')
-                print("ssh ubuntu@{}{}".format(instance_info['public_dns'], tail_cmd))
+                print("ssh ubuntu@{}{}".format(node_info['public_dns'], tail_cmd))
             else:
                 print("ES node{} ssh:\n ssh ubuntu@{}".format(index, node_info['public_dns']))
     elif 'frontend' in instances_info:


### PR DESCRIPTION
5111 is just a typo fix.  The DNS being printed in the console was the head node and not the data node.  Was using the wrong variable.  