### PR TITLE
ENCD-5171-download-fastq-files

### DIFF
--- a/src/encoded/static/components/cart/batch_download.js
+++ b/src/encoded/static/components/cart/batch_download.js
@@ -142,9 +142,9 @@ const CartBatchDownloadComponent = (
         <React.Fragment>
             <DropdownButton.Selected
                 labels={{
-                    processed: 'Processed data files',
-                    raw: 'Raw data files',
-                    all: 'All files',
+                    processed: 'Download processed data files',
+                    raw: 'Download raw data files',
+                    all: 'Download all files',
                 }}
                 execute={handleExecute}
                 id="cart-download"

--- a/src/encoded/static/components/cart/batch_download.js
+++ b/src/encoded/static/components/cart/batch_download.js
@@ -104,7 +104,6 @@ const CartBatchDownloadComponent = (
         datasetFacets,
         savedCartObj,
         sharedCart,
-        fileCount,
         setInProgress,
         cartInProgress,
         visualizable,
@@ -172,7 +171,7 @@ const CartBatchDownloadComponent = (
             </DropdownButton.Selected>
             {isModalOpen ?
                 <BatchDownloadModal
-                    disabled={fileCount === 0 || cartInProgress}
+                    disabled={cartInProgress}
                     downloadClickHandler={handleDownloadClick}
                     closeModalHandler={closeModal}
                     additionalContent={elements.length >= ELEMENT_WARNING_LENGTH_MIN ?
@@ -201,8 +200,6 @@ CartBatchDownloadComponent.propTypes = {
     savedCartObj: PropTypes.object,
     /** Shared cart object */
     sharedCart: PropTypes.object,
-    /** Number of files batch download will cause to be downloaded */
-    fileCount: PropTypes.number,
     /** Redux cart action to set the in-progress state of the cart */
     setInProgress: PropTypes.func.isRequired,
     /** True if cart operation in progress */
@@ -219,7 +216,6 @@ CartBatchDownloadComponent.defaultProps = {
     datasetFacets: [],
     savedCartObj: null,
     sharedCart: null,
-    fileCount: 0,
     cartInProgress: false,
     visualizable: false,
 };
@@ -229,7 +225,6 @@ const mapStateToProps = (state, ownProps) => ({
     elements: ownProps.elements,
     selectedTerms: ownProps.selectedTerms,
     savedCartObj: ownProps.savedCartObj,
-    fileCount: ownProps.fileCount,
     fetch: ownProps.fetch,
 });
 

--- a/src/encoded/static/components/cart/cart.js
+++ b/src/encoded/static/components/cart/cart.js
@@ -836,7 +836,6 @@ const CartTools = ({ elements, selectedTerms, savedCartObj, viewableDatasets, fi
                 cartType={cartType}
                 savedCartObj={savedCartObj}
                 sharedCart={sharedCart}
-                fileCount={fileCount}
                 visualizable={visualizable}
             />
         : null}
@@ -858,8 +857,6 @@ CartTools.propTypes = {
     cartType: PropTypes.string.isRequired,
     /** Elements in the shared cart, if that's being displayed */
     sharedCart: PropTypes.object,
-    /** Number of files batch download will cause to be downloaded */
-    fileCount: PropTypes.number,
     /** True if only visualizable files should be downloaded */
     visualizable: PropTypes.bool,
 };
@@ -1479,7 +1476,6 @@ const CartComponent = ({ context, elements, savedCartObj, loggedIn, fetch, sessi
                             viewableDatasets={viewableDatasets}
                             cartType={cartType}
                             sharedCart={context}
-                            fileCount={selectedFiles.length}
                             visualizable={visualizableOnly}
                         />
                         {selectedTerms.assembly[0] ? <div className="cart-assembly-indicator">{selectedTerms.assembly[0]}</div> : null}

--- a/src/encoded/static/components/cart/cart.js
+++ b/src/encoded/static/components/cart/cart.js
@@ -984,9 +984,10 @@ const addFileTermToFacet = (facets, field, file) => {
 const assembleFacets = (selectedTerms, files) => {
     const assembledFacets = [];
     const facetSelectedFiles = [];
-    if (files.length > 0) {
+    const processedFiles = files.filter(file => file.assembly);
+    if (processedFiles.length > 0) {
         const selectedFacetKeys = Object.keys(selectedTerms).filter(term => selectedTerms[term].length > 0);
-        files.forEach((file) => {
+        processedFiles.forEach((file) => {
             // Determine whether the file passes the currently selected facet terms. Properties
             // within the file have to match any of the terms within a facet, and across all
             // facets that include selected terms. This is the "first test" I refer to later.

--- a/src/encoded/static/components/cart/cart.js
+++ b/src/encoded/static/components/cart/cart.js
@@ -826,7 +826,7 @@ FileFacets.defaultProps = {
  * Display cart tool buttons. If `savedCartObj` is supplied, supply it for the metadata.tsv line
  * in the resulting files.txt.
  */
-const CartTools = ({ elements, selectedTerms, savedCartObj, viewableDatasets, fileCount, cartType, sharedCart, visualizable }) => (
+const CartTools = ({ elements, selectedTerms, savedCartObj, viewableDatasets, fileCounts, cartType, sharedCart, visualizable }) => (
     <div className="cart__tools">
         {elements.length > 0 ?
             <CartBatchDownload
@@ -836,6 +836,7 @@ const CartTools = ({ elements, selectedTerms, savedCartObj, viewableDatasets, fi
                 cartType={cartType}
                 savedCartObj={savedCartObj}
                 sharedCart={sharedCart}
+                fileCounts={fileCounts}
                 visualizable={visualizable}
             />
         : null}
@@ -857,6 +858,8 @@ CartTools.propTypes = {
     cartType: PropTypes.string.isRequired,
     /** Elements in the shared cart, if that's being displayed */
     sharedCart: PropTypes.object,
+    /** Number of files batch download will download for each download type */
+    fileCounts: PropTypes.object,
     /** True if only visualizable files should be downloaded */
     visualizable: PropTypes.bool,
 };
@@ -867,7 +870,7 @@ CartTools.defaultProps = {
     savedCartObj: null,
     viewableDatasets: null,
     sharedCart: null,
-    fileCount: 0,
+    fileCounts: {},
     visualizable: false,
 };
 
@@ -1476,6 +1479,7 @@ const CartComponent = ({ context, elements, savedCartObj, loggedIn, fetch, sessi
                             viewableDatasets={viewableDatasets}
                             cartType={cartType}
                             sharedCart={context}
+                            fileCounts={{ processed: selectedFiles.length, raw: rawdataFiles.length, all: allFiles.length }}
                             visualizable={visualizableOnly}
                         />
                         {selectedTerms.assembly[0] ? <div className="cart-assembly-indicator">{selectedTerms.assembly[0]}</div> : null}

--- a/src/encoded/static/components/dataset.js
+++ b/src/encoded/static/components/dataset.js
@@ -1120,17 +1120,15 @@ export const FilePanelHeader = (props) => {
         <div>
             {context.visualize && context.status === 'released' ?
                 <span className="pull-right">
-                    <DropdownButton title="Visualize Data" label="filepaneheader">
-                        <DropdownMenu>
-                            {Object.keys(context.visualize).sort().map(assembly =>
-                                Object.keys(context.visualize[assembly]).sort().map(browser =>
-                                    <a key={[assembly, '_', browser].join()} data-bypass="true" target="_blank" rel="noopener noreferrer" href={context.visualize[assembly][browser]}>
-                                        {assembly} {browser}
-                                    </a>
-                                )
-                            )}
-                        </DropdownMenu>
-                    </DropdownButton>
+                    <DropdownButton.Immediate label="Visualize Data">
+                        {Object.keys(context.visualize).sort().map(assembly =>
+                            Object.keys(context.visualize[assembly]).sort().map(browser =>
+                                <a key={[assembly, '_', browser].join()} data-bypass="true" target="_blank" rel="noopener noreferrer" href={context.visualize[assembly][browser]}>
+                                    {assembly} {browser}
+                                </a>
+                            )
+                        )}
+                    </DropdownButton.Immediate>
                 </span>
             : null}
             <h4>File summary</h4>

--- a/src/encoded/static/components/form.js
+++ b/src/encoded/static/components/form.js
@@ -294,19 +294,17 @@ class RepeatingFieldset extends UpdateChildMixin(React.Component) {
         if (!this.context.readonly) {
             if (subtypes.length > 1) {
                 button = (
-                    <DropdownButton title="Add" buttonClasses="rf-RepeatingFieldset__add">
-                        <DropdownMenu>
-                            {subtypes.map(subtype =>
-                                <a
-                                    href="#"
-                                    key={subtype}
-                                    data-subtype={subtype}
-                                    onClick={this.handleAdd}
-                                >
-                                    {schemas[subtype].title}
-                                </a>)}
-                        </DropdownMenu>
-                    </DropdownButton>
+                    <DropdownButton.Immediate label="Add" css="rf-RepeatingFieldset__add">
+                        {subtypes.map(subtype =>
+                            <a
+                                href="#"
+                                key={subtype}
+                                data-subtype={subtype}
+                                onClick={this.handleAdd}
+                            >
+                                {schemas[subtype].title}
+                            </a>)}
+                    </DropdownButton.Immediate>
                 );
             } else {
                 button = (

--- a/src/encoded/static/components/view_controls.js
+++ b/src/encoded/static/components/view_controls.js
@@ -296,11 +296,12 @@ const BATCH_DOWNLOAD_PROHIBITED_PATHS = [
 
 
 /**
- * Display the modal for batch download, and pass back clicks in the Download button
+ * Displays the modal to initiate downloading files. This modal gets displayed unconditionally in
+ * this component, so parent components must keep state on whether this modal is visible or not.
  */
-export const BatchDownloadModal = ({ handleDownloadClick, title, additionalContent, disabled }) => (
-    <Modal actuator={<button className="btn btn-info btn-sm" disabled={disabled} data-test="batch-download">{title}</button>} focusId="batch-download-submit">
-        <ModalHeader title="Using batch download" closeModal />
+export const BatchDownloadModal = ({ additionalContent, disabled, downloadClickHandler, closeModalHandler }) => (
+    <Modal focusId="batch-download-submit" closeModal={closeModalHandler} >
+        <ModalHeader title="Using batch download" closeModal={closeModalHandler} />
         <ModalBody>
             <p>
                 Click the &ldquo;Download&rdquo; button below to download a &ldquo;files.txt&rdquo; file that contains a list of URLs to a file containing all the experimental metadata and links to download the file.
@@ -317,14 +318,49 @@ export const BatchDownloadModal = ({ handleDownloadClick, title, additionalConte
             <div>{additionalContent}</div>
         </ModalBody>
         <ModalFooter
-            closeModal={<button className="btn btn-default">Close</button>}
-            submitBtn={<button id="batch-download-submit" className="btn btn-info" disabled={disabled} onClick={handleDownloadClick}>Download</button>}
-            dontClose
+            closeModal={<button className="btn btn-default" onClick={closeModalHandler} >Close</button>}
+            submitBtn={<button id="batch-download-submit" className="btn btn-info" disabled={disabled} onClick={downloadClickHandler}>Download</button>}
         />
     </Modal>
 );
 
 BatchDownloadModal.propTypes = {
+    /** Additional content in modal as component */
+    additionalContent: PropTypes.element,
+    /** True to disable Download button */
+    disabled: PropTypes.bool,
+    /** Called when the user clicks the Download button in the modal */
+    downloadClickHandler: PropTypes.func.isRequired,
+    /** Called when the user does something to close the modal */
+    closeModalHandler: PropTypes.func.isRequired,
+};
+
+BatchDownloadModal.defaultProps = {
+    additionalContent: null,
+    disabled: false,
+};
+
+
+/**
+ * Display the modal for batch download, and pass back clicks in the Download button
+ */
+export const BatchDownloadButton = ({ handleDownloadClick, title, additionalContent, disabled }) => {
+    const [isModalOpen, setIsModalOpen] = React.useState(false);
+
+    const openModal = () => { setIsModalOpen(true); };
+    const closeModal = () => { setIsModalOpen(false); };
+
+    return (
+        <React.Fragment>
+            <button className="btn btn-info btn-sm" onClick={openModal} disabled={disabled} data-test="batch-download">{title}</button>
+            {isModalOpen ?
+                <BatchDownloadModal additionalContent={additionalContent} disabled={disabled} downloadClickHandler={handleDownloadClick} closeModalHandler={closeModal} />
+            : null}
+        </React.Fragment>
+    );
+};
+
+BatchDownloadButton.propTypes = {
     /** Function to call when Download button gets clicked */
     handleDownloadClick: PropTypes.func.isRequired,
     /** Title to override usual actuator "Download" button title */
@@ -335,7 +371,7 @@ BatchDownloadModal.propTypes = {
     additionalContent: PropTypes.object,
 };
 
-BatchDownloadModal.defaultProps = {
+BatchDownloadButton.defaultProps = {
     title: 'Download',
     disabled: false,
     additionalContent: null,
@@ -377,7 +413,7 @@ export class BatchDownloadControls extends React.Component {
             return null;
         }
 
-        return <BatchDownloadModal handleDownloadClick={this.handleDownloadClick} />;
+        return <BatchDownloadButton handleDownloadClick={this.handleDownloadClick} />;
     }
 }
 

--- a/src/encoded/static/libs/ui/button.js
+++ b/src/encoded/static/libs/ui/button.js
@@ -1,110 +1,342 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { DropdownMenu } from './dropdown-menu';
+import { svgIcon } from '../svg-icons';
 
 
-// Render a dropdown menu. All components within the dropdown get wrapped in <li> tags, so the 'a' elements in:
-//
-// <DropdownMenu>
-//   <a href="#">First</a>
-//   <a href="#">Second</a>
-// </DropdownMenu>
-//
-// ...get rendered as
-// <li><a href="#">First</a></li>
-// <li><a href="#">Second</a></li>
-//
-// Click handling method taken from:
-// https://github.com/facebook/react/issues/579#issuecomment-60841923
+/**
+ * This module implements two types of buttons that contain dropdown menus:
+ *
+ * 1. Immediate: Clicking the button opens a dropdown with multiple items. Clicking one of the
+ *    items causes an immediate action to occur.
+ *
+ * <DropdownButton.Immedate>
+ *     label={text, number, component that forms the button's label}
+ *     id={HTML id of this control}
+ *     css={optional CSS classes for button}
+ *     inline={optional boolean; true to give the button an inline CSS style}
+ * >
+ *     <first dropdown item>
+ *     <second dropdown item>
+ *     <...>
+ * </DropdownButton.Immedate>
+ *
+ * The child components each make a clickable dropdown item which you can manage any way you'd
+ * like. A very typical way involves using buttons with ids and each having the same click handler:
+ *
+ * <DropdownButton.Immediate label={<i>Click here</i>} id="example-id">
+ *     <button id="first" onClick={handleClick}>First</button>
+ *     <button id="second" onClick={handleClick}>Second</button>
+ * </DropdownButton.Immedate>
+ *
+ * The `handleClick` callback would then extract the id of the clicked button to determine what
+ * action to take, or each button could get its own click handler.
+ *
+ * 2. Selected: The button has two sections -- a label and a trigger. Clicking the trigger makes a
+ *    dropdown appear with selections you define. Clicking those selections doesn't cause any
+ *    action to occur besides changing the label of the button to the selection. Clicking the label
+ *    then performs the selected action.
+ *
+ * <DropdownButton.Selected
+ *     labels={object with id of each dropdown item and corresponding label text, number, component}
+ *     execute={callback with the id of the current selected dropdown item id}
+ *     id={HTML id to assign to trigger button}
+ *     triggerVoice={text for screen reader to say while trigger button focused}
+ *     css={optional CSS classes for button}
+ *     inline={optional boolean; true to give the button an inline CSS style}
+ * >
+ *     <first dropdown item with first id>
+ *     <second dropdown item with second id>
+ *     <...>
+ * </DropdownButton.Selected>
+ *
+ * The `labels` property connects the button's label with a dropdown item through an id, e.g.:
+ *
+ * labels={{ first: 'First item', second: <b>Second item</b> }}
+ *
+ * Clicking the dropdown item component causes the label of the button to change to the label
+ * object's property with the id matching the clicked item:
+ *
+ * <DropdownButton.Selected
+ *     labels={{ first: 'First item', second: <b>Second item</b> }}
+ *     execute={handleExecute}
+ *     id="example-id"
+ *     triggerVoice="Dropdown options"
+ * >
+ *     <button id="first">The first item in the dropdown</button>
+ *     <button id="second">The second item in the dropdown</button>
+ * </DropdownButton.Selected>
+ *
+ * Clicking the button with id "second" changes the label of the button to the `labels` object
+ * property with the key "second," which changes the label to "Second item" in bold. Notice the
+ * button's contents don't need to match the corresponding label. Do not attach click handlers to
+ * each dropdown item component because a click handler gets automatically assigned to each.
+ *
+ * The function you pass in the `execute` property gets called when the user clicks the label
+ * portion of the button, with the single parameter containing the id of the currently selected
+ * dropdown item (i.e. the id of the current button label).
+ */
 
-export default class DropdownButton extends React.Component {
-    constructor() {
-        super();
 
-        // Set initial React state.
-        this.state = {
-            open: false, // True if dropdown is open
-        };
+/**
+ * Handle the triggering mechanism for dropdown buttons, including reacting to clicks on the
+ * button trigger and reacting to mouse/keyboard events.
+ * @param
+ * children {object} Components/elements inside <DropdownButton> tags.
+ *
+ * @return
+ * state.dropdownOpen {bool} True if the dropdown is currently open
+ * actions.handleTrigger {func} Call when the trigger button is clicked.
+ * actions.handleKey {func} Call when the user presses a key relevant to the trigger button.
+ * actions.handleMouseEnter {func} Call when the mouse enters the trigger or dropdown.
+ * actions.handleMouseLeave {func} Call when the mouse leaves the trigger or dropdown.
+ * actions.handleBlur {func} Call when the focus leaves the trigger or dropdown.
+ * action.handleFocus {func} Call when the trigger or dropdown gets focus.
+ * actions.closeDropdown {func} Call to close the dropdown.
+ */
+const useDropdownButton = () => {
+    const [dropdownOpen, setDropdownOpen] = React.useState(false);
+    let timer = null;
 
-        // Bind this to non-React components.
-        this.documentClickHandler = this.documentClickHandler.bind(this);
-        this.triggerClickHandler = this.triggerClickHandler.bind(this);
-    }
-
-    componentDidMount() {
-        // Add a click handler to the DOM document -- the entire page
-        document.addEventListener('click', this.documentClickHandler);
-    }
-
-    componentWillUnmount() {
-        // Remove the DOM document click handler now that the DropdownButton is going away.
-        document.removeEventListener('click', this.documentClickHandler);
-    }
-
-    documentClickHandler() {
-        // A click outside the DropdownButton closes the dropdown
-        this.setState({ open: false });
-    }
-
-    triggerClickHandler(e) {
-        // After clicking the dropdown trigger button, don't allow the event to bubble to the rest of the DOM.
+    // Called when the user clicks on the button to show or hide the dropdown.
+    const handleTrigger = (e) => {
         e.nativeEvent.stopImmediatePropagation();
-        this.setState(prevState => ({ open: !prevState.open }));
-    }
+        setDropdownOpen(!dropdownOpen);
+    };
 
-    render() {
-        const { title, label, disabled, wrapperClasses, buttonClasses } = this.props;
-
-        // Add the `label` property to any <DropdownMenu> child components
-        const children = React.Children.map(this.props.children, (child) => {
-            if (child.type === DropdownMenu) {
-                return React.cloneElement(child, { label: this.props.label });
-            }
-            return child;
-        });
-
-        // Process the button CSS classes.
-        let usedButtonClasses = 'btn dropdown-toggle';
-        if (buttonClasses === null) {
-            usedButtonClasses = usedButtonClasses.concat(' btn-info btn-sm');
-        } else {
-            usedButtonClasses = usedButtonClasses.concat(` ${buttonClasses}`);
+    // Close the menu in reaction to a user event or an expiring timer. Only a user event includes
+    // a synthetic event.
+    const closeDropdown = (e) => {
+        if (e) {
+            e.stopPropagation();
         }
+        setDropdownOpen(false);
+    };
 
-        return (
-            <div className={`dropdown${this.state.open ? ' open' : ''}${wrapperClasses ? ` ${wrapperClasses}` : ''}`}>
-                <button
-                    disabled={disabled}
-                    className={usedButtonClasses}
-                    type="button"
-                    id={label}
-                    data-toggle="dropdown"
-                    aria-haspopup="true"
-                    aria-expanded={this.state.open}
-                    onClick={this.triggerClickHandler}
-                >
-                    {title}&nbsp;<span className="caret" />
-                </button>
-                {children}
-            </div>
-        );
-    }
-}
+    // Close the menu if ESC key pressed.
+    const handleKey = (e) => {
+        if (e.keyCode === 27) {
+            closeDropdown(e);
+        }
+    };
 
-DropdownButton.propTypes = {
-    title: PropTypes.string, // Title of the trigger button
-    label: PropTypes.string, // id (unique in doc) for this button
-    disabled: PropTypes.bool, // True to disable button
-    wrapperClasses: PropTypes.string, // Classes to add to wrapper div
-    buttonClasses: PropTypes.string, // Classes to add to button triggering the drop-down
-    children: PropTypes.node, // Components rendered inside DropdownButton, usually drop-down items
+    // Called when the mouse enters a dropdown or trigger. Clears the timer if running.
+    const handleMouseEnter = () => {
+        if (timer) {
+            clearTimeout(timer);
+            timer = null;
+        }
+    };
+
+    // Called when the mouse leaves a dropdown or trigger. Starts a timer to close the menu if no
+    // further action.
+    const houseMouseLeave = () => {
+        if (timer) {
+            clearTimeout(timer);
+        }
+        timer = setTimeout(() => {
+            timer = null;
+            closeDropdown();
+        }, 1000);
+    };
+
+    // Called when focus leaves a dropdown item. Start a timer in case the user tabs to another
+    // dropdown item, focusing that within a very short time. If the timer expires, the user must
+    // have focused on something outside the dropdown so we can close it.
+    const handleBlur = () => {
+        if (timer) {
+            clearTimeout(timer);
+        }
+        timer = setTimeout(() => {
+            timer = null;
+            closeDropdown();
+        }, 200);
+    };
+
+    // Called when the user focuses on a dropdown item. If a time was started from a previous blur
+    // event, we can clear it to keep the dropdown open.
+    const handleFocus = () => {
+        if (timer) {
+            clearTimeout(timer);
+            timer = null;
+        }
+    };
+
+    React.useEffect(() => {
+        // Add a click handler to the DOM document to close dropdown on click outside menu.
+        document.addEventListener('click', closeDropdown);
+        return () => {
+            document.removeEventListener('click', closeDropdown);
+        };
+    }, []);
+
+    return [
+        // state
+        {
+            dropdownOpen,
+        },
+        // actions
+        {
+            handleTrigger,
+            handleKey,
+            handleMouseEnter,
+            houseMouseLeave,
+            handleBlur,
+            handleFocus,
+            closeDropdown,
+        },
+    ];
 };
 
-DropdownButton.defaultProps = {
-    title: '',
-    label: '',
-    disabled: false,
-    wrapperClasses: '',
-    buttonClasses: null,
-    children: null,
+
+/**
+ * Implements the immediate form of dropdown button, where selecting an item from the dropdown menu
+ * immediately executes that item.
+ */
+export const Immediate = ({ label, id, css, inline, children }) => {
+    const [state, actions] = useDropdownButton();
+
+    // Wrap each child in an <li> element, as they will be children of a <ul>.
+    const wrappedChildren = React.Children.map(children, child => (
+        <li>{React.cloneElement(child)}</li>
+    ));
+
+    return (
+        <div className={`dropdown-button${css ? ` ${css}` : ''}`} style={inline ? { display: 'inline-flex' } : null}>
+            <button
+                className="btn"
+                onClick={actions.handleTrigger}
+                id={id}
+                aria-haspopup="true"
+                aria-expanded={state.dropdownOpen}
+                onKeyUp={actions.handleKey}
+                onMouseEnter={actions.handleMouseEnter}
+                onMouseLeave={actions.houseMouseLeave}
+                onFocus={actions.handleFocus}
+                onBlur={actions.handleBlur}
+            >
+                {label}
+            </button>
+            {state.dropdownOpen ?
+                <ul
+                    aria-labelledby={id}
+                    className="dropdown-button__content"
+                    onMouseEnter={actions.handleMouseEnter}
+                    onMouseLeave={actions.houseMouseLeave}
+                    onFocus={actions.handleFocus}
+                    onBlur={actions.handleBlur}
+                >
+                    {wrappedChildren}
+                </ul>
+            : null}
+        </div>
+    );
+};
+
+Immediate.propTypes = {
+    /** Label to display in the button */
+    label: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.number,
+        PropTypes.element,
+    ]).isRequired,
+    /** id of this control that's unique on the page */
+    id: PropTypes.string.isRequired,
+    /** CSS styles for the wrapper div */
+    css: PropTypes.string,
+    /** True to make this an inline component */
+    inline: PropTypes.bool,
+    /** Child components within in this component */
+    children: PropTypes.node.isRequired,
+};
+
+Immediate.defaultProps = {
+    css: '',
+    inline: false,
+};
+
+
+/**
+ * Implements the selected form of the dropdown button, where items in the dropdown menu select the
+ * action taken when the button is clicked.
+ */
+export const Selected = ({ labels, execute, id, triggerVoice, css, inline, children }) => {
+    const [state, actions] = useDropdownButton();
+
+    // Extract the id attributes of each of the child components.
+    const labelIds = React.Children.map(children, child => child.props.id);
+
+    // Currently selected dropdown item id; initialized to first item.
+    const [selection, setSelection] = React.useState(labelIds[0]);
+
+    // Called when the user clicks a dropdown item.
+    const handleItemClick = (e) => {
+        setSelection(e.target.id);
+    };
+
+    // Wrap each child in an <li> element, as they will be children of a <ul>. Add this component's
+    // click handler.
+    const wrappedChildren = React.Children.map(children, child => (
+        <li>{React.cloneElement(child, { onClick: handleItemClick })}</li>
+    ));
+
+    // Called when the user clicks the label portion of the button.
+    const handleExecute = () => {
+        execute(selection);
+    };
+
+    return (
+        <div className={`dropdown-button${css ? ` ${css}` : ''}`} style={inline ? { display: 'inline-flex' } : null}>
+            <div className="dropdown-button__composite" onMouseEnter={actions.handleMouseEnter} onMouseLeave={actions.houseMouseLeave}>
+                <button className="dropdown-button__composite-execute" onClick={handleExecute} onKeyUp={actions.handleKey}>
+                    {labels[selection]}
+                </button>
+                <button
+                    className="dropdown-button__composite-trigger"
+                    onClick={actions.handleTrigger}
+                    id={id}
+                    aria-haspopup="true"
+                    aria-expanded={state.dropdownOpen}
+                    aria-label={triggerVoice}
+                    onFocus={actions.handleFocus}
+                    onBlur={actions.handleBlur}
+                >
+                    {svgIcon('chevronDown')}
+                </button>
+            </div>
+            {state.dropdownOpen ?
+                <ul
+                    aria-labelledby={id}
+                    className="dropdown-button__content"
+                    onMouseEnter={actions.handleMouseEnter}
+                    onMouseLeave={actions.houseMouseLeave}
+                    onFocus={actions.handleFocus}
+                    onBlur={actions.handleBlur}
+                >
+                    {wrappedChildren}
+                </ul>
+            : null}
+        </div>
+    );
+};
+
+Selected.propTypes = {
+    /** Labels to display in the execution part of button */
+    labels: PropTypes.object.isRequired,
+    /** Called when user clicks execution part of button */
+    execute: PropTypes.func.isRequired,
+    /** id of this control that's unique on the page */
+    id: PropTypes.string.isRequired,
+    /** Text for screen readers to say when focusing on dropdown trigger */
+    triggerVoice: PropTypes.string.isRequired,
+    /** CSS styles for the wrapper div */
+    css: PropTypes.string,
+    /** True to make this an inline component */
+    inline: PropTypes.bool,
+    /** Child components within in this component */
+    children: PropTypes.node.isRequired,
+};
+
+Selected.defaultProps = {
+    css: '',
+    inline: false,
 };

--- a/src/encoded/static/scss/encoded/_base.scss
+++ b/src/encoded/static/scss/encoded/_base.scss
@@ -346,3 +346,76 @@ pre code {
     background-color: #0000;
     border-radius: 0;
 }
+
+.dropdown-button {
+    position: relative;
+
+    & > &__composite {
+        display: flex;
+        flex-wrap: nowrap;
+    }
+
+    & > &__composite > &__composite-execute {
+        margin: 0;
+        border-right: none;
+        border-top-right-radius: 0;
+        border-bottom-right-radius: 0;
+    }
+
+    & > &__composite > &__composite-trigger {
+        margin: 0;
+        border-top-left-radius: 0;
+        border-bottom-left-radius: 0;
+
+        > svg {
+            width: 8px;
+            fill: white;
+        }
+    }
+
+    @at-root #{&}__content {
+        position: absolute;
+        top: 100%;
+        margin: 4px 0;
+        padding: 0;
+        width: 300px;
+        list-style: none;
+        border: 1px solid #c0c0c0;
+        box-shadow: 0 3px 5px rgba(0, 0, 0, 0.175);
+        z-index: 1000;
+
+        button {
+            height: auto;
+            white-space: normal;
+        }
+
+        // Default link/button styling
+        > li {
+            display: block;
+
+            > button, > a {
+                display: block;
+                width: 100%;
+                text-align: left;
+                padding: 5px 20px;
+                font-size: 0.9rem;
+                font-weight: bold;
+                border: none;
+                border-radius: 0;
+                color: #444;
+                background-color: #fff;
+                border-top: 1px solid transparent;
+                border-right: none;
+                border-bottom: 1px solid transparent;
+                border-left: none;
+
+                &:hover {
+                    color: #fff;
+                    background-color: #4E7294;
+                    border-top: 1px solid #2b3f51;
+                    border-bottom: 1px solid #2b3f51;
+                }
+            }
+        }
+    }
+}

--- a/src/encoded/static/scss/encoded/modules/_cart.scss
+++ b/src/encoded/static/scss/encoded/modules/_cart.scss
@@ -250,10 +250,6 @@
     @at-root #{&}__tools {
         display: flex;
         flex: 0 1 auto;
-
-        button {
-            margin-left: 5px;
-        }
     }
 
     // Header of cart panel.
@@ -262,7 +258,7 @@
         justify-content: space-between;
     }
 
-    @at-root #{&}__facet-progress-overlay {
+    @at-root #{&}__facet-disabled-overlay {
         position: absolute;
         top: 0;
         right: 0;
@@ -1096,4 +1092,42 @@ $file-type-colors: (
         flex: 1 1 auto;
     }
 
+}
+
+
+// Control to batch download cart files.
+.cart-download {
+    margin-right: 5px;
+
+    button {
+        @extend .btn;
+        @extend .btn-info;
+        @extend .btn-sm;
+    }
+
+    @at-root #{&}__option-title {
+        margin: 5px 0;
+        font-size: 1rem;
+        font-weight: bold;
+        pointer-events: none;
+    }
+
+    @at-root #{&}__option-description {
+        margin: 5px 0;
+        font-size: 0.9rem;
+        font-weight: normal;
+        pointer-events: none;
+    }
+
+    .dropdown-button__content {
+        button {
+            color: #000;
+
+            &:hover {
+                color: #fff;
+                
+                background-color: #4f689e;
+            }
+        }
+    }
 }

--- a/src/encoded/tests/features/cart.feature
+++ b/src/encoded/tests/features/cart.feature
@@ -5,10 +5,10 @@ Feature: Cart
         And I wait for the content to load
         Then I should see 25 elements with the css selector ".result-item__cart-control"
 
-        When I press "/experiments/ENCSR003CON/"
+        When I press "/experiments/ENCSR123MRN/"
+        And I press "/experiments/ENCSR003CON/"
         And I press "/experiments/ENCSR001CON/"
         And I press "/experiments/ENCSR000DZQ/"
-        And I press "/experiments/ENCSR123MRN/"
         Then I should see 4 elements with the css selector ".cart__toggle--in-cart"
         And I should see an element with the css selector ".cart__nav-button"
 
@@ -32,7 +32,7 @@ Feature: Cart
         When I press "cart-facet-term-alignments"
         Then I should see "4 files selected"
         And I should see 4 elements with the css selector ".cart-list-item"
-        When I press "Processed data files"
+        When I press "Download processed data files"
         Then I should see an element with the css selector ".modal"
         When I press "Close"
         Then I should not see an element with the css selector ".modal"
@@ -46,7 +46,7 @@ Feature: Cart
         When I press "cart-download"
         Then I should see 3 elements with the css selector ".menu-item"
         When I press "raw"
-        Then I should see "Raw data files"
+        Then I should see "Download raw data files"
 
     Scenario: Dirty cart
         When I visit "/search/?type=Experiment"

--- a/src/encoded/tests/features/cart.feature
+++ b/src/encoded/tests/features/cart.feature
@@ -8,40 +8,52 @@ Feature: Cart
         When I press "/experiments/ENCSR003CON/"
         And I press "/experiments/ENCSR001CON/"
         And I press "/experiments/ENCSR000DZQ/"
-        Then I should see 3 elements with the css selector ".cart__toggle--in-cart"
+        And I press "/experiments/ENCSR123MRN/"
+        Then I should see 4 elements with the css selector ".cart__toggle--in-cart"
         And I should see an element with the css selector ".cart__nav-button"
 
     Scenario: Cart page load
         When I press "cart-control"
         And I click the link to "/cart-view/"
         And I wait for the content to load
-        Then I should see 3 elements with the css selector ".result-item"
+        Then I should see 4 elements with the css selector ".result-item"
         And I should see "4 files selected"
-        When I click the link to "#browser"
-        Then I should see 6 elements with the css selector ".react-object-container"
-        When I click the link to "#files"
+        When I click the link to "#processeddata"
         Then I should see 4 elements with the css selector ".cart-list-item"
+        When I click the link to "#rawdata"
+        Then I should see 3 elements with the css selector ".cart-list-item"
 
     Scenario: Cart page interactions
-        When I press "output_type-label"
+        When I click the link to "#processeddata"
+        And I press "output_type-label"
         And I press "cart-facet-term-alignments"
         Then I should see "2 files selected"
         And I should see 2 elements with the css selector ".cart-list-item"
         When I press "cart-facet-term-alignments"
         Then I should see "4 files selected"
         And I should see 4 elements with the css selector ".cart-list-item"
-        When I press "Download"
+        When I press "Processed data files"
         Then I should see an element with the css selector ".modal"
         When I press "Close"
         Then I should not see an element with the css selector ".modal"
         When I click the link to "#datasets"
         And I press "/experiments/ENCSR003CON/"
         And I wait for the content to load
-        Then I should see 2 elements with the css selector ".result-item"
-        And I should see "3 files selected"
+        Then I should see 3 elements with the css selector ".result-item"
+        And I should see "4 files selected"
+
+    Scenario: Download menu
+        When I press "cart-download"
+        Then I should see 3 elements with the css selector ".menu-item"
+        When I press "raw"
+        Then I should see "Raw data files"
+
+    Scenario: Dirty cart
         When I visit "/search/?type=Experiment"
         And I dismiss the alert
         Then the browser's URL should be "/cart-view/"
+
+    Scenario: Clearing the cart 
         When I press "clear-cart-actuator"
         Then I should see an element with the css selector ".modal"
         When I press "clear-cart-submit"


### PR DESCRIPTION
* I noticed JSDoc doesn't really adequately handle React hooks, so I'm trying out an alternative style of my own, but hopefully some de facto documentation standard comes out.
* I completely rewrote the DownloadButton component to now offer two kinds of dropdown buttons
    * Immediate: The button includes the chevron and executes an action the moment you choose an option from the dropdown menu.
    * Selected: “Github style” — The button and chevron are separate buttons combined, and selecting an option from the dropdown changes the label of the button, and clicking the button then executes the action with the chosen option.
* We have two `<DropdownButton>` uses outside of carts that I converted to use the new `<DropdownButton.Immediate>` component but haven’t tested it because I’m fairly confident that code can never execute. One is in ExperimentSeries when visualizable files exist, but the `visualizable` property is not implemented on ExperimentSeries objects. The other is in edit forms but I could not find a situation that would make that button render.
* In cart/batch_download.js I moved the `batchDownload` function out of `CartBatchDownloadComponent` because I converted to React hooks and didn’t want such a large function allocated on every execution of `CartBatchDownloadComponent.`
* `<DropdownButton.Selected>` is part of a new reusable component to manage the new Download button.
* In view_controls.js, I split the component to display the Download button and modal for non-cart pages into two components — one for the button and one for the modal. This allows cart batch download to use just the modal without also including the button, as the Download button for the cart isn’t a simple button anymore, while non-cart pages do still use a simple button. This modal had to change from plug-and-play into a managed modal.
* For the back end, I removed the “visualizable=true” query string parameter and replaced it with an “option=” parameter. The possible values are “visualizable” and “raw.” The “visualizable” option is just like the old “visualizable=true” parameter, while “option=raw” only downloads files that have no assembly.
* I think this is our first-ever use of custom React hooks, with `useDropdownButton` in button.js. It’s quite a bit like the old mixins so that multiple components can embed the same functionality. The unusual thing I did with this one was to return an object so that I don’t have to return so many array items, which is what you see with most custom React hooks.