### PR TITLE
ENCD-5218-batch-dl-issue

### DIFF
--- a/src/encoded/batch_download.py
+++ b/src/encoded/batch_download.py
@@ -40,7 +40,7 @@ _tsv_mapping = OrderedDict([
     ('Output type', ['files.output_type']),
     ('File assembly', ['files.assembly']),
     ('Experiment accession', ['accession']),
-    ('Assay', ['assay_term_name']),
+    ('Assay', ['assay_term_name', 'files.assay_term_name']),
     ('Biosample term id', ['biosample_ontology.term_id']),
     ('Biosample term name', ['biosample_ontology.term_name']),
     ('Biosample type', ['biosample_ontology.classification']),
@@ -596,7 +596,9 @@ def files_prop_param_list(exp_file, param_list):
     for k, v in param_list.items():
         if k.startswith('files.'):
             file_prop = k[len('files.'):]
-            if file_prop in exp_file and exp_file[file_prop] not in v:
+            if file_prop not in exp_file:
+                return False
+            if exp_file[file_prop] not in v:
                 return False
     return True
 

--- a/src/encoded/tests/test_batch_download.py
+++ b/src/encoded/tests/test_batch_download.py
@@ -48,7 +48,7 @@ def test__tsv_mapping_value():
         ('Output type', ['files.output_type']),
         ('File assembly', ['files.assembly']),
         ('Experiment accession', ['accession']),
-        ('Assay', ['assay_term_name']),
+        ('Assay', ['assay_term_name', 'files.assay_term_name']),
         ('Biosample term id', ['biosample_ontology.term_id']),
         ('Biosample term name', ['biosample_ontology.term_name']),
         ('Biosample type', ['biosample_ontology.classification']),
@@ -398,7 +398,7 @@ def test_metadata_view(testapp, workbook):
     
 
 @pytest.mark.parametrize("test_input,expected", [
-    (files_prop_param_list(exp_file_1, param_list_2), True),
+    (files_prop_param_list(exp_file_1, param_list_2), False),
     (files_prop_param_list(exp_file_1, param_list_1), True),
     (files_prop_param_list(exp_file_2, param_list_1), False),
     (files_prop_param_list(exp_file_3, param_list_3), True),


### PR DESCRIPTION
Made the criteria for inclusion in metadata_tsv and batch_download a bit stricter.

Updated demo at: ~https://encd-5218-batch-dl-issue-dv1-fytanaka.demo.encodedcc.org/~