### PR TITLE
ENCD-5070-missing-img

### DIFF
--- a/src/encoded/static/components/image.js
+++ b/src/encoded/static/components/image.js
@@ -5,55 +5,52 @@ import * as globals from './globals';
 
 
 // Fixed-position lightbox background and image
-class Lightbox extends React.Component {
-    constructor() {
-        super();
+const Lightbox = ({ lightboxVisible, clearLightbox, lightboxImg }) => {
+    // Height of the image within the light box.
+    const [imgHeight, setImgHeight] = React.useState(0);
+    const lightbox = React.useRef(null);
 
-        // Set initial React state.
-        this.state = { imgHeight: 0 };
+    // Called when the window is resized to resize the image within it.
+    const handleResize = () => {
+        setImgHeight(lightbox.current.offsetHeight - 40);
+    };
 
-        // Bind this to non-React methods.
-        this.handleResize = this.handleResize.bind(this);
-    }
+    // Called when a key is pressed to close the lightbox with ESC.
+    const handleKeyDown = (e) => {
+        if (e.keyCode === 27) {
+            clearLightbox();
+        }
+    };
 
-    componentDidMount() {
-        globals.bindEvent(window, 'resize', this.handleResize);
-        this.setState({ imgHeight: this.lightbox.offsetHeight - 40 });
-    }
+    React.useEffect(() => {
+        // Need to resize and attach event handlers at mount.
+        handleResize();
+        window.addEventListener('resize', handleResize);
+        return (() => {
+            window.removeEventListener('resize', handleResize);
+        });
+    }, []);
 
-    componentWillUnmount() {
-        globals.unbindEvent(window, 'resize', this.handleResize);
-    }
-
-    // Window resized; set max-height of image
-    handleResize() {
-        this.setState({ imgHeight: this.lightbox.offsetHeight - 40 });
-    }
-
-    render() {
-        const lightboxVisible = this.props.lightboxVisible;
-        const lightboxClass = `lightbox${lightboxVisible ? ' active' : ''}`;
-        const imgStyle = { maxHeight: this.state.imgHeight };
-
-        /* eslint-disable jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
-        return (
-            <div className={lightboxClass} onClick={this.props.clearLightbox} aria-label="Close" ref={(div) => { this.lightbox = div; }}>
-                <div className="lightbox-img">
-                    <a aria-label="Open image" data-bypass="true" href={this.props.lightboxImg}>
-                        <img src={this.props.lightboxImg} alt="Attachment from submitters" style={imgStyle} />
-                    </a>
-                    <button className="lightbox-close" aria-label="Close" onClick={this.clearLightbox} />
-                </div>
+    const lightboxClass = `lightbox${lightboxVisible ? ' active' : ''}`;
+    return (
+        <div tabIndex="-1" className={lightboxClass} onClick={clearLightbox} onKeyDown={handleKeyDown} role="button" aria-label="Close" ref={lightbox}>
+            <div className="lightbox-img">
+                <a aria-label="Open image" data-bypass="true" href={lightboxImg}>
+                    <img src={lightboxImg} alt="Attachment from submitters" style={{ maxHeight: imgHeight }} />
+                </a>
+                <button className="lightbox-close" aria-label="Close" onClick={clearLightbox} />
             </div>
-        );
-        /* eslint-enable jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
-    }
-}
+        </div>
+    );
+};
 
 Lightbox.propTypes = {
-    lightboxVisible: PropTypes.bool, // True if lightbox should be rendered or hidden initially
-    clearLightbox: PropTypes.func.isRequired, // Callback function to hide light box
-    lightboxImg: PropTypes.string.isRequired, // URI of image to display in the light box
+    /** True if lightbox should be rendered or hidden initially */
+    lightboxVisible: PropTypes.bool,
+    /** Callback function to hide light box */
+    clearLightbox: PropTypes.func.isRequired,
+    /** URI of image to display in the light box */
+    lightboxImg: PropTypes.string.isRequired,
 };
 
 Lightbox.defaultProps = {
@@ -61,121 +58,96 @@ Lightbox.defaultProps = {
 };
 
 
-export class Attachment extends React.Component {
-    constructor() {
-        super();
-
-        // Set initial React state.
-        this.state = { lightboxVisible: false };
-
-        // Bind this to non-React methods.
-        this.lightboxClickImage = this.lightboxClickImage.bind(this);
-        this.clearLightbox = this.clearLightbox.bind(this);
-        this.handleEscKey = this.handleEscKey.bind(this);
-    }
-
-    // Register for keyup events for ESC key
-    componentDidMount() {
-        globals.bindEvent(window, 'keyup', this.handleEscKey);
-    }
-
-    // Unregister keyup events when component closes
-    componentWillUnmount() {
-        globals.unbindEvent(window, 'keyup', this.handleEscKey);
-    }
+export const Attachment = ({ context, attachment, className, showLink }) => {
+    const [lightboxVisible, setLightboxVisible] = React.useState(false);
 
     // Handle a click on the lightbox trigger (thumbnail)
-    lightboxClickImage(e) {
+    const lightboxClickImage = (e) => {
         e.preventDefault();
         e.stopPropagation();
-        this.setState({ lightboxVisible: true });
-    }
+        setLightboxVisible(true);
+    };
 
-    clearLightbox() {
-        this.setState({ lightboxVisible: false });
-    }
+    // Close the lightbox and image.
+    const clearLightbox = () => {
+        setLightboxVisible(false);
+    };
 
-    // If lightbox visible, ESC key closes it
-    handleEscKey(e) {
-        if (this.state.lightboxVisible && e.keyCode === 27) {
-            this.clearLightbox();
-        }
-    }
-
-    render() {
-        const { context, attachment, className, showLink } = this.props;
-        let attachmentHref;
-        let src;
-        let alt;
-        let height = '100';
-        let width = '100';
-        if (attachment && attachment.href && attachment.type) {
-            attachmentHref = url.resolve(context['@id'], attachment.href);
-            const attachmentType = attachment.type.split('/', 1)[0];
-            if (attachmentType === 'image' && attachment.type !== 'image/tiff') {
-                const imgClass = className ? `${className}-img` : '';
-                src = attachmentHref;
-                height = attachment.height || 100;
-                width = attachment.width || 100;
-                alt = 'Attachment from submitter';
-                if (!showLink) {
-                    // Just display the attachment image without any lightbox.
-                    return <img className={imgClass} src={src} height={height} width={width} alt={alt} />;
-                }
-
-                // Display the attachment image in a light box.
-                return (
-                    <div>
-                        <div className="attachment">
-                            <a className="attachment__button" data-bypass="true" href={attachmentHref} onClick={this.lightboxClickImage} title="View attachment in this window">
-                                <div className="attachment__hover" />
-                                <img className={imgClass} src={src} height={height} width={width} alt={alt} />
-                            </a>
-                        </div>
-                        <Lightbox lightboxVisible={this.state.lightboxVisible} lightboxImg={attachmentHref} clearLightbox={this.clearLightbox} />
-                    </div>
-                );
-            } else if (attachment.type === 'application/pdf') {
-                // Attachment is a PDF. Show the PDF icon, and clicks in it show the PDF in a new
-                // window using the browser's PDF viewer.
-                return (
-                    <div className="attachment">
-                        <a data-bypass="true" href={attachmentHref} className="attachment__button" target="_blank" rel="noopener noreferrer" title="Open attachment in a new window">
-                            <div className="attachment__hover" />
-                            <div className="file-pdf">Attachment PDF Icon</div>
-                        </a>
-                    </div>
-                );
+    let attachmentHref;
+    let src;
+    let alt;
+    let height = '100';
+    let width = '100';
+    if (attachment && attachment.href && attachment.type) {
+        attachmentHref = url.resolve(context['@id'], attachment.href);
+        const attachmentType = attachment.type.split('/', 1)[0];
+        if (attachmentType === 'image' && attachment.type !== 'image/tiff') {
+            const imgClass = className ? `${className}-img` : '';
+            src = attachmentHref;
+            height = attachment.height || 100;
+            width = attachment.width || 100;
+            alt = 'Attachment from submitter';
+            if (!showLink) {
+                // Just display the attachment image without any lightbox.
+                return <img className={imgClass} src={src} height={height} width={width} alt={alt} />;
             }
 
-            // Non image, non PDF attachment (likely a text file). Show the generic document icon
-            // and open it in a new window.
+            // Display the attachment image in a light box.
+            return (
+                <div>
+                    <div className="attachment">
+                        <a className="attachment__button" data-bypass="true" href={attachmentHref} onClick={lightboxClickImage} title="View attachment in this window">
+                            <div className="attachment__hover" />
+                            <img className={imgClass} src={src} height={height} width={width} alt={alt} />
+                        </a>
+                    </div>
+                    <Lightbox lightboxVisible={lightboxVisible} lightboxImg={attachmentHref} clearLightbox={clearLightbox} />
+                </div>
+            );
+        } else if (attachment.type === 'application/pdf') {
+            // Attachment is a PDF. Show the PDF icon, and clicks in it show the PDF in a new
+            // window using the browser's PDF viewer.
             return (
                 <div className="attachment">
                     <a data-bypass="true" href={attachmentHref} className="attachment__button" target="_blank" rel="noopener noreferrer" title="Open attachment in a new window">
                         <div className="attachment__hover" />
-                        <div className="file-generic">Attachment Icon</div>
+                        <div className="file-pdf">Attachment PDF Icon</div>
                     </a>
                 </div>
             );
         }
 
-        // No attachment given; display a broken file icon.
+        // Non image, non PDF attachment (likely a text file). Show the generic document icon
+        // and open it in a new window.
         return (
             <div className="attachment">
-                <div className="attachment__button">
-                    <div className="file-missing">Attachment file broken icon</div>
-                </div>
+                <a data-bypass="true" href={attachmentHref} className="attachment__button" target="_blank" rel="noopener noreferrer" title="Open attachment in a new window">
+                    <div className="attachment__hover" />
+                    <div className="file-generic">Attachment Icon</div>
+                </a>
             </div>
         );
     }
-}
+
+    // No attachment given; display a broken file icon.
+    return (
+        <div className="attachment">
+            <div className="attachment__button">
+                <div className="file-missing">Attachment file broken icon</div>
+            </div>
+        </div>
+    );
+};
 
 Attachment.propTypes = {
-    context: PropTypes.object.isRequired, // Object within which the attachment is to be displayed
-    attachment: PropTypes.object, // Attachment object to display
-    className: PropTypes.string, // CSS class name to add to image element; '-img' added to it
-    showLink: PropTypes.bool, // False to just display image preview without link or lightbox
+    /** Object within which the attachment is to be displayed */
+    context: PropTypes.object.isRequired,
+    /** Attachment object to display */
+    attachment: PropTypes.object,
+    /** CSS class name to add to image element; '-img' added to it */
+    className: PropTypes.string,
+    /** False to just display image preview without link or lightbox */
+    showLink: PropTypes.bool,
 };
 
 Attachment.defaultProps = {


### PR DESCRIPTION
The problem was the resize event mount wasn't getting called after the DOM was rendered, so it based the size of the image on a zero height of the parent div which hadn’t been rendered yet. I decided to rewrite this component with React hooks so that I can use useEffect which first gets called _after_ render, so the height of the image gets calculated after we know how big the parent div is.