### PR TITLE
ENCD-5116-pipeline-graph

### DIFF
--- a/src/encoded/static/components/__tests__/filegallery-test.js
+++ b/src/encoded/static/components/__tests__/filegallery-test.js
@@ -1,0 +1,250 @@
+import _ from 'underscore';
+
+
+// Import test component and data.
+import { compileAnalyses } from '../filegallery';
+
+
+const experiment0 = {
+    analyses: [
+        {
+            files: [
+                '/files/ENCFF003MRN/',
+                '/files/ENCFF005MRN/',
+            ],
+            assemblies: [
+                'GRCh38',
+            ],
+            genome_annotations: [
+                'V24',
+            ],
+            pipelines: [
+                '/pipelines/ENCPL001MRN/',
+                '/pipelines/ENCPL003RNA/',
+            ],
+            pipeline_award_rfas: [
+                'ENCODE3',
+            ],
+            pipeline_labs: [
+                '/labs/brenton-graveley/',
+                '/labs/thomas-gingeras/',
+            ],
+        },
+        {
+            files: [
+                '/files/ENCFF004MRN/',
+                '/files/ENCFF006MRN/',
+                '/files/ENCFF807TRA/',
+                '/files/ENCFF783YZT/',
+            ],
+            assemblies: [
+                'hg19',
+            ],
+            genome_annotations: [],
+            pipelines: [
+                '/pipelines/ENCPL001MRN/',
+                '/pipelines/ENCPL003RNA/',
+            ],
+            pipeline_award_rfas: [
+                'ENCODE4',
+            ],
+            pipeline_labs: [
+                '/labs/encode-processing-pipeline/',
+            ],
+        },
+        {
+            files: [
+                '/files/ENCFF001RCY/',
+                '/files/ENCFF001RCV/',
+            ],
+            assemblies: [
+                'GRCh38',
+            ],
+            genome_annotations: [],
+            pipelines: [
+                '/pipelines/ENCPL001GRV/',
+            ],
+            pipeline_award_rfas: [
+                'ENCODE3',
+            ],
+            pipeline_labs: [
+                '/labs/encode-processing-pipeline/',
+            ],
+        },
+        {
+            files: [
+                '/files/ENCFF807TRA/',
+                '/files/ENCFF783YZT/',
+            ],
+            assemblies: [
+                'GRCh38',
+            ],
+            genome_annotations: [],
+            pipelines: [
+                '/pipelines/ENCPL001GRV/',
+            ],
+            pipeline_award_rfas: [
+                'ENCODE3',
+            ],
+            pipeline_labs: [
+                '/labs/encode-processing-pipeline/',
+            ],
+        },
+        {
+            files: [
+                '/files/ENCFF001RCZ/',
+                '/files/ENCFF001RCW/',
+            ],
+            assemblies: [
+                'GRCh38',
+            ],
+            genome_annotations: [
+                'V24',
+            ],
+            pipelines: [
+                '/pipelines/ENCPL001GRV/',
+            ],
+            pipeline_award_rfas: [
+                'ENCODE4',
+            ],
+            pipeline_labs: [
+                '/labs/encode-processing-pipeline/',
+            ],
+        },
+    ],
+};
+
+const files0 = [
+    {
+        '@id': '/files/ENCFF003MRN/',
+        accession: 'ENCFF003MRN',
+        assembly: 'GRCh38',
+        dataset: 'ENCSR123MRN',
+        file_format: 'bam',
+        genome_annotation: 'V24',
+        lab: '/labs/encode-processing-pipeline/',
+        output_type: 'alignments',
+        status: 'released',
+    },
+    {
+        '@id': '/files/ENCFF005MRN/',
+        accession: 'ENCFF005MRN',
+        assembly: 'GRCh38',
+        dataset: 'ENCSR123MRN',
+        file_format: 'tsv',
+        genome_annotation: 'V24',
+        lab: '/labs/encode-processing-pipeline/',
+        output_type: 'transcript quantifications',
+        status: 'released',
+    },
+    {
+        '@id': '/files/ENCFF004MRN/',
+        accession: 'ENCFF004MRN',
+        assembly: 'GRCh38',
+        dataset: 'ENCSR123MRN',
+        file_format: 'bam',
+        genome_annotation: 'V24',
+        lab: '/labs/encode-processing-pipeline/',
+        output_type: 'alignments',
+        status: 'released',
+    },
+    {
+        '@id': '/files/ENCFF006MRN/',
+        accession: 'ENCFF006MRN',
+        assembly: 'GRCh38',
+        dataset: 'ENCSR123MRN',
+        file_format: 'tsv',
+        genome_annotation: 'V24',
+        lab: '/labs/encode-processing-pipeline/',
+        output_type: 'transcript quantifications',
+        status: 'released',
+    },
+    {
+        '@id': '/files/ENCFF807TRA/',
+        accession: 'ENCFF807TRA',
+        dataset: 'ENCSR123MRN',
+        file_format: 'gtf',
+        assembly: 'hg19',
+        lab: '/labs/encode-processing-pipeline/',
+        output_type: 'transcriptome annotations',
+        status: 'released',
+    },
+    {
+        '@id': '/files/ENCFF783YZT/',
+        accession: 'ENCFF783YZT',
+        dataset: 'ENCSR123MRN',
+        file_format: 'gff',
+        file_format_type: 'gff3',
+        assembly: 'hg19',
+        lab: '/labs/encode-processing-pipeline/',
+        output_type: 'miRNA annotations',
+        status: 'released',
+    },
+    {
+        '@id': '/files/ENCFF001RCZ/',
+        accession: 'ENCFF001RCZ',
+        dataset: 'ENCSR000AEN',
+        file_format: 'bigWig',
+        lab: '/labs/j-michael-cherry/',
+        assembly: 'hg19',
+        genome_annotation: 'V19',
+        output_type: 'signal of all reads',
+        status: 'released',
+    },
+    {
+        '@id': '/files/ENCFF001RCW/',
+        accession: 'ENCFF001RCW',
+        dataset: 'ENCSR000AEN',
+        assembly: 'hg19',
+        genome_annotation: 'V19',
+        file_format: 'bam',
+        lab: '/labs/j-michael-cherry/',
+        output_type: 'alignments',
+        status: 'released',
+    },
+    {
+        '@id': '/files/ENCFF001RCY/',
+        accession: 'ENCFF001RCY',
+        dataset: 'ENCSR000AEN',
+        file_format: 'bigWig',
+        assembly: 'GRCh38',
+        genome_annotation: 'V19',
+        lab: '/labs/j-michael-cherry/',
+        output_type: 'signal of all reads',
+        status: 'released',
+    },
+    {
+        '@id': '/files/ENCFF001RCV/',
+        accession: 'ENCFF001RCV',
+        award: 'U41HG006992',
+        dataset: 'ENCSR000AEN',
+        assembly: 'hg19',
+        genome_annotation: 'V19',
+        file_format: 'bam',
+        lab: '/labs/j-michael-cherry/',
+        output_type: 'alignments',
+        status: 'released',
+    },
+];
+
+
+describe('createPipelineFacetObject', () => {
+    describe('Both processed', () => {
+        it('Has both ENCODE Uniform and Lab Custom facet terms and count', () => {
+            const analyses = compileAnalyses(experiment0, files0);
+            expect(analyses).toHaveLength(4);
+            expect(analyses[0].pipelineLab).toEqual('Mixed');
+            expect(analyses[0].assembly).toEqual('GRCh38 V24');
+            expect(analyses[0].files).toHaveLength(2);
+            expect(analyses[1].pipelineLab).toEqual('ENCODE4 uniform');
+            expect(analyses[1].assembly).toEqual('GRCh38 V24');
+            expect(analyses[1].files).toHaveLength(2);
+            expect(analyses[2].pipelineLab).toEqual('ENCODE3 uniform');
+            expect(analyses[2].assembly).toEqual('GRCh38');
+            expect(analyses[2].files).toHaveLength(4);
+            expect(analyses[3].pipelineLab).toEqual('ENCODE4 uniform');
+            expect(analyses[3].assembly).toEqual('hg19');
+            expect(analyses[3].files).toHaveLength(4);
+        });
+    });
+});

--- a/src/encoded/static/components/filegallery.js
+++ b/src/encoded/static/components/filegallery.js
@@ -2784,7 +2784,7 @@ class FileGalleryRendererComponent extends React.Component {
                         >
                             <TabPanelPane key="browser">
                                 <GenomeBrowser
-                                    files={graphIncludedFiles}
+                                    files={includedFiles}
                                     expanded={this.state.facetsOpen}
                                     assembly={this.state.selectedAssembly}
                                 />

--- a/src/encoded/static/scss/encoded/modules/_pipeline.scss
+++ b/src/encoded/static/scss/encoded/modules/_pipeline.scss
@@ -383,3 +383,14 @@ $color-unknown: #ffc0c0;
         box-shadow: inset 0 0 0 1px lighten($color-unknown, 20%);
     }
 }
+
+
+.analyses-selector {
+    @at-root #{&}--file-gallery-facets {
+        margin-bottom: 25px;
+    }
+
+    .file-gallery-facets.collapsed & {
+        display: none;
+    }
+}

--- a/src/encoded/tests/data/inserts/experiment.json
+++ b/src/encoded/tests/data/inserts/experiment.json
@@ -181,6 +181,11 @@
     {
         "_test": "shared biosample",
         "accession": "ENCSR000AEN",
+        "analyses": [
+            {
+                "files": ["ENCFF001RCV", "ENCFF001RCZ"]
+            }
+        ],
         "assay_term_name": "shRNA knockdown followed by RNA-seq",
         "award": "U54HG007005",
         "biosample_ontology": "cell_line_EFO_0002067",
@@ -762,10 +767,13 @@
         "biosample_ontology": "tissue_UBERON_0001891",
         "award": "U54HG007010",
         "assay_term_name": "microRNA-seq",
-        "lab": "/labs/john-stamatoyannopoulos/",
+        "lab": "/labs/encode-processing-pipeline/",
         "date_released": "2015-08-31",
         "accession": "ENCSR123MRN",
         "analyses": [
+            {
+                "files": ["ENCFF101RCZ"]
+            },
             {
                 "files": ["ENCFF003MRN", "ENCFF005MRN"]
             },

--- a/src/encoded/tests/data/inserts/file.json
+++ b/src/encoded/tests/data/inserts/file.json
@@ -2594,6 +2594,27 @@
         "uuid": "16abfcc1-9f85-415a-8eb5-e0f12346f053"
     },
     {
+        "_project": "encode3",
+        "accession": "ENCFF101RCZ",
+        "award":"U41HG006992",
+        "dataset": "ENCSR123MRN",
+        "file_size": 20,
+        "derived_from": [
+            "895fef10-52ed-11e4-916c-0800200c9a66"
+        ],
+        "file_format": "bigWig",
+        "lab":"j-michael-cherry",
+        "assembly": "hg19",
+        "md5sum": "3f78ceaa13a380990ca16d8dcaeffd0b",
+        "output_type": "signal of all reads",
+        "replicate": "e3abd889-053d-44a9-a1f7-90b06bb6d73f",
+        "status": "released",
+        "step_run": "a2cc2a38-ad62-4f01-bd5b-0ae31e6f3024",
+        "submitted_by": "platea.a@volutpat.viverra",
+        "submitted_file_name": "replicate2.bigWig",
+        "uuid": "a00b1ae5-9661-4df9-b504-6e1ed4eee73e"
+   },
+    {
         "dataset": "ENCSR000AJK",
         "status": "released",
         "award": "U54HG006998",

--- a/src/encoded/tests/data/inserts/pipeline.json
+++ b/src/encoded/tests/data/inserts/pipeline.json
@@ -77,7 +77,7 @@
         ],
         "status": "released",
         "title": "Graveley RNA-seq Analysis",
-        "lab": "brenton-graveley",
+        "lab": "encode-processing-pipeline",
         "award": "U54HG007005",
         "uuid": "ab640a00-50aa-11e4-916c-0800200c9a66"
     },


### PR DESCRIPTION
* Most of this change revolves around the “compiled analyses” object which takes the array of analyses objects from an experiment and reassembles them to be more convenient for generating the analyses dropdown that replaces the Assembly facet if conditions are right.
* To be included in compiled analyses, analyses objects have to satisfy several criteria. `compileAnalyses` handles all these checks as well as the conversion to compiled analyses.

An often-updated demo here:
~https://encd-5116-pipeline-graph-pr1-fytanaka.demo.encodedcc.org/search/?type=Experiment&analyses=*~