### PR TITLE
ENCD-5264 fix error on pages missing type

### DIFF
--- a/src/encoded/static/components/app.js
+++ b/src/encoded/static/components/app.js
@@ -1247,7 +1247,7 @@ class App extends React.Component {
                             <Provider store={cartStore}>
                                 <div id="layout">
                                     <Navigation isHomePage={isHomePage} />
-                                    <div id="content" className={`container ${context['@type'].join(' ')}`} key={key}>
+                                    <div id="content" className={context['@type'] ? `container ${context['@type'].join(' ')}` : 'container'} key={key}>
                                         {content}
                                     </div>
                                     {errors}


### PR DESCRIPTION
Some pages do not have an @type, so when I added a class name based on @type (so that I could make some pages, like the summary page with the body map facet, wider), these pages returned an error. Adding a check for @type eliminates this error.