### PR TITLE
ENCD-5243 fix crash on date submitted

### DIFF
--- a/src/encoded/static/components/facets/date_selector.js
+++ b/src/encoded/static/components/facets/date_selector.js
@@ -40,4 +40,4 @@ DateReleasedFacet.defaultProps = {
 
 
 FacetRegistry.Facet.register('date_released', DateReleasedFacet);
-FacetRegistry.Facet.register('date_submitted', null);
+FacetRegistry.Facet.register('date_submitted', DateReleasedFacet);

--- a/src/encoded/static/components/facets/defaults.js
+++ b/src/encoded/static/components/facets/defaults.js
@@ -428,7 +428,7 @@ export class DefaultDateSelectorFacet extends React.Component {
         // "missingField" indicates if there is a field to disable, and if so, which one
         let missingField = null;
         // Check if we are displaying date_submitted facet and there is no date_released data
-        if (facet.field === 'date_submitted' && !(results.facets.filter(f => f.field === 'date_released')).length > 0) {
+        if (facet.field === 'date_submitted') {
             missingField = 'date_released';
         // Check if we are displaying date_released facet and there is no date_submitted data
         } else if (facet.field === 'date_released' && !(results.facets.filter(f => f.field === 'date_submitted')).length > 0) {

--- a/src/encoded/static/components/facets/defaults.js
+++ b/src/encoded/static/components/facets/defaults.js
@@ -421,11 +421,9 @@ export class DefaultDateSelectorFacet extends React.Component {
         // "displayField", when false, hides the duplicate facet when needed (most of the time)
         // If we have date_released or date_submitted data only, then only one facet will be displayed and we don't need to hide one
         // If we have both, we will just display the facet for date_released
-        let displayField = true;
         if (facet.field === 'date_submitted' && results.facets.filter(f => f.field === 'date_released').length > 0) {
-            displayField = false;
+            return null;
         }
-
         // If we are missing data for "date_submitted" or "date_released", we want to disable that radio button
         // "missingField" indicates if there is a field to disable, and if so, which one
         let missingField = null;
@@ -464,7 +462,7 @@ export class DefaultDateSelectorFacet extends React.Component {
 
         if ((activeFacet && (activeFacet.terms.length > 0) && activeFacet.terms.some(term => term.doc_count)) || (field.charAt(field.length - 1) === '!')) {
             return (
-                <div className={`facet date-selector-facet ${facet.field === 'date_released' ? 'display-date-selector' : ''} ${!displayField ? 'hide-facet' : ''}`}>
+                <div className={`facet date-selector-facet ${facet.field === 'date_released' ? 'display-date-selector' : ''}`}>
                     <h5>Date range selection</h5>
                     {existingFilter.length > 0 ?
                         <div className="selected-date-range">

--- a/src/encoded/static/scss/encoded/modules/_facet.scss
+++ b/src/encoded/static/scss/encoded/modules/_facet.scss
@@ -124,6 +124,10 @@
         padding-bottom: 0;
         margin-bottom: 0;
     }
+
+    &.hide-facet {
+        display: none;
+    }
 }
 
 // Radio button facet styles.
@@ -376,6 +380,9 @@ fieldset.facet {
         display: inline-block;
         input {
             margin: 5px;
+        }
+        input[disabled] + label {
+            color: #9F9F9F;
         }
         margin-right: 10px;
     }

--- a/src/encoded/static/scss/encoded/modules/_facet.scss
+++ b/src/encoded/static/scss/encoded/modules/_facet.scss
@@ -124,10 +124,6 @@
         padding-bottom: 0;
         margin-bottom: 0;
     }
-
-    &.hide-facet {
-        display: none;
-    }
 }
 
 // Radio button facet styles.


### PR DESCRIPTION
Two main changes:
(1) create date selector facet for both date_released and date_submitted and if data for both exists, only display one
(2) if data does not exist for either date_released or date_submitted, disable that radio button on the date selector facet