### PR TITLE
ENCD-4927-internal-audit

### DIFF
--- a/src/encoded/static/components/genetic_modification.js
+++ b/src/encoded/static/components/genetic_modification.js
@@ -647,7 +647,7 @@ GeneticModificationComponent.defaultProps = {
 };
 
 const GeneticModificationInternal = (props, reactContext) => (
-    <GeneticModificationComponent {...props} session={reactContext.session} />
+    <GeneticModificationComponent {...props} session={reactContext.session} sessionProperties={reactContext.session_properties} />
 );
 
 GeneticModificationInternal.propTypes = {


### PR DESCRIPTION
I simply hadn’t passed session_properties to the GM-rendering component, so it never knew people had signed in.