### PR TITLE
ENCD-5262 add skinny tracks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6752,7 +6752,7 @@
       }
     },
     "genome-visualizer": {
-      "version": "git://github.com/ENCODE-DCC/valis-hpgv.git#c3b366ed9c3b9de53d9483ec9a58bc0568bbdb17",
+      "version": "git://github.com/ENCODE-DCC/valis-hpgv.git#322639a02b8445a0261a6d5fba9531cd3992efde",
       "from": "git://github.com/ENCODE-DCC/valis-hpgv.git#1.2.0",
       "requires": {
         "@material-ui/core": "^3.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6752,8 +6752,8 @@
       }
     },
     "genome-visualizer": {
-      "version": "git://github.com/ENCODE-DCC/valis-hpgv.git#322639a02b8445a0261a6d5fba9531cd3992efde",
-      "from": "git://github.com/ENCODE-DCC/valis-hpgv.git#1.2.0",
+      "version": "git://github.com/ENCODE-DCC/valis-hpgv.git#b5c9bb34f2747a15a4870b9c6955bfdd08c790a2",
+      "from": "git://github.com/ENCODE-DCC/valis-hpgv.git#1.3.0",
       "requires": {
         "@material-ui/core": "^3.1.0",
         "@material-ui/icons": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "dayjs": "^1.8.16",
     "domready": "^1.0.8",
     "form-serialize": "^0.6.0",
-    "genome-visualizer": "git://github.com/ENCODE-DCC/valis-hpgv.git#ENCD-5262-add-skinny-tracks",
+    "genome-visualizer": "git://github.com/ENCODE-DCC/valis-hpgv.git#1.3.0",
     "google-analytics": "file:node_shims/google-analytics",
     "graphlib": "git://github.com/ENCODE-DCC/graphlib.git#v1.0.8",
     "immutable": "^3.7.5",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "dayjs": "^1.8.16",
     "domready": "^1.0.8",
     "form-serialize": "^0.6.0",
-    "genome-visualizer": "git://github.com/ENCODE-DCC/valis-hpgv.git#1.2.0",
+    "genome-visualizer": "git://github.com/ENCODE-DCC/valis-hpgv.git#ENCD-5262-add-skinny-tracks",
     "google-analytics": "file:node_shims/google-analytics",
     "graphlib": "git://github.com/ENCODE-DCC/graphlib.git#v1.0.8",
     "immutable": "^3.7.5",

--- a/src/encoded/static/components/cart/cart.js
+++ b/src/encoded/static/components/cart/cart.js
@@ -168,7 +168,7 @@ const CartBrowser = ({ files, assembly, pageNumber }) => {
             setPageFiles([]);
         }
     }, [files, assembly, pageNumber]);
-    return <GenomeBrowser files={pageFiles} assembly={assembly} expanded />;
+    return <GenomeBrowser files={pageFiles} label={'cart'} assembly={assembly} expanded />;
 };
 
 CartBrowser.propTypes = {

--- a/src/encoded/static/components/filegallery.js
+++ b/src/encoded/static/components/filegallery.js
@@ -2854,6 +2854,7 @@ class FileGalleryRendererComponent extends React.Component {
                             <TabPanelPane key="browser">
                                 <GenomeBrowser
                                     files={includedFiles}
+                                    label={'file gallery'}
                                     expanded={this.state.facetsOpen}
                                     assembly={this.state.selectedAssembly}
                                 />

--- a/src/encoded/static/components/genome_browser.js
+++ b/src/encoded/static/components/genome_browser.js
@@ -157,7 +157,7 @@ const TrackLabel = ({ file, label, long }) => {
                     {file.biosample_ontology && file.biosample_ontology.term_name ? <span>{file.biosample_ontology.term_name}</span> : null}
                     {long ?
                         <React.Fragment>
-                            <li><a href={file['@id']} className="gb-accession">{file.accession}<span className="sr-only">{`Details for file ${file.accession}`}</span></a></li>
+                            <li><a href={file['@id']} className="gb-accession">{file.title}<span className="sr-only">{`Details for file ${file.title}`}</span></a></li>
                             <li>{file.output_type}</li>
                             <li>{`rep ${biologicalReplicates}`}</li>
                         </React.Fragment>
@@ -166,7 +166,7 @@ const TrackLabel = ({ file, label, long }) => {
             :
                 <ul className="gb-info">
                     <li>
-                        <a href={file['@id']} className="gb-accession">{file.accession}<span className="sr-only">{`Details for file ${file.accession}`}</span></a>
+                        <a href={file['@id']} className="gb-accession">{file.title}<span className="sr-only">{`Details for file ${file.title}`}</span></a>
                         {(biologicalReplicates !== '') ? <span>{` (rep ${biologicalReplicates})`}</span> : null}
                     </li>
                     {long ?

--- a/src/encoded/static/components/genome_browser.js
+++ b/src/encoded/static/components/genome_browser.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'underscore';
-import url from 'url';
 import { FetchedData, Param } from './fetched';
 import { BrowserFeat } from './browserfeat';
 import { filterForVisualizableFiles } from './objectutils';
@@ -147,22 +146,39 @@ function mapGenome(inputAssembly) {
 /**
  * Display a label for a file’s track.
  */
-const TrackLabel = ({ file, long }) => {
-    const biologicalReplicates = file.biological_replicates && file.biological_replicates.join(',');
+const TrackLabel = ({ file, label, long }) => {
+    const biologicalReplicates = file.biological_replicates && file.biological_replicates.join(', ');
     return (
         <React.Fragment>
-            <a href={file['@id']} className="gb-accession">{file.accession}<span className="sr-only">{`Details for file ${file.accession}`}</span></a>
-            <ul className="gb-info">
-                {file.biosample_ontology && file.biosample_ontology.term_name ? <li>{file.biosample_ontology.term_name}</li> : null}
-                {file.target ? <li>{file.target.label}</li> : null}
-                {file.assay_term_name ? <li>{file.assay_term_name}</li> : null}
-                {long ?
-                    <React.Fragment>
-                        <li>{file.output_type}</li>
-                        {(biologicalReplicates !== '') ? <li>{`rep ${biologicalReplicates}`}</li> : null}
-                    </React.Fragment>
-                : null}
-            </ul>
+            {(label === 'cart') ?
+                <ul className="gb-info">
+                    {file.target ? <span>{file.target.label}, </span> : null}
+                    {file.assay_term_name ? <span>{file.assay_term_name}, </span> : null}
+                    {file.biosample_ontology && file.biosample_ontology.term_name ? <span>{file.biosample_ontology.term_name}</span> : null}
+                    {long ?
+                        <React.Fragment>
+                            <li><a href={file['@id']} className="gb-accession">{file.accession}<span className="sr-only">{`Details for file ${file.accession}`}</span></a></li>
+                            <li>{file.output_type}</li>
+                            <li>{`rep ${biologicalReplicates}`}</li>
+                        </React.Fragment>
+                    : null}
+                </ul>
+            :
+                <ul className="gb-info">
+                    <li>
+                        <a href={file['@id']} className="gb-accession">{file.accession}<span className="sr-only">{`Details for file ${file.accession}`}</span></a>
+                        {(biologicalReplicates !== '') ? <span>{` (rep ${biologicalReplicates})`}</span> : null}
+                    </li>
+                    {long ?
+                        <React.Fragment>
+                            {file.biosample_ontology && file.biosample_ontology.term_name ? <li>{file.biosample_ontology.term_name}</li> : null}
+                            {file.target ? <li>{file.target.label}</li> : null}
+                            {file.assay_term_name ? <li>{file.assay_term_name}</li> : null}
+                            <li>{file.output_type}</li>
+                        </React.Fragment>
+                    : null}
+                </ul>
+            }
         </React.Fragment>
     );
 };
@@ -170,6 +186,8 @@ const TrackLabel = ({ file, long }) => {
 TrackLabel.propTypes = {
     /** File object being displayed in the track */
     file: PropTypes.object.isRequired,
+    /** Determines what label to display */
+    label: PropTypes.string.isRequired,
     /** True to generate a long version of the label */
     long: PropTypes.bool,
 };
@@ -264,7 +282,7 @@ class GenomeBrowser extends React.Component {
                 }
                 let tracks = [];
                 if (files.length > 0) {
-                    tracks = this.filesToTracks(newFiles, domain);
+                    tracks = this.filesToTracks(newFiles, this.props.label, domain);
                 }
                 this.setState({ trackList: tracks }, () => {
                     if (this.chartdisplay && tracks !== []) {
@@ -403,7 +421,7 @@ class GenomeBrowser extends React.Component {
             const domain = `${window.location.protocol}//${window.location.hostname}`;
             const files = this.compileFiles(domain);
             if (files.length > 0) {
-                const tracks = this.filesToTracks(files, domain);
+                const tracks = this.filesToTracks(files, this.props.label, domain);
                 this.setState({ trackList: tracks }, () => {
                     this.drawTracks(this.chartdisplay);
                 });
@@ -450,22 +468,37 @@ class GenomeBrowser extends React.Component {
         return newFiles;
     }
 
-    filesToTracks(files, domain) {
+    filesToTracks(files, label, domain) {
         const tracks = files.map((file) => {
+            let labelLength = 0;
+            const defaultHeight = 32;
+            const extraLineHeight = 12;
+            const maxCharPerLine = 30;
+            // Some labels on the cart which have a target, assay name, and biosample are too long for one line (some actually extend to three lines)
+            // Here we do some approximate math to try to figure out how many lines the labels extend to assuming that ~30 characters fit on one line
+            // Labels on the experiment pages are short enough to fit on one line (they contain less information) so we can bypass these calculations for those pages
+            if (label === 'cart') {
+                labelLength += file.target ? file.target.label.length + 2 : 0;
+                labelLength += file.assay_term_name ? file.assay_term_name.length + 2 : 0;
+                labelLength += file.biosample_ontology && file.biosample_ontology.term_name ? file.biosample_ontology.term_name.length : 0;
+                labelLength = Math.floor(labelLength / maxCharPerLine);
+            }
             if (file.name) {
                 const trackObj = {};
                 trackObj.name = <i>{file.name}</i>;
                 trackObj.type = 'signal';
                 trackObj.path = file.href;
-                trackObj.heightPx = 80;
+                trackObj.heightPx = labelLength > 0 ? (defaultHeight + (extraLineHeight * labelLength)) : defaultHeight;
+                trackObj.expandedHeightPx = 140;
                 return trackObj;
             } else if (file.file_format === 'bigWig') {
                 const trackObj = {};
-                trackObj.name = <TrackLabel file={file} />;
-                trackObj.longname = <TrackLabel file={file} long />;
+                trackObj.name = <TrackLabel label={label} file={file} />;
+                trackObj.longname = <TrackLabel label={label} file={file} long />;
                 trackObj.type = 'signal';
                 trackObj.path = domain + file.href;
-                trackObj.heightPx = 80;
+                trackObj.heightPx = labelLength > 0 ? (defaultHeight + (extraLineHeight * labelLength)) : defaultHeight;
+                trackObj.expandedHeightPx = 140;
                 return trackObj;
             } else if (file.file_format === 'vdna-dir') {
                 const trackObj = {};
@@ -473,6 +506,7 @@ class GenomeBrowser extends React.Component {
                 trackObj.type = 'sequence';
                 trackObj.path = file.href;
                 trackObj.heightPx = 40;
+                trackObj.expandable = false;
                 return trackObj;
             } else if (file.file_format === 'vgenes-dir') {
                 const trackObj = {};
@@ -480,19 +514,26 @@ class GenomeBrowser extends React.Component {
                 trackObj.type = 'annotation';
                 trackObj.path = file.href;
                 trackObj.heightPx = 120;
+                trackObj.expandable = false;
+                trackObj.displayLabels = true;
                 return trackObj;
             }
             const trackObj = {};
-            trackObj.name = <TrackLabel file={file} />;
+            trackObj.name = <TrackLabel file={file} label={label} />;
+            trackObj.longname = <TrackLabel file={file} label={label} long />;
             trackObj.type = 'annotation';
             trackObj.path = domain + file.href;
+            trackObj.expandable = true;
+            trackObj.displayLabels = false;
+            trackObj.heightPx = labelLength > 0 ? (defaultHeight + (extraLineHeight * labelLength)) : defaultHeight;
+            trackObj.expandedHeightPx = 140;
             // bigBed bedRNAElements, bigBed peptideMapping, bigBed bedExonScore, bed12, and bed9 have two tracks and need extra height
             // Convert to lower case in case of inconsistency in the capitalization of the file format in the data
             if (file.file_format_type &&
-                (['bedrnaelements', 'peptidemapping', 'bedexonscore', 'bed12', 'bed9'].indexOf(file.file_format_type.toLowerCase() > -1))) {
-                trackObj.heightPx = 120;
-            } else {
-                trackObj.heightPx = 80;
+                (['bedrnaelements', 'peptidemapping', 'bedexonscore', 'bed12', 'bed9'].indexOf(file.file_format_type.toLowerCase()) > -1)) {
+                trackObj.name = <TrackLabel file={file} label={label} long />;
+                trackObj.heightPx = 90;
+                trackObj.expandable = false;
             }
             return trackObj;
         });
@@ -635,6 +676,7 @@ GenomeBrowser.propTypes = {
     files: PropTypes.array.isRequired,
     expanded: PropTypes.bool.isRequired,
     assembly: PropTypes.string,
+    label: PropTypes.string.isRequired,
 };
 
 GenomeBrowser.defaultProps = {

--- a/src/encoded/static/scss/encoded/modules/_genome_browser.scss
+++ b/src/encoded/static/scss/encoded/modules/_genome_browser.scss
@@ -87,6 +87,10 @@
     --secondary-cursor: #3645653b;
 }
 
+.hpgv_track-expander {
+    left: unset;
+}
+
 .hpgv_track-close-button {
     display: none;
 }


### PR DESCRIPTION
This ticket has several goals pertaining to the display of tracks on the Valis browser:
(1) Labels are customized for cart and file gallery views:
     On the cart, the labels for the collapsed tracks should be: target, assay title, biosample
     On the file gallery, the labels for the collapsed tracks should be: accession (replicate number)
(2) bigBed files are now expandable / collapsible ...
(3) ... except for bigBed files with two rows of data ('bedrnaelements', 'peptidemapping', 'bedexonscore', 'bed12', 'bed9') which are automatically expanded and are not collapsible
(4) We are using an updated Valis library which allows for specifying whether or not labels are displayed, and we do not display bigBed track labels except for the gene track
(5) Default track height is significantly smaller and expanded height is quite tall and we've eliminated any medium height
(6) Some of the cart labels are somewhat long (they can be up to 3 lines) so for those cases, the skinny track view is a little taller - we use an estimate of how many characters fit on a line in the label, and calculate from that how many lines we need (it mostly works)