### PR TITLE
ENCD-5181-perturbed-facet-normal

### DIFF
--- a/src/encoded/schemas/biosample.json
+++ b/src/encoded/schemas/biosample.json
@@ -850,6 +850,9 @@
         "award.rfa": {
             "title": "RFA"
         },
+        "perturbation": {
+            "title": "Perturbed"
+        },
         "nih_institutional_certification": {
             "type": "exists",
             "title": "Has NIH institutional certification"

--- a/src/encoded/schemas/experiment.json
+++ b/src/encoded/schemas/experiment.json
@@ -363,6 +363,9 @@
         "replicates.library.depleted_in_term_name": {
             "title": "Library depleted in"
         },
+        "replicates.library.biosample.perturbed": {
+            "title": "Perturbation"
+        },
         "date_released": {
             "title": "Date released",
             "length": "long"

--- a/src/encoded/static/components/app.js
+++ b/src/encoded/static/components/app.js
@@ -41,8 +41,8 @@ const portal = {
             title: 'Data',
             children: [
                 { id: 'functional-genomics', title: 'Functional Genomics data' },
-                { id: 'assaysearch', title: 'Experiment search', url: '/search/?type=Experiment&status=released', tag: 'collection' },
-                { id: 'assaymatrix', title: 'Experiment matrix', url: '/matrix/?type=Experiment&status=released', tag: 'collection' },
+                { id: 'assaysearch', title: 'Experiment search', url: '/search/?type=Experiment&status=released&replicates.library.biosample.perturbed=0', tag: 'collection' },
+                { id: 'assaymatrix', title: 'Experiment matrix', url: '/matrix/?type=Experiment&status=released&replicates.library.biosample.perturbed=0', tag: 'collection' },
                 { id: 'chip', title: 'ChIP-seq matrix', url: '/chip-seq-matrix/?type=Experiment&replicates.library.biosample.donor.organism.scientific_name=Homo%20sapiens&assay_title=Histone%20ChIP-seq&status=released', tag: 'collection' },
                 { id: 'bodymap', title: 'Human body map', url: '/summary/?type=Experiment&replicates.library.biosample.donor.organism.scientific_name=Homo+sapiens', tag: 'collection' },
                 { id: 'sep-mm-0' },

--- a/src/encoded/static/components/facets/defaults.js
+++ b/src/encoded/static/components/facets/defaults.js
@@ -675,6 +675,20 @@ DefaultTermName.propTypes = {
 
 
 /**
+ * Default component to render the name of a selected term from the search result filters. Used for
+ * the "Selected filters" links, and the term gets rendered inside an <a>.
+ */
+export const DefaultSelectedTermName = ({ filter }) => (
+    <span>{filter.term}</span>
+);
+
+DefaultSelectedTermName.propTypes = {
+    /** facet.filters object for the selected term we're rendering */
+    filter: PropTypes.object.isRequired,
+};
+
+
+/**
  * Default component to render a single term within the default facet.
  */
 export const DefaultTerm = ({ term, facet, results, mode, relevantFilters, pathname, queryString, onFilter, allowNegation }) => {
@@ -818,22 +832,27 @@ Typeahead.propTypes = {
  * Display links to clear the terms currently selected in the facet. Display nothing if no terms
  * have been selected.
  */
-const SelectedFilters = ({ selectedTerms }) => (
-    <React.Fragment>
-        {(selectedTerms.length > 0) ?
-            <div className="filter-container">
-                <div className="filter-hed">Selected filters:</div>
-                {selectedTerms.map(filter =>
-                    <a href={filter.remove} key={filter.term} className={(filter.field.indexOf('!') !== -1) ? 'negation-filter' : ''}>
-                        <div className="filter-link"><i className="icon icon-times-circle" /> {filter.term}</div>
-                    </a>
-                )}
-            </div>
-        : null}
-    </React.Fragment>
-);
+const SelectedFilters = ({ facet, selectedTerms }) => {
+    const SelectedTermNameComponent = FacetRegistry.SelectedTermName.lookup(facet.field);
+    return (
+        <React.Fragment>
+            {(selectedTerms.length > 0) ?
+                <div className="filter-container">
+                    <div className="filter-hed">Selected filters:</div>
+                    {selectedTerms.map(filter =>
+                        <a href={filter.remove} key={filter.term} className={(filter.field.indexOf('!') !== -1) ? 'negation-filter' : ''}>
+                            <div className="filter-link"><i className="icon icon-times-circle" /> <SelectedTermNameComponent filter={filter} /></div>
+                        </a>
+                    )}
+                </div>
+            : null}
+        </React.Fragment>
+    );
+};
 
 SelectedFilters.propTypes = {
+    /** Relevant `facet` object from `facets` array in `results` */
+    facet: PropTypes.object.isRequired,
     /** Search-result filters relevant to the facet */
     selectedTerms: PropTypes.array.isRequired,
 };
@@ -992,7 +1011,7 @@ export const DefaultFacet = ({ facet, results, mode, relevantFilters, pathname, 
     return (
         <div className="facet">
             <TitleComponent facet={facet} results={results} mode={mode} pathname={pathname} queryString={queryString} />
-            <SelectedFilters selectedTerms={relevantFilters} />
+            <SelectedFilters facet={facet} selectedTerms={relevantFilters} />
             {facet.type === 'typeahead' ? <Typeahead typeaheadTerm={typeaheadTerm} facet={facet} handleTypeAhead={handleTypeAhead} /> : null}
             <div className={`facet__content${facet.type === 'typeahead' ? ' facet__content--typeahead' : ''}`}>
                 <ul onScroll={handleScroll} ref={scrollingElement}>

--- a/src/encoded/static/components/facets/index.js
+++ b/src/encoded/static/components/facets/index.js
@@ -7,13 +7,14 @@
  * themselves on page load.
  */
 import FacetRegistry from './registry';
-import { DefaultFacet, DefaultTitle, DefaultTerm, DefaultTermName } from './defaults';
+import { DefaultFacet, DefaultTitle, DefaultTerm, DefaultTermName, DefaultSelectedTermName } from './defaults';
 // Custom facet-renderer modules imported here. Keep them alphabetically sorted.
 import './audit';
 import './date_selector';
 import './exists';
 import './internal_status';
 import './organism';
+import './perturbed';
 import './status';
 import './type';
 
@@ -25,6 +26,7 @@ FacetRegistry.Title._setDefaultComponent(DefaultTitle);
 FacetRegistry.Term._setDefaultComponent(DefaultTerm);
 FacetRegistry.TermName._setDefaultComponent(DefaultTermName);
 FacetRegistry.Facet._setDefaultComponent(DefaultFacet);
+FacetRegistry.SelectedTermName._setDefaultComponent(DefaultSelectedTermName);
 
 
 /**
@@ -124,28 +126,28 @@ export default FacetRegistry;
  * component you register gets called once for each term of the facet of a specific "field" value
  * you've attached it to. If you have custom Facet or Term components registered for this facet
  * field value, they would most likely render their own term titles in their own ways, and you
- * would not typically use this TermName registry for that case. It receives the following
- * properties:
- *
- *   selected - True if the term being rendered is currently selected.
+ * would not typically use this TermName registry for that case. Custom TermName components receive
+ * the following properties:
  *
  *   term - Relevant term object within the facet object this component has registered for. The
  *   text of the term is in `term.key` and might have the "string" or "number" type.
  *
- *   facet - Relevant `facet` object from `facets` array in `results`.
- *
- *   results - Complete search-results object for the entire page. This can be the object for a
- *   search-results object, report object, matrix object, etc.
- *
- *   mode (optional) - Indicates any special display modes, e.g. "picker".
- *
- *   pathname - Search results path without query-string portion, e.g. "/search/" or "/matrix/".
- *
- *   queryString (optional) - Query-string portion of current URL without initial question mark,
- *   e.g. "type=Experiment&status=released".
- *
  *   Registration method:
  *   FacetRegistry.TermName.register(<facet field>, <React component to render this term name>);
+ *
+ *
+ * SelectedTermName -- Render the text within the "Selected filters" links. This registry exists
+ * for when you need to change the styling of the terms that can be cleared from the facet, or if
+ * you have a mapping of actual facet term value to displayed term within "Selected filters."
+ * Custom SelectedTermName components receive the folling properties:
+ *
+ *   filter - facets.filters object that is offered to the user for clearing. filter.term holds the
+ *   name for the clear link.
+ *
+ *   Registration method:
+ *   FacetRegistry.SelectedTermName.register(<facet field>
+ *                                           <React component to render this selected term>);
+ *
  *
  * Organization
  * Generally, each type of facet should be implemented in its own file and included above. However,

--- a/src/encoded/static/components/facets/perturbed.js
+++ b/src/encoded/static/components/facets/perturbed.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import FacetRegistry from './registry';
+
+/**
+ * This module handles the “perturbed” boolean facet, needed because the values of the facet terms
+ * aren't human readable and have to be mapped to human-readable forms, and because we didn't want
+ * this facet to be the typical boolean radio buttons.
+ */
+
+const perturbedTerms = ['not perturbed', 'perturbed'];
+
+
+/**
+ * Perturbed terms have a value either 0 or 1. Map them to human-readable names.
+ */
+const PerturbedTermName = ({ term }) => {
+    let mappedTerm;
+    if (term.key === 0 || term.key === 1) {
+        mappedTerm = perturbedTerms[term.key];
+    } else {
+        // Likely will never happen.
+        mappedTerm = 'unknown';
+    }
+    return <span>{mappedTerm}</span>;
+};
+
+PerturbedTermName.propTypes = {
+    /** facet.terms object for the term we're mapping */
+    term: PropTypes.object.isRequired,
+};
+
+
+/**
+ * Maps the "perturbed" "0" and "1" values from the search result filters to human-readable
+ * strings for the "Selected filters" links.
+ */
+const PerturbedSelectedTermName = ({ filter }) => (
+    <span>{perturbedTerms[filter.term]}</span>
+);
+
+PerturbedSelectedTermName.propTypes = {
+    /** facet.filters object for the selected term we're mapping */
+    filter: PropTypes.object.isRequired,
+};
+
+
+FacetRegistry.TermName.register('replicates.library.biosample.perturbed', PerturbedTermName);
+FacetRegistry.TermName.register('perturbed', PerturbedTermName);
+FacetRegistry.SelectedTermName.register('replicates.library.biosample.perturbed', PerturbedSelectedTermName);
+FacetRegistry.SelectedTermName.register('perturbed', PerturbedSelectedTermName);

--- a/src/encoded/static/components/facets/registry.js
+++ b/src/encoded/static/components/facets/registry.js
@@ -57,4 +57,5 @@ FacetRegistry.Title = new FacetRegistryCore();
 FacetRegistry.Term = new FacetRegistryCore();
 FacetRegistry.TermName = new FacetRegistryCore();
 FacetRegistry.Facet = new FacetRegistryCore();
+FacetRegistry.SelectedTermName = new FacetRegistryCore();
 export default FacetRegistry;

--- a/src/encoded/tests/features/search.feature
+++ b/src/encoded/tests/features/search.feature
@@ -32,18 +32,18 @@ Feature: Search
 
     Scenario: Search Experiments
         When I press "Data"
-        And I click the link to "/search/?type=Experiment&status=released"
+        And I click the link to "/search/?type=Experiment&status=released&replicates.library.biosample.perturbed=0"
         And I wait for the content to load
         Then I should see at least 25 elements with the css selector "ul.result-table > li"
         And I should see at least 3 elements with the css selector "div.box.facets > div.orientation > div.facet"
 
-        When I click the link to "?type=Experiment&status=released&assay_title=TF+ChIP-seq"
+        When I click the link to "?type=Experiment&status=released&replicates.library.biosample.perturbed=0&assay_title=TF+ChIP-seq"
         And I wait for the content to load
-        Then I should see at least 7 elements with the css selector "ul.result-table > li"
+        Then I should see at least 2 elements with the css selector "ul.result-table > li"
 
-        When I click the link to "?type=Experiment&status=released&assay_title=TF+ChIP-seq&assay_title=DNAme+array"
+        When I click the link to "?type=Experiment&status=released&replicates.library.biosample.perturbed=0&assay_title=TF+ChIP-seq&assay_title=DNAme+array"
         And I wait for the content to load
-        Then I should see at least 11 elements with the css selector "ul.result-table > li"
+        Then I should see at least 4 elements with the css selector "ul.result-table > li"
 
 
     Scenario: Search BoxI
@@ -62,21 +62,21 @@ Feature: Search
 
     Scenario: Search for Assay term
         When I press "Data"
-        And I click the link to "/search/?type=Experiment&status=released"
+        And I click the link to "/search/?type=Experiment&status=released&replicates.library.biosample.perturbed=0"
         And I wait for the content to load
         When I fill in "searchAssaytitle" with "dna"
         Then I should see at least 2 elements with the css selector "div.facet__term-list.searchAssaytitle > li"
 
     Scenario: Search for Target of Assay term
         When I press "Data"
-        And I click the link to "/search/?type=Experiment&status=released"
+        And I click the link to "/search/?type=Experiment&status=released&replicates.library.biosample.perturbed=0"
         And I wait for the content to load
-        When I fill in "searchTargetofassay" with "h3k2"
-        Then I should see at least 2 elements with the css selector "div.facet__term-list.searchTargetofassay > li"
+        When I fill in "searchTargetofassay" with "fkh-10"
+        Then I should see at least 1 elements with the css selector "div.facet__term-list.searchTargetofassay > li"
 
     Scenario: Search for Organ term
         When I press "Data"
-        And I click the link to "/search/?type=Experiment&status=released"
+        And I click the link to "/search/?type=Experiment&status=released&replicates.library.biosample.perturbed=0"
         And I wait for the content to load
         When I fill in "searchOrgan" with "zzz"
         Then I should see 0 elements with the css selector "div.facet__term-list.searchOrgan > li"

--- a/src/encoded/tests/features/title.feature
+++ b/src/encoded/tests/features/title.feature
@@ -6,6 +6,6 @@ Feature: Title
         And I wait for the content to load
         Then the title should contain the text "ENCODE"
         When I press "Data"
-        And I click the link to "/search/?type=Experiment&status=released"
+        And I click the link to "/search/?type=Experiment&status=released&replicates.library.biosample.perturbed=0"
         And I wait for the content to load
         Then the title should contain the text "Search – ENCODE"


### PR DESCRIPTION
* While defined as a boolean facet, the “perturbed” facet doesn’t use the DefaultBooleanFacet which shows radio buttons, partly because we wanted to have a regular facet, and partly because DefaultBooleanFacet didn’t work for “perturbed” — and it didn’t work for “perturbed” partly because “perturbed” has the values “0” and “1” instead of the “true” and “false” that I had expected when I wrote DefaultBooleanFacet, and partly because Ben wanted unusual selection values.
* We might need to rethink how DefaultBooleanFacet works for future boolean facets if this first potential use couldn’t use it. I think we have to see how future boolean facets work.
* I added a new facet registry, SelectedTermName, that renders a name into the “Selected filters” link. Because “perturbed” uses non-human-readable values (“0” and “1”) for the UI, I not only have to have a custom TermName function to change the term names in the facet terms, I needed to have custom strings in the “Selected filters” link. I think generally if you have a custom TermName, you stand a good chance of needing a custom SelectedTermName.
* I noticed I had incorrect API documentation for TermName in facets/index.js.