### PR TITLE
ENCD-5302-cart-link

### DIFF
--- a/src/encoded/static/components/cart/clear.js
+++ b/src/encoded/static/components/cart/clear.js
@@ -123,7 +123,7 @@ class CartClearButtonComponent extends React.Component {
         if (elements.length > 0) {
             return (
                 <React.Fragment>
-                    <button disabled={inProgress} onClick={this.handleClearCartClick} id="clear-cart-actuator" className="btn btn-danger btn-sm">Clear cart</button>
+                    <button disabled={inProgress} onClick={this.handleClearCartClick} id="clear-cart-actuator" className="btn btn-danger btn-sm btn-inline">Clear cart</button>
                     {this.state.modalOpen ?
                         <CartClearModal closeClickHandler={this.handleCloseClick} />
                     : null}

--- a/src/encoded/static/scss/encoded/_base.scss
+++ b/src/encoded/static/scss/encoded/_base.scss
@@ -210,9 +210,7 @@ $disabled-color-factor: 20%;
     }
 
     &.btn-inline {
-        display: inline-block;
-        margin-right: 2px;
-        margin-left: 2px;
+        margin-right: 5px;
     }
 }
 


### PR DESCRIPTION
Ben hasn’t approved of how this works yet, but given the timing, I figured might as well get the PR in at least.

Nothing uses the .btn-inline CSS class, so I felt safe modifying it to be more useful to situations where buttons sit side-by-side.

Updated demo: https://encd-5302-cart-link-dv1-fytanaka.demo.encodedcc.org/

A QA demo is coming up as well.