### PR TITLE
ENCD-5324-experiment-perturbed

### DIFF
--- a/src/encoded/audit/experiment.py
+++ b/src/encoded/audit/experiment.py
@@ -4097,6 +4097,17 @@ def audit_experiment_inconsistent_genetic_modifications(value, system, excluded_
         yield AuditFailure('inconsistent genetic modifications', detail, level='INTERNAL_ACTION')
 
 
+def audit_biosample_perturbed_mixed(value, system, excluded_types):
+    '''Error for biosamples with mixed perturbed values'''
+    biosamples = get_biosamples(value)
+    bio_perturbed = set()
+    for biosample in biosamples:
+        bio_perturbed.add(biosample['perturbed'])
+    if len(bio_perturbed) > 1:
+        detail = 'Experiment {} contains both perturbed and non-perturbed biosamples'.format(audit_link(path_to_text(value['@id']), value['@id']))
+        yield AuditFailure('mixed biosample perturbations', detail, level='ERROR')
+
+
 #######################
 # utilities
 #######################
@@ -4718,7 +4729,8 @@ function_dispatcher_without_files = {
     'audit_nih_consent': audit_experiment_nih_institutional_certification,
     'audit_replicate_no_files': audit_experiment_replicate_with_no_files,
     'audit_experiment_eclip_queried_RNP_size_range': audit_experiment_eclip_queried_RNP_size_range,
-    'audit_inconsistent_genetic_modifications': audit_experiment_inconsistent_genetic_modifications
+    'audit_inconsistent_genetic_modifications': audit_experiment_inconsistent_genetic_modifications,
+    'audit_biosample_perturbed_mixed': audit_biosample_perturbed_mixed
 }
 
 function_dispatcher_with_files = {

--- a/src/encoded/schemas/biosample.json
+++ b/src/encoded/schemas/biosample.json
@@ -850,8 +850,8 @@
         "award.rfa": {
             "title": "RFA"
         },
-        "perturbation": {
-            "title": "Perturbed"
+        "perturbed": {
+            "title": "Perturbation"
         },
         "nih_institutional_certification": {
             "type": "exists",

--- a/src/encoded/schemas/experiment.json
+++ b/src/encoded/schemas/experiment.json
@@ -363,7 +363,7 @@
         "replicates.library.depleted_in_term_name": {
             "title": "Library depleted in"
         },
-        "replicates.library.biosample.perturbed": {
+        "perturbed": {
             "title": "Perturbation"
         },
         "date_released": {

--- a/src/encoded/static/components/app.js
+++ b/src/encoded/static/components/app.js
@@ -41,8 +41,8 @@ const portal = {
             title: 'Data',
             children: [
                 { id: 'functional-genomics', title: 'Functional Genomics data' },
-                { id: 'assaysearch', title: 'Experiment search', url: '/search/?type=Experiment&status=released&replicates.library.biosample.perturbed=0', tag: 'collection' },
-                { id: 'assaymatrix', title: 'Experiment matrix', url: '/matrix/?type=Experiment&status=released&replicates.library.biosample.perturbed=0', tag: 'collection' },
+                { id: 'assaysearch', title: 'Experiment search', url: '/search/?type=Experiment&status=released&perturbed=false', tag: 'collection' },
+                { id: 'assaymatrix', title: 'Experiment matrix', url: '/matrix/?type=Experiment&status=released&perturbed=false', tag: 'collection' },
                 { id: 'chip', title: 'ChIP-seq matrix', url: '/chip-seq-matrix/?type=Experiment&replicates.library.biosample.donor.organism.scientific_name=Homo%20sapiens&assay_title=Histone%20ChIP-seq&status=released', tag: 'collection' },
                 { id: 'bodymap', title: 'Human body map', url: '/summary/?type=Experiment&replicates.library.biosample.donor.organism.scientific_name=Homo+sapiens', tag: 'collection' },
                 { id: 'sep-mm-0' },

--- a/src/encoded/static/components/facets/defaults.js
+++ b/src/encoded/static/components/facets/defaults.js
@@ -698,14 +698,16 @@ export const DefaultTerm = ({ term, facet, results, mode, relevantFilters, pathn
     let negated = false;
 
     // Find the search-results filter matching this term, which if found indicates this term is
-    // selected; also check if the selection is for negation.
+    // selected; also check if the selection is for negation. Boolean terms have a
+    // term.key_as_string "true" and "false" values, preferable to the "1" and "0" values in
+    // term.key.
     const selectedTermFilter = relevantFilters.find((filter) => {
         let filterField = filter.field;
         const negatedFilter = filterField.slice(-1) === '!';
         if (negatedFilter) {
             filterField = filterField.slice(0, -1);
         }
-        const selected = filterField === facet.field && filter.term === term.key.toString();
+        const selected = filterField === facet.field && (filter.term === term.key_as_string || filter.term === term.key.toString());
         if (selected) {
             negated = negatedFilter;
         }
@@ -721,11 +723,12 @@ export const DefaultTerm = ({ term, facet, results, mode, relevantFilters, pathn
         // Term isn't selected, so build the link URI by adding this term to the existing URL.
         const query = new QueryString(queryString);
         const negQuery = query.clone();
-        query.addKeyValue(facet.field, term.key);
+        const key = term.key_as_string || term.key;
+        query.addKeyValue(facet.field, key);
         href = `?${query.format()}`;
 
         // Also build the negation URI.
-        negQuery.addKeyValue(facet.field, term.key, true);
+        negQuery.addKeyValue(facet.field, key, true);
         negHref = `?${negQuery.format()}`;
     }
 

--- a/src/encoded/static/components/facets/perturbed.js
+++ b/src/encoded/static/components/facets/perturbed.js
@@ -3,27 +3,25 @@ import PropTypes from 'prop-types';
 import FacetRegistry from './registry';
 
 /**
- * This module handles the “perturbed” boolean facet, needed because the values of the facet terms
- * aren't human readable and have to be mapped to human-readable forms, and because we didn't want
- * this facet to be the typical boolean radio buttons.
+ * This module handles the “perturbed” boolean facet, needed to map the 1/0 or true/false term keys
+ * to "not perturbed" and "perturbed".
  */
 
-const perturbedTerms = ['not perturbed', 'perturbed'];
+// The facet term key can be true/false or 1/0 with identical results either way.
+const perturbedTerms = {
+    false: 'not perturbed',
+    true: 'perturbed',
+    0: 'not perturbed',
+    1: 'perturbed',
+};
 
 
 /**
- * Perturbed terms have a value either 0 or 1. Map them to human-readable names.
+ * Perturbed terms have a key either true/false or 1/0. Map them to human-readable term names.
  */
-const PerturbedTermName = ({ term }) => {
-    let mappedTerm;
-    if (term.key === 0 || term.key === 1) {
-        mappedTerm = perturbedTerms[term.key];
-    } else {
-        // Likely will never happen.
-        mappedTerm = 'unknown';
-    }
-    return <span>{mappedTerm}</span>;
-};
+const PerturbedTermName = ({ term }) => (
+    <span>{perturbedTerms[term.key_as_string]}</span>
+);
 
 PerturbedTermName.propTypes = {
     /** facet.terms object for the term we're mapping */
@@ -32,7 +30,7 @@ PerturbedTermName.propTypes = {
 
 
 /**
- * Maps the "perturbed" "0" and "1" values from the search result filters to human-readable
+ * Maps the `perturbed` true/false and 0/1 keys from the search result filters to human-readable
  * strings for the "Selected filters" links.
  */
 const PerturbedSelectedTermName = ({ filter }) => (
@@ -45,7 +43,5 @@ PerturbedSelectedTermName.propTypes = {
 };
 
 
-FacetRegistry.TermName.register('replicates.library.biosample.perturbed', PerturbedTermName);
 FacetRegistry.TermName.register('perturbed', PerturbedTermName);
-FacetRegistry.SelectedTermName.register('replicates.library.biosample.perturbed', PerturbedSelectedTermName);
 FacetRegistry.SelectedTermName.register('perturbed', PerturbedSelectedTermName);

--- a/src/encoded/tests/features/search.feature
+++ b/src/encoded/tests/features/search.feature
@@ -32,16 +32,16 @@ Feature: Search
 
     Scenario: Search Experiments
         When I press "Data"
-        And I click the link to "/search/?type=Experiment&status=released&replicates.library.biosample.perturbed=0"
+        And I click the link to "/search/?type=Experiment&status=released&perturbed=false"
         And I wait for the content to load
         Then I should see at least 25 elements with the css selector "ul.result-table > li"
         And I should see at least 3 elements with the css selector "div.box.facets > div.orientation > div.facet"
 
-        When I click the link to "?type=Experiment&status=released&replicates.library.biosample.perturbed=0&assay_title=TF+ChIP-seq"
+        When I click the link to "?type=Experiment&status=released&perturbed=false&assay_title=TF+ChIP-seq"
         And I wait for the content to load
         Then I should see at least 2 elements with the css selector "ul.result-table > li"
 
-        When I click the link to "?type=Experiment&status=released&replicates.library.biosample.perturbed=0&assay_title=TF+ChIP-seq&assay_title=DNAme+array"
+        When I click the link to "?type=Experiment&status=released&perturbed=false&assay_title=TF+ChIP-seq&assay_title=DNAme+array"
         And I wait for the content to load
         Then I should see at least 4 elements with the css selector "ul.result-table > li"
 
@@ -62,21 +62,21 @@ Feature: Search
 
     Scenario: Search for Assay term
         When I press "Data"
-        And I click the link to "/search/?type=Experiment&status=released&replicates.library.biosample.perturbed=0"
+        And I click the link to "/search/?type=Experiment&status=released&perturbed=false"
         And I wait for the content to load
         When I fill in "searchAssaytitle" with "dna"
         Then I should see at least 2 elements with the css selector "div.facet__term-list.searchAssaytitle > li"
 
     Scenario: Search for Target of Assay term
         When I press "Data"
-        And I click the link to "/search/?type=Experiment&status=released&replicates.library.biosample.perturbed=0"
+        And I click the link to "/search/?type=Experiment&status=released&perturbed=false"
         And I wait for the content to load
         When I fill in "searchTargetofassay" with "fkh-10"
         Then I should see at least 1 elements with the css selector "div.facet__term-list.searchTargetofassay > li"
 
     Scenario: Search for Organ term
         When I press "Data"
-        And I click the link to "/search/?type=Experiment&status=released&replicates.library.biosample.perturbed=0"
+        And I click the link to "/search/?type=Experiment&status=released&perturbed=false"
         And I wait for the content to load
         When I fill in "searchOrgan" with "zzz"
         Then I should see 0 elements with the css selector "div.facet__term-list.searchOrgan > li"

--- a/src/encoded/tests/features/title.feature
+++ b/src/encoded/tests/features/title.feature
@@ -6,6 +6,6 @@ Feature: Title
         And I wait for the content to load
         Then the title should contain the text "ENCODE"
         When I press "Data"
-        And I click the link to "/search/?type=Experiment&status=released&replicates.library.biosample.perturbed=0"
+        And I click the link to "/search/?type=Experiment&status=released&perturbed=false"
         And I wait for the content to load
         Then the title should contain the text "Search – ENCODE"


### PR DESCRIPTION
An update to ENCD-5181. This implements a new `perturbed` property and facet in Experiments. It also now uses everything it can to use “true” and “false” instead of “1” and “0.”