### PR TITLE
ENCD-5310-choose-analysis

### DIFF
--- a/src/encoded/static/components/filegallery.js
+++ b/src/encoded/static/components/filegallery.js
@@ -2446,7 +2446,7 @@ class FileGalleryRendererComponent extends React.Component {
     /**
      * Sets the `selectedAnalysisProps` property to track the corresponding selected assembly/annotation
      * and pipeline lab. Only pass in `compiledAnalyses` if it has been newly determined and might
-     * not yet have propogated to `this.state.compiledAnalyses`.
+     * not yet have propagated to `this.state.compiledAnalyses`.
      * @param {number} selectedAnalysesIndex New index of selected `compiledAnalyses`
      * @param {array} compiledAnalyses Compiled analyses for the experiment if newly determined
      */
@@ -2459,7 +2459,7 @@ class FileGalleryRendererComponent extends React.Component {
     /**
      * Find the compiled analyses object best matching the given assembly/annotation and the last
      * selected pipeline lab and return its index into the compiled analyses array. Only pass in
-     * `compiledAnalyses` if it has been newly determined and might not yet have propogated to
+     * `compiledAnalyses` if it has been newly determined and might not yet have propagated to
      * `this.state.compiledAnalyses`. If no appropriate compiled analyses can be found, return 0
      * which selects the first compiled analyses object.
      * @param {string} assembly Suggested assembly for matching an analysis

--- a/src/encoded/static/components/genome_browser.js
+++ b/src/encoded/static/components/genome_browser.js
@@ -19,6 +19,7 @@ const dummyFiles = [
         assembly: 'GRCh38',
         file_type: 'bigWig',
         assay_term_name: 'shRNA knockdown followed by RNA-seq',
+        dataset: '/experiments/ENCSR585KOJ/',
         biosample_ontology: {
             term_name: 'HepG2',
         },
@@ -26,6 +27,7 @@ const dummyFiles = [
             title: 'ENCODE Processing Pipeline',
         },
         status: 'released',
+        title: 'ENCFF425LKJ',
     },
     {
         file_format: 'bigWig',
@@ -36,6 +38,7 @@ const dummyFiles = [
         assembly: 'GRCh38',
         file_type: 'bigWig',
         assay_term_name: 'shRNA knockdown followed by RNA-seq',
+        dataset: '/experiments/ENCSR585KOJ/',
         biosample_ontology: {
             term_name: 'HepG2',
         },
@@ -43,6 +46,7 @@ const dummyFiles = [
             title: 'ENCODE Processing Pipeline',
         },
         status: 'released',
+        title: 'ENCFF638QHN',
     },
     {
         file_format: 'bigWig',
@@ -52,6 +56,7 @@ const dummyFiles = [
         href: '/files/ENCFF541XFO/@@download/ENCFF541XFO.bigWig',
         assembly: 'GRCh38',
         file_type: 'bigWig',
+        dataset: '/experiments/ENCSR585KOJ/',
         assay_term_name: 'shRNA knockdown followed by RNA-seq',
         biosample_ontology: {
             term_name: 'HepG2',
@@ -60,6 +65,7 @@ const dummyFiles = [
             title: 'ENCODE Processing Pipeline',
         },
         status: 'released',
+        title: 'ENCFF541XFO',
     },
     {
         file_format: 'bigBed bedRNAElements',
@@ -69,6 +75,7 @@ const dummyFiles = [
         href: '/files/ENCFF517WSY/@@download/ENCFF517WSY.bigBed',
         assembly: 'GRCh38',
         file_type: 'bigBed tss_peak',
+        dataset: '/experiments/ENCSR000CIS/',
         assay_term_name: 'shRNA knockdown followed by RNA-seq',
         biosample_ontology: {
             term_name: 'HepG2',
@@ -77,6 +84,7 @@ const dummyFiles = [
             title: 'ENCODE Processing Pipeline',
         },
         status: 'released',
+        title: 'ENCFF517WSY',
     },
     {
         file_format: 'bigBed',
@@ -86,6 +94,7 @@ const dummyFiles = [
         href: '/files/ENCFF026DAN/@@download/ENCFF026DAN.bigBed',
         assembly: 'hg19',
         file_type: 'bigBed narrowPeak',
+        dataset: '/experiments/ENCSR683CSF/',
         assay_term_name: 'ChIP-seq',
         biosample_ontology: {
             term_name: 'HepG2',
@@ -94,6 +103,7 @@ const dummyFiles = [
             title: 'ENCODE Processing Pipeline',
         },
         status: 'released',
+        title: 'ENCFF026DAN',
     },
     {
         file_format: 'bigBed',
@@ -103,6 +113,7 @@ const dummyFiles = [
         href: '/files/ENCFF847CBY/@@download/ENCFF847CBY.bigBed',
         assembly: 'hg19',
         file_type: 'bigBed narrowPeak',
+        dataset: '/experiments/ENCSR683CSF/',
         assay_term_name: 'ChIP-seq',
         biosample_ontology: {
             term_name: 'HepG2',
@@ -111,6 +122,7 @@ const dummyFiles = [
             title: 'ENCODE Processing Pipeline',
         },
         status: 'released',
+        title: 'ENCFF847CBY',
     },
 ];
 


### PR DESCRIPTION
* Before, I based the selected pipeline menu item by calculating it from the currently selected assembly — causing an issue if two menu items used the same assembly. I now store the selected menu index in the `selectedAnalysesIndex` state, and recalculate it when switching tabs.
* To help with this calculation, I keep the last-selected lab and assembly as properties in `this.selectedAnalysisProps`.
* I added a couple fields to all the dummy files in genome_browser.js as some recent code changes couldn’t handle those fields not being there. That issue doesn’t affect demos and production; just local.
* `findCompiledAnalysesIndex` which used to find an appropriate pipeline menu item based only on an assembly, now exists as a method and uses both a given assembly and the last-selected pipeline menu to figure out the index of the best-matching menu item.