### PR TITLE
ENCD-5328 fix released start date

### DIFF
--- a/src/encoded/static/components/facets/defaults.js
+++ b/src/encoded/static/components/facets/defaults.js
@@ -231,8 +231,9 @@ export class DefaultDateSelectorFacet extends React.Component {
     }
 
     componentDidMount() {
-        this.setState({ activeFacet: this.props.facet.field });
-        this.setActiveFacetParameters(true);
+        this.setState({ activeFacet: this.props.facet.field }, () => {
+            this.setActiveFacetParameters(true);
+        });
     }
 
     setActiveFacetParameters(initializationFlag) {


### PR DESCRIPTION
The default start year for the "released" radio button needs to be 2009. I'm not sure why this worked originally but since setting state is asynchronous, the function for setting parameters needs to be a callback.