### PR TITLE
ENCD-5241-search-scroll

### DIFF
--- a/src/encoded/static/components/app.js
+++ b/src/encoded/static/components/app.js
@@ -844,8 +844,7 @@ class App extends React.Component {
         }
 
         // data-noscroll attribute prevents scrolling to the top when clicking a link.
-        const dataNoScroll = target.getAttribute('data-noscroll');
-        if (dataNoScroll !== null) {
+        if (target.getAttribute('data-noscroll') !== null) {
             options.noscroll = true;
         }
 

--- a/src/encoded/static/components/app.js
+++ b/src/encoded/static/components/app.js
@@ -812,6 +812,8 @@ class App extends React.Component {
 
     /* eslint no-script-url: 0 */ // We're not *using* a javascript: link -- just checking them.
     handleClick(event) {
+        const options = {};
+
         // https://github.com/facebook/react/issues/1691
         if (event.isDefaultPrevented()) {
             return;
@@ -839,6 +841,12 @@ class App extends React.Component {
             event.preventDefault();
             this.trigger(dataTrigger);
             return;
+        }
+
+        // data-noscroll attribute prevents scrolling to the top when clicking a link.
+        const dataNoScroll = target.getAttribute('data-noscroll');
+        if (dataNoScroll !== null) {
+            options.noscroll = true;
         }
 
         // Ensure this is a plain click
@@ -883,7 +891,7 @@ class App extends React.Component {
         // through the navigate method.
         if (this.constructor.historyEnabled) {
             event.preventDefault();
-            this.navigate(href);
+            this.navigate(href, options);
         }
     }
 
@@ -985,6 +993,7 @@ class App extends React.Component {
 
         // options.skipRequest only used by collection search form
         // options.replace only used handleSubmit, handlePopState, handleAuth0Login
+        // options.noscroll to prevent scrolling to the top of the page after navigating.
         let mutatableHref = url.resolve(this.state.href, href);
 
         // Strip url fragment.
@@ -1070,7 +1079,8 @@ class App extends React.Component {
             return response.json();
         }).catch(globals.parseAndLogError.bind(undefined, 'contextRequest')).then(this.receiveContextResponse);
 
-        if (!mutatableOptions.replace) {
+        // Scroll to the top of the page unless replacing the URL or option to not scroll given.
+        if (!mutatableOptions.replace && !mutatableOptions.noscroll) {
             promise.then(this.constructor.scrollTo);
         }
 

--- a/src/encoded/static/components/facets/defaults.js
+++ b/src/encoded/static/components/facets/defaults.js
@@ -747,7 +747,7 @@ export const DefaultTerm = ({ term, facet, results, mode, relevantFilters, pathn
 
     return (
         <li className="facet-term">
-            <a href={href} onClick={href ? onFilter : null} className={`facet-term__item${termCss}`}>
+            <a href={href} onClick={mode === 'picker' ? onFilter : null} className={`facet-term__item${termCss}`}>
                 <div className="facet-term__text">
                     <TermNameComponent
                         termName={term.key}
@@ -789,7 +789,7 @@ DefaultTerm.propTypes = {
     pathname: PropTypes.string.isRequired,
     /** Query-string portion of current URL without initial ? */
     queryString: PropTypes.string,
-    /** Special search-result click handler */
+    /** Special facet-term click handler for edit forms */
     onFilter: PropTypes.func,
     /** True to display negation control */
     allowNegation: PropTypes.bool,
@@ -906,7 +906,7 @@ FacetTerms.propTypes = {
     queryString: PropTypes.string,
     /** Array of terms to render */
     filteredTerms: PropTypes.array.isRequired,
-    /** Special search-result click handler */
+    /** Special facet-term click handler for edit forms */
     onFilter: PropTypes.func,
     /** True to display negation control */
     allowNegation: PropTypes.bool,
@@ -1077,7 +1077,7 @@ DefaultFacet.propTypes = {
     pathname: PropTypes.string.isRequired,
     /** Query-string portion of current URL without initial ? */
     queryString: PropTypes.string,
-    /** Special search-result click handler */
+    /** Special facet-term click handler for edit forms */
     onFilter: PropTypes.func,
     /** True to display negation control */
     allowNegation: PropTypes.bool,

--- a/src/encoded/static/components/search.js
+++ b/src/encoded/static/components/search.js
@@ -874,7 +874,7 @@ FacetList.propTypes = {
     addClasses: PropTypes.string, // CSS classes to use if the default isn't needed.
     /** True to supress the display of facet-list title */
     supressTitle: PropTypes.bool,
-    /** Special search-result click handler */
+    /** Special facet-term click handler for edit forms */
     onFilter: PropTypes.func,
     /** True if the collapsible, false otherwise  */
     isExpandable: PropTypes.bool,


### PR DESCRIPTION
You can attach a new `data-noscroll` attribute to `<a>` elements which, when the user clicks the link, navigates to the given href but does _not_ scroll to the top of the page:

```
<a href="#" data-noscroll>Click</a>
```

You can pass a corresponding new option to `context.navigate`:

```
this.context.navigate(href, { noscroll: true });
```

All the normal text facet terms now use the data-noscroll attribute, and the more unusual facets (e.g. “exists” facets) use the `noscroll` option for `navigate`. It would be interesting to see how this works for the body map.