### PR TITLE
ENCD-5353-cart-limit

### DIFF
--- a/src/encoded/cart_view.py
+++ b/src/encoded/cart_view.py
@@ -10,7 +10,8 @@ from collections import OrderedDict
 from snovault import COLLECTIONS
 
 
-CART_USER_MAX = 30  # Maximum number of non-deleted carts allowed per user
+CART_USER_MAX = 30  # Maximum number of non-deleted carts allowed per non-admin user
+CART_ADMIN_MAX = 200  # Maximum per admin user
 
 
 def includeme(config):
@@ -60,7 +61,8 @@ def cart_view(context, request):
 def cart_manager(context, request):
     '''Cart manager page context object generation'''
     userid = get_userid(request)
-    blocked_statuses = ['deleted'] if 'group.admin' not in request.effective_principals else []
+    is_admin = 'group.admin' in request.effective_principals
+    blocked_statuses = ['deleted'] if not is_admin else []
     user_carts = get_cart_objects_by_user(request, userid, blocked_statuses)
     # Calculate the element count in each cart, but remove the elements
     # themselves as this list can be huge.
@@ -76,7 +78,7 @@ def cart_manager(context, request):
         'columns': OrderedDict(),
         'notification': '',
         'filters': [],
-        'cart_user_max': CART_USER_MAX
+        'cart_user_max': CART_ADMIN_MAX if is_admin else CART_USER_MAX
     }
     return result
 


### PR DESCRIPTION
Changes the maximum number of non-deleted carts to 200 for admins, but keeps it at 30 for submitters and non-privileged users.