### PR TITLE
ENCD-5370-pub-dataset-paged

### DIFF
--- a/src/encoded/schemas/publication.json
+++ b/src/encoded/schemas/publication.json
@@ -217,9 +217,13 @@
         "published_by": {
             "title": "Published by"
         },
-        "datasets.accession": {
+        "datasets": {
             "type": "exists",
             "title": "Associated dataset"
+        },
+        "publication_data": {
+            "type": "exists",
+            "title": "Publication data"
         }
     },
     "columns": {

--- a/src/encoded/static/components/cart/add_multiple.js
+++ b/src/encoded/static/components/cart/add_multiple.js
@@ -176,8 +176,7 @@ class CartAddAllElementsComponent extends React.Component {
      * Handle a click in the button to add all datasets from a list to the current cart.
      */
     handleClick() {
-        const elementAtIds = this.props.elements.map(element => element['@id']);
-        this.props.addAllResults(elementAtIds);
+        this.props.addAllResults(this.props.elements);
     }
 
     render() {
@@ -201,7 +200,7 @@ class CartAddAllElementsComponent extends React.Component {
 CartAddAllElementsComponent.propTypes = {
     /** Current cart saved object */
     savedCartObj: PropTypes.object,
-    /** New elements to add to cart as array of dataset objects */
+    /** New elements to add to cart as array of @ids */
     elements: PropTypes.array.isRequired,
     /** True if cart updating operation is in progress */
     inProgress: PropTypes.bool.isRequired,
@@ -232,7 +231,7 @@ export const CartAddAllElements = ({ elements }, reactContext) => (
 );
 
 CartAddAllElements.propTypes = {
-    /** New elements to add to cart as array of dataset objects */
+    /** New elements to add to cart as array of @ids */
     elements: PropTypes.array,
 };
 

--- a/src/encoded/static/components/dataset.js
+++ b/src/encoded/static/components/dataset.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import _ from 'underscore';
 import { Panel, PanelBody } from '../libs/ui/panel';
 import DropdownButton from '../libs/ui/button';
-import { DropdownMenu } from '../libs/ui/dropdown-menu';
 import { CartToggle, CartAddAllElements } from './cart';
 import * as globals from './globals';
 import { Breadcrumbs } from './navigation';
@@ -441,7 +440,7 @@ const ComputationalModelComponent = (props, reactContext) => {
     const itemClass = globals.itemClass(context, 'view-item');
     const adminUser = !!(reactContext.session_properties && reactContext.session_properties.admin);
     const experimentsUrl = `/search/?type=Experiment&possible_controls.accession=${context.accession}`;
-    const fileCountDisplay = <div className="file-table-paged__count">{`${context.files.length} file${context.files.length === 1 ? '' : 's'}`}</div>;
+    const fileCountDisplay = <div className="table-paged__count">{`${context.files.length} file${context.files.length === 1 ? '' : 's'}`}</div>;
 
     // Build up array of documents attached to this dataset
     const datasetDocuments = (context.documents && context.documents.length > 0) ? context.documents : [];
@@ -677,10 +676,10 @@ const ReferenceComponent = (props, reactContext) => {
                                     <dt>Examined loci</dt>
                                     <dd>
                                         <ul>
-                                            {context.examined_loci.map(examined_locus => (
-                                                <li key={examined_locus['@id']} className="multi-comma">
-                                                    <a href={examined_locus['@id']}>
-                                                        {examined_locus.symbol}
+                                            {context.examined_loci.map(examinedLocus => (
+                                                <li key={examinedLocus['@id']} className="multi-comma">
+                                                    <a href={examinedLocus['@id']}>
+                                                        {examinedLocus.symbol}
                                                     </a>
                                                 </li>
                                             ))}
@@ -1496,10 +1495,11 @@ export const SeriesComponent = (props, reactContext) => {
     // them to the current cart.
     let addAllToCartControl;
     if (experimentList.length > 0) {
+        const experimentIds = experimentList.map(experiment => experiment['@id']);
         addAllToCartControl = (
             <div className="experiment-table__header">
                 <h4 className="experiment-table__title">{`Experiments in ${seriesTitle} ${context.accession}`}</h4>
-                <CartAddAllElements elements={experimentList} />
+                <CartAddAllElements elements={experimentIds} />
             </div>
         );
     }

--- a/src/encoded/static/components/experiment_series.js
+++ b/src/encoded/static/components/experiment_series.js
@@ -521,10 +521,11 @@ class ExperimentSeriesComponent extends React.Component {
         const viewableDatasets = this.state.viewableDatasets;
         if (Object.keys(viewableDatasets).length > 0) {
             // Add the "Add all to cart" button and internal tags from all related datasets.
+            const experimentIds = Object.values(viewableDatasets).map(experiment => experiment['@id']);
             addAllToCartControl = (
                 <div className="experiment-table__header">
                     <h4 className="experiment-table__title">{`Experiments in experiment series ${context.accession}`}</h4>
-                    <CartAddAllElements elements={Object.values(viewableDatasets)} />
+                    <CartAddAllElements elements={experimentIds} />
                 </div>
             );
 

--- a/src/encoded/static/components/facets/exists.js
+++ b/src/encoded/static/components/facets/exists.js
@@ -38,5 +38,6 @@ ExistsFacet.defaultProps = {
     queryString: '',
 };
 
-FacetRegistry.Facet.register('datasets.accession', ExistsFacet);
+FacetRegistry.Facet.register('datasets', ExistsFacet);
+FacetRegistry.Facet.register('publication_data', ExistsFacet);
 FacetRegistry.Facet.register('nih_institutional_certification', ExistsFacet);

--- a/src/encoded/static/components/testdata/publication/PMID16395128.js
+++ b/src/encoded/static/components/testdata/publication/PMID16395128.js
@@ -5,6 +5,7 @@ module.exports = {
     "identifiers": [
         "PMID:16395128"
     ],
+    "publication_data": [],
     "status": "released",
     "title": "Possible association between response inhibition and a variant in the brain-expressed tryptophan hydroxylase-2 gene.",
     "uuid": "b163ba10-bd4a-11e4-bb52-0800200c9a66"

--- a/src/encoded/static/components/testdata/publication/PMID23000965.js
+++ b/src/encoded/static/components/testdata/publication/PMID23000965.js
@@ -5,6 +5,7 @@ module.exports = {
     "identifiers": [
         "PMID:23000965"
     ],
+    "publication_data": [],
     "status": "released",
     "title": "Systems-wide analysis of ubiquitylation dynamics reveals a key role for PAF15 ubiquitylation in DNA-damage bypass.",
     "uuid": "4cb65ec0-bd49-11e4-bb52-0800200c9a66"

--- a/src/encoded/static/components/testdata/publication/publication.js
+++ b/src/encoded/static/components/testdata/publication/publication.js
@@ -11,6 +11,7 @@ module.exports = {
     volume: '489',
     issue: '7414',
     page: '57-74',
+    publication_data: [],
     status: 'in progress',
     urls: ['http://www.millipore.com/catalogue/item/05-379#', 'http://www.millipore.com/catalogue/item/07-473'],
     uuid: '52e85c70-fe2d-11e3-9191-0800200c9a66',

--- a/src/encoded/static/components/typeutils.js
+++ b/src/encoded/static/components/typeutils.js
@@ -582,7 +582,7 @@ const derivingCols = {
 };
 
 
-const PAGED_FILE_TABLE_MAX = 50; // Maximnum number of files per page
+const PAGED_FILE_TABLE_MAX = 25; // Maximnum number of files per page
 const PAGED_FILE_CACHE_MAX = 10; // Maximum number of pages to cache
 
 
@@ -608,6 +608,33 @@ const getPageFiles = (files, pageNo) => {
         return files.slice(start, start + PAGED_FILE_TABLE_MAX);
     }
     return [];
+};
+
+
+/**
+ * Display the header for the file table, including the pager.
+ */
+const FileTableHeader = ({ title, currentPage, totalPageCount, updateCurrentPage }) => (
+    <div className="header-paged-sorttable">
+        {title}
+        <div className="header-paged-sorttable__controls">
+            {totalPageCount > 1 ? <Pager total={totalPageCount} current={currentPage} updateCurrentPage={updateCurrentPage} /> : null}
+        </div>
+    </div>
+);
+
+FileTableHeader.propTypes = {
+    /** Title of table */
+    title: PropTypes.oneOfType([
+        PropTypes.element, // Title is a React component
+        PropTypes.string, // Title is an unformatted string
+    ]).isRequired,
+    /** Current displayed page number, 0 based */
+    currentPage: PropTypes.number.isRequired,
+    /** Total number of pages */
+    totalPageCount: PropTypes.number.isRequired,
+    /** Called with the new page number the user selected */
+    updateCurrentPage: PropTypes.func.isRequired,
 };
 
 
@@ -690,18 +717,17 @@ export const FileTablePaged = ({ fileIds, files, title }) => {
     if (currentPageFiles.length > 0) {
         const headerTitle = typeof title === 'string' ? <h4>{title}</h4> : title;
         const fileCount = fileIds ? fileIds.length : files.length;
-        const fileCountDisplay = <div className="file-table-paged__count">{`${fileCount} file${fileCount === 1 ? '' : 's'}`}</div>;
-
-        // If we have more than one page of files to display, render a pager component in the
-        // footer.
-        const pager = totalPages > 1 ? <Pager total={totalPages} current={currentPageNum} updateCurrentPage={updateCurrentPage} /> : null;
+        const fileCountDisplay = <div className="table-paged__count">{`${fileCount} file${fileCount === 1 ? '' : 's'}`}</div>;
 
         return (
-            <SortTablePanel title={headerTitle} subheader={fileCountDisplay} css="file-table-paged">
+            <SortTablePanel
+                header={<FileTableHeader title={headerTitle} currentPage={currentPageNum} totalPageCount={totalPages} updateCurrentPage={updateCurrentPage} />}
+                subheader={fileCountDisplay}
+                css="table-paged"
+            >
                 <SortTable
                     list={currentPageFiles}
                     columns={derivingCols}
-                    footer={pager}
                 />
             </SortTablePanel>
         );

--- a/src/encoded/static/libs/cache.js
+++ b/src/encoded/static/libs/cache.js
@@ -1,0 +1,136 @@
+// Implements a simple LRU cache to hold any items based on a unique key for each item.
+// Based on:
+// https://medium.com/dsinjs/implementing-lru-cache-in-javascript-94ba6755cda9
+const CACHE_COUNT_DEFAULT = 10; // Default cache size
+
+
+/**
+ * Tracks one item in the double-linked-list. Not used outside the Cache class.
+ */
+class Node {
+    constructor(key, value, next = null, prev = null) {
+        this._key = key;
+        this._value = value;
+        this._next = next;
+        this._prev = prev;
+    }
+}
+
+
+/**
+ * Implements an LRU generic cache able to hold any values identified by a unique key for each item.
+ */
+export default class Cache {
+    /**
+     * @param {number} limit Maximum number of entries in the cache
+     */
+    constructor(limit = CACHE_COUNT_DEFAULT) {
+        this._size = 0;
+        this._limit = limit;
+        this._head = null;
+        this._tail = null;
+        this._cache = {};
+    }
+
+    /**
+     * Write value to cache. This method does no collision detection, so the caller needs to make
+     * sure they don't write an item with a key that already exists in the cache.
+     * @param {string,number} key Unique cache-retrieval key
+     * @param {any} value Value to write to the cache
+     */
+    write(key, value) {
+        // Open space in the cache if the cache has filled.
+        this._ensureLimit();
+
+        if (!this._head) {
+            // First item written to cache. Head and tail point at the new item.
+            this._tail = new Node(key, value);
+            this._head = this._tail;
+        } else {
+            // Add the new item to the cache at the head.
+            const node = new Node(key, value, this._head);
+            this._head._prev = node;
+            this._head = node;
+        }
+
+        // Place new node in the cache index.
+        this._cache[key] = this._head;
+        this._size += 1;
+    }
+
+    /**
+     * Read from cache and make the read node the head.
+     * @param {string,number} key Identifies desired cached value
+     *
+     * @return {any} Cached data corresponding to key; "undefined" if cache miss
+     */
+    read(key) {
+        if (this._cache[key]) {
+            // Cache hit. Retrieve the value, then remove and rewrite the node so it moves to the
+            // head for LRU and becomes most distant from being removed from the cache.
+            const value = this._cache[key]._value;
+            this.remove(key);
+            this.write(key, value);
+            return value;
+        }
+
+        // Cache miss.
+        return undefined;
+    }
+
+    /**
+     * Remove least-recently used node if cache bumping against its count limit.
+     */
+    _ensureLimit() {
+        if (this._size === this._limit) {
+            this.remove(this._tail._key);
+        }
+    }
+
+    /**
+     * Remove the node with the given key. Assumes the item exists in the cache.
+     * @param {string number} key Identifies cache entry to remove
+     */
+    remove(key) {
+        const node = this._cache[key];
+
+        if (node._prev !== null) {
+            node._prev._next = node._next;
+        } else {
+            this._head = node._next;
+        }
+
+        if (node._next !== null) {
+            node._next._prev = node._prev;
+        } else {
+            this._tail = node._prev;
+        }
+
+        delete this._cache[key];
+        this._size -= 1;
+    }
+
+    /**
+     * Clear the cache entirely.
+     */
+    clear() {
+        this._head = null;
+        this._tail = null;
+        this._size = 0;
+        this._cache = {};
+    }
+
+    /**
+     * Invokes the callback function with every node of the chain and the index of the node.
+     * @param {func} fn Function to call with the item's node and index into the cache.
+     */
+    forEach(fn) {
+        let node = this._head;
+        let counter = 0;
+        while (node) {
+            fn(node, counter);
+            node = node._next;
+            counter += 1;
+        }
+    }
+}

--- a/src/encoded/static/libs/ui/pager.js
+++ b/src/encoded/static/libs/ui/pager.js
@@ -2,47 +2,42 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 
-// Displays a pager component that lets users navigate a list of items. It displays a left and
-// right arrow, and the current displayed item number and tht total number of items. When the
-// user clicks a page, it calls the `updateCurrentPage` callback so that the component that uses
-// <Pager> can react to the click.
-
-class Pager extends React.Component {
-    constructor() {
-        super();
-        this.handlePrev = this.handlePrev.bind(this);
-        this.handleNext = this.handleNext.bind(this);
-    }
-
-    handlePrev() {
-        const { current, updateCurrentPage } = this.props;
+/**
+ * Displays a pager component that lets users navigate a list of items. It displays a left and
+ * right arrow, and the current displayed item number and the total number of items. When the
+ * user clicks a page, it calls the `updateCurrentPage` callback so that the component that uses
+ * <Pager> can react to the click.
+ */
+const Pager = ({ total, current, updateCurrentPage }) => {
+    const handlePrev = () => {
         updateCurrentPage(current - 1);
-    }
+    };
 
-    handleNext() {
-        const { current, updateCurrentPage } = this.props;
+    const handleNext = () => {
         updateCurrentPage(current + 1);
-    }
+    };
 
-    render() {
-        const { total, current } = this.props;
-        const prevDisabled = current === 0;
-        const nextDisabled = current === (total - 1);
+    const prevDisabled = current === 0;
+    const nextDisabled = current === (total - 1);
 
-        return (
-            <div className="pager" role="navigation" aria-label="Pagination">
-                <button className="pager__dir" disabled={prevDisabled} aria-label={prevDisabled ? '' : 'Previous page'} onClick={this.handlePrev}><i className="icon icon-chevron-left" /></button>
-                <div className="pager__index">{current + 1} OF {total}</div>
-                <button className="pager__dir" disabled={nextDisabled} aria-label={nextDisabled ? '' : 'Next page'} onClick={this.handleNext}><i className="icon icon-chevron-right" /></button>
-            </div>
-        );
-    }
-}
+    return (
+        <nav className="pager" aria-label="Pagination">
+            <ul>
+                <li><button className="pager__dir" disabled={prevDisabled} aria-label={prevDisabled ? '' : `Previous page ${current} of ${total}`} onClick={handlePrev}><i className="icon icon-chevron-left" /></button></li>
+                <li><div className="pager__index"><div>{current + 1} OF {total}</div></div></li>
+                <li><button className="pager__dir" disabled={nextDisabled} aria-label={nextDisabled ? '' : `Next page ${current + 2} of ${total}`} onClick={handleNext}><i className="icon icon-chevron-right" /></button></li>
+            </ul>
+        </nav>
+    );
+};
 
 Pager.propTypes = {
-    total: PropTypes.number.isRequired, // Total number of pages
-    current: PropTypes.number.isRequired, // Current page number; 0 based
-    updateCurrentPage: PropTypes.func.isRequired, // Callback with new page number of user selects
+    /** Total number of pages */
+    total: PropTypes.number.isRequired,
+    /** Current page number; 0 based */
+    current: PropTypes.number.isRequired,
+    /** Callback with new page number user selects */
+    updateCurrentPage: PropTypes.func.isRequired,
 };
 
 export default Pager;

--- a/src/encoded/static/scss/encoded/modules/_pager.scss
+++ b/src/encoded/static/scss/encoded/modules/_pager.scss
@@ -3,10 +3,22 @@ $pager-dimension: 24px;
 
 // Contains the pager's direcion buttons and index.
 .pager {
-    display: inline-flex;
+    display: inline;
     border: 1px solid #c0c0c0;
     border-radius: 2px;
     background-color: white;
+    align-items: center;
+
+    > ul {
+        display: flex;
+        padding: 0;
+        margin: 0;
+        height: 100%;
+
+        > li {
+            list-style: none;
+        }
+    }
 }
 
 
@@ -14,9 +26,9 @@ $pager-dimension: 24px;
 .pager__dir {
     flex: 0 0 auto;
     padding: 0;
-    height: $pager-dimension;
+    min-height: $pager-dimension;
     width: $pager-dimension;
-    line-height: $pager-dimension;
+    height: 100%;
     border: none;
     background-color: transparent;
     color: $std-href-color;
@@ -28,16 +40,19 @@ $pager-dimension: 24px;
     &:disabled {
         color: #a0a0a0;
         background-color: #fff;
+        cursor: default;
     }
 }
 
 // Pager index (x OF y)
 .pager__index {
+    display: flex;
+    align-items: center;
     flex: 0 0 auto;
     padding-left: 10px;
     padding-right: 10px;
-    height: $pager-dimension;
-    line-height: $pager-dimension;
+    min-height: $pager-dimension;
+    height: 100%;
     font-weight: bold;
     border-left: 1px solid #c0c0c0;
     border-right: 1px solid #c0c0c0;

--- a/src/encoded/static/scss/encoded/modules/_panels.scss
+++ b/src/encoded/static/scss/encoded/modules/_panels.scss
@@ -756,7 +756,7 @@ $nav-tab-border-radius: 4px;
     font-size: 0.8rem;
 }
 
-.file-table-paged {
+.table-paged {
     @at-root #{&}__count {
         @extend .file-gallery-counts;
         border-top: 1px solid #a0a0a0;

--- a/src/encoded/static/scss/encoded/modules/_tables.scss
+++ b/src/encoded/static/scss/encoded/modules/_tables.scss
@@ -329,3 +329,21 @@ form.table-filter {
 .table-raw-separator td {
     border-top: 2px solid #606060;
 }
+
+
+// Header for a SortTable including a pager.
+.header-paged-sorttable {
+    display: flex;
+    justify-content: space-between;
+
+    @at-root #{&}__controls {
+        display: flex;
+        margin-top: -3px;
+        margin-right: -3px;
+        margin-bottom: -3px;
+
+        .pager {
+            margin-left: 5px;
+        }
+    }
+}

--- a/src/encoded/tests/data/inserts/publication.json
+++ b/src/encoded/tests/data/inserts/publication.json
@@ -160,7 +160,13 @@
             "database"
         ],
         "datasets": [
-            "/experiments/ENCSR000DZQ/"
+            "/experiments/ENCSR000DZQ/",
+            "/experiments/ENCSR003CON/",
+            "/experiments/ENCSR002CON/",
+            "/experiments/ENCSR001CON/",
+            "/experiments/ENCSR002SER/",
+            "/experiments/ENCSR001SER/",
+            "/experiments/ENCSR000INT/"
         ],
         "date_published": "2012 Jan",
         "issue": "Database issue",

--- a/src/encoded/tests/data/inserts/publication_data.json
+++ b/src/encoded/tests/data/inserts/publication_data.json
@@ -1,15 +1,37 @@
 [
-	{
-		"_test": "publication data",
-		"accession": "ENCSR727WCB",
+    {
+        "_test": "publication data",
+        "accession": "ENCSR727WCB",
         "award": "U54HG007004",
         "description": "Supplemental data for Heidari et al., Genome-wide map of regulatory interactions in the human genome.",
         "status": "released",
         "lab": "michael-snyder",
-        "references": ["e5e336a0-bdde-11e4-bb52-0800200c9a66"],
+        "references": [
+            "e5e336a0-bdde-11e4-bb52-0800200c9a66"
+        ],
         "submitted_by": "facilisi.tristique@potenti.vivamus",
         "uuid": "4eafdd35-40ea-463a-9e05-c85fb91d25d0",
-        "related_files": ["ENCFF002COS", "ENCFF003COS"],
+        "related_files": [
+            "ENCFF002COS",
+            "ENCFF003COS"
+        ],
         "date_released": "2014-10-07"
+    },
+    {
+        "related_files": [
+            "ENCFF001MYM",
+            "ENCFF002MYM"
+        ],
+        "accession": "ENCSR129LGO",
+        "description": "Data published in Grubert et al., Landscape of Chromatin Loops in the Human Genome Across Multiple Cell Types. Note that the files currently listed on this page belong to experiments ENCSR014ZXR, ENCSR465NNU, ENCSR716WZI, ENCSR981FNA, ENCSR466AXT, and ENCSR011ITK. More datasets analyzed in the publication will be added to the ENCODE portal shortly.",
+        "date_released": "2017-09-19",
+        "status": "released",
+        "submitted_by": "rutrum.fermentum@platea.turpis",
+        "lab": "michael-snyder",
+        "award": "U54HG006996",
+        "references": [
+            "d40de6c3-7b60-4567-8282-b29f0cafc0e1"
+        ],
+        "uuid": "9e03585f-9301-4123-b20e-4a1802834473"
     }
 ]

--- a/src/encoded/types/__init__.py
+++ b/src/encoded/types/__init__.py
@@ -232,7 +232,6 @@ class Library(Item):
 class Publication(Item):
     item_type = 'publication'
     schema = load_schema('encoded:schemas/publication.json')
-    embedded = ['datasets']
     rev = {
         'publication_data': ('PublicationData', 'references')
     }


### PR DESCRIPTION
* publication_data is a calculated property in publication objects so it always appears though often with zero elements. I check for this property now, so the Jest test data had to include it to avoid “undefined” crashes during Jest tests.
* I put in a new generic cache in libs so that paging between datasets doesn’t force a request to the server for _every_ page, if that page was already in the cache. I had done caches for similar tables but each had its own cache implementation. They should all be modified to use this generic cache, but there wasn’t enough time this round to test them.
* About the cache, it can cache anything, and has any size you’d like. It doesn’t hash the keys and has no collision detection — a very simple cache implementation I adapted from a blog post I linked to in the comments.
* In `FileTablePaged` I moved the pager from the footer to the header to match the Datasets table on the publication page. And I put the pager in the header because I noticed the pager jumps around when it goes in the footer, because the height of the table can change, page to page.