### PR TITLE
ENCD-5405 Fix cart file download metadata URL

### DIFF
--- a/src/encoded/static/components/cart/batch_download.js
+++ b/src/encoded/static/components/cart/batch_download.js
@@ -24,11 +24,11 @@ const ELEMENT_WARNING_LENGTH_MIN = 500;
  */
 const batchDownload = (cartType, elements, selectedTerms, facets, savedCartObj, sharedCart, setInProgress, options, fetch) => {
     let contentDisposition;
-    let cartUuid;
-    if (!cartType === 'OBJECT') {
-        cartUuid = sharedCart.uuid;
+    let cartId;
+    if (cartType === 'OBJECT') {
+        cartId = sharedCart['@id'];
     } else {
-        cartUuid = savedCartObj && savedCartObj.uuid;
+        cartId = savedCartObj && savedCartObj['@id'];
     }
 
     // Form query string from currently selected file formats.
@@ -48,7 +48,7 @@ const batchDownload = (cartType, elements, selectedTerms, facets, savedCartObj, 
     setInProgress(true);
     const visualizableOption = `${options.visualizable ? '&option=visualizable' : ''}`;
     const rawOption = `${options.raw ? '&option=raw' : ''}`;
-    fetch(`/batch_download/?type=Experiment${cartUuid ? `&cart=${cartUuid}` : ''}${fileFormatSelections.length > 0 ? `&${fileFormatSelections.join('&')}` : ''}${visualizableOption}${rawOption}`, {
+    fetch(`/batch_download/?type=Experiment${cartId ? `&cart=${encoding.encodedURIComponent(cartId)}` : ''}${fileFormatSelections.length > 0 ? `&${fileFormatSelections.join('&')}` : ''}${visualizableOption}${rawOption}`, {
         method: 'POST',
         headers: {
             Accept: 'text/plain',

--- a/src/encoded/static/components/cart/status.js
+++ b/src/encoded/static/components/cart/status.js
@@ -104,6 +104,8 @@ class CartStatusComponent extends React.Component {
             const clearCartItem = !locked ? <button key="clear" onClick={this.clearCartClick}>Clear cart</button> : null;
             const lockIcon = cartName ? <div className="cart-nav-lock">{svgIcon(locked ? 'lockClosed' : 'lockOpen')}</div> : null;
             if (loggedIn) {
+                // The href is just to quiet ESLint for the bad href. This code shouldn't do this
+                // but the CSS looks difficult to fix after the tooltip updates.
                 menuItems.push(
                     <span key="name" className="disabled-menu-item">
                         {`Current: ${cartName}`}{lockIcon}

--- a/src/encoded/static/scss/encoded/modules/_navbar.scss
+++ b/src/encoded/static/scss/encoded/modules/_navbar.scss
@@ -289,9 +289,9 @@ $navbar-bg-color:            #0a253d;
         padding: 2px 30px 2px 20px;
         font-weight: 400;
         letter-spacing: 1px;
-        font-size: 1.1rem;
-        @media screen and (max-width: $screen-md-min) {
-            font-size: 0.9rem;
+        font-size: 0.9rem;
+        @media screen and (min-width: $screen-md-min) {
+            font-size: 1.1rem;
         }
     }
 
@@ -305,7 +305,7 @@ $navbar-bg-color:            #0a253d;
         border-bottom-left-radius:  3px;
 
         &>li {
-            &>a, &>button, &>span &>div {
+            &>a, &>button, &>span, &>div {
                 display: block;
                 width: 100%;
                 margin: 0;
@@ -329,6 +329,14 @@ $navbar-bg-color:            #0a253d;
                         background-color: $navbar-inverse-link-active-bg;
                         color: #fff;
                     }
+                }
+
+                // Dropdown menu separator item
+                &.dropdown-sep {
+                    pointer-events: none;
+                    margin: 5px 0 0;
+                    border-top: 1px solid #c0c0c0;
+                    border-bottom: 1px solid #fff;
                 }
             }
         }
@@ -371,14 +379,6 @@ $navbar-bg-color:            #0a253d;
         }
     }
 }
-
-// Dropdown menu separator item
-.dropdown-sep {
-    margin: 5px 0;
-    border-top: 1px solid #c0c0c0;
-    border-bottom: 1px solid #fff;
-}
-
 
 // Wrapper for <GlobalSections> and <CartStatus>
 .navbar__global-cart {


### PR DESCRIPTION
Combined a couple other fixes:

* files.txt linked to the cart’s UUID-based path rather than its user-configured custom path.
* Tooltip style changes broke cart menu.