### PR TITLE
ENCD-5427 Make title underlines consistent

### DIFF
--- a/src/encoded/static/components/cart/cart.js
+++ b/src/encoded/static/components/cart/cart.js
@@ -1533,7 +1533,7 @@ const CartComponent = ({ context, elements, savedCartObj, loggedIn, inProgress, 
     return (
         <div className={itemClass(context, 'view-item')}>
             <header>
-                <h2>{cartName}</h2>
+                <h1>{cartName}</h1>
                 {cartType === 'OBJECT' ? <ItemAccessories item={context} /> : null}
             </header>
             <Panel addClasses="cart__result-table">

--- a/src/encoded/static/components/donor.js
+++ b/src/encoded/static/components/donor.js
@@ -568,7 +568,7 @@ class DonorComponent extends React.Component {
             <div className={itemClass}>
                 <header>
                     <Breadcrumbs crumbs={crumbs} crumbsReleased={crumbsReleased} />
-                    <h2>{context.accession}</h2>
+                    <h1>{context.accession}</h1>
                     <div className="replacement-accessions">
                         <AlternateAccession altAcc={context.alternate_accessions} />
                     </div>

--- a/src/encoded/static/components/experiment_series.js
+++ b/src/encoded/static/components/experiment_series.js
@@ -584,7 +584,7 @@ class ExperimentSeriesComponent extends React.Component {
             <div className={itemClass}>
                 <header>
                     <Breadcrumbs crumbs={crumbs} crumbsReleased={crumbsReleased} />
-                    <h2>Summary for experiment series {context.accession}</h2>
+                    <h1>Summary for experiment series {context.accession}</h1>
                     <ItemAccessories item={context} audit={{ auditIndicators, auditId: 'series-audit' }} />
                 </header>
                 {auditDetail(context.audit, 'series-audit', { session: this.context.session, sessionProperties: this.context.session_properties })}

--- a/src/encoded/static/components/file.js
+++ b/src/encoded/static/components/file.js
@@ -286,7 +286,7 @@ class FileComponent extends React.Component {
         return (
             <div className={itemClass}>
                 <header>
-                    <h2>File summary for {context.title} (<span className="sentence-case">{context.file_format}</span>)</h2>
+                    <h1>File summary for {context.title} (<span className="sentence-case">{context.file_format}</span>)</h1>
                     <ReplacementAccessions context={context} />
                     <MatchingMD5Sum file={context} />
                     {context.restricted ?

--- a/src/encoded/static/components/filegallery.js
+++ b/src/encoded/static/components/filegallery.js
@@ -3293,7 +3293,7 @@ const FileDetailView = function FileDetailView(node, qcClick, auditIndicators, a
         );
     } else {
         header = (
-            <div className="details-view-info">Unknown file</div>
+            <div className="graph-modal-header__content"><h2>Unknown file</h2></div>
         );
         body = <p className="browser-error">No information available</p>;
     }
@@ -3361,7 +3361,7 @@ export const CoalescedDetailsView = function CoalescedDetailsView(node) {
         );
     } else {
         header = (
-            <div className="details-view-info">
+            <div className="graph-modal-header__content">
                 <h2>Unknown files</h2>
             </div>
         );

--- a/src/encoded/static/components/gene.js
+++ b/src/encoded/static/components/gene.js
@@ -77,7 +77,7 @@ class Gene extends React.Component {
             <div className={globals.itemClass(context, 'view-item')}>
                 <header>
                     <Breadcrumbs root="/search/?type=Gene" crumbs={crumbs} crumbsReleased={crumbsReleased} />
-                    <h2>{context.symbol} (<em>{context.organism.scientific_name}</em>)</h2>
+                    <h1>{context.symbol} (<em>{context.organism.scientific_name}</em>)</h1>
                     <ItemAccessories item={context} />
                 </header>
 

--- a/src/encoded/static/components/item.js
+++ b/src/encoded/static/components/item.js
@@ -16,7 +16,7 @@ const Fallback = (props, reactContext) => {
     return (
         <div className="view-item">
             <header>
-                <h2>{title}</h2>
+                <h1>{title}</h1>
                 <ItemAccessories item={context} />
             </header>
             {typeof context.description === 'string' ? <p className="description">{context.description}</p> : null}
@@ -45,7 +45,7 @@ const Item = (props) => {
     return (
         <div className={itemClass}>
             <header>
-                <h2>{title}</h2>
+                <h1>{title}</h1>
                 <div className="replacement-accessions">
                     <AlternateAccession altAcc={context.alternate_accessions} />
                 </div>

--- a/src/encoded/static/components/publication.js
+++ b/src/encoded/static/components/publication.js
@@ -248,7 +248,7 @@ const PublicationComponent = (props, reactContext) => {
     return (
         <div className={itemClass}>
             <Breadcrumbs root="/search/?type=Publication" crumbs={crumbs} crumbsReleased={crumbsReleased} />
-            <h2>{context.title}</h2>
+            <h1>{context.title}</h1>
             <ItemAccessories item={context} audit={{ auditIndicators: props.auditIndicators, auditId: 'publication-audit' }} />
             {props.auditDetail(context.audit, 'publication-audit', { session: reactContext.session, sessionProperties: reactContext.session_properties, except: context['@id'] })}
             {context.authors ? <div className="authors">{context.authors}.</div> : null}

--- a/src/encoded/static/components/schema.js
+++ b/src/encoded/static/components/schema.js
@@ -603,7 +603,7 @@ const SchemaPage = (props) => {
         <div className={itemClass}>
             <header>
                 <Breadcrumbs root="/profiles/" crumbs={crumbs} crumbsReleased={crumbsReleased} />
-                <h2>{title}</h2>
+                <h1>{title}</h1>
             </header>
             {typeof context.description === 'string' ? <p className="description">{context.description}</p> : null}
             <SchemaPanel schema={context} schemaName={schemaName} />

--- a/src/encoded/static/components/target.js
+++ b/src/encoded/static/components/target.js
@@ -38,7 +38,7 @@ const Target = ({ context }) => {
         <div className={globals.itemClass(context, 'view-item')}>
             <header>
                 <Breadcrumbs root="/search/?type=Target" crumbs={crumbs} crumbsReleased={crumbsReleased} />
-                <h2>{context.label} (<em>{source}</em>)</h2>
+                <h1>{context.label} (<em>{source}</em>)</h1>
                 <ItemAccessories item={context} />
             </header>
 

--- a/src/encoded/static/components/user.js
+++ b/src/encoded/static/components/user.js
@@ -343,7 +343,7 @@ class ImpersonateUserFormComponent extends React.Component {
     render() {
         return (
             <div>
-                <h2>Impersonate User</h2>
+                <h1>Impersonate User</h1>
                 <Form
                     schema={ImpersonateUserSchema}
                     submitLabel="Submit"

--- a/src/encoded/static/scss/encoded/modules/_matrix.scss
+++ b/src/encoded/static/scss/encoded/modules/_matrix.scss
@@ -734,6 +734,7 @@ $row-data-header-width: 200px;
         h2 {
             margin: 0;
             font-size: 1.3rem;
+            border-bottom: none;
         }
     }
 

--- a/src/encoded/static/scss/encoded/modules/_pipeline.scss
+++ b/src/encoded/static/scss/encoded/modules/_pipeline.scss
@@ -329,6 +329,7 @@ g.pipeline-node-qc-metric {
         h2 {
             margin: 0;
             font-size: 1.3rem;
+            border-bottom: none;
         }
 
         h5 {


### PR DESCRIPTION
This mostly involved changing `<h2>` tags to `<h1>` as they were the only titles on the page, and should have been `<h1>`.