### PR TITLE
ENCD-5437 Highlight file graph arrows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4201,17 +4201,18 @@
       }
     },
     "dagre-d3": {
-      "version": "git+https://github.com/ENCODE-DCC/dagre-d3.git#3c99a06af7837611676c98d6cccee3f23127d9d0",
-      "from": "git+https://github.com/ENCODE-DCC/dagre-d3.git#v1.2.3",
+      "version": "github:ENCODE-DCC/dagre-d3#9c71a2a3d43f04f7ff46ce8f607f1cd61901af65",
+      "from": "github:ENCODE-DCC/dagre-d3#1.3.0",
       "requires": {
         "d3": "^3.3.8",
         "dagre": "^0.8.4",
+        "graphlib": "git+https://github.com/ENCODE-DCC/graphlib.git#c13bf9646745117c06c3d7a67701079d255fd1f6",
         "lodash": "^4.17.15"
       },
       "dependencies": {
         "graphlib": {
-          "version": "git+https://github.com/ENCODE-DCC/graphlib.git#df17f0dc51178d5a49f4a0cc638dcebcf9746b2d",
-          "from": "git+https://github.com/ENCODE-DCC/graphlib.git#df17f0dc51178d5a49f4a0cc638dcebcf9746b2d",
+          "version": "git+https://github.com/ENCODE-DCC/graphlib.git#c13bf9646745117c06c3d7a67701079d255fd1f6",
+          "from": "git+https://github.com/ENCODE-DCC/graphlib.git",
           "requires": {
             "lodash": "^4.17.15"
           }
@@ -4668,16 +4669,6 @@
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "requires": {
         "once": "^1.4.0"
-      }
-    },
-    "engine": {
-      "version": "github:VALIS-software/Engine#edef83c9b3507fb037443343bd06a97dae5f8ca7",
-      "from": "github:VALIS-software/Engine",
-      "dependencies": {
-        "gputext": {
-          "version": "github:VALIS-software/GPUText#0e82871954fa8fe4af82517cbeb1841dd1100fbf",
-          "from": "github:VALIS-software/GPUText#0e82871954fa8fe4af82517cbeb1841dd1100fbf"
-        }
       }
     },
     "enhanced-resolve": {
@@ -6759,18 +6750,25 @@
         "@material-ui/icons": "^3.0.1",
         "axios": "^0.18.0",
         "bigwig-reader": "^1.0.9",
-        "engine": "github:VALIS-software/Engine#edef83c9b3507fb037443343bd06a97dae5f8ca7",
         "fast-deep-equal": "^2.0.1",
-        "genomics-formats": "github:VALIS-software/Genomics-Formats#f1e2a3f6afb4bf3b848ba4f4a48e8e595b6f7cbe",
         "mkdirp": "^0.5.1",
         "react": "16.x",
         "react-dom": "16.x",
         "string-split-by": "^1.0.0"
+      },
+      "dependencies": {
+        "engine": {
+          "version": "github:VALIS-software/Engine#edef83c9b3507fb037443343bd06a97dae5f8ca7",
+          "from": "github:VALIS-software/Engine#edef83c9b3507fb037443343bd06a97dae5f8ca7",
+          "requires": {
+            "gputext": "github:VALIS-software/GPUText#0e82871954fa8fe4af82517cbeb1841dd1100fbf"
+          }
+        },
+        "genomics-formats": {
+          "version": "github:VALIS-software/Genomics-Formats#f1e2a3f6afb4bf3b848ba4f4a48e8e595b6f7cbe",
+          "from": "github:VALIS-software/Genomics-Formats#f1e2a3f6afb4bf3b848ba4f4a48e8e595b6f7cbe"
+        }
       }
-    },
-    "genomics-formats": {
-      "version": "github:VALIS-software/Genomics-Formats#f1e2a3f6afb4bf3b848ba4f4a48e8e595b6f7cbe",
-      "from": "github:VALIS-software/Genomics-Formats"
     },
     "gensync": {
       "version": "1.0.0-beta.1",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "ckeditor": "file:node_shims/ckeditor",
     "create-react-class": "^15.5.2",
     "d3": "^3.4.6",
-    "dagre-d3": "git+https://github.com/ENCODE-DCC/dagre-d3.git#v1.2.3",
+    "dagre-d3": "github:ENCODE-DCC/dagre-d3#1.3.0",
     "dayjs": "^1.8.16",
     "domready": "^1.0.8",
     "form-serialize": "^0.6.0",

--- a/src/encoded/static/components/graph.js
+++ b/src/encoded/static/components/graph.js
@@ -64,11 +64,14 @@ export class JsonGraph {
     // Add edge to the graph architecture
     // source: ID of node for the edge to originate; corresponds to 'id' parm of addNode
     // target: ID of node for the edge to terminate
-    addEdge(source, target) {
+    // options: Object containing options to save in the edge that can be used later when displayed
+    addEdge(source, target, options) {
         const newEdge = {};
         newEdge.id = '';
         newEdge.source = source;
         newEdge.target = target;
+        newEdge.class = options ? options.class : '';
+        newEdge.metadata = _.clone(options);
         this.edges.push(newEdge);
     }
 
@@ -212,6 +215,12 @@ export class Graph extends React.Component {
                     paddingTop: '10',
                     paddingBottom: '10',
                     subnodes: node.subnodes,
+                    decoration: {
+                        id: `${node.id}-highlight`,
+                        position: 'top',
+                        icon: 'arrow-right',
+                        class: node.metadata.decorationClass,
+                    },
                 });
                 if (!parent.root) {
                     subgraph.setParent(node.id, parent.id);
@@ -227,7 +236,7 @@ export class Graph extends React.Component {
 
         // Convert the edges
         jsonGraph.edges.forEach((edge) => {
-            graph.setEdge(edge.source, edge.target, { lineInterpolate: 'basis' });
+            graph.setEdge(edge.source, edge.target, { lineInterpolate: 'basis', class: edge.class });
         });
     }
 
@@ -429,7 +438,7 @@ export class Graph extends React.Component {
         return { viewBoxWidth, viewBoxHeight };
     }
 
-    nodeIdClick(nodeId) {
+    nodeIdClick(nodeId, openInfoModal) {
         let node;
 
         // Find data matching selected node, if any
@@ -447,7 +456,7 @@ export class Graph extends React.Component {
                         // We have the requested coalesced files in the cache, so just display
                         // them.
                         coalescedNode.metadata.coalescedFiles = currCoalescedFiles[coalescedNode.metadata.contributing];
-                        node = coalescedNode;
+                        this.props.nodeClickHandler(coalescedNode, openInfoModal);
                     } else if (!this.contributingRequestOutstanding) {
                         // We don't have the requested coalesced files in the cache, so we have to
                         // request them from the DB.
@@ -456,8 +465,7 @@ export class Graph extends React.Component {
                             this.contributingRequestOutstanding = false;
                             currCoalescedFiles[coalescedNode.metadata.contributing] = contributingFiles;
                             coalescedNode.metadata.coalescedFiles = contributingFiles;
-                            this.props.nodeClickHandler(coalescedNode);
-                            node = null;
+                            this.props.nodeClickHandler(coalescedNode, openInfoModal);
                         }).catch(() => {
                             this.contributingRequestOutstanding = false;
                             currCoalescedFiles[coalescedNode.metadata.contributing] = [];
@@ -477,6 +485,7 @@ export class Graph extends React.Component {
                         if (currContributing[node.metadata.contributing]) {
                             // We have this file's object in the cache, so just display it.
                             node.metadata.ref = currContributing[node.metadata.contributing];
+                            this.props.nodeClickHandler(node, openInfoModal);
                         } else if (!this.contributingRequestOutstanding) {
                             // We don't have this file's object in the cache, so request it from
                             // the DB.
@@ -485,37 +494,42 @@ export class Graph extends React.Component {
                                 this.contributingRequestOutstanding = false;
                                 currContributing[node.metadata.contributing] = contributingFile[0];
                                 node.metadata.ref = contributingFile[0];
-                                this.props.nodeClickHandler(node);
-                                node = null;
+                                this.props.nodeClickHandler(node, openInfoModal);
                             }).catch(() => {
                                 this.contributingRequestOutstanding = false;
                                 currContributing[node.metadata.contributing] = {};
-                                node = null;
                             });
                         }
+                    } else {
+                        this.props.nodeClickHandler(node, openInfoModal);
                     }
                 }
             }
         }
-
-        // Tell the upper-level rendering component to render the node information.
-        if (node) {
-            this.props.nodeClickHandler(node);
-        }
     }
 
     bindClickHandlers(d3, el) {
-        // Add click event listeners to each node rendering. Node's ID is its ENCODE object ID
+        // Add click event listeners to each node. The `nodeId` parameters contain the IDs kept in
+        // our JSON graph structure, and attached to each node by d3.
         const svg = d3.select(el);
-        const nodes = svg.selectAll('g.node');
+        const nodes = svg.selectAll('g.node > rect, g.node > g.stack');
         const subnodes = svg.selectAll('g.subnode circle');
+        const highlights = svg.selectAll('g.node > g.decoration');
 
-        nodes.on('click', (nodeId) => {
-            this.nodeIdClick(nodeId);
+        // Attach click handler to arrow-highlighting toggle decorations.
+        highlights.on('click', (nodeId) => {
+            this.nodeIdClick(nodeId, false);
         });
+
+        // Attach click handler to file and step nodes.
+        nodes.on('click', (nodeId) => {
+            this.nodeIdClick(nodeId, true);
+        });
+
+        // Attach click handler to QC bubbles.
         subnodes.on('click', (subnode) => {
             d3.event.stopPropagation();
-            this.nodeIdClick(subnode.id);
+            this.nodeIdClick(subnode.id, true);
         });
     }
 

--- a/src/encoded/static/components/graph.js
+++ b/src/encoded/static/components/graph.js
@@ -447,6 +447,7 @@ export class Graph extends React.Component {
                 // QC subnode.
                 node = this.props.graph.getSubnode(nodeId);
                 node.schemas = this.props.schemas;
+                this.props.nodeClickHandler(node, openInfoModal);
             } else if (nodeId.indexOf('coalesced:') >= 0) {
                 // Coalesced contributing files.
                 const coalescedNode = this.props.graph.getNode(nodeId);

--- a/src/encoded/static/scss/encoded/modules/_pipeline.scss
+++ b/src/encoded/static/scss/encoded/modules/_pipeline.scss
@@ -75,6 +75,7 @@ g.label {
     font-size: $font-size-base * 0.85; // Don't use rems; maintain size on mobile
     font-weight: bold;
     fill: #000;
+    pointer-events: none;
 }
 
 g.node {
@@ -90,11 +91,41 @@ g.node {
             stroke: #a0a0a0;
             stroke-width: 1.5px;
         }
+
+        .decoration {
+            stroke-dasharray: none;
+        }
     }
 
     line {
         stroke: #a0a0a0;
         stroke-width: .5px;
+    }
+
+    .decoration {
+        rect {
+            fill: #e0e0e0;
+        }
+
+        &__border {
+            fill: none;
+            stroke-width: 1px;
+            stroke: #a0a0a0;
+        }
+
+        &__icon {
+            fill: #606060;
+        }
+
+        &.decoration--active {
+            rect {
+                fill: #606060;
+            }
+
+            .decoration__icon {
+                fill: #e0e0e0;
+            }
+        }
     }
 }
 
@@ -118,9 +149,23 @@ g.cluster {
 }
 
 g.edgePath {
-    path {
+    path.path {
         stroke: #c0c0c0;
-        stroke-width: 1.5px;
+        stroke-width: 2px;
+    }
+
+    defs > marker > path {
+        fill: #c0c0c0;
+    }
+
+    &.highlighted {
+        path.path {
+            stroke: #00f;
+        }
+
+        defs > marker > path {
+            fill: #00f;
+        }
     }
 }
 


### PR DESCRIPTION
* Much of the changes in graph.js and filegallery.js involve adding classes to edges, but also a couple significant existing bug fixes that had no previous effect:
    * Some places tested infoNode against fileNodeID, which wasn't a valid comparison. I’ve fixed these.
    * nodeIdClick in `<Graph>` sometimes called the click handler twice without any noticeable effect. I’ve rearranged the code to prevent this because we now toggle node highlighting when you click the decoration.
* Unexpectedly, npm install --save for dagre-d3 version 1.3.0 removed some parts of the URL in package.json, but it seems to work fine.
