### PR TITLE
ENCD-5495-remove-dirty-cart-test

### DIFF
--- a/src/encoded/tests/features/cart.feature
+++ b/src/encoded/tests/features/cart.feature
@@ -48,11 +48,6 @@ Feature: Cart
         When I press "raw"
         Then I should see "Download raw data files"
 
-    Scenario: Dirty cart
-        When I visit "/search/?type=Experiment"
-        And I dismiss the alert
-        Then the browser's URL should be "/cart-view/"
-
     Scenario: Clearing the cart 
         When I press "clear-cart-actuator"
         Then I should see an element with the css selector ".modal"


### PR DESCRIPTION
Probably temporary to work around chrome/chromedriver 85 bug.