### PR TITLE
ENCD-5377-generate-glossary-page-from-glossary-json

### DIFF
--- a/src/encoded/__init__.py
+++ b/src/encoded/__init__.py
@@ -227,6 +227,7 @@ def main(global_config, **local_config):
     config.include('.reports.batch_download')
     config.include('.reports.metadata')
     config.include('.visualization')
+    config.include('.glossary')
 
     if 'elasticsearch.server' in config.registry.settings:
         config.include('snovault.elasticsearch')

--- a/src/encoded/glossary.py
+++ b/src/encoded/glossary.py
@@ -1,0 +1,23 @@
+from pyramid.view import view_config
+from pyramid.httpexceptions import HTTPBadRequest
+from urllib.parse import (
+    parse_qs,
+    urlencode,
+)
+
+def includeme(config):
+    config.add_route('glossary', '/glossary{slash:/?}')
+    config.scan(__name__)
+
+@view_config(route_name='glossary', request_method='GET', permission='search')
+def glossary(context, request):
+    result = {
+        '@id': '/glossary/',
+        '@type': ['Glossary'],
+        'title': 'Glossary',
+        '@graph': [],
+        'columns': [],
+        'notification': '',
+        'filters': []
+    }
+    return result

--- a/src/encoded/glossary.py
+++ b/src/encoded/glossary.py
@@ -1,13 +1,10 @@
 from pyramid.view import view_config
-from pyramid.httpexceptions import HTTPBadRequest
-from urllib.parse import (
-    parse_qs,
-    urlencode,
-)
+
 
 def includeme(config):
     config.add_route('glossary', '/glossary{slash:/?}')
     config.scan(__name__)
+
 
 @view_config(route_name='glossary', request_method='GET', permission='search')
 def glossary(context, request):

--- a/src/encoded/static/components/glossary.js
+++ b/src/encoded/static/components/glossary.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import * as globals from './globals';
+
+const Glossary = (props) => {
+    const { context } = props;
+    const glossary = require('./glossary/glossary.json');
+
+    return (
+        <div className="layout">
+            <div className="layout__block layout__block--100">
+                <div className="ricktextblock block" data-pos="0,0,0">
+                    <center>
+                        <h1>{context.title}</h1>
+                    </center>
+                    {glossary.map(g => (
+                        <div key={g.term} className="glossary-element">
+                            <h4 className="glossary-term">{g.term}</h4>
+                            <p className="glossary-definition">{g.definition}</p>
+                        </div>
+                    ))}
+                </div>
+            </div>
+        </div>
+    );
+};
+
+Glossary.propTypes = {
+    context: PropTypes.object.isRequired,
+};
+
+globals.contentViews.register(Glossary, 'Glossary');

--- a/src/encoded/static/components/index.js
+++ b/src/encoded/static/components/index.js
@@ -48,6 +48,7 @@ require('./region_search');
 require('./gene');
 require('./biosample_type');
 require('./experiment_series');
+require('./glossary');
 
 
 module.exports = require('./app');

--- a/src/encoded/static/scss/encoded/modules/_faq_glossary.scss
+++ b/src/encoded/static/scss/encoded/modules/_faq_glossary.scss
@@ -36,3 +36,9 @@
         margin: 0.2em;
     }
 }
+
+.glossary-element {
+    h4 {
+        font-size: 1.1rem;
+    }
+}

--- a/src/encoded/static/scss/style.scss
+++ b/src/encoded/static/scss/style.scss
@@ -259,7 +259,7 @@ $link-hover-color:                          darken($link-color, 15%);
         "encoded/modules/layout-editor",
         "encoded/modules/layout",
         "encoded/modules/schema",
-        "encoded/modules/faq",
+        "encoded/modules/faq_glossary",
         "encoded/modules/user";
 @import "encoded/state";
 @import "encoded/theme";


### PR DESCRIPTION
We are adding a page so that encodeproject.org/glossary is generated from data in glossary.json.
This new page will replace encodeproject.org/help/glossary/.