### PR TITLE
VALIS-4 rearrange tracks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6743,8 +6743,8 @@
       }
     },
     "genome-visualizer": {
-      "version": "git://github.com/ENCODE-DCC/valis-hpgv.git#b5c9bb34f2747a15a4870b9c6955bfdd08c790a2",
-      "from": "git://github.com/ENCODE-DCC/valis-hpgv.git#1.3.0",
+      "version": "git://github.com/ENCODE-DCC/valis-hpgv.git#58d79c6c1aee052f28e4eef022a32699f5b093b1",
+      "from": "git://github.com/ENCODE-DCC/valis-hpgv.git#VALIS-4-rearrange-tracks",
       "requires": {
         "@material-ui/core": "^3.1.0",
         "@material-ui/icons": "^3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6743,7 +6743,7 @@
       }
     },
     "genome-visualizer": {
-      "version": "git://github.com/ENCODE-DCC/valis-hpgv.git#58d79c6c1aee052f28e4eef022a32699f5b093b1",
+      "version": "git://github.com/ENCODE-DCC/valis-hpgv.git#9320d4b4c61cb9f95fb22e78147d017bffb3f0cd",
       "from": "git://github.com/ENCODE-DCC/valis-hpgv.git#VALIS-4-rearrange-tracks",
       "requires": {
         "@material-ui/core": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "dayjs": "^1.8.16",
     "domready": "^1.0.8",
     "form-serialize": "^0.6.0",
-    "genome-visualizer": "git://github.com/ENCODE-DCC/valis-hpgv.git#1.3.0",
+    "genome-visualizer": "git://github.com/ENCODE-DCC/valis-hpgv.git#VALIS-4-rearrange-tracks",
     "google-analytics": "file:node_shims/google-analytics",
     "graphlib": "git://github.com/ENCODE-DCC/graphlib.git#v1.0.8",
     "immutable": "^3.7.5",

--- a/src/encoded/static/components/cart/cart.js
+++ b/src/encoded/static/components/cart/cart.js
@@ -171,7 +171,8 @@ const CartBrowser = ({ files, assembly, pageNumber }) => {
             setPageFiles([]);
         }
     }, [files, assembly, pageNumber]);
-    return <GenomeBrowser files={pageFiles} label={'cart'} assembly={assembly} expanded />;
+    const sortParam = ['Assay term name', 'Biosample term name', 'Output type'];
+    return <GenomeBrowser files={pageFiles} label={'cart'} assembly={assembly} expanded sortParam={sortParam} />;
 };
 
 CartBrowser.propTypes = {

--- a/src/encoded/static/components/filegallery.js
+++ b/src/encoded/static/components/filegallery.js
@@ -2925,6 +2925,7 @@ class FileGalleryRendererComponent extends React.Component {
                                     label={'file gallery'}
                                     expanded={this.state.facetsOpen}
                                     assembly={this.state.selectedAssembly}
+                                    displaySort
                                 />
                             </TabPanelPane>
                             <TabPanelPane key="graph">

--- a/src/encoded/static/components/genome_browser.js
+++ b/src/encoded/static/components/genome_browser.js
@@ -163,21 +163,20 @@ function mapGenome(inputAssembly) {
 // Ordering by replicate is like this: 'Rep 1,2' -> 'Rep 1,3,...' -> 'Rep 2,3,...' -> 'Rep 1' -> 'Rep 2' -> 'Rep N'
 // Multiplication by 1000 orders the replicates with a single replicate at the end
 const sortLookUp = (obj, param) => {
-    if (param === 'Replicates') {
-        if (obj.biological_replicates.length > 1) {
-            return +obj.biological_replicates.join('');
-        }
-        return +obj.biological_replicates * 1000;
-    } else if (param === 'Output type') {
+    switch (param) {
+    case 'Replicates':
+        return obj.biological_replicates.length > 1 ? +obj.biological_replicates.join('') : +obj.biological_replicates * 1000;
+    case 'Output type':
         return obj.output_type.toLowerCase();
-    } else if (param === 'File type') {
+    case 'File type':
         return obj.file_type.toLowerCase();
-    } else if (param === 'Assay term name') {
+    case 'Assay term name':
         return obj.assay_term_name.toLowerCase();
-    } else if (param === 'Biosample term name') {
+    case 'Biosample term name':
         return obj.biosample_ontology.term_name.toLowerCase();
+    default:
+        return null;
     }
-    return null;
 };
 
 /**
@@ -524,7 +523,7 @@ class GenomeBrowser extends React.Component {
             tracks = this.filesToTracks(newFiles, this.props.label, domain);
         }
         this.setState({ trackList: tracks }, () => {
-            if (this.chartdisplay && tracks !== []) {
+            if (this.chartdisplay && tracks.length > 0) {
                 this.drawTracks(this.chartdisplay);
             }
         });

--- a/src/encoded/static/scss/encoded/modules/_genome_browser.scss
+++ b/src/encoded/static/scss/encoded/modules/_genome_browser.scss
@@ -53,6 +53,67 @@
     font-size: 12px;
 }
 
+.hpgv_track-reorder-container {
+    top: 0;
+    left: 0;
+    pointer-events: none;
+}
+
+a {
+    pointer-events: all;
+}
+
+.hpgv_track-reorder-button {
+    height: 8px;
+    opacity: 0.8;
+    pointer-events: all;
+    cursor: pointer;
+    svg {
+        display: none;
+    }
+    &.move-up {
+        background: linear-gradient(#a2a2a2, 30%, #f2f2f2);
+        &:hover {
+            background: linear-gradient(#f1c428, #fff0c1);
+        }
+    }
+    &.move-down {
+        background: linear-gradient(#f2f2f2, 70%, #a2a2a2);
+        &:hover {
+            background: linear-gradient(#fff0c1, #f1c428);
+        }
+    }
+}
+
+.sort-control-container {
+    display: flex;
+    .sort-label {
+        margin: 2px 5px;
+    }
+    .sort-button {
+        display: flex;
+        padding: 2px 2px;
+        margin: 0 5px;
+        border: 1px solid #BFBFBF;
+        border-radius: 4px;
+        i, .sort-label {
+            flex: 0 1 auto;
+        }
+        &.active {
+            border: 2px solid #757575;
+            background-color: #dedede;
+        }
+    }
+    i {
+        font-size: 16px;
+        height: 12px;
+        margin-right: 5px;
+    }
+    .tcell-asc {
+        margin-top: 5px;
+    }
+}
+
 .hpgv_track-sequence {
     --nucleobase-a: #0C7489;
     --nucleobase-t: #F9CE70;
@@ -164,7 +225,7 @@
             color: black;
             margin-top: 0;
         }
-        
+
     }
     .btn {
         margin-left: 10px;
@@ -272,6 +333,6 @@
     color: #606060;
 
     > li {
-        margin: 5px 0;
+        margin: 2px 0;
     }
 }


### PR DESCRIPTION
There are a number of changes in this ticket:
- Encode points at a new Valis branch which allows you to click the tops and bottoms of tracks to move them up and down in the browser, reordering the browser files
- Sorting buttons are optionally displayed to sort the browser files
- An arbitrary number of sort parameters can be listed in order to sort the files, and they can be ordered in ascending or descending order
- The sort button for "Output type" is secretly also a sort button for "File type", so that all the bigWigs and bigBeds are grouped with each other

The implementation for the experiments has two sort parameters, the defaults, "Replicate" and "Output type", with "Replicate" as the primary sort, in descending order.

The implementation for the carts has three sort parameters, "Assay term name", "Biosample term name", and "Output type", with "Output type" as the primary sort, in descending order. No sort buttons are displayed because the cart browser is paginated so the sort only applies to the files on a page, not all the files in the cart - therefore displaying the sort buttons would be confusing.