### PR TITLE
ENCD-4275 ENCORE Matrix

### DIFF
--- a/src/encoded/search_views.py
+++ b/src/encoded/search_views.py
@@ -45,6 +45,8 @@ def includeme(config):
     config.add_route('sescc-stem-cell-matrix', '/sescc-stem-cell-matrix{slash:/?}')
     config.add_route('chip-seq-matrix', '/chip-seq-matrix{slash:/?}')
     config.add_route('mouse-development-matrix', '/mouse-development-matrix{slash:/?}')
+    config.add_route('encore-matrix', '/encore-matrix{slash:/?}')
+    config.add_route('encore-rna-seq-matrix', '/encore-rna-seq-matrix{slash:/?}')
     config.add_route('summary', '/summary{slash:/?}')
     config.add_route('audit', '/audit{slash:/?}')
     config.scan(__name__)
@@ -357,6 +359,64 @@ def mouse_development(context, request):
             BasicMatrixWithFacetsResponseField(
                 default_item_types=DEFAULT_ITEM_TYPES,
                 matrix_definition_name='mouse_development'
+            ),
+            NotificationResponseField(),
+            FiltersResponseField(),
+            TypeOnlyClearFiltersResponseField(),
+            DebugQueryResponseField()
+        ]
+    )
+    return fr.render()
+
+
+@view_config(route_name='encore-matrix', request_method='GET', permission='search')
+def encore_matrix(context, request):
+    fr = FieldedResponse(
+        _meta={
+            'params_parser': ParamsParser(request)
+        },
+        response_fields=[
+            TitleResponseField(
+                title='ENCORE Matrix'
+            ),
+            TypeResponseField(
+                at_type=['EncoreMatrix']
+            ),
+            IDResponseField(),
+            SearchBaseResponseField(),
+            ContextResponseField(),
+            BasicMatrixWithFacetsResponseField(
+                default_item_types=DEFAULT_ITEM_TYPES,
+                matrix_definition_name='encore_matrix'
+            ),
+            NotificationResponseField(),
+            FiltersResponseField(),
+            TypeOnlyClearFiltersResponseField(),
+            DebugQueryResponseField()
+        ]
+    )
+    return fr.render()
+
+
+@view_config(route_name='encore-rna-seq-matrix', request_method='GET', permission='search')
+def encore_rna_seq_matrix(context, request):
+    fr = FieldedResponse(
+        _meta={
+            'params_parser': ParamsParser(request)
+        },
+        response_fields=[
+            TitleResponseField(
+                title='ENCORE RNA-seq Matrix'
+            ),
+            TypeResponseField(
+                at_type=['EncoreRnaSeqMatrix']
+            ),
+            IDResponseField(),
+            SearchBaseResponseField(),
+            ContextResponseField(),
+            MissingMatrixWithFacetsResponseField(
+                default_item_types=DEFAULT_ITEM_TYPES,
+                matrix_definition_name='encore_rna_seq_matrix'
             ),
             NotificationResponseField(),
             FiltersResponseField(),

--- a/src/encoded/static/components/app.js
+++ b/src/encoded/static/components/app.js
@@ -54,7 +54,7 @@ const portal = {
                 { id: 'aws-link', title: 'AWS Open Data', url: 'https://registry.opendata.aws/encode-project/', tag: 'cloud' },
                 { id: 'sep-mm-2' },
                 { id: 'collections', title: 'Collections' },
-                { id: 'encore', title: 'RNA-protein interactions (ENCORE)', url: '/encore-matrix/?type=Experiment&internal_tags=ENCORE', tag: 'collection' },
+                { id: 'encore', title: 'RNA-protein interactions (ENCORE)', url: '/encore-matrix/?type=Experiment&status=released&internal_tags=ENCORE', tag: 'collection' },
                 { id: 'entex', title: 'Epigenomes from four individuals (ENTEx)', url: '/entex-matrix/?type=Experiment&status=released&internal_tags=ENTEx', tag: 'collection' },
                 { id: 'sescc', title: 'Stem Cell Development Matrix (SESCC)', url: '/sescc-stem-cell-matrix/?type=Experiment&internal_tags=SESCC', tag: 'collection' },
                 { id: 'reference-epigenomes-human', title: 'Human reference epigenomes', url: '/reference-epigenome-matrix/?type=Experiment&related_series.@type=ReferenceEpigenome&replicates.library.biosample.donor.organism.scientific_name=Homo+sapiens', tag: 'collection' },

--- a/src/encoded/static/components/app.js
+++ b/src/encoded/static/components/app.js
@@ -54,7 +54,7 @@ const portal = {
                 { id: 'aws-link', title: 'AWS Open Data', url: 'https://registry.opendata.aws/encode-project/', tag: 'cloud' },
                 { id: 'sep-mm-2' },
                 { id: 'collections', title: 'Collections' },
-                { id: 'encore', title: 'RNA-protein interactions (ENCORE)', url: '/matrix/?type=Experiment&status=released&internal_tags=ENCORE', tag: 'collection' },
+                { id: 'encore', title: 'RNA-protein interactions (ENCORE)', url: '/encore-matrix/?type=Experiment&internal_tags=ENCORE', tag: 'collection' },
                 { id: 'entex', title: 'Epigenomes from four individuals (ENTEx)', url: '/entex-matrix/?type=Experiment&status=released&internal_tags=ENTEx', tag: 'collection' },
                 { id: 'sescc', title: 'Stem Cell Development Matrix (SESCC)', url: '/sescc-stem-cell-matrix/?type=Experiment&internal_tags=SESCC', tag: 'collection' },
                 { id: 'reference-epigenomes-human', title: 'Human reference epigenomes', url: '/reference-epigenome-matrix/?type=Experiment&related_series.@type=ReferenceEpigenome&replicates.library.biosample.donor.organism.scientific_name=Homo+sapiens', tag: 'collection' },

--- a/src/encoded/static/components/facets/defaults.js
+++ b/src/encoded/static/components/facets/defaults.js
@@ -4,6 +4,7 @@ import dayjs from 'dayjs';
 import _ from 'underscore';
 import url from 'url';
 import QueryString from '../../libs/query_string';
+import { sanitizedString } from '../globals';
 import FacetRegistry from './registry';
 
 
@@ -13,12 +14,6 @@ import FacetRegistry from './registry';
  * components can use them. Default facet components get exported so that custom components that
  * simply alter the appearance of default components can call the default components.
  */
-
-
-// Sanitize user input and facet terms for comparison: convert to lowercase, remove white space and asterisks (which cause regular expression error)
-const sanitizedString = inputString => inputString.toLowerCase()
-    .replace(/ /g, '') // remove spaces (to allow multiple word searches)
-    .replace(/[*?()+[\]\\/]/g, ''); // remove certain special characters (these cause console errors)
 
 
 /**

--- a/src/encoded/static/components/globals.js
+++ b/src/encoded/static/components/globals.js
@@ -311,6 +311,12 @@ export const dbxrefPrefixMap = {
 };
 
 
+// Sanitize user input and facet terms for comparison: convert to lowercase, remove white space and asterisks (which cause regular expression error)
+export const sanitizedString = inputString => inputString.toLowerCase()
+    .replace(/ /g, '') // remove spaces (to allow multiple word searches)
+    .replace(/[*?()+[\]\\/]/g, ''); // remove certain special characters (these cause console errors)
+
+
 // Keep lists of currently known project and biosample_type. As new project and biosample_type
 // enter the system, these lists must be updated. Used mostly to keep chart and matrix colors
 // consistent.

--- a/src/encoded/static/components/index.js
+++ b/src/encoded/static/components/index.js
@@ -33,6 +33,7 @@ require('./matrix_experiment');
 require('./matrix_reference_epigenome');
 require('./matrix_sescc_stem_cell');
 require('./matrix_chip_seq');
+require('./matrix_encore');
 require('./target');
 require('./publication');
 require('./pipeline');

--- a/src/encoded/static/components/matrix_encore.js
+++ b/src/encoded/static/components/matrix_encore.js
@@ -316,7 +316,6 @@ const MatrixHeader = ({ context, targetFilterText, textChangeHandler }) => (
                 <TargetFilter filterText={targetFilterText} textChangeHandler={textChangeHandler} />
             </div>
             <div className="matrix-header__search-controls">
-                <h4>Showing {context.total} results</h4>
                 <SearchControls context={context} hideBrowserSelector />
             </div>
         </div>

--- a/src/encoded/static/components/matrix_encore.js
+++ b/src/encoded/static/components/matrix_encore.js
@@ -205,10 +205,12 @@ const convertEncoreToDataTable = (context, displayedAssays, rowCategoryFilterTex
         return termKey.match(typeaheadVal);
     }) : context.matrix.y[rowCategory].buckets;
 
+    // Generate query strings to filter targets to the relevant biosample term names.
     let displayedTermNamesQuery = displayedTermNames.map(displayedTermName => (
         `${colSubCategory}=${encoding.encodedURIComponent(displayedTermName)}`
     )).join('&');
     if (rowCategory === 'target.label') {
+        // Also add cell-free sample on the main ENCORE matrix.
         displayedTermNamesQuery += `&${colSubCategory}=${encoding.encodedURIComponent('cell-free sample')}`;
     }
 

--- a/src/encoded/static/components/matrix_encore.js
+++ b/src/encoded/static/components/matrix_encore.js
@@ -9,7 +9,6 @@ import { svgIcon } from '../libs/svg-icons';
 import DataTable from './datatable';
 import * as globals from './globals';
 import { MatrixInternalTags } from './objectutils';
-import { SearchControls } from './search';
 
 
 /**
@@ -221,7 +220,7 @@ const convertEncoreToDataTable = (context, displayedAssays, rowCategoryFilterTex
         if (hasTermName) {
             rowCategoryUrl = `${baseUrlWithoutColCategoryType}&${rowCategory}=${encoding.encodedURIComponent(rowCategoryItem.key)}&${displayedTermNamesQuery}`;
         } else {
-            rowCategoryUrl = `${baseUrlWithoutColCategoryType}&${rowCategory}!=*&${encoding.encodedURIComponent(rowCategoryItem.key)}&${displayedTermNamesQuery}`;
+            rowCategoryUrl = `${baseUrlWithoutColCategoryType}&${rowCategory}!=*&${displayedTermNamesQuery}`;
         }
 
         // Make a new array for the whole row so we can fill individual cells, and fill in the left

--- a/src/encoded/static/components/matrix_encore.js
+++ b/src/encoded/static/components/matrix_encore.js
@@ -206,15 +206,22 @@ const convertEncoreToDataTable = (context, displayedAssays, rowCategoryFilterTex
         return termKey.match(typeaheadVal);
     }) : context.matrix.y[rowCategory].buckets;
 
+    let displayedTermNamesQuery = displayedTermNames.map(displayedTermName => (
+        `${colSubCategory}=${encoding.encodedURIComponent(displayedTermName)}`
+    )).join('&');
+    if (rowCategory === 'target.label') {
+        displayedTermNamesQuery += `&${colSubCategory}=${encoding.encodedURIComponent('cell-free sample')}`;
+    }
+
     // Fill in the data portion of the table.
     rowCategoryBuckets.forEach((rowCategoryItem) => {
         // Targets without a biosample get the special key "no_term_name."
         let rowCategoryUrl;
         const hasTermName = rowCategoryItem.key !== 'no_term_name';
         if (hasTermName) {
-            rowCategoryUrl = `${baseUrlWithoutColCategoryType}&${rowCategory}=${encoding.encodedURIComponent(rowCategoryItem.key)}`;
+            rowCategoryUrl = `${baseUrlWithoutColCategoryType}&${rowCategory}=${encoding.encodedURIComponent(rowCategoryItem.key)}&${displayedTermNamesQuery}`;
         } else {
-            rowCategoryUrl = `${baseUrlWithoutColCategoryType}&${rowCategory}!=*`;
+            rowCategoryUrl = `${baseUrlWithoutColCategoryType}&${rowCategory}!=*&${encoding.encodedURIComponent(rowCategoryItem.key)}&${displayedTermNamesQuery}`;
         }
 
         // Make a new array for the whole row so we can fill individual cells, and fill in the left

--- a/src/encoded/static/components/matrix_encore.js
+++ b/src/encoded/static/components/matrix_encore.js
@@ -315,9 +315,6 @@ const MatrixHeader = ({ context, targetFilterText, textChangeHandler }) => (
             <div className="matrix-header__target-filter-controls">
                 <TargetFilter filterText={targetFilterText} textChangeHandler={textChangeHandler} />
             </div>
-            <div className="matrix-header__search-controls">
-                <SearchControls context={context} hideBrowserSelector />
-            </div>
         </div>
     </div>
 );

--- a/src/encoded/static/components/matrix_encore.js
+++ b/src/encoded/static/components/matrix_encore.js
@@ -1,0 +1,607 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import _ from 'underscore';
+import url from 'url';
+import QueryString from '../libs/query_string';
+import * as encoding from '../libs/query_encoding';
+import { Panel, PanelBody } from '../libs/ui/panel';
+import { svgIcon } from '../libs/svg-icons';
+import DataTable from './datatable';
+import * as globals from './globals';
+import { MatrixInternalTags } from './objectutils';
+import { SearchControls } from './search';
+
+
+/**
+ * Limit the assays to display on the horizontal axis of the main ENCORE matrix to these.
+ */
+const encoreDisplayedAssays = [
+    'shRNA RNA-seq',
+    'CRISPR RNA-seq',
+    'eCLIP',
+    'TF ChIP-seq',
+    'RNA Bind-n-Seq',
+    'iCLIP',
+];
+
+/**
+ * Limit the assays to display on the horizontal axis of the inset RNA-seq matrix to these.
+ */
+const rnaSeqDisplayedAssays = [
+    'total RNA-seq',
+    'polyA plus RNA-seq',
+];
+
+/**
+ * Limit the biosample term names to display within each assay to these.
+ */
+const displayedTermNames = [
+    'K562',
+    'HepG2',
+];
+
+/**
+ * Assays in which we don't display a biosample.
+ */
+const noBiosampleAssays = [
+    'RNA Bind-n-Seq',
+];
+
+
+/**
+ * The ENCORE matrix does front-end filtering, which means we could have columns we can display
+ * according to the `encoreDisplayedAssays` global, but which might only contain data we *don't*
+ * display because it doesn’t have data in terms names we display from the `displayedTermNames`
+ * global. This function checks `colCategoryKey` (assay_title) to see if it has any data for term
+ * names in `displayedTermNames`. If not, we don’t render that column even though it exists in the
+ * matrix JSON.
+ * @param {object} context Matrix data object for the page
+ * @param {string} colCategoryKey Title of assay column we're checking
+ * @param {string} colCategory Column category property e.g. assay_title
+ * @param {string} colSubCategory Column subcategory property e.g. biosample_ontology.term_name
+ * @param {string} rowCategory Row category property e.g. target.label
+ *
+ * @return {bool} True if we should display the given colCategoryKey column
+ */
+const doesRowDataExist = (context, colCategoryKey, colCategory, colSubCategory, rowCategory) => {
+    const isColCategoryDataFound = context.matrix.y[rowCategory].buckets.find((rowCategoryItem) => {
+        const isColCategoryFound = rowCategoryItem[colCategory].buckets.find((rowColCategoryItem) => {
+            // See if data contains column category we're looking for.
+            if (rowColCategoryItem.key === colCategoryKey) {
+                // See if row includes data for a displayed subcategory column.
+                return rowColCategoryItem[colSubCategory].buckets.find(rowColSubCategoryItem => (
+                    displayedTermNames.includes(rowColSubCategoryItem.key)
+                ));
+            }
+            return false;
+        });
+        return isColCategoryFound;
+    });
+    return isColCategoryDataFound;
+};
+
+
+/**
+ * Takes matrix data from the ENCORE matrix JSON and generates an object that <DataTable> can use to
+ * generate the JSX for the matrix. Both the main ENCORE matrix as well as the RNA-seq matrix use
+ * this function with slight special cases for each.
+ * @param {object} context Matrix JSON for the page
+ * @param {array} displayedAssays List of assays to include in the table.
+ * @param {string} rowCategoryFilterText Displayed targets must partially match this text
+ *
+ * @return {object} Generated object suitable for passing to <DataTable>
+ */
+
+const convertEncoreToDataTable = (context, displayedAssays, rowCategoryFilterText) => {
+    const colCategory = context.matrix.x.group_by[0];
+    const colSubCategory = context.matrix.x.group_by[1];
+
+    // Especially for the RNA-seq matrix, links should only have the column category (assay_title)
+    // for the clicked column, not all assay_title that might be in the query string.
+    const query = new QueryString(context.search_base);
+    query.deleteKeyValue(colCategory);
+    const baseUrlWithoutColCategoryType = query.format();
+
+    // The inset RNA-seq matrix has an array of arrays of strings instead of just an array of
+    // strings. The ENCORE matrix search view uses this mechanism to let us capture data that has no
+    // biosamples.
+    const rowCategory = typeof context.matrix.y.group_by[0] === 'string' ? context.matrix.y.group_by[0] : context.matrix.y.group_by[0][0];
+
+    // Collect column header table data and build a map of column category to corresponding table
+    // column index. Initialize with an empty corner cell as the first item in each header row.
+    const colCategoryData = [null];
+    const colSubCategoryData = [null];
+    let colIndex = 1;
+    let firstColumn = true;
+    const colMap = {};
+    const spacerIndices = [];
+    context.matrix.x[colCategory].buckets.forEach((colCategoryItem) => {
+        if (displayedAssays.includes(colCategoryItem.key) && doesRowDataExist(context, colCategoryItem.key, colCategory, colSubCategory, rowCategory)) {
+            colMap[colCategoryItem.key] = {};
+            const colCategoryUrl = `${baseUrlWithoutColCategoryType}&${colCategory}=${encoding.encodedURIComponent(colCategoryItem.key)}`;
+
+            // Add a spacer between the current and previous biosample term name column if not the
+            // first assay column.
+            if (!firstColumn) {
+                colSubCategoryData.push({ header: <div className="encore-column-spacer" /> });
+            }
+
+            // Filter and sort column subcategory buckets according to `displayedTermNames` so
+            // that the column subcategories always appear in the same order under each column
+            // category.
+            const colSubCategoryBuckets = _.sortBy(colCategoryItem[colSubCategory].buckets.filter(bucket => (
+                displayedTermNames.includes(bucket.key) || noBiosampleAssays.includes(colCategoryItem.key)
+            )), bucket => displayedTermNames.indexOf(bucket.key));
+
+            // Generate the biosample term name column subheaders within one assay column.
+            let subCategoryCount = 0;
+            colSubCategoryBuckets.forEach((colSubCategoryItem) => {
+                // Only include allowed biosample term names.
+                if (noBiosampleAssays.includes(colCategoryItem.key)) {
+                    // No biosample associated with assay; fill with &nbsp;.
+                    colSubCategoryData.push({ header: '\u00A0', css: 'category-subheader category-subheader--none' });
+                } else {
+                    // K562 or HepG2 biosample associated with assay.
+                    colSubCategoryData.push({
+                        header: (
+                            <a href={`${colCategoryUrl}&${colSubCategory}=${encoding.encodedURIComponent(colSubCategoryItem.key)}`}>
+                                {colSubCategoryItem.key}
+                            </a>
+                        ),
+                        css: `category-subheader category-subheader--${colSubCategoryItem.key}`,
+                    });
+                }
+
+                // Generate the two-level map of categories and subcategories to table column
+                // number, then go on to the next column. Each colMap key represents an assay, and
+                // its value another object containing the biosample term names as keys, with their
+                // values being the column number for that assay/biosample-term-name pair.
+                colMap[colCategoryItem.key][colSubCategoryItem.key] = colIndex;
+                colIndex += 1;
+                subCategoryCount += 1;
+            });
+
+            // Add a spacer between the current and previous assay column if not the first assay
+            // column.
+            if (!firstColumn) {
+                // Push the spacer into the column header.
+                colCategoryData.push({ header: <div className="encore-column-spacer" /> });
+
+                // Keep track of which columns the spacers exist in so we can insert the same spacers
+                // into the row data.
+                spacerIndices.push(colIndex);
+            } else {
+                firstColumn = false;
+            }
+
+            // Generate one assay column header.
+            colCategoryData.push({
+                header: <a href={colCategoryUrl}>{colCategoryItem.key}</a>,
+                colSpan: subCategoryCount,
+                css: `category-header${subCategoryCount > 1 ? ' category-header--spanned' : ''}`,
+            });
+            colIndex += 1;
+        }
+    });
+
+    // Initialize the <DataTable> data with the column headers, or with a message if we have no
+    // data available.
+    let matrixDataTable;
+    if (colCategoryData.length > 1) {
+        matrixDataTable = [
+            { rowContent: colCategoryData, css: 'matrix__col-category-header' },
+            { rowContent: colSubCategoryData, css: 'matrix__col-category-subheader' },
+        ];
+    } else {
+        matrixDataTable = [
+            { rowContent: ['No data available'], css: 'matrix__message' },
+        ];
+    }
+
+    // The search field lets the user filter on the target of the main ENCORE matrix only, and does
+    // not result in a query to the server -- just a visual filtering.
+    const rowCategoryBuckets = rowCategoryFilterText ? context.matrix.y[rowCategory].buckets.filter((bucket) => {
+        const termKey = globals.sanitizedString(bucket.key);
+        const typeaheadVal = String(globals.sanitizedString(rowCategoryFilterText));
+        return termKey.match(typeaheadVal);
+    }) : context.matrix.y[rowCategory].buckets;
+
+    // Fill in the data portion of the table.
+    rowCategoryBuckets.forEach((rowCategoryItem) => {
+        // Targets without a biosample get the special key "no_term_name."
+        let rowCategoryUrl;
+        const hasTermName = rowCategoryItem.key !== 'no_term_name';
+        if (hasTermName) {
+            rowCategoryUrl = `${baseUrlWithoutColCategoryType}&${rowCategory}=${encoding.encodedURIComponent(rowCategoryItem.key)}`;
+        } else {
+            rowCategoryUrl = `${baseUrlWithoutColCategoryType}&${rowCategory}!=*`;
+        }
+
+        // Make a new array for the whole row so we can fill individual cells, and fill in the left
+        // header column.
+        let usedRowCellCount = 0;
+        const cells = new Array(colIndex - 1).fill(null);
+        cells[0] = { header: <a href={rowCategoryUrl}>{hasTermName ? rowCategoryItem.key : '(all)'}</a> };
+        rowCategoryItem[colCategory].buckets.forEach((rowColCategoryItem) => {
+            // Retrieve the column map object containing the biosample term name column numbers for
+            // each assay column. Then generate cells for the target row.
+            const colMapCategory = colMap[rowColCategoryItem.key];
+            if (colMapCategory) {
+                rowColCategoryItem[colSubCategory].buckets.forEach((rowColSubCategoryItem) => {
+                    const cellIndex = colMapCategory[rowColSubCategoryItem.key];
+                    const cellCss = noBiosampleAssays.includes(rowColCategoryItem.key) ? 'none' : rowColSubCategoryItem.key;
+                    cells[cellIndex] = {
+                        content: (
+                            <a
+                                href={`${rowCategoryUrl}&${colCategory}=${encoding.encodedURIComponent(rowColCategoryItem.key)}&${colSubCategory}=${encoding.encodedURIComponent(rowColSubCategoryItem.key)}`}
+                                className={`encore-cell encore-cell--${cellCss}`}
+                            >
+                                {'\u00A0'}
+                                <div className="sr-only">{`${hasTermName ? rowCategoryItem.key : 'all subcellular localizations'}, ${rowColCategoryItem.key}, ${rowColSubCategoryItem.key}`}</div>
+                            </a>
+                        ),
+                    };
+                    usedRowCellCount += 1;
+                });
+            }
+        });
+
+        // Insert the spacer columns.
+        spacerIndices.forEach((spacerIndex) => {
+            cells[spacerIndex] = { content: '\u00A0', css: 'encore-column-spacer' };
+        });
+
+        // Add the completed row to the entire datatable object.
+        if (usedRowCellCount > 0) {
+            matrixDataTable.push({ rowContent: cells, css: 'matrix__row-data' });
+        }
+    });
+
+    return { dataTable: matrixDataTable };
+};
+
+
+/**
+ * Renders the search field that filters the target rows with partial text matches. This search,
+ * unlike some other matrices, does not generate a new query, but just visually filters the
+ * targets.
+ */
+const TargetFilter = ({ filterText, textChangeHandler }) => (
+    <div className="matrix-general-search">
+        <label htmlFor="target-filter">Enter filter terms to filter the targets included in the matrix.</label>
+        <div className="general-search-entry">
+            <i className="icon icon-filter" />
+            <div className="searchform">
+                <input
+                    type="search"
+                    className="search-query"
+                    name="target-filter"
+                    id="target-filter"
+                    onChange={textChangeHandler}
+                    value={filterText}
+                />
+            </div>
+        </div>
+    </div>
+);
+
+TargetFilter.propTypes = {
+    /** Current value of filtering text */
+    filterText: PropTypes.string,
+    /** Called when the user changes a search input field */
+    textChangeHandler: PropTypes.func.isRequired,
+};
+
+TargetFilter.defaultProps = {
+    filterText: '',
+};
+
+
+/**
+ * Render the area above the facets and matrix content.
+ */
+const MatrixHeader = ({ context, targetFilterText, textChangeHandler }) => (
+    <div className="matrix-header">
+        <div className="matrix-header__title">
+            <h1>{context.title}</h1>
+            <div className="matrix-tags">
+                <MatrixInternalTags context={context} />
+                <div className="matrix-description">
+                    The ENCORE project aims to study protein-RNA interactions by creating a map of RNA binding proteins (RBPs) encoded in the human genome and identifying the RNA elements that the RBPs bind to.
+                </div>
+            </div>
+        </div>
+        <div className="matrix-header__controls">
+            <div className="matrix-header__target-filter-controls">
+                <TargetFilter filterText={targetFilterText} textChangeHandler={textChangeHandler} />
+            </div>
+            <div className="matrix-header__search-controls">
+                <h4>Showing {context.total} results</h4>
+                <SearchControls context={context} hideBrowserSelector />
+            </div>
+        </div>
+    </div>
+);
+
+MatrixHeader.propTypes = {
+    /** Matrix search result object */
+    context: PropTypes.object.isRequired,
+    /** Current value of filtering text */
+    targetFilterText: PropTypes.string,
+    /** Called when the user changes a search input field */
+    textChangeHandler: PropTypes.func.isRequired,
+};
+
+MatrixHeader.defaultProps = {
+    targetFilterText: '',
+};
+
+
+/**
+ * Custom react hook to handle matrix scrolling.
+ * @param {node} Ref to scrolling matrix element
+ *
+ * @return {array} States and actions usable to this hook's clients
+ */
+const useMatrixScrollHandler = (scrollElement) => {
+    const [scrolledRight, setScrolledRight] = React.useState(true);
+
+    /**
+     * Show a scroll indicator depending on current scrolled position.
+     * @param {object} element DOM element to apply shading to
+     */
+    const handleScrollIndicator = React.useCallback((element) => {
+        // Have to use a "roughly equal to" test because of an MS Edge bug mentioned here:
+        // https://stackoverflow.com/questions/30900154/workaround-for-issue-with-ie-scrollwidth
+        const scrollDiff = Math.abs((element.scrollWidth - element.scrollLeft) - element.clientWidth);
+        if (scrollDiff < 2 && !scrolledRight) {
+            // Right edge of matrix scrolled into view.
+            setScrolledRight(true);
+        } else if (scrollDiff >= 2 && scrolledRight) {
+            // Right edge of matrix scrolled out of view.
+            setScrolledRight(false);
+        }
+    }, [scrolledRight]);
+
+    React.useEffect(() => {
+        if (scrollElement.current) {
+            // Install the scroll and resize event handlers.
+            const handleScrollEvent = event => handleScrollIndicator(event.target);
+            const handleResizeEvent = () => handleScrollIndicator(scrollElement.current);
+
+            // Cache the reference to the scrollable matrix <div> so that we can remove the "scroll"
+            // event handler on unmount, when scrollElement.current might no longer point at this <div>.
+            const matrixNode = scrollElement.current;
+
+            // Attach the scroll- and resize- event handlers, then force the initial calculation of
+            // `scrolledRight`.
+            scrollElement.current.addEventListener('scroll', handleScrollEvent);
+            window.addEventListener('resize', handleResizeEvent);
+            handleScrollIndicator(scrollElement.current);
+
+            // Callback called when unmounting component.
+            return () => {
+                matrixNode.removeEventListener('scroll', handleScrollEvent);
+                window.removeEventListener('resize', handleResizeEvent);
+            };
+        }
+
+        // To make both ESLint (consistent-return rule) and React (return undefined or nothing if
+        // no clean-up) happy...
+        return undefined;
+    }, [handleScrollIndicator, scrollElement]);
+
+    /**
+     * Called when the user scrolls the matrix horizontally within its div to handle scroll
+     * indicators.
+     * @param {object} e React synthetic scroll event
+     */
+    const handleOnScroll = (e) => {
+        handleScrollIndicator(e.target);
+    };
+
+    return [
+        // State indicating whether the user scrolled the matrix all the way to the right edge.
+        scrolledRight,
+        // Callback to handle scroll events
+        handleOnScroll,
+    ];
+};
+
+
+/**
+ * Display the RNA-seq inset matrix. This data gets loaded after page render, so `rnaSeqData` has a
+ * null SSR value.
+ */
+const RnaSeqMatrixContent = ({ rnaSeqData }) => {
+    const scrollElement = React.useRef(null);
+    const [scrolledRight, handleOnScroll] = useMatrixScrollHandler(scrollElement);
+
+    if (rnaSeqData) {
+        const { dataTable } = convertEncoreToDataTable(rnaSeqData, rnaSeqDisplayedAssays);
+        const matrixConfig = {
+            rows: dataTable,
+            tableCss: 'matrix matrix--rna-seq',
+        };
+
+        return (
+            <div className="matrix__rna-seq">
+                <div className={`matrix__label matrix__label--horz${!scrolledRight ? ' horz-scroll' : ''}`}>
+                    <span>{rnaSeqData.matrix.x.label}</span>
+                    {svgIcon('largeArrow')}
+                </div>
+                <div className="matrix__presentation-content">
+                    <div className="matrix__label matrix__label--vert"><div>{svgIcon('largeArrow')}{rnaSeqData.matrix.y.label}</div></div>
+                    <div className="matrix__data-wrapper">
+                        <div className="matrix__data" onScroll={handleOnScroll} ref={scrollElement}>
+                            <DataTable tableData={matrixConfig} />
+                        </div>
+                    </div>
+                </div>
+            </div>
+        );
+    }
+    return null;
+};
+
+RnaSeqMatrixContent.propTypes = {
+    /** Matrix search results for the RNA-seq inset matrix */
+    rnaSeqData: PropTypes.object,
+};
+
+RnaSeqMatrixContent.defaultProps = {
+    rnaSeqData: null,
+};
+
+
+const EncoreMatrixContent = ({ encoreData, targetFilterText }) => {
+    const scrollElement = React.useRef(null);
+    const [scrolledRight, handleOnScroll] = useMatrixScrollHandler(scrollElement);
+
+    // Convert encode matrix data to a DataTable object.
+    const { dataTable } = convertEncoreToDataTable(encoreData, encoreDisplayedAssays, targetFilterText);
+    const matrixConfig = {
+        rows: dataTable,
+        tableCss: 'matrix matrix--encore',
+    };
+
+    return (
+        <div className="matrix__encore">
+            <div className={`matrix__label matrix__label--horz${!scrolledRight ? ' horz-scroll' : ''}`}>
+                <span>{encoreData.matrix.x.label}</span>
+                {svgIcon('largeArrow')}
+            </div>
+            <div className="matrix__presentation-content">
+                <div className="matrix__label matrix__label--vert"><div>{svgIcon('largeArrow')}{encoreData.matrix.y.label}</div></div>
+                <div className="matrix__data-wrapper">
+                    <div className="matrix__data" onScroll={handleOnScroll} ref={scrollElement}>
+                        <DataTable tableData={matrixConfig} />
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+EncoreMatrixContent.propTypes = {
+    /** ENCORE matrix data */
+    encoreData: PropTypes.object.isRequired,
+    /** Text used to filter target list */
+    targetFilterText: PropTypes.string,
+};
+
+EncoreMatrixContent.defaultProps = {
+    targetFilterText: '',
+};
+
+
+/**
+ * Display the matrix and associated controls above them.
+ */
+const MatrixPresentation = ({ context, targetFilterText }) => {
+    const [rnaSeqData, setRnaSeqData] = React.useState(null);
+
+    React.useEffect(() => {
+        // Request the RNA-seq ENCORE sub-matrix by taking the existing URI and modifying it to
+        // form the RNA-seq URI that includes the RNA-seq matrix path and filters down to the
+        // needed assay titles. Any other assay_title query-string parameters get removed.
+        const parsedUrl = url.parse(context['@id']);
+        const query = new QueryString(parsedUrl.query);
+        query.replaceKeyValue('assay_title', 'total RNA-seq').addKeyValue('assay_title', 'polyA plus RNA-seq');
+        parsedUrl.search = `?${query.format()}`;
+        parsedUrl.pathname = '/encore-rna-seq-matrix/';
+        const updatedUrl = parsedUrl.format();
+        fetch(updatedUrl, {
+            method: 'GET',
+            headers: {
+                Accept: 'application/json',
+            },
+        }).then((response) => {
+            // Convert the response to JSON.
+            if (response.ok) {
+                return response.json();
+            }
+            return Promise.resolve(null);
+        }).then((response) => {
+            setRnaSeqData(response);
+        });
+    }, [context]);
+
+    return (
+        <div className="matrix__presentation">
+            <RnaSeqMatrixContent rnaSeqData={rnaSeqData} />
+            <EncoreMatrixContent encoreData={context} targetFilterText={targetFilterText} />
+        </div>
+    );
+};
+
+MatrixPresentation.propTypes = {
+    /** Matrix data object for the page */
+    context: PropTypes.object.isRequired,
+    /** Text used to filter target list */
+    targetFilterText: PropTypes.string,
+};
+
+MatrixPresentation.defaultProps = {
+    targetFilterText: '',
+};
+
+
+/**
+ * Render the vertical facets and the matrix itself.
+ */
+const MatrixContent = ({ context, targetFilterText }) => (
+    <div className="matrix__content matrix__content--encore">
+        <MatrixPresentation context={context} targetFilterText={targetFilterText} />
+    </div>
+);
+
+MatrixContent.propTypes = {
+    /** Matrix data object for the page */
+    context: PropTypes.object.isRequired,
+    /** Text used to filter target list */
+    targetFilterText: PropTypes.string,
+};
+
+MatrixContent.defaultProps = {
+    targetFilterText: '',
+};
+
+
+/**
+ * View component for the experiment matrix page.
+ */
+const EncoreMatrix = ({ context }) => {
+    const [targetFilterText, setTargetFilterText] = React.useState('');
+    const itemClass = globals.itemClass(context, 'view-item');
+
+    // Called when the user changes the contents of the target filter text field.
+    const handleTextChange = React.useCallback((e) => {
+        setTargetFilterText(e.target.value);
+    }, []);
+
+    if (context.total > 0) {
+        return (
+            <Panel addClasses={itemClass}>
+                <PanelBody>
+                    <MatrixHeader context={context} targetFilterText={targetFilterText} textChangeHandler={handleTextChange} />
+                    <MatrixContent context={context} targetFilterText={targetFilterText} />
+                </PanelBody>
+            </Panel>
+        );
+    }
+    return <h4>No results found</h4>;
+};
+
+EncoreMatrix.propTypes = {
+    /** Matrix data object for the page */
+    context: PropTypes.object.isRequired,
+};
+
+EncoreMatrix.contextTypes = {
+    location_href: PropTypes.string,
+    navigate: PropTypes.func,
+    biosampleTypeColors: PropTypes.object,
+};
+
+globals.contentViews.register(EncoreMatrix, 'EncoreMatrix');

--- a/src/encoded/static/components/matrix_encore.js
+++ b/src/encoded/static/components/matrix_encore.js
@@ -70,7 +70,7 @@ const doesRowDataExist = (context, colCategoryKey, colCategory, colSubCategory, 
             if (rowColCategoryItem.key === colCategoryKey) {
                 // See if row includes data for a displayed subcategory column.
                 return rowColCategoryItem[colSubCategory].buckets.find(rowColSubCategoryItem => (
-                    displayedTermNames.includes(rowColSubCategoryItem.key)
+                    noBiosampleAssays.includes(rowColCategoryItem.key) || displayedTermNames.includes(rowColSubCategoryItem.key)
                 ));
             }
             return false;

--- a/src/encoded/static/components/search.js
+++ b/src/encoded/static/components/search.js
@@ -1034,7 +1034,7 @@ export const SearchControls = ({ context, visualizeDisabledTitle, showResultsTog
 SearchControls.propTypes = {
     /** Search results object that generates this page */
     context: PropTypes.object.isRequired,
-    /** True to disable Visualize button */
+    /** Text to display with disabled Visualize button */
     visualizeDisabledTitle: PropTypes.string,
     /** True to show View All/View 25 control */
     showResultsToggle: (props, propName, componentName) => {

--- a/src/encoded/static/scss/encoded/modules/_matrix.scss
+++ b/src/encoded/static/scss/encoded/modules/_matrix.scss
@@ -1376,6 +1376,7 @@ $encore-subheader-width: 30px;
 $encore-subheader-height: 56px;
 $encore-header-width: $encore-subheader-width;
 $encore-header-height: 150px;
+$encore-header-height-xs: 200px;
 $encore-header-width-spanned: $encore-subheader-width * 2;
 $encore-cell-width: $encore-subheader-width;
 $encore-spacer-width: 10px;
@@ -1496,17 +1497,29 @@ $rnaseq-term-name-colors:
         }
 
         .matrix__col-category-header {
-            height: $encore-header-height;
+            height: $encore-header-height-xs;
+
+            @media screen and (min-width: $screen-sm-min) {
+                height: $encore-header-height;
+            }
 
             > th {
-                height: $encore-header-height;
+                height: $encore-header-height-xs;
+
+                @media screen and (min-width: $screen-sm-min) {
+                    height: $encore-header-height;
+                }
 
                 &.encore-column-spacer {
                     width: $encore-spacer-width;
                 }
 
                 > a {
-                    height: $encore-header-height;
+                    height: $encore-header-height-xs;
+
+                    @media screen and (min-width: $screen-sm-min) {
+                        height: $encore-header-height;
+                    }
                 }
             }
 

--- a/src/encoded/static/scss/encoded/modules/_matrix.scss
+++ b/src/encoded/static/scss/encoded/modules/_matrix.scss
@@ -1611,6 +1611,18 @@ $rnaseq-term-name-colors:
     }
 }
 
+.type-EncoreMatrix {
+    .matrix-header__target-filter-controls {
+        @media screen and (min-width: $screen-md-min) {
+            flex: 0 1 450px;
+        }
+
+        .general-search-entry {
+            padding-right: 0;
+        }
+    }
+}
+
 .encore-column-spacer {
     border-left: 1px solid $matrix-border-color;
     width: $encore-spacer-width;

--- a/src/encoded/static/scss/encoded/modules/_matrix.scss
+++ b/src/encoded/static/scss/encoded/modules/_matrix.scss
@@ -2,6 +2,7 @@ $data-cell-width: 40px;
 $col-category-header-height: 200px;
 $row-category-cell-height: 22px;
 $row-data-header-width: 200px;
+$matrix-border-color: #f0f0f0;
 
 // Add a shadow to the right edge of the first column's cells.
 @mixin matrix-freeze-shadow {
@@ -371,6 +372,8 @@ $row-data-header-width: 200px;
 .matrix {
     border-collapse: separate;
     max-width: none;
+    width: 1px;
+    height: 1px;
     border-spacing: 0;
 
     // Holds vertical facets and matrix itself.
@@ -475,7 +478,7 @@ $row-data-header-width: 200px;
         > th {
             width: $row-data-header-width;
             text-align: right;
-            border-left: 1px solid #f0f0f0;
+            border-left: 1px solid $matrix-border-color;
             font-size: 1rem;
             border-bottom: 1px solid #fff;
             @extend %sticky-column;
@@ -519,8 +522,8 @@ $row-data-header-width: 200px;
             width: $data-cell-width;
             padding: 0 !important;
             text-align: center;
-            border-bottom: 1px solid #f0f0f0;
-            border-left: 1px solid #f0f0f0;
+            border-bottom: 1px solid $matrix-border-color;
+            border-left: 1px solid $matrix-border-color;
             font-size: 1rem;
 
             > a {
@@ -542,7 +545,7 @@ $row-data-header-width: 200px;
     @at-root #{&}__row-spacer {
         margin: 0;
         height: $row-category-cell-height;
-        border-top: 1px solid #f0f0f0;
+        border-top: 1px solid $matrix-border-color;
         vertical-align: top;
 
         > td {
@@ -601,6 +604,14 @@ $row-data-header-width: 200px;
                     flex: 0 1 auto;
                     font-weight: bold;
                     text-decoration: none;
+
+                    @media screen and (min-width: $screen-md-min) {
+                        white-space: normal;
+                    }
+
+                    @media screen and (min-width: $screen-lg-min) {
+                        white-space: nowrap;
+                    }
                 }
             }
         }
@@ -621,7 +632,7 @@ $row-data-header-width: 200px;
 
         > td {
             padding: 0 !important;
-            border-left: 1px solid #f0f0f0;
+            border-left: 1px solid $matrix-border-color;
             font-size: 1rem;
 
             &:last-child > div, &:last-child > a {
@@ -1353,4 +1364,261 @@ $divider-color: #000; // Color of dividers between assays with targets
         stroke: #ccc;
         stroke-width: 2px;
       }
+}
+
+
+/**
+ * ENCORE Styles
+ */
+
+// Width of the ENCORE header and subheader cells.
+$encore-subheader-width: 30px;
+$encore-subheader-height: 56px;
+$encore-header-width: $encore-subheader-width;
+$encore-header-height: 150px;
+$encore-header-width-spanned: $encore-subheader-width * 2;
+$encore-cell-width: $encore-subheader-width;
+$encore-spacer-width: 10px;
+$encore-term-name-colors:
+    HepG2 #eed78c #000 #e4bc52,
+    K562 #879acd #000 #354b77,
+    none #e0e0e0 #000 #c0c0c0;
+$rnaseq-term-name-colors:
+    HepG2 #e4bc52 #000 #eed78c,
+    K562 #354b77 #fff #879acd,
+    none #c0c0c0 #000 #e0e0e0;
+
+// Styles specific to the ENCORE matrix.
+.matrix__content {
+    // Content for the whole ENCORE page, including the RNA-seq matrix
+    &.matrix__content--encore {
+        display: block;
+
+        .matrix__data {
+            display: flex;
+            align-items: flex-start;
+        }
+
+        .category-header {
+            padding: 0;
+            border-left: 1px solid transparent;
+            width: $encore-header-width;
+
+            > a {
+                width: $encore-header-width;
+                line-height: $encore-header-width;
+            }
+
+            &.category-header--spanned {
+                width: $encore-header-width-spanned;
+
+                > a {
+                    width: $encore-header-width-spanned;
+                    line-height: $encore-header-width-spanned;
+                }
+            }
+        }
+
+        .category-subheader {
+            width: $encore-subheader-width;
+            padding: 5px 0;
+            vertical-align: bottom;
+            border-left: 1px solid $matrix-border-color;
+            border-bottom: 1px solid $matrix-border-color;
+
+            @each $term, $header-color, $text-color in $encore-term-name-colors {
+                &.category-subheader--#{$term} {
+                    background-color: $header-color;
+
+                    a {
+                        display: block;
+                        font-weight: normal;
+                        color: $text-color;
+                        width: $encore-subheader-width;
+                        height: $encore-subheader-height;
+                        line-height: $encore-subheader-width;
+                        text-align: left;
+                        writing-mode: tb-rl;
+                        transform: rotate(180deg);
+
+                        &:hover {
+                            text-decoration: none;
+                        }
+                    }
+                }
+            }
+        }
+
+        td {
+            width: $encore-subheader-width;
+            padding: 0 0 1px 1px;
+        }
+
+        .matrix__row-data {
+            height: 100%;
+
+            > th {
+                position: static;
+                width: auto;
+                border-left: none;
+                background-color: transparent;
+                border-bottom: 1px solid transparent;
+
+                > a {
+                    white-space: nowrap;
+                }
+            }
+
+            > td {
+                height: 100%;
+
+                > a {
+                    width: $encore-cell-width;
+                    height: 100%;
+                }
+
+                &:first-of-type {
+                    border-left: 1px solid $matrix-border-color;
+                }
+
+                .encore-cell {
+                    @each $term, $color, $text-color, $cell-color in $encore-term-name-colors {
+                        &.encore-cell--#{$term} {
+                            background-color: $cell-color;
+                        }
+                    }
+                }
+
+                &.encore-column-spacer {
+                    border-bottom: none;
+                }
+            }
+        }
+
+        .matrix__col-category-header {
+            height: $encore-header-height;
+
+            > th {
+                height: $encore-header-height;
+
+                &.encore-column-spacer {
+                    width: $encore-spacer-width;
+                }
+
+                > a {
+                    height: $encore-header-height;
+                }
+            }
+
+            > td {
+                position: static;
+            }
+        }
+
+        .matrix__message {
+            height: 200px;
+            vertical-align: top;
+
+            > td {
+                padding: 5px 30px;
+                min-height: 100px;
+                text-align: center;
+                white-space: nowrap;
+                font-style: italic;
+            }
+        }
+    }
+}
+
+.matrix {
+    &.matrix--rna-seq {
+        padding: 0 20px 20px 0;
+        border-top: 1px solid $matrix-border-color;
+        border-left: 1px solid $matrix-border-color;
+    }
+}
+
+// Inset RNA-seq matrix.
+.matrix__content.matrix__content--encore {
+    .matrix__presentation {
+        display: block;
+
+        @media screen and (min-width: $screen-md-min) {
+            display: flex;
+            align-items: flex-start;
+        }
+
+        // The RNA-seq portion of the page.
+        .matrix__rna-seq {
+            margin-top: 10px;
+            padding: 3px 0 0 3px;
+            background-color: #e8e8e8;
+            border: 1px solid #d0d0d0;
+            margin-bottom: 50px;
+
+            @media screen and (min-width: $screen-md-min) {
+                order: 1;
+                margin-left: 50px;
+                margin-bottom: 0;
+                min-width: 1px; // Prevents flex row overflow by allowing scrolling of this matrix.
+
+                .uaTrident & {
+                    flex-grow: 1;
+                }
+            }
+
+            .matrix__col-category-header {
+                > td {
+                    background-color: transparent;
+                }
+            }
+
+            .category-subheader {
+                @each $term, $header-color, $text-color, $cell-color in $rnaseq-term-name-colors {
+                    &.category-subheader--#{$term} {
+                        background-color: $header-color;
+
+                        a {
+                            color: $text-color;
+                        }
+                    }
+                }
+            }
+
+            .matrix__row-data {
+                > td {
+                    .encore-cell {
+                        @each $term, $header-color, $text-color, $cell-color in $rnaseq-term-name-colors {
+                            &.encore-cell--#{$term} {
+                                background-color: $cell-color;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // The ENCORE portion of the page.
+        .matrix__encore {
+            @media screen and (min-width: $screen-md-min) {
+                order: 0;
+
+                .uaTrident & {
+                    flex-grow: 1;
+                }
+            }
+        }
+    }
+}
+
+.encore-column-spacer {
+    border-left: 1px solid $matrix-border-color;
+    width: $encore-spacer-width;
+}
+
+.type-EncoreMatrix {
+    .general-search-entry {
+        margin-bottom: 0;
+        padding-bottom: 0;
+    }
 }

--- a/src/encoded/tests/data/inserts/biosample.json
+++ b/src/encoded/tests/data/inserts/biosample.json
@@ -1247,5 +1247,22 @@
         "status": "in progress",
         "submitted_by": "elementum.mus@dictumst.nostra",
         "uuid": "3440ad39-bb3a-488f-8a88-525027b8e943"
+    },
+    {
+        "accession": "ENCBS470XDJ",
+        "aliases": ["eric-lecuyer:HepG2-init-Insoluble_1"],
+        "award": "UM1HG009442",
+        "biosample_ontology": "cell_line_EFO_0001187",
+        "description": "Initial insoluble fractions on HepG2 Long Total from Lecuyer",
+        "donor": "ENCDO017AAA",
+        "lab": "brenton-graveley",
+        "lot_id": "59635738",
+        "organism": "human",
+        "product_id": "HB-8065",
+        "source": "dana-levasseur",
+        "subcellular_fraction_term_name": "insoluble cytoplasmic fraction",
+        "status": "released",
+        "submitted_by": "mus.mi@porttitor.molestie",
+        "uuid": "2ee9acb1-6a04-4226-ac62-afcf1e1f5db3"
     }
 ]

--- a/src/encoded/tests/data/inserts/experiment.json
+++ b/src/encoded/tests/data/inserts/experiment.json
@@ -10,7 +10,7 @@
         "status": "released",
         "date_submitted": "2015-01-20",
         "date_released": "2016-01-01",
-        "internal_tags":["DREAM", "ENCORE"],
+        "internal_tags": ["DREAM"],
         "submitted_by": "dignissim.euismod@amet.habitant",
         "uuid": "5a6d5a57-e62d-44b9-a1bd-5d1815247348"
     },
@@ -1098,5 +1098,54 @@
         "date_released": "2015-08-31",
         "biosample_ontology": "tissue_UBERON_0001891",
         "assay_term_name": "CUT&Tag"
+    },
+    {
+        "accession": "ENCSR611ZAL",
+        "aliases": ["brenton-graveley:TAF15-LV08"],
+        "assay_term_name": "shRNA knockdown followed by RNA-seq",
+        "award": "UM1HG009442",
+        "biosample_ontology": "cell_line_EFO_0002067",
+        "date_released": "2014-10-16",
+        "date_submitted": "2014-09-15",
+        "dbxrefs": ["GEO:GSE80910"],
+        "description": "shRNA knockdown against TAF15 in K562 cells followed by RNA-seq. (TAF15-LV08)",
+        "internal_tags": ["ENCORE"],
+        "lab": "brenton-graveley",
+        "status": "released",
+        "submitted_by": "mus.mi@porttitor.molestie",
+        "target": "TAF15-human",
+        "uuid": "dffa753d-f35a-4df9-a5cb-86bea9862069"
+    },
+    {
+        "accession": "ENCSR696JWA",
+        "aliases": ["brenton-graveley:ZC3H8-BGHLV37-B"],
+        "assay_term_name": "shRNA knockdown followed by RNA-seq",
+        "award": "UM1HG009442",
+        "biosample_ontology": "cell_line_EFO_0001187",
+        "date_released": "2017-12-06",
+        "date_submitted": "2017-11-21",
+        "description": "RNA-seq on HepG2 cells treated with an shRNA knockdown against ZC3H8. (ZC3H8-BGHLV37-B)",
+        "internal_tags": ["ENCYCLOPEDIAv5", "ENCORE"],
+        "lab": "brenton-graveley",
+        "status": "released",
+        "submitted_by": "mus.mi@porttitor.molestie",
+        "target": "ZC3H8-human",
+        "uuid": "f1e6498b-9eae-481a-8db1-b5c35e09e254"
+    },
+    {
+        "accession": "ENCSR813BDU",
+        "aliases": ["eric-lecuyer:HepG2-init-Insoluble"],
+        "assay_term_name": "RNA-seq",
+        "award": "UM1HG009442",
+        "biosample_ontology": "cell_line_EFO_0001187",
+        "date_released": "2016-04-21",
+        "date_submitted": "2015-02-21",
+        "description": "Initial insoluble cytoplasmic fractions on HepG2 Long Total from Lecuyer",
+        "internal_status": "unreviewed",
+        "internal_tags": ["ENCORE"],
+        "lab": "brenton-graveley",
+        "status": "released",
+        "submitted_by": "mus.mi@porttitor.molestie",
+        "uuid": "ce726926-60ac-434d-a5d4-6bbf54e3ece4"
     }
 ]

--- a/src/encoded/tests/data/inserts/gene.json
+++ b/src/encoded/tests/data/inserts/gene.json
@@ -513,4 +513,46 @@
         "start": 47808713,
         "end": 47814692
     }]
+}, {
+    "dbxrefs": ["ENSEMBL:ENSG00000270647", "MIM:601574", "RefSeq:NM_139215.3", "Vega:OTTHUMG00000188384", "HGNC:11547", "GeneCards:TAF15", "UniProtKB:Q92804"],
+    "geneid": "8148",
+    "locations": [{
+        "assembly": "GRCh38",
+        "chromosome": "chr17",
+        "start": 35809484,
+        "end": 35847242
+    }, {
+        "assembly": "hg19",
+        "chromosome": "chr17",
+        "start": 34136488,
+        "end": 34174246
+    }],
+    "name": "TATA-box binding protein associated factor 15",
+    "ncbi_entrez_status": "live",
+    "organism": "human",
+    "status": "released",
+    "symbol": "TAF15",
+    "synonyms": ["TAFII68", "Npl3", "hTAFII68", "TAF2N", "RBP56"],
+    "uuid": "9edb73ff-3ba7-43fc-a038-b5042b252f62"
+}, {
+    "status": "released",
+    "geneid": "84524",
+    "ncbi_entrez_status": "live",
+    "symbol": "ZC3H8",
+    "name": "zinc finger CCCH-type containing 8",
+    "synonyms": ["Fliz1", "ZC3HDC8"],
+    "dbxrefs": ["HGNC:30941", "GeneCards:ZC3H8", "RefSeq:NM_032494.3", "ENSEMBL:ENSG00000144161", "UniProtKB:Q8N5P1", "Vega:OTTHUMG00000153270"],
+    "locations": [{
+        "assembly": "GRCh38",
+        "chromosome": "chr2",
+        "start": 112211529,
+        "end": 112255042
+    }, {
+        "assembly": "hg19",
+        "chromosome": "chr2",
+        "start": 112969106,
+        "end": 113012619
+    }],
+    "organism": "human",
+    "uuid": "13082204-d87e-4564-a49a-215b6f07fc31"
 }]

--- a/src/encoded/tests/data/inserts/library.json
+++ b/src/encoded/tests/data/inserts/library.json
@@ -1049,5 +1049,22 @@
         "status": "released",
         "submitted_by": "amet.fusce@est.fermentum",
         "uuid": "60c0d6d6-3d79-430b-bbdf-6b035fdb4b29"
+    },
+    {
+        "accession": "ENCLB414HBO",
+        "aliases": ["eric-lecuyer:L-HepG2-init-Insoluble_1"],
+        "award": "UM1HG009442",
+        "biosample": "ENCBS470XDJ",
+        "depleted_in_term_name": ["rRNA"],
+        "extraction_method": "Trizol",
+        "fragmentation_methods": ["chemical (Illumina TruSeq)"],
+        "lab": "brenton-graveley",
+        "library_size_selection_method": "SPRI beads",
+        "nucleic_acid_term_name": "RNA",
+        "size_range": ">200",
+        "status": "released",
+        "strand_specificity": "strand-specific",
+        "submitted_by": "mus.mi@porttitor.molestie",
+        "uuid": "1de973bf-ebe1-4644-9333-6de525db0bd4"
     }
 ]

--- a/src/encoded/tests/data/inserts/replicate.json
+++ b/src/encoded/tests/data/inserts/replicate.json
@@ -863,5 +863,15 @@
         "submitted_by": "elementum.mus@dictumst.nostra",
         "technical_replicate_number": 1,
         "uuid": "9287fe0e-59a4-45ef-87fb-4b3b285a64c8"
+    },
+    {
+        "aliases": ["eric-lecuyer:R-HepG2-init-Insoluble_1"],
+        "biological_replicate_number": 1,
+        "experiment": "ENCSR813BDU",
+        "library": "ENCLB414HBO",
+        "status": "released",
+        "submitted_by": "mus.mi@porttitor.molestie",
+        "technical_replicate_number": 1,
+        "uuid": "6c430a38-35b9-4a67-8506-1c8c1871a9a9"
     }
 ]

--- a/src/encoded/tests/data/inserts/target.json
+++ b/src/encoded/tests/data/inserts/target.json
@@ -266,5 +266,20 @@
         ],
         "label": "eGFP-ab",
         "status": "released"
+    },
+    {
+        "genes": ["8148"],
+        "investigated_as": ["RNA binding protein"],
+        "label": "TAF15",
+        "status": "released",
+        "uuid": "837ed39c-1bd1-4b92-9d04-b011dc9bdc39"
+    },
+    {
+        "dbxrefs": ["FactorBook:ZC3H8"],
+        "genes": ["84524"],
+        "investigated_as": ["transcription factor"],
+        "label": "ZC3H8",
+        "status": "released",
+        "uuid": "05666fd7-2881-4560-b28f-918c4ebf9a26"
     }
 ]

--- a/src/encoded/tests/features/biosamples.feature
+++ b/src/encoded/tests/features/biosamples.feature
@@ -16,7 +16,7 @@ Feature: Biosamples
         And I wait for the content to load
         When I click the link to "/search/?type=Biosample&organism.scientific_name=Homo+sapiens"
         Then I should see an element with the css selector "div.search-results"
-        And I should see "Showing 25 of 37 results"
+        And I should see "Showing 25 of 38 results"
 
         When I go back
         And I wait for the content to load

--- a/src/encoded/tests/features/matrix_encore.feature
+++ b/src/encoded/tests/features/matrix_encore.feature
@@ -1,0 +1,27 @@
+@matrix @usefixtures(index_workbook)
+Feature: Matrix
+    Scenario: Matrix ENCORE
+        When I visit "/"
+        And I wait for the content to load
+        Then the title should contain the text "ENCODE"
+
+        # Main ENCORE matrix
+        When I press "Data"
+        And I click the link with text that contains "RNA-protein interactions (ENCORE)"
+        And I wait for the content to load
+        Then the title should contain the text "ENCORE Matrix – ENCODE"
+        And I should see at least 4 elements with the css selector ".matrix.matrix--encore tbody > tr"
+        And I should see 1 elements with the css selector ".matrix.matrix--encore tr.matrix__col-category-header > th"
+        And I should see 2 elements with the css selector ".matrix.matrix--encore tr.matrix__col-category-subheader > th"
+        And I should see 2 elements with the css selector ".matrix.matrix--encore tr.matrix__row-data"
+        # Inset RNA-seq matrix
+        And I should see 1 elements with the css selector ".matrix__rna-seq"
+        And I should see 1 elements with the css selector ".matrix.matrix--rna-seq"
+        And I should see at least 3 elements with the css selector ".matrix.matrix--rna-seq > tbody > tr"
+        And I should see 1 elements with the css selector ".matrix.matrix--rna-seq tr.matrix__col-category-header > th"
+        And I should see 1 elements with the css selector ".matrix.matrix--rna-seq tr.matrix__col-category-subheader > th"
+        And I should see 1 elements with the css selector ".matrix.matrix--rna-seq tr.matrix__row-data > th"
+
+    Scenario: Matrix ENCORE filtering
+        When I fill in "target-filter" with "TAF"
+        Then I should see 1 elements with the css selector ".matrix.matrix--encore tr.matrix__row-data"

--- a/src/encoded/tests/features/targets.feature
+++ b/src/encoded/tests/features/targets.feature
@@ -11,10 +11,10 @@ Feature: Targets
         And I wait for the content to load
         When I click the link to "/search/?type=Target&organism.scientific_name=Homo+sapiens"
         Then I should see an element with the css selector "div.search-results"
-        And I should see "Showing 21 of 21 results"
+        And I should see "Showing 23 of 23 results"
 
         When I go back
         And I wait for the content to load
         When I click the link to "/search/?type=Target&investigated_as=transcription+factor"
         Then I should see an element with the css selector "div.search-results"
-        And I should see "Showing 15 of 15 results"
+        And I should see "Showing 16 of 16 results"

--- a/src/encoded/tests/features/test_matrix.py
+++ b/src/encoded/tests/features/test_matrix.py
@@ -18,5 +18,6 @@ scenarios(
     'matrix_reference_epigenome_homo_sapien_nonroadmap.feature',
     'matrix_reference_epigenome_mus_musculus.feature',
     'matrix_sescc_stem_cell.feature',
+    'matrix_encore.feature',
     strict_gherkin=False,
 )

--- a/src/encoded/tests/features/views.feature
+++ b/src/encoded/tests/features/views.feature
@@ -18,7 +18,7 @@ Feature: Views
         And I should see exactly one element with the css selector "[data-test='report']"
 
         When I click the link to "/matrix/?type=Experiment"
-        Then I should see "Showing 69 results"
+        Then I should see "Showing 70 results"
 
         When I click the link to "/report/?type=Experiment"
         Then I should see "Experiment report"

--- a/src/encoded/tests/features/views.feature
+++ b/src/encoded/tests/features/views.feature
@@ -18,7 +18,7 @@ Feature: Views
         And I should see exactly one element with the css selector "[data-test='report']"
 
         When I click the link to "/matrix/?type=Experiment"
-        Then I should see "Showing 70 results"
+        Then I should see "Showing 71 results"
 
         When I click the link to "/report/?type=Experiment"
         Then I should see "Experiment report"

--- a/src/encoded/tests/test_batch_download.py
+++ b/src/encoded/tests/test_batch_download.py
@@ -46,7 +46,7 @@ def test_batch_download_report_download(testapp, index_workbook):
         b'Post-synchronization time', b'Post-synchronization time units',
         b'Replicates',
     ]
-    assert len(lines) == 72
+    assert len(lines) == 73
 
 
 def test_batch_download_matched_set_report_download(testapp, index_workbook):

--- a/src/encoded/tests/test_batch_download.py
+++ b/src/encoded/tests/test_batch_download.py
@@ -46,7 +46,7 @@ def test_batch_download_report_download(testapp, index_workbook):
         b'Post-synchronization time', b'Post-synchronization time units',
         b'Replicates',
     ]
-    assert len(lines) == 73
+    assert len(lines) == 74
 
 
 def test_batch_download_matched_set_report_download(testapp, index_workbook):

--- a/src/encoded/types/experiment.py
+++ b/src/encoded/types/experiment.py
@@ -452,6 +452,28 @@ class Experiment(Dataset,
         },
     }
 
+    encore_matrix = {
+        'y': {
+            'group_by': ['target.label'],
+            'label': 'Target',
+        },
+        'x': {
+            'group_by': ['assay_title', 'biosample_ontology.term_name'],
+            'label': 'Assay',
+        },
+    }
+
+    encore_rna_seq_matrix = {
+        'y': {
+            'group_by': [('replicates.library.biosample.subcellular_fraction_term_name', 'no_term_name')],
+            'label': 'Subcellular localization',
+        },
+        'x': {
+            'group_by': ['assay_title', 'biosample_ontology.term_name'],
+            'label': 'Assay',
+        },
+    }
+
     audit = {
         'audit.ERROR.category': {
             'group_by': 'audit.ERROR.category',


### PR DESCRIPTION
* A lot of files changed, but test data and BDD tests comprise most of those changes. The big Javascript-side change involves the addition of matrix_encore.js and modifications to _matrix.scss.
* On the Python side, I added two new endpoints — one selected through a menu (/encore-matrix/) and one only loaded by the page itself after page load (/encore-rna-seq-matrix/) that users wouldn’t go directly to themselves. The second needs to include results that don’t include the Y-axis property, so I use the same technique as carts.