### PR TITLE
ENCD-5535 Fix pipeline graph arrows

### DIFF
--- a/src/encoded/static/components/filegallery.js
+++ b/src/encoded/static/components/filegallery.js
@@ -1639,6 +1639,7 @@ export function assembleGraph(files, highlightedFiles, dataset, options, loggedI
                     cornerRadius: 16,
                     contributing: fileId,
                     ref: {},
+                    displayDecoration: true,
                     decorationClass: infoNode && infoNode.id === fileNodeId ? 'decoration--active' : '',
                 });
             }
@@ -1675,6 +1676,7 @@ export function assembleGraph(files, highlightedFiles, dataset, options, loggedI
                 cornerRadius: 16,
                 parentNode: replicateNode,
                 ref: fileRef,
+                displayDecoration: true,
                 decorationClass: infoNode && infoNode.id === fileNodeId ? 'decoration--active' : '',
             }, metricsInfo);
 
@@ -1717,6 +1719,7 @@ export function assembleGraph(files, highlightedFiles, dataset, options, loggedI
                         fileId: file['@id'],
                         fileAccession: file.title,
                         stepVersion: file.analysis_step_version,
+                        displayDecoration: true,
                         decorationClass: infoNode && infoNode.id === stepId ? 'decoration--active' : '',
                     });
                 }
@@ -1774,6 +1777,7 @@ export function assembleGraph(files, highlightedFiles, dataset, options, loggedI
                 cornerRadius: 16,
                 contributing: groupHash,
                 ref: coalescingGroup,
+                displayDecoration: true,
                 decorationClass: infoNode && infoNode.id === fileNodeId ? 'decoration--active' : '',
             });
         }

--- a/src/encoded/static/components/graph.js
+++ b/src/encoded/static/components/graph.js
@@ -204,7 +204,7 @@ export class Graph extends React.Component {
         function convertGraphInner(subgraph, parent) {
             // For each node in parent node (or top-level graph)
             parent.nodes.forEach((node) => {
-                subgraph.setNode(node.id, {
+                const nodeOptions = {
                     label: node.label.length > 1 ? node.label : node.label[0],
                     rx: node.metadata.cornerRadius,
                     ry: node.metadata.cornerRadius,
@@ -215,13 +215,16 @@ export class Graph extends React.Component {
                     paddingTop: '10',
                     paddingBottom: '10',
                     subnodes: node.subnodes,
-                    decoration: {
+                };
+                if (node.metadata.displayDecoration) {
+                    nodeOptions.decoration = {
                         id: `${node.id}-highlight`,
                         position: 'top',
                         icon: 'arrow-right',
                         class: node.metadata.decorationClass,
-                    },
-                });
+                    };
+                }
+                subgraph.setNode(node.id, nodeOptions);
                 if (!parent.root) {
                     subgraph.setParent(node.id, parent.id);
                 }


### PR DESCRIPTION
Added a flag, `displayDecoration`, to graph creation to determine whether to add the arrow highlighting decoration or not. Pipeline graphs don’t use this flag while file graphs now do.