### PR TITLE
ENCD-5542 Display average fragment size

### DIFF
--- a/src/encoded/static/components/experiment.js
+++ b/src/encoded/static/components/experiment.js
@@ -38,6 +38,7 @@ const displayedLibraryProperties = [
     { property: 'depleted_in_term_name', title: 'Depleted in', test: 'depletedin' },
     { property: 'nucleic_acid_starting_quantity', title: 'Library starting quantity', test: 'startingquantity' },
     { property: 'size_range', title: 'Size range', test: 'sizerange' },
+    { property: 'average_fragment_size', title: 'Average fragment size', test: 'avgfragmentsize' },
     { property: 'lysis_method', title: 'Lysis method', test: 'lysismethod' },
     { property: 'extraction_method', title: 'Extraction method', test: 'extractionmethod' },
     { property: 'fragmentation_methods', title: 'Fragmentation methods', test: 'fragmentationmethod' },

--- a/src/encoded/tests/data/inserts/library.json
+++ b/src/encoded/tests/data/inserts/library.json
@@ -182,7 +182,7 @@
         "lab": "brenton-graveley",
         "library_size_selection_method": "SPRI beads",
         "nucleic_acid_term_name": "RNA",
-        "average_fragment_size": 243,
+        "size_range": ">200",
         "strand_specificity": "forward",
         "submitted_by": "platea.a@volutpat.viverra",
         "uuid": "5b9eb9a1-6c21-45dd-988b-0e23fddba71d"
@@ -258,7 +258,7 @@
         "lab": "sherman-weissman",
         "library_size_selection_method": "gel",
         "nucleic_acid_term_name": "DNA",
-        "average_fragment_size": 230,
+        "size_range": "150-350",
         "submitted_by": "amet.fusce@est.fermentum",
         "uuid": "35c0e686-00a2-4b24-8b8f-1bcf3379824b"
     },
@@ -275,7 +275,7 @@
         "lab": "brenton-graveley",
         "library_size_selection_method": "SPRI beads",
         "nucleic_acid_term_name": "RNA",
-        "average_fragment_size": 246,
+        "size_range": ">200",
         "strand_specificity": "strand-specific",
         "submitted_by": "platea.a@volutpat.viverra",
         "uuid": "9679f34a-ed04-45f2-8129-5ffbcc565bde"
@@ -670,7 +670,6 @@
         "lab": "john-stamatoyannopoulos",
         "status": "released",
         "nucleic_acid_term_name": "DNA",
-        "average_fragment_size": 243,
         "uuid": "65a36949-a525-4f2b-ba22-3a7eee53edfd",
         "submitted_by": "/users/4c23ec32-c7c8-4ac0-affb-04befcc881d4/",
         "award": "U54HG007010"
@@ -682,7 +681,6 @@
         "lab": "john-stamatoyannopoulos",
         "status": "released",
         "nucleic_acid_term_name": "DNA",
-        "size_range": "170-200",
         "uuid": "1ad8e550-4ca7-4121-8168-748efc2c5895",
         "submitted_by": "/users/4c23ec32-c7c8-4ac0-affb-04befcc881d4/",
         "award": "U54HG007010"
@@ -694,7 +692,6 @@
         "lab": "john-stamatoyannopoulos",
         "status": "released",
         "nucleic_acid_term_name": "DNA",
-        "size_range": ">200",
         "uuid": "bbadf7f4-40ca-4440-b6c2-3003f98b49fe",
         "submitted_by": "/users/4c23ec32-c7c8-4ac0-affb-04befcc881d4/",
         "award": "U54HG007010"

--- a/src/encoded/tests/data/inserts/library.json
+++ b/src/encoded/tests/data/inserts/library.json
@@ -182,7 +182,7 @@
         "lab": "brenton-graveley",
         "library_size_selection_method": "SPRI beads",
         "nucleic_acid_term_name": "RNA",
-        "size_range": ">200",
+        "average_fragment_size": 243,
         "strand_specificity": "forward",
         "submitted_by": "platea.a@volutpat.viverra",
         "uuid": "5b9eb9a1-6c21-45dd-988b-0e23fddba71d"
@@ -258,7 +258,7 @@
         "lab": "sherman-weissman",
         "library_size_selection_method": "gel",
         "nucleic_acid_term_name": "DNA",
-        "size_range": "150-350",
+        "average_fragment_size": 230,
         "submitted_by": "amet.fusce@est.fermentum",
         "uuid": "35c0e686-00a2-4b24-8b8f-1bcf3379824b"
     },
@@ -275,7 +275,7 @@
         "lab": "brenton-graveley",
         "library_size_selection_method": "SPRI beads",
         "nucleic_acid_term_name": "RNA",
-        "size_range": ">200",
+        "average_fragment_size": 246,
         "strand_specificity": "strand-specific",
         "submitted_by": "platea.a@volutpat.viverra",
         "uuid": "9679f34a-ed04-45f2-8129-5ffbcc565bde"
@@ -670,6 +670,7 @@
         "lab": "john-stamatoyannopoulos",
         "status": "released",
         "nucleic_acid_term_name": "DNA",
+        "average_fragment_size": 243,
         "uuid": "65a36949-a525-4f2b-ba22-3a7eee53edfd",
         "submitted_by": "/users/4c23ec32-c7c8-4ac0-affb-04befcc881d4/",
         "award": "U54HG007010"
@@ -681,6 +682,7 @@
         "lab": "john-stamatoyannopoulos",
         "status": "released",
         "nucleic_acid_term_name": "DNA",
+        "size_range": "170-200",
         "uuid": "1ad8e550-4ca7-4121-8168-748efc2c5895",
         "submitted_by": "/users/4c23ec32-c7c8-4ac0-affb-04befcc881d4/",
         "award": "U54HG007010"
@@ -692,6 +694,7 @@
         "lab": "john-stamatoyannopoulos",
         "status": "released",
         "nucleic_acid_term_name": "DNA",
+        "size_range": ">200",
         "uuid": "bbadf7f4-40ca-4440-b6c2-3003f98b49fe",
         "submitted_by": "/users/4c23ec32-c7c8-4ac0-affb-04befcc881d4/",
         "award": "U54HG007010"


### PR DESCRIPTION
Old code needed to generate `<dt>`/`<dl>` pairs in a component without an enclosing div because React.Fragment didn’t exist. That’s why this complicated mechanism exists to display library properties in the experiment summary panel. It should be rewritten to use React.Fragment someday, but I felt like this ticket wasn’t the one to do that, since only one line gets added.