### PR TITLE
ENCD-5526 Display motified_site_by_gene_id on GM pages

### DIFF
--- a/src/encoded/static/scss/encoded/modules/_genetic_modification.scss
+++ b/src/encoded/static/scss/encoded/modules/_genetic_modification.scss
@@ -58,6 +58,10 @@
     dt {
         display: none;
     }
+
+    dd {
+        margin-left: 0;
+    }
 }
 
 .gm-summary-subsection {

--- a/src/encoded/types/genetic_modification.py
+++ b/src/encoded/types/genetic_modification.py
@@ -26,6 +26,7 @@ class GeneticModification(Item):
         'characterizations.lab',
         'modified_site_by_target_id',
         'modified_site_by_target_id.genes',
+        'modified_site_by_gene_id',
         'treatments',
         'lab'
     ]


### PR DESCRIPTION
I moved the `renderers` static object out of `ModificationSiteItems` to the module name space where I should have put that object to begin with and removed the redundant `modificationSitePropNames` variable.