### PR TITLE
ENCD-5534 Allow annotations and FCCs in carts

### DIFF
--- a/src/encoded/static/components/cart/add_multiple.js
+++ b/src/encoded/static/components/cart/add_multiple.js
@@ -63,8 +63,8 @@ class CartAddAllSearchComponent extends React.Component {
                         // Not logged in, so test whether the merged new and existing carts would have
                         // more elements than allowed in a logged-out cart. Display an error modal if
                         // that happens.
-                        const margedCarts = mergeCarts(this.props.elements, elementsForCart);
-                        if (margedCarts.length > CART_MAXIMUM_ELEMENTS_LOGGEDOUT) {
+                        const mergedCarts = mergeCarts(this.props.elements, elementsForCart);
+                        if (mergedCarts.length > CART_MAXIMUM_ELEMENTS_LOGGEDOUT) {
                             this.setState({ overMaximumError: true });
                             return;
                         }

--- a/src/encoded/static/components/cart/add_multiple.js
+++ b/src/encoded/static/components/cart/add_multiple.js
@@ -5,7 +5,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import * as encoding from '../../libs/query_encoding';
+import url from 'url';
+import QueryString from '../../libs/query_string';
 import { addMultipleToCartAndSave, cartOperationInProgress } from './actions';
 import { atIdToType } from '../globals';
 import { requestSearch } from '../objectutils';
@@ -36,56 +37,40 @@ class CartAddAllSearchComponent extends React.Component {
      * all their @ids that we can add to the cart.
      */
     handleClick() {
-        // Get the array of object types in the cart and remove any types found in the filter
-        // array of the current search results. Also make a copy of the current search results
-        // including only the properties we need to avoid mutating a prop.
-        const allowedTypes = cartGetAllowedTypes();
-        const queryFilters = [];
-        this.props.searchResults.filters.forEach((filter) => {
-            // Copy all filter fields and terms to our array of filters used for the query, except
-            // any 'type=something' terms for types not allowed in carts.
-            if (filter.field !== 'type' || allowedTypes.indexOf(filter.term) !== -1) {
-                queryFilters.push({ field: filter.field, term: filter.term });
-            }
+        // Don't use existing search results as they might only include 25 results and we need all
+        // of them. Do the same search but with limit=all and field=@id.
+        const parsedUrl = url.parse(this.props.searchResults['@id']);
+        const query = new QueryString(parsedUrl.query);
+        query.replaceKeyValue('limit', 'all').addKeyValue('field', '@id');
+        const searchQuery = query.format();
 
-            // If the filter is for a type allowed in the cart, remove it from the allowedTypes
-            // list as we don't need to add it later.
-            if (filter.field === 'type') {
-                const index = allowedTypes.indexOf(filter.term);
-                if (index !== -1) {
-                    allowedTypes.splice(index, 1);
-                }
-            }
-        });
-
-        // Add a partial filter entry for any types not included in the current search result
-        // filters.
-        allowedTypes.forEach((type) => {
-            queryFilters.push({ field: 'type', term: type });
-        });
-
-        // Use the existing query plus any cartable object types to search for all @ids to add to
-        // the cart.
-        const searchQuery = `${queryFilters.map(element => (
-            `${element.field}=${encoding.encodedURIComponentOLD(element.term)}`
-        )).join('&')}&limit=all&field=%40id`;
+        // With the updated query string, perform the search of all @ids matching the current
+        // search.
         this.props.setInProgress(true);
         requestSearch(searchQuery).then((results) => {
             this.props.setInProgress(false);
             if (Object.keys(results).length > 0 && results['@graph'].length > 0) {
                 const loggedIn = !!(this.props.session && this.props.session['auth.userid']);
-                const elementsForCart = results['@graph'].map(result => result['@id']);
-                if (!loggedIn) {
-                    // Not logged in, so test whether the merged new and existing carts would have
-                    // more elements than allowed in a logged-out cart. Display an error modal if
-                    // that happens.
-                    const margedCarts = mergeCarts(this.props.elements, elementsForCart);
-                    if (margedCarts.length > CART_MAXIMUM_ELEMENTS_LOGGEDOUT) {
-                        this.setState({ overMaximumError: true });
-                        return;
+                const allowedTypes = cartGetAllowedTypes();
+
+                // Get all elements from results that qualify to exist in carts.
+                const elementsForCart = results['@graph'].filter(result => allowedTypes.includes(result['@type'][0])).map(result => result['@id']);
+                if (elementsForCart.length > 0) {
+                    // We should always have elements qualified to exist in a cart because we
+                    // wouldn't have shown the "Add all items to cart" button if we didn't know we
+                    // had qualfied elements in the search results, but just in case.
+                    if (!loggedIn) {
+                        // Not logged in, so test whether the merged new and existing carts would have
+                        // more elements than allowed in a logged-out cart. Display an error modal if
+                        // that happens.
+                        const margedCarts = mergeCarts(this.props.elements, elementsForCart);
+                        if (margedCarts.length > CART_MAXIMUM_ELEMENTS_LOGGEDOUT) {
+                            this.setState({ overMaximumError: true });
+                            return;
+                        }
                     }
+                    this.props.addAllResults(elementsForCart);
                 }
-                this.props.addAllResults(elementsForCart);
             }
         });
     }

--- a/src/encoded/static/components/cart/cart.js
+++ b/src/encoded/static/components/cart/cart.js
@@ -11,7 +11,7 @@ import { Modal, ModalHeader, ModalBody, ModalFooter } from '../../libs/ui/modal'
 import Pager from '../../libs/ui/pager';
 import { Panel, PanelBody, PanelHeading, TabPanel, TabPanelPane } from '../../libs/ui/panel';
 import { tintColor, isLight } from '../datacolors';
-import GenomeBrowser from '../genome_browser';
+import GenomeBrowser, { annotationTypeMap } from '../genome_browser';
 import { itemClass, atIdToType } from '../globals';
 import { requestObjects, ItemAccessories, isFileVisualizable, computeAssemblyAnnotationValue, filterForVisualizableFiles } from '../objectutils';
 import { ResultTableList } from '../search';
@@ -101,16 +101,6 @@ const requestedFacetFields = displayedFacetFields.concat([
     { field: 'dataset' },
     { field: 'biological_replicates' },
 ]);
-
-
-/**
- * Maps long annotation_type values to shorter versions for Valis track labels. Any not included
- * remain unchanged.
- */
-const annotationTypeMap = {
-    'candidate Cis-Regulatory Elements': 'cCRE',
-    'representative DNase hypersensitivity sites (rDHSs)': 'rDHS',
-};
 
 
 /**

--- a/src/encoded/static/components/cart/cart.js
+++ b/src/encoded/static/components/cart/cart.js
@@ -12,7 +12,7 @@ import Pager from '../../libs/ui/pager';
 import { Panel, PanelBody, PanelHeading, TabPanel, TabPanelPane } from '../../libs/ui/panel';
 import { tintColor, isLight } from '../datacolors';
 import GenomeBrowser from '../genome_browser';
-import { itemClass } from '../globals';
+import { itemClass, atIdToType } from '../globals';
 import { requestObjects, ItemAccessories, isFileVisualizable, computeAssemblyAnnotationValue, filterForVisualizableFiles } from '../objectutils';
 import { ResultTableList } from '../search';
 import CartBatchDownload from './batch_download';
@@ -20,6 +20,7 @@ import CartClearButton from './clear';
 import CartLockTrigger from './lock';
 import CartMergeShared from './merge_shared';
 import Status from '../status';
+import { allowedDatasetTypes, defaultDatasetType } from './util';
 
 /**
  * This file uses some shorthand terms that need some explanation.
@@ -55,6 +56,19 @@ const assemblySorter = facetTerms => (
 
 
 /**
+ * List of allowed dataset types. Generally maps from collection names (e.g. '/experiments/' to a
+ * displayable title.
+ */
+const datasetTypes = {
+    all: { title: 'All dataset types', type: '' }, // Default always first
+    experiments: { title: 'Experiments', type: 'Experiment' },
+    annotations: { title: 'Annotations', type: 'Annotation' },
+    'functional-characterization-experiments': { title: 'Functional characterizations', type: 'FunctionalCharacterizationExperiment' },
+};
+const DEFAULT_DATASET_TYPE = Object.keys(datasetTypes)[0];
+
+
+/**
  * File facet fields to display in order of display.
  * - field: `facet` field property
  * - title: Displayed facet title
@@ -70,6 +84,7 @@ const displayedFacetFields = [
     { field: 'assay_term_name', title: 'Assay term name' },
     { field: 'biosample_ontology.term_name', title: 'Biosample term name', dataset: true },
     { field: 'target.label', title: 'Target of assay', dataset: true },
+    { field: 'annotation_type', title: 'Annotation type', dataset: true },
     { field: 'lab.title', title: 'Lab' },
     { field: 'status', title: 'Status' },
 ];
@@ -82,7 +97,20 @@ const requestedFacetFields = displayedFacetFields.concat([
     { field: '@id' },
     { field: 'file_format_type' },
     { field: 'title' },
+    { field: 'href' },
+    { field: 'dataset' },
+    { field: 'biological_replicates' },
 ]);
+
+
+/**
+ * Maps long annotation_type values to shorter versions for Valis track labels. Any not included
+ * remain unchanged.
+ */
+const annotationTypeMap = {
+    'candidate Cis-Regulatory Elements': 'cCRE',
+    'representative DNase hypersensitivity sites (rDHSs)': 'rDHS',
+};
 
 
 /**
@@ -156,27 +184,27 @@ CartSearchResults.defaultProps = {
  * Display browser tracks for the selected page of files.
  */
 const CartBrowser = ({ files, assembly, pageNumber }) => {
-    const [pageFiles, setPageFiles] = React.useState([]);
+    // Extract the current page of file objects.
+    const pageStartingIndex = pageNumber * PAGE_TRACK_COUNT;
+    const pageFiles = files.slice(pageStartingIndex, pageStartingIndex + PAGE_TRACK_COUNT);
 
-    // Request full file objects for the genome browser but only for the given page of file @ids.
-    React.useEffect(() => {
-        if (files.length > 0 && assembly) {
-            const pageStartingIndex = pageNumber * PAGE_TRACK_COUNT;
-            const pageFilesIds = files.slice(pageStartingIndex, pageStartingIndex + PAGE_TRACK_COUNT);
-            requestObjects(pageFilesIds, '/search/?type=File').then((fileResults) => {
-                setPageFiles(fileResults);
-            });
-        } else {
-            // Clear genome browser if new props have no visualizable tracks.
-            setPageFiles([]);
+    // Shorten long annotation_type values for the Valis track label; fine to mutate `pageFiles` as
+    // it holds a copy of a segment of `files`.
+    pageFiles.forEach((file) => {
+        if (file.annotation_type) {
+            const mappedAnnotationType = annotationTypeMap[file.annotation_type];
+            if (mappedAnnotationType) {
+                file.annotation_type = mappedAnnotationType;
+            }
         }
-    }, [files, assembly, pageNumber]);
+    });
+
     const sortParam = ['Assay term name', 'Biosample term name', 'Output type'];
     return <GenomeBrowser files={pageFiles} label={'cart'} assembly={assembly} expanded sortParam={sortParam} />;
 };
 
 CartBrowser.propTypes = {
-    /** File @ids of all visualizable tracks, not just on the displayed page */
+    /** Files of all visualizable tracks, not just on the displayed page */
     files: PropTypes.array.isRequired,
     /** Assembly to display; can be empty before partial files loaded */
     assembly: PropTypes.string,
@@ -486,7 +514,7 @@ const requestDatasets = (elements, fetch, session) => {
     // so pass the @ids in a POST request payload instead to the /search_elements/ endpoint.
     const fieldQuery = requestedFacetFields.reduce((query, facetField) => `${query}&field=${facetField.dataset ? '' : 'files.'}${facetField.field}`, '');
     return sessionPromise.then(csrfToken => (
-        fetch(`/search_elements/type=Experiment${fieldQuery}&field=files.restricted&limit=all&filterresponse=off`, {
+        fetch(`/search_elements/type=Dataset${fieldQuery}&field=files.restricted&limit=all&filterresponse=off`, {
             method: 'POST',
             headers: {
                 Accept: 'application/json',
@@ -857,7 +885,7 @@ const CartDatasetSearch = ({ elements }, reactContext) => {
     if (experimentElements.length > 0) {
         return (
             <React.Fragment>
-                <button onClick={handleButtonClick} className="btn btn-sm btn-info btn-inline">Dataset search</button>
+                <button onClick={handleButtonClick} className="btn btn-sm btn-info btn-inline cart-dataset-search">Dataset search</button>
                 {isWarningVisible ?
                     <Modal closeModal={handleCloseClick}>
                         <ModalHeader title={<h4>Cart dataset search results</h4>} closeModal={handleCloseClick} />
@@ -887,35 +915,82 @@ CartDatasetSearch.contextTypes = {
 
 
 /**
+ * Selector menu to choose between dataset types to view and download.
+ */
+const CartTypeSelector = ({ selectedDatasetType, elements, typeChangeHandler }) => {
+    // Make a list of all the dataset types currently in the cart.
+    const usedDatasetTypes = [Object.keys(defaultDatasetType)[0]].concat(elements.reduce((types, elementAtId) => {
+        const type = atIdToType(elementAtId);
+        return types.includes(type) ? types : types.concat(type);
+    }, []));
+
+    // Add the "All datasets" option to the used dataset types.
+    const displayedDatasets = Object.assign(defaultDatasetType, allowedDatasetTypes);
+
+    return (
+        <select value={selectedDatasetType} onChange={typeChangeHandler} className="cart-dataset-selector">
+            {usedDatasetTypes.map(type => <option key={type} value={type} className={`cart-dataset-option cart-dataset-option--${type}`}>{displayedDatasets[type].title}</option>)}
+        </select>
+    );
+};
+
+CartTypeSelector.propTypes = {
+    /** Currently selected dataset type */
+    selectedDatasetType: PropTypes.string.isRequired,
+    /** Cart elements */
+    elements: PropTypes.array.isRequired,
+    /** Called when the user selects a new dataset type from the dropdown */
+    typeChangeHandler: PropTypes.func.isRequired,
+};
+
+
+/**
  * Display cart tool buttons. If `savedCartObj` is supplied, supply it for the metadata.tsv line
  * in the resulting files.txt.
  */
-const CartTools = ({ elements, selectedTerms, savedCartObj, viewableDatasets, fileCounts, cartType, sharedCart, visualizable, inProgress }) => (
-    <div className="cart__tools">
-        {elements.length > 0 ?
-            <CartBatchDownload
-                elements={elements}
-                selectedTerms={selectedTerms}
-                datasetFacets={datasetFacets}
-                cartType={cartType}
-                savedCartObj={savedCartObj}
-                sharedCart={sharedCart}
-                fileCounts={fileCounts}
-                visualizable={visualizable}
-            />
-        : null}
-        {cartType === 'OBJECT' ? <CartMergeShared sharedCartObj={sharedCart} viewableDatasets={viewableDatasets} /> : null}
-        {cartType === 'ACTIVE' ? <CartLockTrigger savedCartObj={savedCartObj} inProgress={inProgress} /> : null}
-        {cartType === 'ACTIVE' || cartType === 'MEMORY' ? <CartClearButton /> : null}
-        <CartDatasetSearch elements={elements} />
-    </div>
-);
+const CartTools = ({ elements, selectedTerms, selectedDatasetType, typeChangeHandler, savedCartObj, viewableDatasets, fileCounts, cartType, sharedCart, visualizable, inProgress }) => {
+    // Disable the download button and show `disabledMessage` if the selected dataset matches "All
+    // datasets."
+    const disabledMessage = selectedDatasetType === DEFAULT_DATASET_TYPE ? 'Select dataset type to download' : '';
+    const selectedType = datasetTypes[selectedDatasetType].type;
+    return (
+        <div className="cart-tools">
+            <CartTypeSelector selectedDatasetType={selectedDatasetType} elements={elements} typeChangeHandler={typeChangeHandler} />
+            {elements.length > 0 ?
+                <CartBatchDownload
+                    elements={elements}
+                    selectedTerms={selectedTerms}
+                    selectedType={selectedType}
+                    datasetFacets={datasetFacets}
+                    cartType={cartType}
+                    savedCartObj={savedCartObj}
+                    sharedCart={sharedCart}
+                    fileCounts={fileCounts}
+                    visualizable={visualizable}
+                    disabledMessage={disabledMessage}
+                />
+            : null}
+            {cartType === 'OBJECT' ? <CartMergeShared sharedCartObj={sharedCart} viewableDatasets={viewableDatasets} /> : null}
+            {cartType === 'ACTIVE' || cartType === 'MEMORY' ?
+                <div className="cart-tools-extras">
+                    {cartType !== 'MEMORY' ? <CartLockTrigger savedCartObj={savedCartObj} inProgress={inProgress} /> : null}
+                    <CartClearButton />
+                </div>
+            : null}
+            <CartDatasetSearch elements={elements} />
+        </div>
+    );
+};
 
 CartTools.propTypes = {
     /** Cart elements */
     elements: PropTypes.array,
     /** Selected facet terms */
     selectedTerms: PropTypes.object,
+    /** Selected dataset type */
+    selectedDatasetType: PropTypes.string.isRequired,
+    /** Called when the user selects a new dataset type */
+    typeChangeHandler: PropTypes.func.isRequired,
     /** Cart as it exists in the database; use JSON payload method if none */
     savedCartObj: PropTypes.object,
     /** Viewable cart element @ids */
@@ -1045,13 +1120,13 @@ const addFileTermToFacet = (facets, field, file) => {
  * @param {array} files Partial files to consider when building these facets.
  *
  * @return {object}
- *     {array} assembledFacets - Array of simplified facet objects including fields and terms;
+ *     {array} facets - Array of simplified facet objects including fields and terms;
  *                               empty array if none
- *     {array} facetSelectedFiles - Array of partial files selected by currently selected facets
+ *     {array} selectedFiles - Array of partial files selected by currently selected facets
  */
 const assembleFacets = (selectedTerms, files) => {
     const assembledFacets = [];
-    const facetSelectedFiles = [];
+    const selectedFiles = [];
     const processedFiles = files.filter(file => file.assembly);
     if (processedFiles.length > 0) {
         const selectedFacetKeys = Object.keys(selectedTerms).filter(term => selectedTerms[term].length > 0);
@@ -1079,7 +1154,7 @@ const assembleFacets = (selectedTerms, files) => {
                 Object.keys(selectedTerms).forEach((facetField) => {
                     addFileTermToFacet(assembledFacets, facetField, file);
                 });
-                facetSelectedFiles.push(file);
+                selectedFiles.push(file);
             } else {
                 // The file didn't pass the first test, so run the same test repeatedly but
                 // with one facet removed from the test each time. For each easier test the
@@ -1133,7 +1208,7 @@ const assembleFacets = (selectedTerms, files) => {
         });
     }
 
-    return { assembledFacets: assembledFacets.length > 0 ? assembledFacets : [], facetSelectedFiles };
+    return { facets: assembledFacets.length > 0 ? assembledFacets : [], selectedFiles };
 };
 
 
@@ -1182,8 +1257,8 @@ const resetFacets = (files) => {
 
     // Build the facets based on no selections, then select the first term of any radio-button
     // facets.
-    const { assembledFacets } = assembleFacets(emptySelectedTerms, files);
-    return initRadioFacets(assembledFacets, emptySelectedTerms);
+    const { facets } = assembleFacets(emptySelectedTerms, files);
+    return initRadioFacets(facets, emptySelectedTerms);
 };
 
 
@@ -1234,6 +1309,7 @@ CounterTab.defaultProps = {
  *           'MEMORY': Viewing carts in browser memory (non-logged-in user)
  * @param {object} context Cart search results object; often empty depending on cart type
  * @param {object} savedCartObj Cart object in Redux store for active logged-in carts
+ * @param {object} elements Elements of the in-memory cart
  *
  * @return {object} -
  * {
@@ -1388,11 +1464,11 @@ const calcTotalPageCount = (itemCount, maxCount) => Math.floor(itemCount / maxCo
  * of these files, complete file objects get retrieved.
  */
 const CartComponent = ({ context, elements, savedCartObj, loggedIn, inProgress, fetch, session }) => {
-    // Array of currently displayed facets and the terms each contains.
-    const [facets, setFacets] = React.useState([]);
     // Keeps track of currently selected facet terms keyed by facet fields.
     const [selectedTerms, setSelectedTerms] = React.useState(() => generateFacetTermsTemplate());
-    // Array of dataset @ids the user has access to view; subset of `datasets`; shared carts only.
+    // Currently selected dataset type.
+    const [selectedDatasetType, setSelectedDatasetType] = React.useState(DEFAULT_DATASET_TYPE);
+    // Array of dataset @ids the user has access to view; subset of `cartDatasets`.
     const [viewableDatasets, setViewableDatasets] = React.useState(null);
     // Currently displayed page number for each tab panes; for pagers.
     const [pageNumbers, dispatchPageNumbers] = React.useReducer(reducerTabPanePageNumber, { datasets: 0, browser: 0, processeddata: 0, rawdata: 0 });
@@ -1400,24 +1476,32 @@ const CartComponent = ({ context, elements, savedCartObj, loggedIn, inProgress, 
     const [totalPageCount, dispatchTotalPageCounts] = React.useReducer(reducerTabPaneTotalPageCount, { datasets: 0, browser: 0, processeddata: 0, rawdata: 0 });
     // Currently displayed tab; match key of first TabPanelPane initially.
     const [displayedTab, setDisplayedTab] = React.useState('datasets');
-    // All currently selected partial file objects, visualizable or not.
-    const [selectedFiles, setSelectedFiles] = React.useState([]);
-    // All currently selected visualizable partial file objects.
-    const [selectedVisualizableFiles, setSelectedVisualizableFiles] = React.useState([]);
     // Facet-loading progress bar value; null=indeterminate; -1=disable
     const [facetProgress, setFacetProgress] = React.useState(null);
     // True if only facet terms for visualizable files displayed.
     const [visualizableOnly, setVisualizableOnly] = React.useState(false);
     // All partial file objects in the cart datasets. Not affected by currently selected facets.
     const [allFiles, setAllFiles] = React.useState([]);
-    // All raw data files in all datasets in the cart.
-    const [rawdataFiles, setRawdataFiles] = React.useState([]);
 
-    // Retrieve current cart information regardless of its source (memory, object, active).
-    const { cartType, cartName, cartDatasets } = getCartInfo(context, savedCartObj, elements);
+    // Retrieve current unfiltered cart information regardless of its source (memory, object,
+    // active).
+    const { cartType, cartName, cartDatasets } = React.useMemo(() => (
+        getCartInfo(context, savedCartObj, elements)
+    ), [context, savedCartObj, elements]);
 
-    // Get all files or just visualizable ones based on the Show Visualizable Data Only switch.
-    const getConsideredFiles = () => (visualizableOnly ? filterForVisualizableFiles(allFiles) : allFiles);
+    // Get the cart datasets subject to the dataset-type dropdown.
+    const cartDatasetsForType = React.useMemo(() => (
+        selectedDatasetType === 'all' ? cartDatasets : cartDatasets.filter(datasetAtId => atIdToType(datasetAtId) === selectedDatasetType)
+    ), [selectedDatasetType, cartDatasets]);
+
+    // Build the facets based on the currently selected facet terms.
+    const { facets, selectedFiles } = React.useMemo(() => (
+        assembleFacets(selectedTerms, visualizableOnly ? filterForVisualizableFiles(allFiles) : allFiles)
+    ), [selectedTerms, visualizableOnly, allFiles]);
+    const rawdataFiles = React.useMemo(() => allFiles.filter(files => !files.assembly), [allFiles]);
+    const selectedVisualizableFiles = React.useMemo(() => (
+        getSelectedVisualizableFiles(filterForVisualizableFiles(allFiles), selectedTerms)
+    ), [allFiles, selectedTerms]);
 
     // Called when the user selects a new page of items to view using the pager.
     const updateDisplayedPage = (newDisplayedPage) => {
@@ -1464,12 +1548,7 @@ const CartComponent = ({ context, elements, savedCartObj, loggedIn, inProgress, 
             }
         }
 
-        // Rebuild the facets with the new selected terms.
-        const { assembledFacets, facetSelectedFiles } = assembleFacets(newSelectedTerms, getConsideredFiles());
-        setFacets(assembledFacets);
         setSelectedTerms(newSelectedTerms);
-        setSelectedFiles(facetSelectedFiles);
-        setSelectedVisualizableFiles(getSelectedVisualizableFiles(filterForVisualizableFiles(allFiles), newSelectedTerms));
     };
 
     // Called when the user clicks the Show Visualizable Only checkbox.
@@ -1482,32 +1561,41 @@ const CartComponent = ({ context, elements, savedCartObj, loggedIn, inProgress, 
         setDisplayedTab(newTab);
     };
 
-    // After mount, we can fetch all datasets in the cart and from them extract all their files.
+    // Called when the user changes the currently selected dataset type.
+    const handleTypeChange = (e) => {
+        setSelectedDatasetType(e.target.value);
+    };
+
+    // After mount, we can fetch all datasets in the cart that are viewable at the user's
+    // permission level and from them extract all their files.
     React.useEffect(() => {
-        if (cartDatasets.length > 0) {
-            retrieveDatasetsFiles(cartDatasets, setFacetProgress, fetch, session).then(({ datasetFiles, datasets }) => {
+        if (cartDatasetsForType.length > 0) {
+            retrieveDatasetsFiles(cartDatasetsForType, setFacetProgress, fetch, session).then(({ datasetFiles, datasets }) => {
+                // Mutate files for special cases.
+                datasetFiles.forEach((file) => {
+                    // De-embed any embedded datasets.files.dataset.
+                    if (typeof file.dataset === 'object') {
+                        file.dataset = file.dataset['@id'];
+                    }
+                });
+
                 setAllFiles(datasetFiles);
-                setRawdataFiles(datasetFiles.filter(datasetFile => !datasetFile.assembly));
                 setViewableDatasets(datasets);
             });
         }
-    }, [cartDatasets, fetch, session]);
+    }, [cartDatasetsForType, fetch, session]);
 
     // Use the file information to build the facets and its initial selections.
     React.useEffect(() => {
         const allVisualizableFiles = filterForVisualizableFiles(allFiles);
         const consideredFiles = visualizableOnly ? allVisualizableFiles : allFiles;
         const newSelectedTerms = resetFacets(consideredFiles);
-        const { assembledFacets, facetSelectedFiles } = assembleFacets(newSelectedTerms, consideredFiles);
-        setFacets(assembledFacets);
-        setSelectedFiles(facetSelectedFiles);
-        setSelectedVisualizableFiles(getSelectedVisualizableFiles(allVisualizableFiles, newSelectedTerms));
         setSelectedTerms(newSelectedTerms);
     }, [visualizableOnly, allFiles]);
 
     // Data changes or initial load need a total-page-count calculation.
     React.useEffect(() => {
-        const datasetPageCount = calcTotalPageCount(cartDatasets.length, PAGE_ELEMENT_COUNT);
+        const datasetPageCount = calcTotalPageCount(cartDatasetsForType.length, PAGE_ELEMENT_COUNT);
         const browserPageCount = calcTotalPageCount(selectedVisualizableFiles.length, PAGE_TRACK_COUNT);
         const processedDataPageCount = calcTotalPageCount(selectedFiles.length, PAGE_FILE_COUNT);
         const rawdataPageCount = calcTotalPageCount(rawdataFiles.length, PAGE_FILE_COUNT);
@@ -1529,7 +1617,7 @@ const CartComponent = ({ context, elements, savedCartObj, loggedIn, inProgress, 
         if (pageNumbers.rawdata >= rawdataPageCount) {
             dispatchPageNumbers({ tab: 'rawdata', pageNumber: 0 });
         }
-    }, [cartDatasets, selectedVisualizableFiles, selectedFiles, rawdataFiles, pageNumbers.datasets, pageNumbers.browser, pageNumbers.processeddata, pageNumbers.rawdata]);
+    }, [cartDatasetsForType, selectedVisualizableFiles, selectedFiles, rawdataFiles, pageNumbers.datasets, pageNumbers.browser, pageNumbers.processeddata, pageNumbers.rawdata]);
 
     return (
         <div className={itemClass(context, 'view-item')}>
@@ -1538,12 +1626,14 @@ const CartComponent = ({ context, elements, savedCartObj, loggedIn, inProgress, 
                 {cartType === 'OBJECT' ? <ItemAccessories item={context} /> : null}
             </header>
             <Panel addClasses="cart__result-table">
-                {cartDatasets.length > 0 ?
+                {cartDatasetsForType.length > 0 ?
                     <PanelHeading addClasses="cart__header">
                         <CartTools
                             elements={cartDatasets}
                             savedCartObj={savedCartObj}
                             selectedTerms={selectedTerms}
+                            selectedDatasetType={selectedDatasetType}
+                            typeChangeHandler={handleTypeChange}
                             viewableDatasets={viewableDatasets}
                             cartType={cartType}
                             sharedCart={context}
@@ -1555,11 +1645,11 @@ const CartComponent = ({ context, elements, savedCartObj, loggedIn, inProgress, 
                     </PanelHeading>
                 : null}
                 <PanelBody>
-                    {cartDatasets.length > 0 ?
+                    {cartDatasetsForType.length > 0 ?
                         <div className="cart__display">
                             <FileFacets
                                 facets={facets}
-                                elements={cartDatasets}
+                                elements={cartDatasetsForType}
                                 selectedTerms={selectedTerms}
                                 termClickHandler={handleTermClick}
                                 selectedFileCount={selectedFiles.length}
@@ -1571,9 +1661,9 @@ const CartComponent = ({ context, elements, savedCartObj, loggedIn, inProgress, 
                             />
                             <TabPanel
                                 tabPanelCss="cart__display-content"
-                                tabs={{ datasets: 'Datasets', browser: 'Genome browser', processeddata: 'Processed data', rawdata: 'Raw data' }}
+                                tabs={{ datasets: 'All datasets', browser: 'Genome browser', processeddata: 'Processed data', rawdata: 'Raw data' }}
                                 tabDisplay={{
-                                    datasets: <CounterTab title="Datasets" count={cartDatasets.length} voice="datasets" />,
+                                    datasets: <CounterTab title={datasetTypes[selectedDatasetType].title} count={cartDatasetsForType.length} voice="datasets" />,
                                     browser: <CounterTab title="Genome browser" count={selectedVisualizableFiles.length} voice="visualizable tracks" />,
                                     processeddata: <CounterTab title="Processed data" count={selectedFiles.length} voice="processed data files" />,
                                     rawdata: <CounterTab title="Raw data" count={rawdataFiles.length} voice="raw data files" />,
@@ -1587,7 +1677,7 @@ const CartComponent = ({ context, elements, savedCartObj, loggedIn, inProgress, 
                                         updateCurrentPage={updateDisplayedPage}
                                     />
                                     <CartSearchResults
-                                        elements={cartDatasets}
+                                        elements={cartDatasetsForType}
                                         currentPage={pageNumbers.datasets}
                                         cartControls={cartType !== 'OBJECT'}
                                         loggedIn={loggedIn}
@@ -1599,7 +1689,7 @@ const CartComponent = ({ context, elements, savedCartObj, loggedIn, inProgress, 
                                         totalPageCount={totalPageCount.browser}
                                         updateCurrentPage={updateDisplayedPage}
                                     />
-                                    <CartBrowser files={selectedVisualizableFiles.map(file => file['@id'])} assembly={selectedTerms.assembly[0]} pageNumber={pageNumbers.browser} />
+                                    <CartBrowser files={selectedVisualizableFiles} assembly={selectedTerms.assembly[0]} pageNumber={pageNumbers.browser} />
                                 </TabPanelPane>
                                 <TabPanelPane key="processeddata">
                                     <CartPager

--- a/src/encoded/static/components/cart/clear.js
+++ b/src/encoded/static/components/cart/clear.js
@@ -122,12 +122,12 @@ class CartClearButtonComponent extends React.Component {
         const { elements, inProgress } = this.props;
         if (elements.length > 0 && !this.props.locked) {
             return (
-                <React.Fragment>
+                <div className="cart-tools-extras__button">
                     <button disabled={inProgress} onClick={this.handleClearCartClick} id="clear-cart-actuator" className="btn btn-danger btn-sm btn-inline">Clear cart</button>
                     {this.state.modalOpen ?
                         <CartClearModal closeClickHandler={this.handleCloseClick} />
                     : null}
-                </React.Fragment>
+                </div>
             );
         }
         return null;

--- a/src/encoded/static/components/cart/lock.js
+++ b/src/encoded/static/components/cart/lock.js
@@ -27,7 +27,7 @@ const CartLockTriggerComponent = ({ savedCartObj, inProgress, onLock }) => {
     }
 
     return (
-        <div className="cart-manager-table__tooltip-group">
+        <div className="cart-manager-table__tooltip-group cart-tools-extras__button">
             {disabledTooltip ?
                 <div
                     className="cart-manager-table__button-overlay"

--- a/src/encoded/static/components/cart/merge_shared.js
+++ b/src/encoded/static/components/cart/merge_shared.js
@@ -69,7 +69,7 @@ class CartMergeSharedComponent extends React.Component {
         if ((viewableDatasets && viewableDatasets.length > 0) && (sharedCartObj['@id'] !== savedCartObj['@id'])) {
             const cartName = (savedCartObj && Object.keys(savedCartObj).length > 0 ? savedCartObj.name : '');
             return (
-                <span>
+                <div className="cart-merge">
                     <button className="btn btn-info btn-sm" disabled={this.props.inProgress} onClick={this.handleMergeButtonClick}>Add to current cart</button>
                     {this.state.mergeCartDisplayed ?
                         <Modal labelId="merge-cart-label" descriptionId="merge-cart-description" focusId="merge-cart-close">
@@ -90,7 +90,7 @@ class CartMergeSharedComponent extends React.Component {
                     {this.state.overMaximumError ?
                         <MaximumElementsLoggedoutModal closeClickHandler={this.handleErrorModalClose} />
                     : null}
-                </span>
+                </div>
             );
         }
 

--- a/src/encoded/static/components/cart/util.js
+++ b/src/encoded/static/components/cart/util.js
@@ -6,10 +6,25 @@ import PropTypes from 'prop-types';
 import { Modal, ModalHeader, ModalBody, ModalFooter } from '../../libs/ui/modal';
 
 
-/** List of object @type and object path element allowed in the cart. */
-const allowedCartTypes = {
-    Experiment: 'experiments',
+/**
+ * List of dataset types allowed in carts. Maps from collection names to corresponding data:
+ *     title: Displayable title for the type
+ *     type: Object @type, i.e. RHS of "type=<dataset type>" in a query string
+ */
+export const allowedDatasetTypes = {
+    experiments: { title: 'Experiments', type: 'Experiment' },
+    annotations: { title: 'Annotations', type: 'Annotation' },
+    'functional-characterization-experiments': { title: 'Functional characterizations', type: 'FunctionalCharacterizationExperiment' },
 };
+
+/**
+ * The default dataset type for All Datasets. The object matches the real dataset types in
+ * `allowedDatasetTypes` but without a type.
+ */
+export const defaultDatasetType = {
+    all: { title: 'All dataset types' },
+};
+
 
 /** Maximum number of elements allowed in cart while not logged in */
 export const CART_MAXIMUM_ELEMENTS_LOGGEDOUT = 4000;
@@ -35,11 +50,12 @@ MaximumElementsLoggedoutModal.propTypes = {
 
 
 /**
- * Get a mutatable array of object types allowed in carts.
+ * Get a mutatable array of dataset types allowed in carts, i.e. an array of types on the right-
+ * hand side of "type=<dataset type>" in a query string.
  * @return {array} Copy of `allowedCartTypes` global
  */
 export const cartGetAllowedTypes = () => (
-    Object.keys(allowedCartTypes)
+    Object.keys(allowedDatasetTypes).map(datasetType => allowedDatasetTypes[datasetType].type)
 );
 
 
@@ -49,7 +65,7 @@ export const cartGetAllowedTypes = () => (
  * @return {array} Copy of `allowedCartTypes` global
  */
 export const cartGetAllowedObjectPathTypes = () => (
-    Object.keys(allowedCartTypes).map(type => allowedCartTypes[type])
+    Object.keys(allowedDatasetTypes)
 );
 
 

--- a/src/encoded/static/components/dataset.js
+++ b/src/encoded/static/components/dataset.js
@@ -86,7 +86,7 @@ const AnnotationComponent = (props, reactContext) => {
                 <Breadcrumbs crumbs={crumbs} crumbsReleased={crumbsReleased} />
                 <h1>Summary for annotation file set {context.accession}</h1>
                 <ReplacementAccessions context={context} />
-                <ItemAccessories item={context} audit={{ auditIndicators, auditId: 'annotation-audit' }} />
+                <ItemAccessories item={context} audit={{ auditIndicators, auditId: 'annotation-audit' }} hasCartControls />
             </header>
             {auditDetail(context.audit, 'annotation-audit', { session: reactContext.session, sessionProperties: reactContext.session_properties, except: context['@id'] })}
             <Panel>
@@ -1508,7 +1508,7 @@ export const SeriesComponent = (props, reactContext) => {
                 <Breadcrumbs crumbs={crumbs} crumbsReleased={crumbsReleased} />
                 <h1>Summary for {seriesTitle} {context.accession}</h1>
                 <ReplacementAccessions context={context} />
-                <ItemAccessories item={context} audit={{ auditIndicators, auditId: 'series-audit' }} />
+                <ItemAccessories item={context} audit={{ auditIndicators, auditId: 'series-audit' }} hasCartControls={seriesType === 'FunctionalCharacterizationSeries'} />
             </header>
             {auditDetail(context.audit, 'series-audit', { session: reactContext.session, sessionProperties: reactContext.session_properties, except: context['@id'] })}
             <Panel>

--- a/src/encoded/static/components/experiment.js
+++ b/src/encoded/static/components/experiment.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import dayjs from 'dayjs';
 import _ from 'underscore';
-import url from 'url';
 import { Panel, PanelHeading, PanelBody } from '../libs/ui/panel';
 import { auditDecor } from './audit';
 import { DocumentsPanelReq, DocumentsSubpanels } from './doc';

--- a/src/encoded/static/components/genetic_modification.js
+++ b/src/encoded/static/components/genetic_modification.js
@@ -18,16 +18,6 @@ import Status from './status';
 import { BiosampleTable, DonorTable } from './typeutils';
 
 
-/**
- * Maps long annotation_type values to shorter versions for Valis track labels. Any not included
- * remain unchanged.
- */
-export const annotationTypeMap = {
-    'candidate Cis-Regulatory Elements': 'cCRE',
-    'representative DNase hypersensitivity sites (rDHSs)': 'rDHS',
-};
-
-
 // Generate a <dt>/<dd> combination to render GeneticModification.epitope_tags into a <dl>. If no
 // epitope_tags exist in the given genetic modification object, nothing gets rendered.
 const IntroducedTags = (props) => {

--- a/src/encoded/static/components/genetic_modification.js
+++ b/src/encoded/static/components/genetic_modification.js
@@ -18,6 +18,16 @@ import Status from './status';
 import { BiosampleTable, DonorTable } from './typeutils';
 
 
+/**
+ * Maps long annotation_type values to shorter versions for Valis track labels. Any not included
+ * remain unchanged.
+ */
+export const annotationTypeMap = {
+    'candidate Cis-Regulatory Elements': 'cCRE',
+    'representative DNase hypersensitivity sites (rDHSs)': 'rDHS',
+};
+
+
 // Generate a <dt>/<dd> combination to render GeneticModification.epitope_tags into a <dl>. If no
 // epitope_tags exist in the given genetic modification object, nothing gets rendered.
 const IntroducedTags = (props) => {

--- a/src/encoded/static/components/genome_browser.js
+++ b/src/encoded/static/components/genome_browser.js
@@ -3,9 +3,19 @@ import PropTypes from 'prop-types';
 import _ from 'underscore';
 import { FetchedData, Param } from './fetched';
 import { BrowserFeat } from './browserfeat';
-import { truncateString } from './globals';
 import { filterForVisualizableFiles } from './objectutils';
 import AutocompleteBox from './region_search';
+
+
+/**
+ * Maps long annotation_type values to shorter versions for Valis track labels. Any not included
+ * remain unchanged.
+ */
+export const annotationTypeMap = {
+    'candidate Cis-Regulatory Elements': 'cCRE',
+    'representative DNase hypersensitivity sites (rDHSs)': 'rDHS',
+};
+
 
 // Files to be displayed for local version of browser
 const dummyFiles = [
@@ -168,9 +178,9 @@ const sortLookUp = (obj, param) => {
     case 'Replicates':
         return obj.biological_replicates.length > 1 ? +obj.biological_replicates.join('') : +obj.biological_replicates * 1000;
     case 'Output type':
-        return obj.output_type.toLowerCase();
+        return obj.output_type && obj.output_type.toLowerCase();
     case 'File type':
-        return obj.file_type.toLowerCase();
+        return obj.file_type && obj.file_type.toLowerCase();
     case 'Assay term name':
         return obj.assay_term_name && obj.assay_term_name.toLowerCase();
     case 'Biosample term name':
@@ -497,11 +507,13 @@ class GenomeBrowser extends React.Component {
         let files = propsFiles;
 
         // Apply sort parameters
-        orderedSortParam.forEach((param) => {
-            files = _.chain(files)
-                .sortBy(obj => sortLookUp(obj, param));
-        });
-        files = files.value();
+        if (this.props.displaySort) {
+            orderedSortParam.forEach((param) => {
+                files = _.chain(files)
+                    .sortBy(obj => sortLookUp(obj, param));
+            });
+            files = files.value();
+        }
 
         // sortBy sorts in ascending order and sortDirection is true if descending
         // We want to reverse the sort order when the sort is toggled and ascending (to make it descending)

--- a/src/encoded/static/components/genome_browser.js
+++ b/src/encoded/static/components/genome_browser.js
@@ -178,13 +178,13 @@ const sortLookUp = (obj, param) => {
     case 'Replicates':
         return obj.biological_replicates.length > 1 ? +obj.biological_replicates.join('') : +obj.biological_replicates * 1000;
     case 'Output type':
-        return obj.output_type && obj.output_type.toLowerCase();
+        return obj.output_type.toLowerCase();
     case 'File type':
-        return obj.file_type && obj.file_type.toLowerCase();
+        return obj.file_type.toLowerCase();
     case 'Assay term name':
-        return obj.assay_term_name && obj.assay_term_name.toLowerCase();
+        return obj.assay_term_name.toLowerCase();
     case 'Biosample term name':
-        return obj.biosample_ontology && obj.biosample_ontology.term_name.toLowerCase();
+        return obj.biosample_ontology.term_name.toLowerCase();
     default:
         return null;
     }

--- a/src/encoded/static/components/genome_browser.js
+++ b/src/encoded/static/components/genome_browser.js
@@ -620,7 +620,7 @@ class GenomeBrowser extends React.Component {
             if (file.file_format_type &&
                 (['bedrnaelements', 'peptidemapping', 'bedexonscore', 'bed12', 'bed9'].indexOf(file.file_format_type.toLowerCase()) > -1)) {
                 trackObj.name = <TrackLabel file={file} label={label} long />;
-                trackObj.heightPx = 90;
+                trackObj.heightPx = 95;
                 trackObj.expandable = false;
             }
             return trackObj;

--- a/src/encoded/static/components/objectutils.js
+++ b/src/encoded/static/components/objectutils.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import _ from 'underscore';
 import url from 'url';
 import * as encoding from '../libs/query_encoding';
-import { CartToggle } from './cart';
+import { CartToggle, cartGetAllowedTypes } from './cart';
 import * as globals from './globals';
 import { BrowserFeat } from './browserfeat';
 
@@ -776,21 +776,24 @@ DocTypeTitle.contextTypes = {
 /**
  * Display a block of accessory controls on object-display pages, e.g. the audit indicator button.
  */
-export const ItemAccessories = ({ item, audit, hasCartControls }, reactContext) => (
-    <div className="item-accessories">
-        <div className="item-accessories--left">
-            {audit ?
-                audit.auditIndicators(item.audit, audit.auditId, { session: reactContext.session, sessionProperties: reactContext.session_properties, except: audit.except })
-            : null}
+export const ItemAccessories = ({ item, audit, hasCartControls }, reactContext) => {
+    const isItemAllowedInCart = cartGetAllowedTypes().includes(item['@type'][0]);
+    return (
+        <div className="item-accessories">
+            <div className="item-accessories--left">
+                {audit ?
+                    audit.auditIndicators(item.audit, audit.auditId, { session: reactContext.session, sessionProperties: reactContext.session_properties, except: audit.except })
+                : null}
+            </div>
+            <div className="item-accessories--right">
+                <DisplayAsJson />
+                {hasCartControls && isItemAllowedInCart ?
+                    <CartToggle element={item} />
+                : null}
+            </div>
         </div>
-        <div className="item-accessories--right">
-            <DisplayAsJson />
-            {hasCartControls ?
-                <CartToggle element={item} />
-            : null}
-        </div>
-    </div>
-);
+    );
+};
 
 ItemAccessories.propTypes = {
     /** Object being displayed that needs these accessories */

--- a/src/encoded/static/components/search.js
+++ b/src/encoded/static/components/search.js
@@ -303,7 +303,7 @@ const ExperimentComponent = (props, reactContext) => {
 
     if (isEnhancerExperiment) {
         if (result.biosamples && result.biosamples.length > 0) {
-            biosamples = result.biosamples.map(sample => biosamples);
+            biosamples = result.biosamples;
         }
     } else {
         if (result.replicates && result.replicates.length > 0) {
@@ -319,9 +319,9 @@ const ExperimentComponent = (props, reactContext) => {
     // Collect synchronizations
     if (isEnhancerExperiment) {
         if (biosamples && biosamples.length > 0) {
-            synchronizations = _.uniq(biosamples.filter(biosample => biosample && biosample.synchronization).map((biosample) => {
-                return `${biosample.synchronization}${biosample.post_synchronization_time ? ` + ${biosample.age_display}` : ''}`;
-            }));
+            synchronizations = _.uniq(biosamples.filter(biosample => biosample && biosample.synchronization).map(biosample => (
+                `${biosample.synchronization}${biosample.post_synchronization_time ? ` + ${biosample.age_display}` : ''}`
+            )));
         }
     } else if (result.replicates && result.replicates.length > 0) {
         synchronizations = _.uniq(result.replicates.filter(replicate =>
@@ -455,6 +455,68 @@ const Experiment = auditDecor(ExperimentComponent);
 globals.listingViews.register(Experiment, 'Experiment');
 globals.listingViews.register(Experiment, 'FunctionalCharacterizationExperiment');
 globals.listingViews.register(Experiment, 'TransgenicEnhancerExperiment');
+
+
+const AnnotationComponent = ({ context: result, cartControls, mode, auditIndicators, auditDetail }, reactContext) => (
+    <li className={resultItemClass(result)}>
+        <div className="result-item">
+            <div className="result-item__data">
+                <a href={result['@id']} className="result-item__link">
+                    {datasetTypes[result['@type'][0]]}
+                    {result.description ? <span>{`: ${result.description}`}</span> : null}
+                </a>
+                <div className="result-item__data-row">
+                    <div><strong>Lab: </strong>{result.lab.title}</div>
+                    <div><strong>Project: </strong>{result.award.project}</div>
+                </div>
+            </div>
+            <div className="result-item__meta">
+                <div className="result-item__meta-title">Annotation</div>
+                <div className="result-item__meta-id">{` ${result.accession}`}</div>
+                {mode !== 'cart-view' ?
+                    <React.Fragment>
+                        <Status item={result.status} badgeSize="small" css="result-table__status" />
+                        {auditIndicators(result.audit, result['@id'], { session: reactContext.session, sessionProperties: reactContext.session_properties, search: true })}
+                    </React.Fragment>
+                : null}
+            </div>
+            {cartControls && !(reactContext.actions && reactContext.actions.length > 0) ?
+                <div className="result-item__cart-control">
+                    <CartToggle element={result} />
+                </div>
+            : null}
+            <PickerActions context={result} />
+        </div>
+        {auditDetail(result.audit, result['@id'], { session: reactContext.session, sessionProperties: reactContext.session_properties })}
+    </li>
+);
+
+AnnotationComponent.propTypes = {
+    /** Dataset search results */
+    context: PropTypes.object.isRequired,
+    /** True if displayed in active cart */
+    cartControls: PropTypes.bool,
+    /** Special search-result modes, e.g. "picker" */
+    mode: PropTypes.string,
+    /** Audit decorator function */
+    auditIndicators: PropTypes.func.isRequired,
+    /** Audit decorator function */
+    auditDetail: PropTypes.func.isRequired,
+};
+
+AnnotationComponent.defaultProps = {
+    cartControls: false,
+    mode: '',
+};
+
+AnnotationComponent.contextTypes = {
+    session: PropTypes.object, // Login information from <App>
+    session_properties: PropTypes.object,
+};
+
+const Annotation = auditDecor(AnnotationComponent);
+
+globals.listingViews.register(Annotation, 'Annotation');
 
 
 const DatasetComponent = (props, reactContext) => {

--- a/src/encoded/static/components/search.js
+++ b/src/encoded/static/components/search.js
@@ -5,7 +5,7 @@ import url from 'url';
 import { Panel, PanelBody } from '../libs/ui/panel';
 import QueryString from '../libs/query_string';
 import { auditDecor } from './audit';
-import { CartToggle, CartSearchControls } from './cart';
+import { CartToggle, CartSearchControls, cartGetAllowedTypes } from './cart';
 import FacetRegistry from './facets';
 import * as globals from './globals';
 import {
@@ -283,6 +283,9 @@ const ExperimentComponent = (props, reactContext) => {
     const { context: result, cartControls, mode } = props;
     let synchronizations;
 
+    // Determine if search result is allowed in carts.
+    const isResultAllowedInCart = cartGetAllowedTypes().includes(result['@type'][0]);
+
     // Determine whether object is Experiment, FunctionalCharacterizationExperiment, or TransgenicEnhancerExperiment.
     const experimentType = result['@type'][0];
     const isFunctionalExperiment = experimentType === 'FunctionalCharacterizationExperiment';
@@ -419,7 +422,7 @@ const ExperimentComponent = (props, reactContext) => {
                         </React.Fragment>
                     : null}
                 </div>
-                {cartControls && !(reactContext.actions && reactContext.actions.length > 0) ?
+                {cartControls && isResultAllowedInCart && !(reactContext.actions && reactContext.actions.length > 0) ?
                     <div className="result-item__cart-control">
                         <CartToggle element={result} />
                     </div>

--- a/src/encoded/static/libs/ui/button.js
+++ b/src/encoded/static/libs/ui/button.js
@@ -192,7 +192,7 @@ const useDropdownButton = () => {
  * Implements the immediate form of dropdown button, where selecting an item from the dropdown menu
  * immediately executes that item.
  */
-export const Immediate = ({ label, id, css, inline, children }) => {
+export const Immediate = ({ label, id, css, inline, disabled, children }) => {
     const [state, actions] = useDropdownButton();
 
     // Wrap each child in an <li> element, as they will be children of a <ul>.
@@ -213,6 +213,7 @@ export const Immediate = ({ label, id, css, inline, children }) => {
                 onMouseLeave={actions.houseMouseLeave}
                 onFocus={actions.handleFocus}
                 onBlur={actions.handleBlur}
+                disabled={disabled}
             >
                 {label}
             </button>
@@ -245,6 +246,8 @@ Immediate.propTypes = {
     css: PropTypes.string,
     /** True to make this an inline component */
     inline: PropTypes.bool,
+    /** True to disable the button */
+    disabled: PropTypes.bool,
     /** Child components within in this component */
     children: PropTypes.node.isRequired,
 };
@@ -252,6 +255,7 @@ Immediate.propTypes = {
 Immediate.defaultProps = {
     css: '',
     inline: false,
+    disabled: false,
 };
 
 
@@ -259,7 +263,7 @@ Immediate.defaultProps = {
  * Implements the selected form of the dropdown button, where items in the dropdown menu select the
  * action taken when the button is clicked.
  */
-export const Selected = ({ labels, execute, id, triggerVoice, css, inline, children }) => {
+export const Selected = ({ labels, execute, id, triggerVoice, css, inline, disabled, children }) => {
     const [state, actions] = useDropdownButton();
 
     // Extract the id attributes of each of the child components.
@@ -287,7 +291,7 @@ export const Selected = ({ labels, execute, id, triggerVoice, css, inline, child
     return (
         <div className={`dropdown-button${css ? ` ${css}` : ''}`} style={inline ? { display: 'inline-flex' } : null}>
             <div className="dropdown-button__composite" onMouseEnter={actions.handleMouseEnter} onMouseLeave={actions.houseMouseLeave}>
-                <button className="dropdown-button__composite-execute" onClick={handleExecute} onKeyUp={actions.handleKey}>
+                <button className="dropdown-button__composite-execute" onClick={handleExecute} onKeyUp={actions.handleKey} disabled={disabled}>
                     {labels[selection]}
                 </button>
                 <button
@@ -299,6 +303,7 @@ export const Selected = ({ labels, execute, id, triggerVoice, css, inline, child
                     aria-label={triggerVoice}
                     onFocus={actions.handleFocus}
                     onBlur={actions.handleBlur}
+                    disabled={disabled}
                 >
                     {svgIcon('chevronDown')}
                 </button>
@@ -332,6 +337,8 @@ Selected.propTypes = {
     css: PropTypes.string,
     /** True to make this an inline component */
     inline: PropTypes.bool,
+    /** True to disable the action and menu buttons */
+    disabled: PropTypes.bool,
     /** Child components within in this component */
     children: PropTypes.node.isRequired,
 };
@@ -339,4 +346,5 @@ Selected.propTypes = {
 Selected.defaultProps = {
     css: '',
     inline: false,
+    disabled: false,
 };

--- a/src/encoded/static/scss/encoded/_base.scss
+++ b/src/encoded/static/scss/encoded/_base.scss
@@ -15,6 +15,7 @@ $std-href-color:               #428bca;
 
 $site-font:                    'Mada', sans-serif;
 $brand-font:                   'Mada', sans-serif;
+$button-font:                  'Quicksand', sans-serif;
 
 $Homo-sapiens:                  #63326E;
 $Mus-musculus:                  #3D518C;
@@ -73,6 +74,11 @@ body {
     button {
         cursor: pointer;
         font-family: $site-font;
+        font-size: $font-size-base * $mobile-font-factor;
+
+        @media screen and (min-width: $screen-sm-min) {
+            font-size: $font-size-base;
+        }
     }
 }
 
@@ -184,9 +190,13 @@ blockquote {
  */
 @mixin button-size($padding-vertical, $padding-horizontal, $font-size, $btn-height, $border-radius) {
     padding: 0 $padding-horizontal;
-    font-size: $font-size;
+    font-size: $font-size * $mobile-font-factor;
     height: $btn-height;
     border-radius: $border-radius;
+
+    @media screen and (min-width: $screen-sm-min) {
+        font-size: $font-size;
+    }
 }
 
 $disabled-color-factor: 20%;
@@ -393,6 +403,7 @@ pre code {
         border-right: none;
         border-top-right-radius: 0;
         border-bottom-right-radius: 0;
+        text-align: left;
     }
 
     & > &__composite > &__composite-trigger {
@@ -409,6 +420,7 @@ pre code {
     @at-root #{&}__content {
         position: absolute;
         top: 100%;
+        right: 0;
         margin: 4px 0;
         padding: 0;
         width: 300px;
@@ -450,5 +462,13 @@ pre code {
                 }
             }
         }
+    }
+
+    @at-root #{&}__overlay {
+        position: absolute;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
     }
 }

--- a/src/encoded/static/scss/encoded/_theme.scss
+++ b/src/encoded/static/scss/encoded/_theme.scss
@@ -6,6 +6,9 @@ select {
     border: 1px solid #428bca !important;
     color: #428bca !important;
     font-weight: bold;
+    font-family: $button-font;
+    font-weight: 700;
+    font-size: 1rem;
 
     &::-ms-expand {
         display: none;

--- a/src/encoded/static/scss/encoded/modules/_cart.scss
+++ b/src/encoded/static/scss/encoded/modules/_cart.scss
@@ -1218,13 +1218,13 @@ $file-type-colors: (
 .cart-dataset-selector {
     width: 100%;
     margin-bottom: 5px;
+    padding: 0 5px;
 
     @media screen and (min-width: $screen-md-min) {
         width: auto;
         height: 29px;
         margin-right: 5px;
         margin-bottom: 0;
-        padding: 0;
     }
 }
 

--- a/src/encoded/static/scss/encoded/modules/_cart.scss
+++ b/src/encoded/static/scss/encoded/modules/_cart.scss
@@ -252,15 +252,14 @@
         }
     }
 
-    @at-root #{&}__tools {
-        display: flex;
-        flex: 0 1 auto;
-    }
-
     // Header of cart panel.
     @at-root #{&}__header {
-        display: flex;
-        justify-content: space-between;
+        display: block;
+
+        @media screen and (min-width: $screen-md-min) {
+            display: flex;
+            justify-content: space-between;
+        }
     }
 
     @at-root #{&}__facet-disabled-overlay {
@@ -299,13 +298,26 @@
     }
 }
 
+.cart-tools {
+    display: block;
+
+    @media screen and (min-width: $screen-md-min) {
+        display: flex;
+        flex: 0 1 auto;
+    }
+}
+
 .cart-assembly-indicator {
-    display: flex;
-    padding: 0 10px;
-    align-items: center;
-    border: 1px solid #a0a0a0;
-    color: #606060;
-    font-weight: bold;
+    display: none;
+
+    @media screen and (min-width: $screen-md-min) {
+        display: flex;
+        padding: 0 10px;
+        align-items: center;
+        border: 1px solid #a0a0a0;
+        color: #606060;
+        font-weight: bold;
+    }
 }
 
 // Cart button in navigation bar
@@ -1094,12 +1106,19 @@ $file-type-colors: (
 
 // Control to batch download cart files.
 .cart-download {
-    margin-right: 5px;
+    margin-bottom: 5px;
+
+    @media screen and (min-width: $screen-md-min) {
+        margin-right: 5px;
+        margin-bottom: 0;
+    }
 
     button {
         @extend .btn;
         @extend .btn-info;
         @extend .btn-sm;
+
+        font-size: inherit; // Override .btn
     }
 
     @at-root #{&}__option-title {
@@ -1114,6 +1133,20 @@ $file-type-colors: (
         font-size: 0.9rem;
         font-weight: normal;
         pointer-events: none;
+    }
+
+    .dropdown-button__composite {
+        .dropdown-button__composite-execute {
+            flex-grow: 1;
+            flex-basis: auto;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+
+        .dropdown-button__composite-trigger {
+            flex-grow: 0;
+            flex-basis: 30px;
+        }
     }
 
     .dropdown-button__content {
@@ -1154,5 +1187,69 @@ $file-type-colors: (
 
     > svg {
         fill: #000;
+    }
+}
+
+// Cart-tools buttons that stay side by side even on mobile.
+.cart-tools-extras {
+    display: flex;
+    align-content: stretch;
+    margin-bottom: 5px;
+
+    @media screen and (min-width: $screen-md-min) {
+        margin-right: 5px;
+        margin-bottom: 0;
+    }
+
+    .cart-tools-extras__button {
+        margin-right: 5px;
+        flex-grow: 1;
+
+        &:last-child {
+            margin-right: 0;
+        }
+
+        button {
+            width: 100%;
+        }
+    }
+}
+
+.cart-dataset-selector {
+    width: 100%;
+    margin-bottom: 5px;
+
+    @media screen and (min-width: $screen-md-min) {
+        width: auto;
+        height: 29px;
+        margin-right: 5px;
+        margin-bottom: 0;
+        padding: 0;
+    }
+}
+
+.cart-merge {
+    margin-bottom: 5px;
+
+    @media screen and (min-width: $screen-md-min) {
+        margin-right: 5px;
+        margin-bottom: 0;
+    }
+
+    button {
+        width: 100%;
+
+        @media screen and (min-width: $screen-md-min) {
+            width: auto;
+        }
+    }
+}
+
+.cart-dataset-search {
+    display: block;
+    width: 100%;
+
+    @media screen and (min-width: $screen-md-min) {
+        width: auto;
     }
 }

--- a/src/encoded/tests/features/cart.feature
+++ b/src/encoded/tests/features/cart.feature
@@ -12,19 +12,30 @@ Feature: Cart
         Then I should see 4 elements with the css selector ".cart__toggle--in-cart"
         And I should see an element with the css selector ".cart__nav-button"
 
+        When I press "Data"
+        And I click the link with text that contains "High-throughput assays"
+        And I wait for the content to load
+        Then I should see 10 elements with the css selector ".result-item__cart-control"
+
+        When I press "Add all items to cart"
+        Then I should see 10 elements with the css selector ".cart__toggle--in-cart"
+
     Scenario: Cart page load
         When I press "cart-control"
         And I click the link to "/cart-view/"
         And I wait for the content to load
-        Then I should see 4 elements with the css selector ".result-item"
-        And I should see "4 files selected"
+        Then I should see 14 elements with the css selector ".result-item"
+        And I should see "5 files selected"
         When I click the link to "#processeddata"
-        Then I should see 4 elements with the css selector ".cart-list-item"
+        Then I should see 5 elements with the css selector ".cart-list-item"
         When I click the link to "#rawdata"
-        Then I should see 3 elements with the css selector ".cart-list-item"
+        Then I should see 8 elements with the css selector ".cart-list-item"
 
     Scenario: Cart page interactions
         When I click the link to "#processeddata"
+        And I click the element with the css selector ".cart-dataset-selector"
+        And I click the element with the css selector ".cart-dataset-option.cart-dataset-option--experiments"
+        And I wait for the content to load
         And I press "output_type-label"
         And I press "cart-facet-term-alignments"
         Then I should see "2 files selected"


### PR DESCRIPTION
I moved `rawdataFiles` and `selectedVisualizableFiles` out of state and now calculate them each time something they depend on changes, to remove potential extra re-renderings from state changes. Those variables’ contents directly rely on the contents of other states.

I used to keep a small subset of properties of the file objects involved with the datasets, and then before having Valis render a page of tracks, I requested real file objects for that page of files. I no longer do this, and instead keep a larger subset of properties of the file objects — enough to give to `<GenomeBrowser>` and Valis directly. As a side effect, we now have a mechanism to sort the files in Valis in the cart by presorting them before giving them to `<GenomeBrowser>`. But that also means cart page needs to own the sorting controls, or the sorting controls have to call the parent when sorting options change.
