### PR TITLE
ENCD-5559 FCC processed data facet

### DIFF
--- a/src/encoded/static/components/app.js
+++ b/src/encoded/static/components/app.js
@@ -47,7 +47,7 @@ const portal = {
                 { id: 'bodymap', title: 'Human body map', url: '/summary/?type=Experiment&replicates.library.biosample.donor.organism.scientific_name=Homo+sapiens', tag: 'collection' },
                 { id: 'sep-mm-0' },
                 { id: 'functional-characterization', title: 'Functional Characterization data' },
-                { id: 'functional-char-assays', title: 'High-throughput assays', url: '/search/?type=FunctionalCharacterizationExperiment', tag: 'collection' },
+                { id: 'functional-char-assays', title: 'High-throughput assays', url: '/search/?type=FunctionalCharacterizationExperiment&audit.WARNING.category!=lacking+processed+data', tag: 'collection' },
                 { id: 'transgenic-enhancer-assays', title: 'In vivo validation assays', url: '/search/?type=TransgenicEnhancerExperiment', tag: 'collection' },
                 { id: 'sep-mm-1' },
                 { id: 'cloud', title: 'Cloud Resources' },

--- a/src/encoded/static/components/facets/audit_processed_data.js
+++ b/src/encoded/static/components/facets/audit_processed_data.js
@@ -1,0 +1,106 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import url from 'url';
+import QueryString from '../../libs/query_string';
+import BooleanSwitch from '../../libs/ui/boolean-switch';
+import { SpecialFacetRegistry } from './registry';
+
+
+/**
+ * Special facet to display a switch to select between having the search result query string
+ * contain: "audit.WARNING.category!=lacking processed data" and without that term at all, with the
+ * boolean switch component showing the "on" state with the former and the "off" state with the
+ * latter.
+ */
+const AuditProcessedData = ({ facet, results, mode, pathname, queryString, isExpanded, handleExpanderClick, handleKeyDown, isExpandable }, reactContext) => {
+    /** Keeps track of the switch state for `handleSwitch` */
+    const switchState = React.useRef(false);
+
+    /**
+     * Called when the user clicks the term to flip the switch and modify the query string
+     * accordingly.
+     */
+    const handleSwitch = () => {
+        const parsedUrl = url.parse(results['@id']);
+        const query = new QueryString(parsedUrl.query);
+        if (switchState.current) {
+            query.deleteKeyValue('audit.WARNING.category');
+        } else {
+            query.replaceKeyValue('audit.WARNING.category', 'lacking processed data', true);
+        }
+        const href = `?${query.format()}`;
+        reactContext.navigate(href, { noscroll: true });
+    };
+
+    // Make sure a single type=FunctionalCharacterization experiment exists, or display no facet.
+    const fccTypeFilters = results.filters.filter(filter => filter.field === 'type' && filter.term === 'FunctionalCharacterizationExperiment');
+    if (fccTypeFilters.length === 1) {
+        // Determine the state of the switch from the query string, and save it so that
+        // `handleSwitch` doesn't have to do this same calculation later.
+        const parsedUrl = url.parse(results['@id']);
+        const query = new QueryString(parsedUrl.query);
+        const auditWarningValues = query.getKeyValues('audit.WARNING.category', true);
+        switchState.current = auditWarningValues.length === 1 && auditWarningValues[0] === 'lacking processed data';
+
+        // Retrieve reference to the registered facet title component for this facet.
+        const TitleComponent = SpecialFacetRegistry.Title.lookup();
+
+        return (
+            <div className="facet facet--audit-warning">
+                <div
+                    className="facet__expander--header"
+                    tabIndex="0"
+                    role="button"
+                    aria-label="audit.WARNING.category"
+                    aria-pressed={isExpanded}
+                    onClick={e => handleExpanderClick(e, isExpanded, facet.field)}
+                    onKeyDown={e => handleKeyDown(e, isExpanded, facet.field)}
+                >
+                    <TitleComponent facet={facet} results={results} mode={mode} pathname={pathname} queryString={queryString} />
+                    {isExpandable ? <i className={`facet-chevron icon icon-chevron-${isExpanded ? 'up' : 'down'}`} /> : null}
+                </div>
+                <div className={`facet-content facet-${(isExpanded || !isExpandable) ? 'open' : 'close'}`}>
+                    <BooleanSwitch id="facet-audit-warning" state={switchState.current} title="with processed data" triggerHandler={handleSwitch} />
+                </div>
+            </div>
+        );
+    }
+    return null;
+};
+
+AuditProcessedData.propTypes = {
+    /** Relevant `facet` object from `facets` array in `results` */
+    facet: PropTypes.object.isRequired,
+    /** Complete search-results object */
+    results: PropTypes.object.isRequired,
+    /** Facet display mode */
+    mode: PropTypes.string,
+    /** Search results path without query-string portion */
+    pathname: PropTypes.string.isRequired,
+    /** Query-string portion of current URL without initial ? */
+    queryString: PropTypes.string,
+    /** True if facet is to be expanded */
+    isExpanded: PropTypes.bool,
+    /** Expand or collapse facet */
+    handleExpanderClick: PropTypes.func,
+    /** Handles key-press and toggling facet */
+    handleKeyDown: PropTypes.func,
+    /** True if expandable, false otherwise */
+    isExpandable: PropTypes.bool,
+};
+
+AuditProcessedData.defaultProps = {
+    mode: '',
+    queryString: '',
+    isExpanded: false,
+    handleExpanderClick: () => {},
+    handleKeyDown: () => {},
+    isExpandable: true,
+};
+
+AuditProcessedData.contextTypes = {
+    navigate: PropTypes.func,
+};
+
+
+SpecialFacetRegistry.Facet.register('audit.WARNING.category', AuditProcessedData, 'Processed data', true);

--- a/src/encoded/static/components/facets/audit_processed_data.js
+++ b/src/encoded/static/components/facets/audit_processed_data.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import url from 'url';
 import QueryString from '../../libs/query_string';
 import BooleanSwitch from '../../libs/ui/boolean-switch';
 import { SpecialFacetRegistry } from './registry';
@@ -12,7 +11,7 @@ import { SpecialFacetRegistry } from './registry';
  * boolean switch component showing the "on" state with the former and the "off" state with the
  * latter.
  */
-const AuditProcessedData = ({ facet, results, mode, pathname, queryString, isExpanded, handleExpanderClick, handleKeyDown, isExpandable }, reactContext) => {
+const AuditProcessedData = ({ results, queryString }, reactContext) => {
     /** Keeps track of the switch state for `handleSwitch` */
     const switchState = React.useRef(false);
 
@@ -21,8 +20,7 @@ const AuditProcessedData = ({ facet, results, mode, pathname, queryString, isExp
      * accordingly.
      */
     const handleSwitch = () => {
-        const parsedUrl = url.parse(results['@id']);
-        const query = new QueryString(parsedUrl.query);
+        const query = new QueryString(queryString);
         if (switchState.current) {
             query.deleteKeyValue('audit.WARNING.category');
         } else {
@@ -37,31 +35,19 @@ const AuditProcessedData = ({ facet, results, mode, pathname, queryString, isExp
     if (fccTypeFilters.length === 1) {
         // Determine the state of the switch from the query string, and save it so that
         // `handleSwitch` doesn't have to do this same calculation later.
-        const parsedUrl = url.parse(results['@id']);
-        const query = new QueryString(parsedUrl.query);
+        const query = new QueryString(queryString);
         const auditWarningValues = query.getKeyValues('audit.WARNING.category', true);
         switchState.current = auditWarningValues.length === 1 && auditWarningValues[0] === 'lacking processed data';
 
-        // Retrieve reference to the registered facet title component for this facet.
-        const TitleComponent = SpecialFacetRegistry.Title.lookup();
-
         return (
             <div className="facet facet--audit-warning">
-                <div
-                    className="facet__expander--header"
-                    tabIndex="0"
-                    role="button"
-                    aria-label="audit.WARNING.category"
-                    aria-pressed={isExpanded}
-                    onClick={e => handleExpanderClick(e, isExpanded, facet.field)}
-                    onKeyDown={e => handleKeyDown(e, isExpanded, facet.field)}
-                >
-                    <TitleComponent facet={facet} results={results} mode={mode} pathname={pathname} queryString={queryString} />
-                    {isExpandable ? <i className={`facet-chevron icon icon-chevron-${isExpanded ? 'up' : 'down'}`} /> : null}
-                </div>
-                <div className={`facet-content facet-${(isExpanded || !isExpandable) ? 'open' : 'close'}`}>
-                    <BooleanSwitch id="facet-audit-warning" state={switchState.current} title="with processed data" triggerHandler={handleSwitch} />
-                </div>
+                <BooleanSwitch
+                    id="facet-audit-warning"
+                    state={switchState.current}
+                    title={switchState.current ? 'With processed data' : 'All data'}
+                    triggerHandler={handleSwitch}
+                    options={{ cssTitle: 'facet-audit-switch-title'}}
+                />
             </div>
         );
     }
@@ -69,33 +55,14 @@ const AuditProcessedData = ({ facet, results, mode, pathname, queryString, isExp
 };
 
 AuditProcessedData.propTypes = {
-    /** Relevant `facet` object from `facets` array in `results` */
-    facet: PropTypes.object.isRequired,
     /** Complete search-results object */
     results: PropTypes.object.isRequired,
-    /** Facet display mode */
-    mode: PropTypes.string,
-    /** Search results path without query-string portion */
-    pathname: PropTypes.string.isRequired,
     /** Query-string portion of current URL without initial ? */
     queryString: PropTypes.string,
-    /** True if facet is to be expanded */
-    isExpanded: PropTypes.bool,
-    /** Expand or collapse facet */
-    handleExpanderClick: PropTypes.func,
-    /** Handles key-press and toggling facet */
-    handleKeyDown: PropTypes.func,
-    /** True if expandable, false otherwise */
-    isExpandable: PropTypes.bool,
 };
 
 AuditProcessedData.defaultProps = {
-    mode: '',
     queryString: '',
-    isExpanded: false,
-    handleExpanderClick: () => {},
-    handleKeyDown: () => {},
-    isExpandable: true,
 };
 
 AuditProcessedData.contextTypes = {

--- a/src/encoded/static/components/facets/audit_processed_data.js
+++ b/src/encoded/static/components/facets/audit_processed_data.js
@@ -1,29 +1,25 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import QueryString from '../../libs/query_string';
-import BooleanSwitch from '../../libs/ui/boolean-switch';
 import { SpecialFacetRegistry } from './registry';
 
 
 /**
- * Special facet to display a switch to select between having the search result query string
- * contain: "audit.WARNING.category!=lacking processed data" and without that term at all, with the
- * boolean switch component showing the "on" state with the former and the "off" state with the
- * latter.
+ * Special facet to display a dropdown to select between having the search result query string
+ * contain "audit.WARNING.category!=lacking processed data" and without that term at all.
  */
 const AuditProcessedData = ({ results, queryString }, reactContext) => {
-    /** Keeps track of the switch state for `handleSwitch` */
-    const switchState = React.useRef(false);
-
     /**
-     * Called when the user clicks the term to flip the switch and modify the query string
-     * accordingly.
+     * Called when the user changes the dropdown to a new value.
      */
-    const handleSwitch = () => {
+    const handleChange = (event) => {
         const query = new QueryString(queryString);
-        if (switchState.current) {
+        if (event.target.value === 'all-data') {
+            // "All data" selected. Clear out any audit.WARNING.category from the query string.
             query.deleteKeyValue('audit.WARNING.category');
         } else {
+            // "Processed data" selected. Replace any audit.WARNING.category in the query string
+            // with audit.WARNING.category!=lacking+processed+data.
             query.replaceKeyValue('audit.WARNING.category', 'lacking processed data', true);
         }
         const href = `?${query.format()}`;
@@ -37,17 +33,14 @@ const AuditProcessedData = ({ results, queryString }, reactContext) => {
         // `handleSwitch` doesn't have to do this same calculation later.
         const query = new QueryString(queryString);
         const auditWarningValues = query.getKeyValues('audit.WARNING.category', true);
-        switchState.current = auditWarningValues.length === 1 && auditWarningValues[0] === 'lacking processed data';
+        const dataSelection = (auditWarningValues.length === 1 && auditWarningValues[0] === 'lacking processed data') ? 'processed-data' : 'all-data';
 
         return (
             <div className="facet facet--audit-warning">
-                <BooleanSwitch
-                    id="facet-audit-warning"
-                    state={switchState.current}
-                    title={switchState.current ? 'With processed data' : 'All data'}
-                    triggerHandler={handleSwitch}
-                    options={{ cssTitle: 'facet-audit-switch-title'}}
-                />
+                <select value={dataSelection} onChange={handleChange}>
+                    <option value="processed-data">With processed data</option>
+                    <option value="all-data">All data</option>
+                </select>
             </div>
         );
     }

--- a/src/encoded/static/components/facets/index.js
+++ b/src/encoded/static/components/facets/index.js
@@ -6,10 +6,11 @@
  * Custom facet-renderer modules all need to be imported anonymously here so that they can register
  * themselves on page load.
  */
-import FacetRegistry from './registry';
+import FacetRegistry, { SpecialFacetRegistry } from './registry';
 import { DefaultFacet, DefaultTitle, DefaultTerm, DefaultTermName, DefaultSelectedTermName } from './defaults';
 // Custom facet-renderer modules imported here. Keep them alphabetically sorted.
 import './audit';
+import './audit_processed_data';
 import './date_selector';
 import './exists';
 import './internal_status';
@@ -30,10 +31,20 @@ FacetRegistry.SelectedTermName._setDefaultComponent(DefaultSelectedTermName);
 
 
 /**
+ * Set the default special facet components.
+ */
+SpecialFacetRegistry.Title._setDefaultComponent(DefaultTitle);
+SpecialFacetRegistry.Term._setDefaultComponent(DefaultTerm);
+SpecialFacetRegistry.TermName._setDefaultComponent(DefaultTermName);
+SpecialFacetRegistry.Facet._setDefaultComponent(DefaultFacet);
+SpecialFacetRegistry.SelectedTermName._setDefaultComponent(DefaultSelectedTermName);
+
+
+/**
  * All usage of the facet registry external to this directory should only use what gets exported
  * here.
  */
-export default FacetRegistry;
+export { FacetRegistry, SpecialFacetRegistry };
 
 
 /**

--- a/src/encoded/static/components/facets/registry.js
+++ b/src/encoded/static/components/facets/registry.js
@@ -49,7 +49,59 @@ class FacetRegistryCore {
         // suppresses facet display if needed.
         return this._registry[field] === null ? null : this._defaultComponent;
     }
-};
+}
+
+
+/**
+ * Registry used for special facets that don't have a corresponding search-result `facet` property.
+ */
+class SpecialFacetRegistryCore extends FacetRegistryCore {
+    /**
+     * Register a React component to render a facet with the field value matching `field`.
+     * `specialFieldName` exists to use as React keys, in case the registered name matches an
+     * existing real facet. Returned object appears as a normal facet so existing search code can
+     * work largely the same.
+     * @param {string} field facet.field value to register
+     * @param {array} component Rendering component to call for this field value
+     * @param {string} title Title for the facet
+     * @param {bool} openOnLoad True to have the facet open by default
+     */
+    register(field, component, title, openOnLoad) {
+        const specialFieldName = `${field}-special`;
+        this._registry[field] = {
+            component,
+            appended: false,
+            field,
+            specialFieldName,
+            open_on_load: openOnLoad,
+            title,
+            special: true,
+        };
+    }
+
+    /**
+     * Look up the views available for the given object @type. If the given @type was never
+     * registered, an array of the default types gets returned. Mostly this gets used internally
+     * but available for external use if needed.
+     * @param {string} resultType `type` property of search result `filters` property.
+     *
+     * @return {array} Array of available/registered views for the given type.
+     */
+    lookup(field) {
+        if (this._registry[field]) {
+            // Registered search result type. Sort and return saved views for that type.
+            return this._registry[field].component;
+        }
+
+        // Return the default facet if field is unregistered, or null for null facets which
+        // suppresses facet display if needed.
+        return this._registry[field] === null ? null : this._defaultComponent;
+    }
+
+    getFacets() {
+        return Object.keys(this._registry).map(field => this._registry[field]);
+    }
+}
 
 
 const FacetRegistry = {};
@@ -59,3 +111,10 @@ FacetRegistry.TermName = new FacetRegistryCore();
 FacetRegistry.Facet = new FacetRegistryCore();
 FacetRegistry.SelectedTermName = new FacetRegistryCore();
 export default FacetRegistry;
+
+export const SpecialFacetRegistry = {};
+SpecialFacetRegistry.Title = new SpecialFacetRegistryCore();
+SpecialFacetRegistry.Term = new SpecialFacetRegistryCore();
+SpecialFacetRegistry.TermName = new SpecialFacetRegistryCore();
+SpecialFacetRegistry.Facet = new SpecialFacetRegistryCore();
+SpecialFacetRegistry.SelectedTermName = new SpecialFacetRegistryCore();

--- a/src/encoded/static/libs/query_string.js
+++ b/src/encoded/static/libs/query_string.js
@@ -102,7 +102,7 @@ class QueryString {
      * key/value pair.
      * @param {string} key Key value to replace
      * @param {string} value Non-URL-encoded value to replace
-     * @param {string} negative True if new key/value is a negative (a!=b)
+     * @param {bool} negative True if new key/value is a negative (a!=b)
      *
      * @param {object} Reference to this object for method chaining.
      */

--- a/src/encoded/static/libs/ui/boolean-switch.js
+++ b/src/encoded/static/libs/ui/boolean-switch.js
@@ -1,0 +1,88 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+
+/**
+ * Renders a boolean switch in the style of iOS. This keeps no internal state -- the parent
+ * component keeps this state and passes it down. The "frame" of the switch represents the space in
+ * which the actuator slides. The actuator represents the "physical" switch you would slide in real
+ * life.
+ */
+const DEFAULT_SWITCH_HEIGHT = 22;
+const DEFAULT_SWITCH_WIDTH = DEFAULT_SWITCH_HEIGHT * 1.6;
+const BooleanSwitch = ({ id, state, title, triggerHandler, options: { width, height, cssTitle, cssFrame, cssActuator } }) => {
+    // True if checkbox input has focus.
+    const [focused, setFocused] = React.useState(false);
+
+    /**
+     * Called when the user focuses on this control.
+     */
+    const handleFocus = () => {
+        setFocused(true);
+    };
+
+    /**
+     * Called when the user moves focus away from this control.
+     */
+    const handleBlur = () => {
+        setFocused(false);
+    };
+
+    // Calculate the inline styles for the switch and actuator.
+    const switchWidth = width || DEFAULT_SWITCH_WIDTH;
+    const switchHeight = height || DEFAULT_SWITCH_HEIGHT;
+    const triggerSize = switchHeight - 4;
+    const switchStyles = {
+        width: switchWidth,
+        height: switchHeight,
+        borderRadius: switchHeight / 2,
+        backgroundColor: state ? '#65afeb' : '#e9e9eb',
+    };
+    const actuatorStyles = {
+        width: triggerSize,
+        height: triggerSize,
+        borderRadius: (switchHeight / 2) - 2,
+        top: 2,
+        left: state ? (switchWidth - switchHeight) + 2 : 2,
+    };
+
+    return (
+        <label htmlFor={id} className={`boolean-switch${focused ? ' boolean-switch--focused' : ''}`}>
+            <div className={`boolean-switch__title${cssTitle ? ` ${cssTitle}` : ''}`}>{title}</div>
+            <div style={switchStyles} className={`boolean-switch__frame${cssFrame ? ` ${cssFrame}` : ''}`}>
+                <div style={actuatorStyles} className={`boolean-switch__actuator${cssActuator ? ` ${cssActuator}` : ''}`} />
+            </div>
+            <input id={id} type="checkbox" checked={state} onChange={triggerHandler} onFocus={handleFocus} onBlur={handleBlur} />
+        </label>
+    );
+};
+
+BooleanSwitch.propTypes = {
+    /** Unique HTML ID for <input> */
+    id: PropTypes.string.isRequired,
+    /** Current state to display in the switch */
+    state: PropTypes.bool.isRequired,
+    /** Title of the button for screen readers */
+    title: PropTypes.string.isRequired,
+    /** Called when the user clicks anywhere in the switch */
+    triggerHandler: PropTypes.func.isRequired,
+    /** Other styling options */
+    options: PropTypes.exact({
+        /** Width of switch in pixels; 36px by default */
+        width: PropTypes.number,
+        /** Height of switch in pixels; 22px by default */
+        height: PropTypes.number,
+        /** CSS class to add to the switch title */
+        cssTitle: PropTypes.string,
+        /** CSS class to add to the switch frame */
+        cssFrame: PropTypes.string,
+        /** CSS class to add to the switch actuator */
+        cssActuator: PropTypes.string,
+    }),
+};
+
+BooleanSwitch.defaultProps = {
+    options: {},
+};
+
+export default BooleanSwitch;

--- a/src/encoded/static/libs/ui/boolean-switch.js
+++ b/src/encoded/static/libs/ui/boolean-switch.js
@@ -36,7 +36,7 @@ const BooleanSwitch = ({ id, state, title, triggerHandler, options: { width, hei
         width: switchWidth,
         height: switchHeight,
         borderRadius: switchHeight / 2,
-        backgroundColor: state ? '#65afeb' : '#e9e9eb',
+        backgroundColor: state ? '#4183c4' : '#e9e9eb',
     };
     const actuatorStyles = {
         width: triggerSize,

--- a/src/encoded/static/scss/encoded/modules/_boolean_switch.scss
+++ b/src/encoded/static/scss/encoded/modules/_boolean_switch.scss
@@ -1,0 +1,45 @@
+.boolean-switch {
+    display: flex;
+    position: relative;
+    margin-bottom: 4px;
+    padding: 2px;
+    justify-content: space-between;
+    cursor: pointer;
+    border-radius: 3px;
+    border: 2px solid transparent;
+
+    input[type='checkbox'] {
+        position: absolute;
+        width: 100%;
+        height: 100%;
+        top: 0;
+        left: 0;
+        opacity: 0;
+        z-index: -1;
+    }
+
+    @at-root #{&}__title {
+        display: flex;
+        align-items: center;
+        flex-grow: 1;
+    }
+
+    // The actuator slides inside the frame.
+    @at-root #{&}__frame {
+        position: relative;
+        border: none;
+        box-shadow: 0 1px 1px inset rgba(0,0,0,0.2);
+    }
+
+    @at-root #{&}__actuator {
+        position: absolute;
+        top: 2px;
+        background-color: #fff;
+        box-shadow: 0 1px 1px rgba(0,0,0,0.2);
+    }
+
+    // Focus border because opacity:0 on <input> also hides this.
+    @at-root #{&}--focused {
+        border: 2px solid #000;
+    }
+}

--- a/src/encoded/static/scss/encoded/modules/_facet.scss
+++ b/src/encoded/static/scss/encoded/modules/_facet.scss
@@ -609,6 +609,10 @@ div.meta-status {
 
 .facet--audit-warning {
     .boolean-switch {
-        padding: 0 20px 0 10px;
+        padding: 0 20px 0 8px;
     }
+}
+
+.facet-audit-switch-title {
+    font-weight: bold;
 }

--- a/src/encoded/static/scss/encoded/modules/_facet.scss
+++ b/src/encoded/static/scss/encoded/modules/_facet.scss
@@ -606,3 +606,9 @@ div.meta-status {
         display: block;
     }
 }
+
+.facet--audit-warning {
+    .boolean-switch {
+        padding: 0 20px 0 10px;
+    }
+}

--- a/src/encoded/static/scss/encoded/modules/_facet.scss
+++ b/src/encoded/static/scss/encoded/modules/_facet.scss
@@ -608,11 +608,9 @@ div.meta-status {
 }
 
 .facet--audit-warning {
-    .boolean-switch {
-        padding: 0 20px 0 8px;
-    }
-}
+    margin-right: 20px;
 
-.facet-audit-switch-title {
-    font-weight: bold;
+    select {
+        width: 100%;
+    }
 }

--- a/src/encoded/static/scss/style.scss
+++ b/src/encoded/static/scss/style.scss
@@ -220,6 +220,7 @@ $link-hover-color:                          darken($link-color, 15%);
 @import "encoded/math";
 @import "encoded/layout";
 @import "encoded/modules/common_item",
+        "encoded/modules/boolean_switch",
         "encoded/modules/breadcrumbs",
         "encoded/modules/pager",
         "encoded/modules/forms",


### PR DESCRIPTION
The facet mechanism now has _two_ registries: the existing `FacetRegistry` and a new `SpecialFacetRegistry` that you use for facets not based on the contents of the `facet` property of search results, at least not directly. Special facets always appear above the normal facets, though I could see an option to put certain special facets at the end in the future.