### PR TITLE
ENCD-5576 Matrix disclosure arrow alignment

### DIFF
--- a/src/encoded/static/scss/encoded/modules/_matrix.scss
+++ b/src/encoded/static/scss/encoded/modules/_matrix.scss
@@ -621,6 +621,7 @@ $matrix-border-color: #f0f0f0;
             padding: 0;
             flex: 0 0 auto;
             height: 10px;
+            font-size: 0;
             border: none;
             background-color: transparent;
 


### PR DESCRIPTION
A button font-size change left these arrows unaligned. This change prevents this element from getting affected by font-size changes in buttons.