### PR TITLE
ENCD-5566 fix cropped tooltips

### DIFF
--- a/src/encoded/static/libs/ui/tooltip.js
+++ b/src/encoded/static/libs/ui/tooltip.js
@@ -120,7 +120,7 @@ const Tooltip = (props) => {
                 >
                     {trigger}
                 </button>
-                {showDefinition ?
+                {(showDefinition && children) ?
                     <div
                         className={tooltipCss}
                         role="tooltip"
@@ -146,7 +146,7 @@ const Tooltip = (props) => {
             >
                 {trigger}
             </button>
-            {showDefinition ?
+            {(showDefinition && children) ?
                 <RenderInBody>
                     <div
                         className={tooltipCss}

--- a/src/encoded/static/libs/ui/tooltip.js
+++ b/src/encoded/static/libs/ui/tooltip.js
@@ -62,11 +62,12 @@ const Tooltip = (props) => {
     // The tooltip bubble is assumed to be 250px wide and an update is required if that is no longer true
     // Code could determine the width of the tooltip upon load but then the tooltip will need to be rendered in an incorrect position -- or the mechanics of hiding/showing the tooltip would need to be changed
     const positionTooltip = React.useCallback(() => {
-        // Determining the position of the tooltip trigger
+        // Determining the position of the tooltip trigger and accounting for vertical scroll
+        const scrollTop = (window.pageYOffset !== undefined) ? window.pageYOffset : (document.documentElement || document.body.parentNode || document.body).scrollTop;
         const viewportWidth = window.innerWidth || document.documentElement.clientWidth;
         const tooltipTriggerRight = buttonRef.current.getBoundingClientRect().right;
         const tooltipTriggerLeft = buttonRef.current.getBoundingClientRect().left;
-        const tooltipTriggerTop = buttonRef.current.getBoundingClientRect().top;
+        const tooltipTriggerTop = scrollTop + buttonRef.current.getBoundingClientRect().top;
         // Ascertaining if tooltip bubble needs to be placed to the left or right to stay on document body
         const rightOverlap = viewportWidth - (tooltipTriggerRight + 125);
         const leftOverlap = tooltipTriggerLeft - 125;

--- a/src/encoded/static/scss/encoded/modules/_tooltip.scss
+++ b/src/encoded/static/scss/encoded/modules/_tooltip.scss
@@ -61,7 +61,6 @@ $tooltip-color: #000;
     display: block;
     line-height: 1.4;
     font-size: 0.8rem;
-    pointer-events: none;
     @media screen and (min-width: $screen-md-min) {
         font-size: 1rem;
         line-height: 1.2;
@@ -132,6 +131,7 @@ $tooltip-color: #000;
     white-space: pre-wrap;
     letter-spacing: 0;
     font-weight: 400;
+    // For now, we do not keep the menu tooltip bubbles open when they are hovered over
     pointer-events: none;
     &.sub-menu {
         margin-left: -45px;

--- a/src/encoded/static/scss/encoded/modules/_tooltip.scss
+++ b/src/encoded/static/scss/encoded/modules/_tooltip.scss
@@ -59,10 +59,9 @@ $tooltip-color: #000;
     position: absolute;
     z-index: 1030;
     display: block;
-    visibility: hidden;
     line-height: 1.4;
     font-size: 0.8rem;
-    opacity: 0;
+    pointer-events: none;
     @media screen and (min-width: $screen-md-min) {
         font-size: 1rem;
         line-height: 1.2;
@@ -133,6 +132,7 @@ $tooltip-color: #000;
     white-space: pre-wrap;
     letter-spacing: 0;
     font-weight: 400;
+    pointer-events: none;
     &.sub-menu {
         margin-left: -45px;
         padding-left: 60px;


### PR DESCRIPTION
To prevent tooltips from being cropped when their containers do not display overflow, we are now attaching tooltips to the document body.