### PR TITLE
ENCD-5345-pipeline-prop-on-reference-obj

### DIFF
--- a/src/encoded/loadxl.py
+++ b/src/encoded/loadxl.py
@@ -641,7 +641,7 @@ PHASE1_PIPELINES = {
         remove_keys('related_files'),
     ],
     'reference': [
-        remove_keys('related_files', 'software_used'),
+        remove_keys('related_files', 'software_used', 'related_pipelines'),
     ],
     'computational_model': [
         remove_keys('related_files', 'software_used'),
@@ -739,7 +739,7 @@ PHASE2_PIPELINES = {
         skip_rows_missing_all_keys('related_files'),
     ],
     'reference': [
-        skip_rows_missing_all_keys('related_files', 'software_used'),
+        skip_rows_missing_all_keys('related_files', 'software_used', 'related_pipelines'),
     ],
     'computational_model': [
         skip_rows_missing_all_keys('related_files', 'software_used'),

--- a/src/encoded/schemas/changelogs/reference.md
+++ b/src/encoded/schemas/changelogs/reference.md
@@ -2,6 +2,7 @@
 
 ### Minor changes since schema version 19
 
+* *related_pipelines* property was added to link relevant pipelines to their corresponding reference fileset 
 * *reference_type* was updated to include the enum *sequence barcodes*
 
 ### Schema version 19

--- a/src/encoded/schemas/reference.json
+++ b/src/encoded/schemas/reference.json
@@ -118,6 +118,18 @@
                 "type": "string",
                 "linkTo": "Gene"
             }
+        },
+        "related_pipelines": {
+            "title": "Related pipelines",
+            "description": "The pipelines this reference file set is used for",
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+                "title": "Related pipeline",
+                "description": "A particular pipeline this reference file set is used for",
+                "type": "string",
+                "linkTo": "Pipeline"
+            }
         }
     },
     "facets": {

--- a/src/encoded/static/components/dataset.js
+++ b/src/encoded/static/components/dataset.js
@@ -686,6 +686,20 @@ const ReferenceComponent = (props, reactContext) => {
                                 </div>
                             : null}
 
+                            {context.related_pipelines && context.related_pipelines.length > 0 ?
+                                <div data-test="relatedpipelines">
+                                    <dt>Related Pipelines</dt>
+                                    <dd>
+                                        {context.related_pipelines.map((pipeline, i) =>
+                                            <React.Fragment>
+                                                {i > 0 ? <span>, </span> : null}
+                                                <a href={pipeline['@id']}>{pipeline.accession}</a>
+                                            </React.Fragment>
+                                        )}
+                                    </dd>
+                                </div>
+                            : null}
+
                             {context.software_used && context.software_used.length > 0 ?
                                 <div data-test="softwareused">
                                     <dt>Software used</dt>

--- a/src/encoded/tests/data/inserts/reference.json
+++ b/src/encoded/tests/data/inserts/reference.json
@@ -125,6 +125,9 @@
         "reference_type": "sequence barcodes",
         "submitted_by": "/users/7e944358-625c-426c-975c-7d875e22f753/",
         "status": "in progress",
-        "accession": "ENCSR063SBC"
+        "accession": "ENCSR063SBC",
+        "related_pipelines": [
+            "ENCPL001MRN"
+        ]
     }
 ]

--- a/src/encoded/types/dataset.py
+++ b/src/encoded/types/dataset.py
@@ -570,8 +570,15 @@ class PublicationData(FileSet):
 class Reference(FileSet):
     item_type = 'reference'
     schema = load_schema('encoded:schemas/reference.json')
-    embedded = FileSet.embedded + ['software_used', 'software_used.software', 'organism', 'files.dataset', 'donor', 'examined_loci']
-
+    embedded = FileSet.embedded + [
+        'software_used',
+        'software_used.software',
+        'organism',
+        'files.dataset',
+        'donor',
+        'examined_loci',
+        'related_pipelines'
+    ]
 
 @collection(
     name='ucsc-browser-composites',


### PR DESCRIPTION
I didn't add inserts due to how the inserts are loaded in loadxl.py. Since reference objects are loaded before pipeline objects, this causes an error when specifying a pipeline in the related pipelines property. I can't move reference to be after pipeline in loadxl.py because the reverse link is already in place from ENCD-5298, which will invalidate the pipeline object that has anything in the reference_fileset property. 
