### PR TITLE
ENCD-5444 Rewrite the report page

### DIFF
--- a/src/encoded/static/components/cart/cart.js
+++ b/src/encoded/static/components/cart/cart.js
@@ -8,7 +8,7 @@ import _ from 'underscore';
 import { encodedURIComponent } from '../../libs/query_encoding';
 import { svgIcon } from '../../libs/svg-icons';
 import { Modal, ModalHeader, ModalBody, ModalFooter } from '../../libs/ui/modal';
-import Pager from '../../libs/ui/pager';
+import * as Pager from '../../libs/ui/pager';
 import { Panel, PanelBody, PanelHeading, TabPanel, TabPanelPane } from '../../libs/ui/panel';
 import { tintColor, isLight } from '../datacolors';
 import GenomeBrowser, { annotationTypeMap } from '../genome_browser';
@@ -1020,7 +1020,7 @@ const CartPager = ({ currentPage, totalPageCount, updateCurrentPage }) => (
     <React.Fragment>
         {totalPageCount > 1 ?
             <div className="cart-pager-area">
-                <Pager total={totalPageCount} current={currentPage} updateCurrentPage={updateCurrentPage} />
+                <Pager.Simple total={totalPageCount} current={currentPage} updateCurrentPage={updateCurrentPage} />
             </div>
         : null}
     </React.Fragment>

--- a/src/encoded/static/components/globals.js
+++ b/src/encoded/static/components/globals.js
@@ -107,7 +107,7 @@ export function atIdToAccession(atId) {
     if (matched && matched.length === 2) {
         return matched[1];
     }
-    return '';
+    return atId;
 }
 
 
@@ -359,4 +359,51 @@ export const viewToSvg = {
     table: 'table',
     summary: 'summary',
     th: 'matrix',
+};
+
+
+// Media query breakpoints to match those in style.scss.
+const SCREEN_XS = 480;
+const SCREEN_SM = 768;
+const SCREEN_MD = 960;
+const SCREEN_LG = 1160;
+const SCREEN_XL = 1716;
+
+
+/**
+ * Determine whether the current browser-window width activates the given Bootstrap-based media
+ * query code. The component this function gets called from must have mounted.
+ * @param min {string} Bootstrap-based code for each breakpoint
+ *
+ * @return {bool} True if specified breakpoint is active
+ */
+export const isMediaQueryBreakpointActive = (min) => {
+    if (window.matchMedia) {
+        let breakpoint;
+        switch (min) {
+        case 'XS':
+            breakpoint = SCREEN_XS;
+            break;
+        case 'SM':
+            breakpoint = SCREEN_SM;
+            break;
+        case 'MD':
+            breakpoint = SCREEN_MD;
+            break;
+        case 'LG':
+            breakpoint = SCREEN_LG;
+            break;
+        case 'XL':
+            breakpoint = SCREEN_XL;
+            break;
+        default:
+            // Undefined code; default to mobile.
+            breakpoint = 0;
+        }
+        const mql = window.matchMedia(`(min-width: ${breakpoint}px)`);
+        return mql.matches;
+    }
+
+    // Browser doesn't support matchMedia, so default to mobile.
+    return false;
 };

--- a/src/encoded/static/components/globals.js
+++ b/src/encoded/static/components/globals.js
@@ -101,7 +101,7 @@ export const sanitizeId = id => (id ? `${id.replace(/\s/g, '_')}` : '-');
 
 
 // Take an @id and return the corresponding accession. If no accession could be found in the @id,
-// the empty string is returned.
+// the unchanged @id is returned.
 export function atIdToAccession(atId) {
     const matched = atId.match(/^\/.+\/(.+)\/$/);
     if (matched && matched.length === 2) {

--- a/src/encoded/static/components/matrix_audit.js
+++ b/src/encoded/static/components/matrix_audit.js
@@ -296,12 +296,11 @@ MatrixHeader.propTypes = {
 /**
  * Render the vertical facets.
  */
-const MatrixVerticalFacets = ({ context }, reactContext) => (
+const MatrixVerticalFacets = ({ context }) => (
     <FacetList
         context={context}
         facets={context.facets}
         filters={context.filters}
-        searchBase={`${url.parse(reactContext.location_href).search}&` || '?'}
         addClasses="matrix-facets"
         supressTitle
     />
@@ -310,10 +309,6 @@ const MatrixVerticalFacets = ({ context }, reactContext) => (
 MatrixVerticalFacets.propTypes = {
     /** Matrix search result object */
     context: PropTypes.object.isRequired,
-};
-
-MatrixVerticalFacets.contextTypes = {
-    location_href: PropTypes.string,
 };
 
 

--- a/src/encoded/static/components/matrix_experiment.js
+++ b/src/encoded/static/components/matrix_experiment.js
@@ -334,12 +334,11 @@ MatrixHeader.propTypes = {
 /**
  * Render the vertical facets.
  */
-const MatrixVerticalFacets = ({ context }, reactContext) => (
+const MatrixVerticalFacets = ({ context }) => (
     <FacetList
         context={context}
         facets={context.facets}
         filters={context.filters}
-        searchBase={`${url.parse(reactContext.location_href).search}&` || '?'}
         addClasses="matrix-facets"
         supressTitle
     />
@@ -348,11 +347,6 @@ const MatrixVerticalFacets = ({ context }, reactContext) => (
 MatrixVerticalFacets.propTypes = {
     /** Matrix search result object */
     context: PropTypes.object.isRequired,
-};
-
-MatrixVerticalFacets.contextTypes = {
-    location_href: PropTypes.string,
-    navigate: PropTypes.func,
 };
 
 

--- a/src/encoded/static/components/objectutils.js
+++ b/src/encoded/static/components/objectutils.js
@@ -493,13 +493,11 @@ export const DownloadableAccession = (props) => {
 
 DownloadableAccession.propTypes = {
     file: PropTypes.object.isRequired, // File whose accession to render
-    buttonEnabled: PropTypes.bool, // Check if button is enabled
     clickHandler: PropTypes.func, // Function to call when button is clicked
     loggedIn: PropTypes.bool, // True if current user is logged in
 };
 
 DownloadableAccession.defaultProps = {
-    buttonEnabled: true,
     clickHandler: null,
     loggedIn: false,
 };
@@ -899,3 +897,15 @@ export const isFileVisualizable = file => (
 export function filterForVisualizableFiles(fileList) {
     return fileList.filter(file => isFileVisualizable(file));
 }
+
+
+/**
+ * Displays an item count intended for the tops of table, normally reflecting a search result count.
+ */
+export const TableItemCount = ({ count }) => (
+    <div className="table-item-count">{count}</div>
+);
+
+TableItemCount.propTypes = {
+    count: PropTypes.string.isRequired,
+};

--- a/src/encoded/static/components/publication.js
+++ b/src/encoded/static/components/publication.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Cache from '../libs/cache';
-import Pager from '../libs/ui/pager';
+import * as Pager from '../libs/ui/pager';
 import { Panel, PanelHeading, PanelBody } from '../libs/ui/panel';
 import { CartAddAllElements, CartToggle, cartGetAllowedTypes } from './cart';
 import { auditDecor } from './audit';
@@ -105,7 +105,7 @@ const DatasetTableHeader = ({ title, elements, currentPage, totalPageCount, upda
         <h4>{title}</h4>
         <div className="header-paged-sorttable__controls">
             <CartAddAllElements elements={elements} />
-            {totalPageCount > 1 ? <Pager total={totalPageCount} current={currentPage} updateCurrentPage={updateCurrentPage} /> : null}
+            {totalPageCount > 1 ? <Pager.Simple total={totalPageCount} current={currentPage} updateCurrentPage={updateCurrentPage} /> : null}
         </div>
     </div>
 );

--- a/src/encoded/static/components/region_search.js
+++ b/src/encoded/static/components/region_search.js
@@ -303,7 +303,6 @@ class RegionSearch extends React.Component {
                                         {...this.props}
                                         facets={facets}
                                         filters={filters}
-                                        searchBase={searchBase ? `${searchBase}&` : `${searchBase}?`}
                                         onFilter={this.onFilter}
                                     />
                                 </div>

--- a/src/encoded/static/components/report.js
+++ b/src/encoded/static/components/report.js
@@ -3,403 +3,521 @@ import PropTypes from 'prop-types';
 import _ from 'underscore';
 import url from 'url';
 import { Modal, ModalHeader, ModalBody, ModalFooter } from '../libs/ui/modal';
-import { Panel, PanelBody } from '../libs/ui/panel';
-import { FetchedData, Param } from './fetched';
+import { encodedURIComponent } from '../libs/query_encoding';
+import * as Pager from '../libs/ui/pager';
+import QueryString from '../libs/query_string';
 import * as globals from './globals';
+import { TableItemCount } from './objectutils';
 import { FacetList } from './search';
 import { ViewControls } from './view_controls';
 
 
-function columnChoices(schema, selected) {
-    // start with id
-    const columns = {};
-    columns['@id'] = {
-        title: 'ID',
-        visible: true,
-    };
-    // default selected columns are the schema's `columns`,
-    // or whichever of title, description, name, accession & aliases
-    // are found in the schema's properties
-    // (note, this has to match the defaults sent from the server)
-    let schemaColumns = schema.columns;
-    const defaultColumns = { title: 'Title', description: 'Description', name: 'Name', accession: 'Accession', aliases: 'Aliases' };
-    if (schemaColumns === undefined) {
-        schemaColumns = {};
-        Object.keys(defaultColumns).forEach((name) => {
-            if (schema.properties[name] !== undefined) {
-                schemaColumns[name] = { title: defaultColumns[name], type: 'string' };
-            }
-        });
-    }
-    // add embedded columns
-    _.each(schemaColumns, (column, path) => {
-        columns[path] = {
-            title: column.title,
-            visible: !selected,
-        };
-    });
+/**
+ * Default number of results when no "limit=x" specified in the query string. Determined by our
+ * back-end search code.
+ */
+const DEFAULT_PAGE_LIMIT = 25;
 
-    // add all properties (with a few exceptions)
-    const schemaColumnTitles = Object.keys(schemaColumns).map(schemaColumnsProperty => schemaColumns[schemaColumnsProperty].title);
-    const filteredSchemaProperties = Object.keys(schema.properties).filter((schemaProperty) => {
-        const schemaPropertyTitle = schema.properties[schemaProperty].title;
-        return schemaColumnTitles.indexOf(schemaPropertyTitle) === -1 && ['@id', '@type', 'uuid', 'replicates'].indexOf(schemaProperty) === -1;
-    });
-    filteredSchemaProperties.forEach((schemaProperty) => {
-        const title = schema.properties[schemaProperty].title;
-        if (!Object.prototype.hasOwnProperty.call(columns, schemaProperty) && title) {
-            columns[schemaProperty] = {
-                title,
-                visible: false,
-            };
-        }
-    });
-
-    // if selected fields are specified, update visibility
-    if (selected) {
-        // Reset @id to not visible if not in selected
-        if (!selected['@id'] && columns['@id']) {
-            columns['@id'].visible = false;
-        }
-        _.each(selected, (path) => {
-            if (columns[path] === undefined) {
-                columns[path] = {
-                    title: path,
-                    visible: true,
-                };
-            } else {
-                columns[path].visible = true;
-            }
-        });
-    }
-
-    return columns;
-}
+/**
+ * Maximum number of results we can set "from=x" that elasticsearch allows.
+ */
+const MAX_VIEWABLE_RESULTS = 99999;
 
 
-function getVisibleColumns(columns) {
-    const visibleColumns = [];
-    _.mapObject(columns, (column, path) => {
-        if (column.visible) {
-            visibleColumns.push({
-                path,
-                title: column.title,
-            });
-        }
-    });
-    return visibleColumns;
-}
-
-
-function lookupColumn(result, column) {
-    let nodes = [result];
-    const names = column.split('.');
-
-    // Get the column's custom display function and call it if it exists
-    const colViewer = globals.reportCell.lookup(result, column);
-    if (colViewer) {
-        const colViewResult = colViewer(result, column);
-        if (colViewResult) {
-            return <div>{colViewResult}</div>;
-        }
-    }
-
-    for (let i = 0, len = names.length; i < len && nodes.length > 0; i += 1) {
-        let nextnodes = [];
-        _.each(nodes.map(node => node[names[i]]), (v) => {
-            if (v === undefined) return;
-            if (Array.isArray(v)) {
-                nextnodes = nextnodes.concat(v);
-            } else {
-                nextnodes.push(v);
-            }
-        });
-        if (names[i + 1] === 'length' || names[i + 1] === 'uuid') {
-            // Displaying the length of an array. That's not a property of each array element so we
-            // can't get it that way. Just return the length of the array.
-            nodes = [nextnodes.length];
-            break;
-        } else {
-            // Moving on to the next node defined by the `names` array.
-            nodes = nextnodes;
-        }
-    }
-    // if we ended with an embedded object, show the @id
-    if (nodes.length > 0 && nodes[0]['@id'] !== undefined) {
-        nodes = nodes.map(node => node['@id']);
-    }
-
-    // Stringify any nodes that are objects or arrays. Objects and arrays have typeof `object`.
-    if (nodes.length > 0) {
-        nodes = nodes.map(item => (typeof item === 'object' ? JSON.stringify(item) : item));
-    }
-
-    return _.uniq(nodes).join(', ');
-}
-
-
-class Cell {
-    constructor(value, type) {
-        this.value = value;
-        this.type = type;
-    }
-}
-
-
-class Row {
-    constructor(item, cells) {
-        this.item = item;
-        this.cells = cells;
-    }
-}
-
-
-function RowView(rowInfo) {
-    const row = rowInfo.row;
-    const id = row.item['@id'];
-    const tds = row.cells.map((cell, index) => {
-        const cellValue = cell.value;
-        if (cell.type === 'thumb_nail') {
-            return (
-                <td key={index}>
-                    <div className="tcell-thumbnail">
-                        <a href={cellValue} target="_blank" rel="noopener noreferrer">
-                            <img src={cellValue} alt={cellValue} />
-                        </a>
-                    </div>
-                </td>
-            );
-        } else if (cell.type === 'download_url') {
-            return (
-                <td key={index}>
-                    <a href={cellValue}>{`${window.location.origin}${cellValue}`}</a>
-                </td>
-            );
-        } else if (index === 0) {
-            return (
-                <td key={index}><a href={row.item['@id']}>{cellValue}</a></td>
-            );
-        }
-
-        return (
-            <td key={index}>{cellValue}</td>
-        );
-    });
-    return (
-        <tr key={id}>{tds}</tr>
-    );
-}
-
-
-class Table extends React.Component {
+/**
+ * A single instance of this class gets used to register special-case displays of data in a cell in
+ * cases where the default renderer won't do. You can register rendering components for a specific
+ * field regardless of the "type=x" type, or you can register one for a specific field only when
+ * a specific "type=x" type gets displayed.
+ */
+class ReportDataRegistryCore {
     constructor() {
-        super();
-
-        // Bind this to non-React methods.
-        this.setSort = this.setSort.bind(this);
-        this.extractData = this.extractData.bind(this);
-        this.getSort = this.getSort.bind(this);
+        this._registry = {};
     }
 
-    setSort(path) {
-        const sort = this.getSort();
-        const column = sort.column === path && !sort.reversed ? `-${path}` : path;
-        this.props.setSort(column);
+    /**
+     * Utility to convert a field and type to a key used to retrieve a rendering component. For
+     * fields used regardless of the type, use "*" as the type.
+     * @param {string} field: search result `field` value to match.
+     * @param {string} type: "type=" type to optionally match.
+     *
+     * @return {string} Key corresponding to the given field and type.
+     */
+    static _generateKey(field, type) {
+        return `${field}-${type || '*'}`;
     }
 
-    getSort() {
-        if (this.props.context.sort) {
-            const sortColumn = Object.keys(this.props.context.sort)[0];
-            return {
-                column: sortColumn,
-                reversed: this.props.context.sort[sortColumn].order === 'desc',
-            };
+    /**
+     * Register a React component to render a type-field or *-field pair.
+     * @param {object} {field, type} Field and type to register component for; type optional
+     * @param {array} component Rendering component to call for this field-type value
+     */
+    register({ field, type }, component) {
+        const key = ReportDataRegistryCore._generateKey(field, type);
+        if (this._registry[key]) {
+            // Registering key already exists.
+            console.warn('ReportDataRegistry collision %s:%s', field, type);
+        } else {
+            this._registry[key] = component;
         }
-        return {};
     }
 
-    extractData(items) {
-        const columns = getVisibleColumns(this.props.columns);
-        const rows = items.map((item) => {
-            const cells = columns.map((column) => {
-                let factory;
-                let value = lookupColumn(item, column.path);
-                if (column.path === '@id') {
-                    factory = globals.listingTitles.lookup(item);
-                    value = factory({ context: item });
-                } else if (value === null || value === undefined) {
-                    value = '';
-                } else if (!(value instanceof Array) && value['@type']) {
-                    factory = globals.listingTitles.lookup(value);
-                    value = factory({ context: value });
-                }
-                return new Cell(value, column.path);
-            });
-            return new Row(item, cells);
-        });
-        return rows;
-    }
-
-    render() {
-        const context = this.props.context;
-        const columns = getVisibleColumns(this.props.columns);
-        const sort = this.getSort();
-
-        const headers = columns.map((column, index) => {
-            const sortable = context.non_sortable.indexOf(column.path) === -1;
-            return <ColumnHeader key={index} setSort={this.setSort} sortable={sortable} column={column} sort={sort} reversed={sort.reversed} />;
-        });
-
-        const data = this.extractData(context['@graph']).concat(this.extractData(this.props.more));
-        const rows = data.map(row => RowView({ row }));
-        const tableClass = 'collection-table';
-        return (
-            <div className="report__table">
-                <table className={`${tableClass} table table-panel table-striped`}>
-                    <thead>
-                        <tr className="col-headers">{headers}</tr>
-                    </thead>
-                    <tbody>{rows}</tbody>
-                </table>
-            </div>
-        );
+    /**
+     * Look up the view registered for the given search-result field and type. If no rendering
+     * components have been registered to match the given field and type, it then searches for
+     * registered for the field for any type.
+     * @param {string} field Field to match
+     * @param {string} type to match
+     *
+     * @return {array} Array of available/registered views for the given type.
+     */
+    lookup(field, type) {
+        return this._registry[ReportDataRegistryCore._generateKey(field, type)] || this._registry[ReportDataRegistryCore._generateKey(field, '*')];
     }
 }
 
-Table.propTypes = {
-    setSort: PropTypes.func.isRequired,
-    context: PropTypes.object.isRequired,
-    columns: PropTypes.object.isRequired,
-    more: PropTypes.array.isRequired,
+const ReportDataRegistry = new ReportDataRegistryCore();
+
+
+/**
+ * @id cell renderer that displays the accession and links to the object.
+ */
+const AtIdRenderer = ({ value }) => (
+    <a href={value}>{globals.atIdToAccession(value)}</a>
+);
+
+AtIdRenderer.propTypes = {
+    /** @id value to render */
+    value: PropTypes.any.isRequired,
 };
 
-Table.contextTypes = {
+ReportDataRegistry.register({ field: '@id' }, AtIdRenderer);
+ReportDataRegistry.register({ field: 'dataset', type: 'File' }, AtIdRenderer);
+
+
+/**
+ * Accession renderer that links to the object.
+ */
+const AccessionRenderer = ({ value, item }) => (
+    <>{value ? <a href={item['@id']}>{value}</a> : null}</>
+);
+
+AccessionRenderer.propTypes = {
+    /** Accession to render */
+    value: PropTypes.string,
+    /** Object being rendered in the row */
+    item: PropTypes.object.isRequired,
+};
+
+AccessionRenderer.defaultProps = {
+    value: '',
+};
+
+ReportDataRegistry.register({ field: 'accession' }, AccessionRenderer);
+ReportDataRegistry.register({ field: 'title', type: 'File' }, AccessionRenderer);
+
+
+/**
+ * `related_series` renderer for type=Experiment. Displays a comma-separated list of their @ids.
+ */
+const ExperimentRelatedSeriesRenderer = ({ value }) => {
+    if (value && typeof value === 'object' && Array.isArray(value) && value.length > 0) {
+        return value.map(relatedSeries => relatedSeries['@id']).join();
+    }
+    return null;
+};
+
+ReportDataRegistry.register({ field: 'related_series', type: 'Experiment' }, ExperimentRelatedSeriesRenderer);
+
+
+/**
+ * `thumb_nail` renderer for type=Image. Displays an image thumbnail that links to a full-size
+ * image.
+ */
+const ImageThumbnailRenderer = ({ value }) => (
+    <div className="tcell-thumbnail">
+        <a href={value} target="_blank" rel="noopener noreferrer">
+            <img src={value} alt={value} />
+        </a>
+    </div>
+);
+
+ImageThumbnailRenderer.propTypes = {
+    /** Path of image to display */
+    value: PropTypes.string.isRequired,
+};
+
+ReportDataRegistry.register({ field: 'thumb_nail', type: 'Image' }, ImageThumbnailRenderer);
+
+
+/**
+ * Displays the image download_url path as a link to the image.
+ */
+const ImageDownloadRenderer = ({ value }, reactContext) => {
+    const parsedUrl = url.parse(reactContext.location_href);
+    return <a href={`${parsedUrl.protocol}//${parsedUrl.host}${value}`}>{value}</a>;
+};
+
+ImageDownloadRenderer.propTypes = {
+    /** path to image */
+    value: PropTypes.string.isRequired,
+};
+
+ImageDownloadRenderer.contextTypes = {
     location_href: PropTypes.string,
 };
 
+ReportDataRegistry.register({ field: 'download_url', type: 'Image' }, ImageDownloadRenderer);
 
-class ColumnHeader extends React.Component {
-    constructor() {
-        super();
 
-        // Bind this to non-React methods.
-        this.setSort = this.setSort.bind(this);
+/**
+ * `files` renderer for type=Experiment. Displays a comma separated list of accessions that link to
+ * the corresponding file page.
+ */
+const ExperimentFilesRenderer = ({ value }) => {
+    if (value && typeof value === 'object' && Array.isArray(value) && value.length > 0) {
+        return value.map(file => <a key={file} href={file}>{globals.atIdToAccession(file)}</a>).reduce((prev, curr) => [prev, ', ', curr]);
     }
+    return null;
+};
 
-    setSort() {
-        if (this.props.sortable) {
-            this.props.setSort(this.props.column.path);
-        }
-    }
+ReportDataRegistry.register({ field: 'files.@id', type: 'Experiment' }, ExperimentFilesRenderer);
 
-    render() {
-        const { column, sort, reversed, sortable } = this.props;
 
-        let columnClass;
-        if (sortable) {
-            if (column.path === sort.column) {
-                columnClass = reversed ? 'tcell-desc' : 'tcell-asc';
-            } else {
-                columnClass = 'tcell-sort';
+/**
+ * Make complete URLs from the file download paths.
+ */
+const FileDownloadHref = ({ value }, reactContext) => {
+    const parsedUrl = url.parse(reactContext.location_href);
+    return `${parsedUrl.protocol}//${parsedUrl.host}${value}`;
+};
+
+FileDownloadHref.contextTypes = {
+    location_href: PropTypes.string,
+};
+
+ReportDataRegistry.register({ field: 'href', type: 'File' }, FileDownloadHref);
+
+
+/**
+ * Extract the value of an object property based on a dotted-notation field,
+ * e.g. { a: 1, b: { c: 5 }} you could retrieve the 5 by passing 'b.c' in `field`. Cannot use the
+ * simple one in the cart code as this one has to handle more complicated objects in a way that
+ * works for reports.
+ * Based on https://stackoverflow.com/questions/6393943/convert-javascript-string-in-dot-notation-into-an-object-reference#answer-6394168
+ * @param {object} object Object containing the value you want to extract.
+ * @param {string} field  Dotted notation for the property to extract.
+ *
+ * @return {value} Whatever value the dotted notation specifies, or undefined.
+ */
+const getObjectPropValue = (object, field) => {
+    let rawValue;
+
+    // Break the specified property into its dot-separated components.
+    const propNameParts = field.split('.');
+    if (propNameParts.length > 1) {
+        // Extract from an embedded array or object. Use the property name parts to drill into
+        // `object`.
+        rawValue = propNameParts.reduce((extractedObject, propNamePart) => {
+            if (extractedObject && Array.isArray(extractedObject)) {
+                // Get the requested property out of each of the objects within the extracted array.
+                return extractedObject.map(partObjectElement => partObjectElement[propNamePart] || '');
             }
-        } else {
-            columnClass = null;
-        }
 
-        return (
-            <th onClick={this.setSort} className={sortable ? 'tcell-sortable' : null}>
-                <div className={sortable ? 'tcell-sortable__column-header' : null}>
-                    {column.title}
-                    <i className={columnClass} />
-                </div>
-            </th>
-        );
-    }
-}
-
-ColumnHeader.propTypes = {
-    /** Column whose header is being displayed */
-    column: PropTypes.object.isRequired,
-    /** Column sort information */
-    sort: PropTypes.object.isRequired,
-    /** Parent function to handle a click in a column header */
-    setSort: PropTypes.func,
-    /** True if column sort is reversed */
-    reversed: PropTypes.bool,
-    /** True if column is sortable */
-    sortable: PropTypes.bool,
-};
-
-ColumnHeader.defaultProps = {
-    setSort: null,
-    reversed: false,
-    sortable: true,
-};
-
-
-class ColumnSelectorControls extends React.Component {
-    constructor() {
-        super();
-
-        // Set initial React state.
-        this.state = {
-            selectedSort: 'default',
-        };
-
-        // Bind `this` to non-React methods.
-        this.handleSortChange = this.handleSortChange.bind(this);
+            // The requested property has a primitive type or an object.
+            return extractedObject && extractedObject[propNamePart];
+        }, object);
+    } else {
+        // Extract a top-level property.
+        rawValue = object[field];
     }
 
-    handleSortChange(e) {
-        // Called when the user changes the sorting option. Sets a component state so that the
-        // controlled <select> component renders properly. It then calls the parent's callback to
-        // react to the new sorting option.
-        this.setState({ selectedSort: e.target.value });
-        this.props.handleSortChange(e.target.value);
-    }
-
-    render() {
-        const { handleSelectAll, handleSelectOne, firstColumnTitle } = this.props;
-
-        return (
-            <div className="column-selector__controls">
-                <div className="column-selector__utility-buttons">
-                    <button onClick={handleSelectAll} className="btn btn-info">Select all</button>
-                    <button onClick={handleSelectOne} className="btn btn-info">Select {firstColumnTitle} only</button>
-                </div>
-                <div className="column-selector__sort-selector">
-                    <select className="form-control--select" value={this.state.selectedSort} onChange={this.handleSortChange}>
-                        <option value="default">Default sort</option>
-                        <option value="alpha">Alphabetical sort</option>
-                    </select>
-                </div>
-            </div>
-        );
-    }
-}
-
-ColumnSelectorControls.propTypes = {
-    handleSelectAll: PropTypes.func.isRequired, // Callback when Select All button clicked
-    handleSelectOne: PropTypes.func.isRequired, // Callback when SelectOne button clicked
-    handleSortChange: PropTypes.func.isRequired, // Callback when sorting option changed
-    firstColumnTitle: PropTypes.string.isRequired, // Title of first column
+    return rawValue;
 };
 
 
 /**
- * Extract the list of column paths from `columns`, with an order according to the given sorting
+ * Reduces an array, object, or array of objects into something generically displayable.
+ * @param {value,object,array} rawValue Value to reduce to a displayable form.
+ */
+const reduceComplexValue = (rawValue) => {
+    let result = rawValue;
+    if (typeof rawValue === 'object') {
+        if (Array.isArray(rawValue)) {
+            // Flatten and dedupe arrays.
+            const flattenedValue = _.chain(rawValue)
+                .flatten()
+                .uniq()
+                .value();
+
+            // Take care of arrays by concatenting their elements into one string.
+            result = flattenedValue.map((item) => {
+                if (typeof item === 'object') {
+                    // The array contains objects. If each object has an @id, display that.
+                    if (item['@id']) {
+                        return item['@id'];
+                    }
+
+                    // Objects don't contain an @id, so display a stringified object.
+                    return JSON.stringify(item);
+                }
+
+                // Item has a simple value.
+                return item;
+            }).join(', ');
+        } else if (rawValue['@id']) {
+            // For objects with @ids, just display the @id of that object.
+            result = rawValue['@id'];
+        } else {
+            // For objects without @ids, stringify the object.
+            result = JSON.stringify(rawValue);
+        }
+    }
+    return result;
+};
+
+
+/**
+ * Render each cell of the table header. This exists as a component mostly to reduce code
+ * duplication in the parent.
+ */
+const ReportHeaderCell = ({ title, sortable, sortIcon }) => (
+    <React.Fragment>
+        {title}
+        {sortable && sortIcon ?
+            <i className={`icon ${sortIcon}`} />
+        : null}
+    </React.Fragment>
+);
+
+ReportHeaderCell.propTypes = {
+    /** Display title in header cell */
+    title: PropTypes.string.isRequired,
+    /** True if column is sortable */
+    sortable: PropTypes.bool.isRequired,
+    /** CSS class for sorting icon to display */
+    sortIcon: PropTypes.string,
+};
+
+ReportHeaderCell.defaultProps = {
+    sortIcon: '',
+};
+
+
+/**
+ * Display the header row of the report table.
+ */
+const NAV_HEIGHT = 40;
+const ReportHeader = ({ context, allColumns, visibleFields, tableRef }) => {
+    /** Ref for the table <thead> */
+    const headerRef = React.useRef(null);
+
+    // Extract the sorting field and direction from the report results.
+    const sortField = context.sort ? Object.keys(context.sort)[0] : '';
+    const sortDirection = sortField ? context.sort[sortField].order : '';
+
+    // Extract current query string so we can use it for each of the column headers for sorting.
+    const parsedUrl = url.parse(context['@id']);
+    const query = new QueryString(parsedUrl.query);
+
+    React.useEffect(() => {
+        // Implements the sticky header for the table. On scroll events, check if the top
+        // coordinate of the table is above the bottom of the navigation bar. If it is, set the
+        // translation of the thead to hold it in place. Support sticky header only if
+        // screen_lg_min breakpoint or wider met.
+        const handleScroll = () => {
+            if (tableRef.current && headerRef.current && globals.isMediaQueryBreakpointActive('MD')) {
+                const tableTop = tableRef.current.getBoundingClientRect().top - NAV_HEIGHT;
+                if (tableTop < 0) {
+                    // Table top above the bottom of the navigation bar; keep the thead pinned
+                    // there.
+                    headerRef.current.style.cssText = `transform: translateY(${-tableTop}px)`;
+                } else {
+                    // Table top below the bottom of the navigation bar; put the thead in its
+                    // natural place.
+                    headerRef.current.style.cssText = '';
+                }
+            }
+        };
+
+        window.addEventListener('scroll', handleScroll, { passive: true });
+
+        return () => window.removeEventListener('scroll', handleScroll);
+    });
+
+    return (
+        <thead ref={headerRef}>
+            <tr>
+                {visibleFields.map((field) => {
+                    // Determine whether the column is sortable or not.
+                    const sortable = !context.non_sortable.includes(field);
+
+                    // Determine the column header title from `allColumns`, or from any available
+                    // columns in `context.columns` if `allColumns` has not yet loaded.
+                    let title;
+                    if (allColumns) {
+                        title = allColumns[field];
+                    } else if (context.columns[field]) {
+                        title = context.columns[field].title;
+                    } else {
+                        // Display no title until `allColumns` eventually loads.
+                        title = '';
+                    }
+
+                    // Generate a sorting href for this column header.
+                    let sortIcon;
+                    const fieldQuery = query.clone();
+                    if (sortable) {
+                        if (field === sortField) {
+                            // Current column is the sorting column. Clicks on this header change the
+                            // sort direction.
+                            fieldQuery.replaceKeyValue('sort', sortDirection === 'desc' ? field : `-${field}`);
+                            sortIcon = `icon-sort-${sortDirection}`;
+                        } else {
+                            // Not the sorting column, so this href sorts on this field.
+                            fieldQuery.replaceKeyValue('sort', field);
+                            sortIcon = 'icon-sort';
+                        }
+                    }
+
+                    return (
+                        <th key={field}>
+                            {sortable ?
+                                <a href={`?${fieldQuery.format()}`} className={`report-header-cell${sortable ? ' report-header-cell--sortable' : ''}`}>
+                                    <ReportHeaderCell title={title} sortable={sortable} sortIcon={sortIcon} />
+                                </a>
+                            :
+                                <div className="report-header-cell">
+                                    <ReportHeaderCell title={title} sortable={sortable} />
+                                </div>
+                            }
+                        </th>
+                    );
+                })}
+            </tr>
+        </thead>
+    );
+};
+
+ReportHeader.propTypes = {
+    /** Report data JSON */
+    context: PropTypes.object.isRequired,
+    /** All column fields and titles; loaded with separate GET request */
+    allColumns: PropTypes.object,
+    /** Indicates visibility of each column of report */
+    visibleFields: PropTypes.array.isRequired,
+    /** Ref for the <table> DOM element */
+    tableRef: PropTypes.object,
+};
+
+ReportHeader.defaultProps = {
+    allColumns: null,
+    tableRef: null,
+};
+
+
+/**
+ * Display all the data rows of the report table.
+ */
+const ReportData = ({ context, visibleFields, type }) => (
+    <tbody>
+        {context['@graph'].map(item => (
+            <tr key={item['@id']}>
+                {visibleFields.map((field) => {
+                    // Get the value of the property in `item` and see if the currenet field and
+                    // type have a registered renderer.
+                    const value = getObjectPropValue(item, field);
+                    const ReportCellRenderer = ReportDataRegistry.lookup(field, type);
+                    if (ReportCellRenderer) {
+                        // Registered renderer available, so use that to render the value of the
+                        // cell.
+                        return (
+                            <td key={field}>
+                                <ReportCellRenderer value={value} field={field} item={item} />
+                            </td>
+                        );
+                    }
+
+                    // No registered renderer. Convert any complex values to a displayable string
+                    // and display that.
+                    const reducedValue = reduceComplexValue(value);
+                    return (
+                        <td key={field}>
+                            {reducedValue}
+                        </td>
+                    );
+                })}
+            </tr>
+        ))}
+    </tbody>
+);
+
+ReportData.propTypes = {
+    /** Report data JSON */
+    context: PropTypes.object.isRequired,
+    /** Indicates visibility of each column of report */
+    visibleFields: PropTypes.array.isRequired,
+    /** Currently selected type for the report */
+    type: PropTypes.string.isRequired,
+};
+
+
+/**
+ * Displays the controls at the top of the column selection modal.
+ */
+const ColumnSelectorControls = ({ handleSelectAll, handleSelectOne, handleSortChange, firstColumnTitle }) => {
+    const [selectedSort, setSelectedSort] = React.useState('default');
+
+    // Called when the user changes the sorting option. Sets a component state so that the
+    // controlled <select> component renders properly. It then calls the parent's callback to react
+    // to the new sorting option.
+    const handleOnChange = (e) => {
+        setSelectedSort(e.target.value);
+        handleSortChange(e.target.value);
+    };
+
+    return (
+        <div className="column-selector__controls">
+            <div className="column-selector__utility-buttons">
+                <button onClick={handleSelectAll} className="btn btn-info">Select all</button>
+                <button onClick={handleSelectOne} className="btn btn-info">Select {firstColumnTitle} only</button>
+            </div>
+            <div className="column-selector__sort-selector">
+                <select className="form-control--select" value={selectedSort} onChange={handleOnChange}>
+                    <option value="default">Default sort</option>
+                    <option value="alpha">Alphabetical sort</option>
+                </select>
+            </div>
+        </div>
+    );
+};
+
+ColumnSelectorControls.propTypes = {
+    /** Callback when Select All button clicked */
+    handleSelectAll: PropTypes.func.isRequired,
+    /** Callback when SelectOne button clicked */
+    handleSelectOne: PropTypes.func.isRequired,
+    /** Callback when sorting option changed */
+    handleSortChange: PropTypes.func.isRequired,
+    /** Title of first column */
+    firstColumnTitle: PropTypes.string.isRequired,
+};
+
+
+/**
+ * Extract the list of column fields from `columns`, with an order according to the given sorting
  * option.
+ * @param {object} columns - Object mapping column fields to titles
+ * @param {bool} sorted - True to retrieve fields sorted by their titles
  *
- * @param {object} columns - Object with column states controlled by <Report> component.
- * @param {string} sortOption - Current sort option; 'default' or 'alpha' currently.
  * @return (array) - List of column paths, optionally sorted.
  */
-function getColumnPaths(columns, sortOption) {
+function getColumnFields(columns, sorted) {
     const columnPaths = Object.keys(columns);
-    if (sortOption === 'alpha') {
+    if (sorted) {
         columnPaths.sort((aKey, bKey) => {
-            const aTitle = columns[aKey].title.toLowerCase();
-            const bTitle = columns[bKey].title.toLowerCase();
+            const aTitle = columns[aKey].toLowerCase();
+            const bTitle = columns[bKey].toLowerCase();
             return (aTitle < bTitle ? -1 : (bTitle < aTitle ? 1 : 0));
         });
     }
@@ -407,41 +525,64 @@ function getColumnPaths(columns, sortOption) {
 }
 
 
-// Displays a modal dialog with every possible column for the type of object being displayed.
-// This lets you choose which columns you want to appear in the report.
-class ColumnSelector extends React.Component {
-    constructor(props) {
-        super(props);
+/**
+ * Render one column selector item.
+ */
+const ColumnItem = ({ field, title, selected, toggleColumn }) => {
+    const handleChange = () => {
+        toggleColumn(field);
+    };
 
-        // Set the initial React states.
-        this.state = {
-            columns: props.columns, // Make (effectively) a local mutatable copy of the columns
-            sortOption: 'default', // Default sorting option
-        };
+    return (
+        <div className="column-selector__selector-item">
+            <input id={field} type="checkbox" onChange={handleChange} checked={selected} />
+            <label htmlFor={field}>{title}</label>
+        </div>
+    );
+};
 
-        // Bind `this` to non-React methods.
-        this.submitHandler = this.submitHandler.bind(this);
-        this.toggleColumn = this.toggleColumn.bind(this);
-        this.handleSelectAll = this.handleSelectAll.bind(this);
-        this.handleSelectOne = this.handleSelectOne.bind(this);
-        this.handleSortChange = this.handleSortChange.bind(this);
-    }
+ColumnItem.propTypes = {
+    /** encoded field name for the column */
+    field: PropTypes.string.isRequired,
+    /** Title for the checkbox; same as column header title */
+    title: PropTypes.string.isRequired,
+    /** True for selected columns; i.e. checked checkboxes */
+    selected: PropTypes.bool.isRequired,
+    /** Parent function to call when item is clicked */
+    toggleColumn: PropTypes.func.isRequired,
+};
 
-    toggleColumn(columnPath) {
-        // Called every time a column's checkbox gets clicked on or off in the modal. `columnPath`
-        // is the query-string term corresponding to each column. First, if the column is getting
-        // turned off, make sure we have at least one other column selected, because at least one
-        // column has to be selected.
-        if (this.state.columns[columnPath].visible) {
+
+/**
+ * Displays a modal dialog with every possible column for the type of object being displayed. This
+ * lets you choose which columns you want to appear in the report.
+ */
+const ColumnSelector = ({ allColumns, visibleFields, setVisibleFields, closeSelector }) => {
+    /** Field names of columns currently selected for display */
+    const [selectedFields, setSelectedFields] = React.useState(visibleFields);
+    /** True if column list appears sorted */
+    const [sorted, setSorted] = React.useState(false);
+
+    // Get all the the column field names, sorting them by the corresponding column title if the
+    // user asked for that.
+    const columnFields = getColumnFields(allColumns, sorted === 'alpha');
+
+    const toggleColumn = (clickedField) => {
+        let updatedColumns;
+
+        // Called every time a column's checkbox gets clicked on or off in the modal.
+        if (selectedFields.includes(clickedField)) {
             // The clicked column is currently visible, so before we make it invisible, make sure
             // at least one other column is also visible.
-            const allColumnKeys = Object.keys(this.state.columns);
-            const anotherVisible = allColumnKeys.some(key => key !== columnPath && this.state.columns[key].visible);
-            if (!anotherVisible) {
-                // A checkbox is being turned off, and no other checkbox is checked, so ignore the
-                // click.
+            if (Object.keys(selectedFields).length === 1) {
+                // Unchecking the the only checked checkbox, so ignore the click.
                 return;
             }
+
+            // Remove selected column field from selectedColumns.
+            updatedColumns = selectedFields.filter(field => field !== clickedField);
+        } else {
+            updatedColumns = selectedFields.concat(clickedField);
         }
 
         // Either a checkbox is being turned on, or it's being turned off and another checkbox is
@@ -450,329 +591,339 @@ class ColumnSelector extends React.Component {
         // test could be done inside the setState callback. The React docs don't say what happens
         // if you return no properties (https://reactjs.org/docs/react-component.html#setstate) so
         // I avoided doing this.
-        this.setState((prevState) => {
-            // Toggle the `visible` state corresponding to the column whose checkbox was toggled.
-            // Then set that as the new React state which causes a redraw of the modal with all the
-            // checkboxes in the correct state.
-            const columns = Object.assign({}, prevState.columns);
-            columns[columnPath] = Object.assign({}, columns[columnPath]);
-            columns[columnPath].visible = !columns[columnPath].visible;
-            return { columns };
-        });
-    }
+        setSelectedFields(updatedColumns);
+    };
 
-    submitHandler() {
+    const submitHandler = () => {
         // Called when the user clicks the Select button in the column checkbox modal, which
         // sets a new state for all checked report columns.
-        this.props.setColumnState(this.state.columns);
-    }
+        setVisibleFields(selectedFields);
+    };
 
-    handleSelectAll() {
-        // Called when the "Select all" button is clicked.
-        this.setState((prevState) => {
-            // For every column in this.state.columns, set its `visible` property to true.
-            const columns = Object.assign({}, prevState.columns);
-            Object.keys(columns).forEach((columnPath) => {
-                columns[columnPath] = Object.assign({}, columns[columnPath]);
-                columns[columnPath].visible = true;
-            });
-            return { columns };
-        });
-    }
+    const handleSelectAll = () => {
+        // Called when the user clicks "Select all."
+        setSelectedFields(Object.keys(allColumns));
+    };
 
-    handleSelectOne() {
-        // Called when the "Select (first) only" button is clicked.
-        this.setState((prevState) => {
-            // Set all columns to invisible first.
-            const columns = Object.assign({}, prevState.columns);
-            const columnPaths = Object.keys(columns);
-            columnPaths.forEach((columnPath) => {
-                columns[columnPath] = Object.assign({}, columns[columnPath]);
-                columns[columnPath].visible = false;
-            });
-
-            // Now set the column for the first key to true so that only it's selected.
-            columns[columnPaths[0]].visible = true;
-            return { columns };
-        });
-    }
+    const handleSelectOne = () => {
+        setSelectedFields(['@id']);
+    };
 
     // Called when the sorting option gets changed.
-    handleSortChange(sortOption) {
-        this.setState({ sortOption });
-    }
+    const handleSortChange = (selectedSortOption) => {
+        setSorted(selectedSortOption);
+    };
 
-    render() {
-        const { columns } = this.state;
-        const firstColumnKey = Object.keys(columns)[0];
-
-        // Get the column paths, sorting them by the corresponding column title if the user asked
-        // for that.
-        const columnPaths = getColumnPaths(columns, this.state.sortOption);
-
-        return (
-            <Modal addClasses="column-selector">
-                <ModalHeader title="Select columns to view" closeModal={this.props.closeSelector} />
-                <ColumnSelectorControls
-                    handleSelectAll={this.handleSelectAll}
-                    handleSelectOne={this.handleSelectOne}
-                    handleSortChange={this.handleSortChange}
-                    firstColumnTitle={columns[firstColumnKey].title}
-                />
-                <ModalBody>
-                    <div className="column-selector__selectors">
-                        {columnPaths.map((columnPath) => {
-                            const column = columns[columnPath];
-                            return <ColumnItem key={columnPath} columnPath={columnPath} column={column} toggleColumn={this.toggleColumn} />;
-                        })}
-                    </div>
-                </ModalBody>
-                <ModalFooter
-                    closeModal={this.props.closeSelector}
-                    submitBtn={this.submitHandler}
-                    submitTitle="View selected columns"
-                />
-            </Modal>
-        );
-    }
-}
+    return (
+        <Modal addClasses="column-selector" closeModal={closeSelector}>
+            <ModalHeader title="Select columns to view" closeModal={closeSelector} />
+            <ColumnSelectorControls
+                handleSelectAll={handleSelectAll}
+                handleSelectOne={handleSelectOne}
+                handleSortChange={handleSortChange}
+                firstColumnTitle={Object.keys(allColumns)[0]}
+            />
+            <ModalBody>
+                <div className="column-selector__selectors">
+                    {columnFields.map(field => <ColumnItem key={field} field={field} title={allColumns[field]} selected={selectedFields.includes(field)} toggleColumn={toggleColumn} />)}
+                </div>
+            </ModalBody>
+            <ModalFooter
+                closeModal={closeSelector}
+                submitBtn={submitHandler}
+                submitTitle="View selected columns"
+            />
+        </Modal>
+    );
+};
 
 ColumnSelector.propTypes = {
-    columns: PropTypes.object.isRequired,
-    setColumnState: PropTypes.func.isRequired,
+    /** All possible columns for the current type, and their titles */
+    allColumns: PropTypes.object.isRequired,
+    /** Specifies currently selected columns and their titles */
+    visibleFields: PropTypes.array.isRequired,
+    /** Function to call when user has specified the selected columns */
+    setVisibleFields: PropTypes.func.isRequired,
+    /** Called when the user wants to close the selector modal without change */
     closeSelector: PropTypes.func.isRequired,
 };
 
 
-// Render one column selector item.
-class ColumnItem extends React.Component {
-    constructor() {
-        super();
+/**
+ * Load the schema corresponding to the given type, where `type` contains an encode @type.
+ * @param type {string} Selects schema based on @type
+ *
+ * @return {promise} Schema corresponding to selected `type`; null if error.
+ */
+const loadSchemaColumns = type => (
+    fetch('/profiles/', {
+        method: 'GET',
+        headers: { Accept: 'application/json' },
+    }).then((response) => {
+        // Convert the response to JSON.
+        if (response.ok) {
+            return response.json();
+        }
+        return Promise.resolve(null);
+    }).then(responseJson => (responseJson ? responseJson[type] : null))
+);
 
-        // Bind this to non-React methods.
-        this.toggleColumn = this.toggleColumn.bind(this);
-    }
 
-    toggleColumn() {
-        this.props.toggleColumn(this.props.columnPath);
-    }
+/**
+ * Generate an object containing the title and visibility status of every possible column for the
+ * current type. These get collected from the returned JSON `columns` property as well as the
+ * `properties` of the matching schema.
+ */
+const generateColumns = (context, schema) => {
+    const generatedColumns = {};
 
-    render() {
-        const { column } = this.props;
+    // Convert `columns` from returned JSON to our columns object, and make an array of column
+    // titles for each deduping later.
+    const columnTitles = [];
+    Object.keys(context.columns).forEach((column) => {
+        generatedColumns[column] = context.columns[column].title;
+        columnTitles.push(generatedColumns[column]);
+    });
 
-        /* eslint-disable jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
-        return (
-            <div className="column-selector__selector-item">
-                <input type="checkbox" onChange={this.toggleColumn} checked={column.visible} />&nbsp;
-                <span onClick={this.toggleColumn} style={{ cursor: 'pointer' }}>{column.title}</span>
-            </div>
-        );
-        /* eslint-enable jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
-    }
-}
-
-ColumnItem.propTypes = {
-    columnPath: PropTypes.string.isRequired, // encoded path for the column
-    column: PropTypes.object.isRequired, // Column information
-    toggleColumn: PropTypes.func.isRequired, // Parent function to call when item is clicked
+    // Convert the schema properties to our columns object.
+    Object.keys(schema.properties).forEach((column) => {
+        // Only include if the search result columns doesn't already have the property, and only if
+        // the schema property title doesn't match an existing search result columns title.
+        if (!generatedColumns[column] && !columnTitles.includes(schema.properties[column].title)) {
+            generatedColumns[column] = schema.properties[column].title;
+        }
+    });
+    return generatedColumns;
 };
 
 
-class Report extends React.Component {
-    constructor(props, context) {
-        super(props, context);
+/**
+ * Displays a control allowing the user to select the maximum number of items to display on one page.
+ */
+const pageLimitOptions = [25, 50, 100, 200];
+const PageLimitSelector = ({ pageLimit, query }) => (
+    <div className="page-limit-selector">
+        <div className="page-limit-selector__label">Items per page:</div>
+        <div className="page-limit-selector__options">
+            {pageLimitOptions.map((limit) => {
+                // When changing the number of items per page, also go back to the first page by
+                // removing the "from=x" query-string parameter.
+                const limitQuery = query.clone();
+                limitQuery.deleteKeyValue('from');
+                if (limit === DEFAULT_PAGE_LIMIT) {
+                    limitQuery.deleteKeyValue('limit');
+                } else {
+                    limitQuery.replaceKeyValue('limit', limit);
+                }
 
-        // Set initial React state.
-        const parsedUrl = url.parse(context.location_href, true);
-        const from = parseInt(parsedUrl.query.from, 10) || 0;
-        const size = parseInt(parsedUrl.query.limit, 10) || 25;
-        this.state = {
-            from,
-            size,
-            to: from + size,
-            more: [],
-            selectorOpen: false, // True if column selector modal is open
-        };
+                return (
+                    <a
+                        key={limit}
+                        href={`?${limitQuery.format()}`}
+                        className={`page-limit-selector__option${limit === pageLimit ? ' page-limit-selector__option--selected' : ''}`}
+                        aria-label={`Show ${limit} items per page`}
+                    >
+                        {limit}
+                    </a>
+                );
+            })}
+        </div>
+    </div>
+);
 
-        // Bind this to non-React methods.
-        this.setSort = this.setSort.bind(this);
-        this.setColumnState = this.setColumnState.bind(this);
-        this.loadMore = this.loadMore.bind(this);
-        this.handleSelectorClick = this.handleSelectorClick.bind(this);
-        this.closeSelector = this.closeSelector.bind(this);
-    }
+PageLimitSelector.propTypes = {
+    /** New page limit to display */
+    pageLimit: PropTypes.number.isRequired,
+    /** Current page's QueryString query */
+    query: PropTypes.object.isRequired,
+};
 
-    componentWillReceiveProps(nextProps, nextContext) {
-        // reset pagination when filter is changed
-        if (nextContext.location_href !== this.context.location_href) {
-            const parsedUrl = url.parse(this.context.location_href, true);
-            const from = parseInt(parsedUrl.query.from, 10) || 0;
-            const size = parseInt(parsedUrl.query.limit, 10) || 25;
-            this.setState({
-                from,
-                to: from + size,
-                more: [],
+
+/**
+ * Renderer for the entire /report/ page.
+ */
+const Report = ({ context }, reactContext) => {
+    /** All possible columns for the current type */
+    const [allColumns, setAllColumns] = React.useState(null);
+    /** True if column selector modal visible */
+    const [selectorOpen, setSelectorOpen] = React.useState(false);
+    /** True if request for schema in progress */
+    const schemaLoadInProgress = React.useRef(false);
+    /** True if we have requested a redirect; prevents state changes from multiple redirects */
+    const redirectInProgress = React.useRef(false);
+    /** Table DOM element to handle its sticky header */
+    const tableRef = React.useRef(null);
+
+    // Calculate values from the search results and query string usuable by the rest of the
+    // component. The back end report code allows exactly one "type=x" parameter.
+    const parsedUrl = React.useMemo(() => url.parse(context['@id']), [context]);
+    const query = React.useMemo(() => new QueryString(parsedUrl.query), [parsedUrl]);
+    const fieldOrder = React.useMemo(() => (allColumns ? Object.keys(allColumns) : Object.keys(context.columns)), [allColumns, context.columns]);
+    const typeFilter = context.filters.find(filter => filter.field === 'type');
+    const type = typeFilter.term;
+
+    // Based on the query string's "field=x" elements, generate an array of visible columns
+    // properties. If no "field=x" elements exist in the query string, use the search results'
+    // `columns` property instead as default columns.
+    const visibleFields = React.useMemo(() => {
+        const fieldValues = query.getKeyValues('field');
+        const fields = fieldValues.length > 0 ? fieldValues : Object.keys(context.columns);
+
+        // Sort the fields according to the order in the schema or result columns.
+        const result = _(fields).sortBy((field) => {
+            const index = fieldOrder.indexOf(field);
+            return index >= 0 ? index : fieldOrder.length + 1;
+        });
+        return result;
+    }, [context.columns, query, fieldOrder]);
+
+    // Get the current value of the "limit=x" query string parameter. No "limit=x" means the
+    // default value applies. The back end allows exactly zero or one "limit=x" parameter.
+    const pageLimit = React.useMemo(() => {
+        const limitValues = query.getKeyValues('limit');
+        return limitValues.length === 1 ? Number(limitValues[0]) || DEFAULT_PAGE_LIMIT : DEFAULT_PAGE_LIMIT;
+    }, [query]);
+
+    // Calculate the current page number and total number of pages. The current page number relies
+    // on the current "from=x" query string parameter, which the back end allows exactly zero or
+    // one of.
+    const fromIndices = query.getKeyValues('from');
+    const fromIndex = fromIndices.length === 1 ? Number(fromIndices[0]) : 0;
+    const currentPage = (fromIndex / pageLimit) + 1;
+    const viewableTotal = Math.min(context.total, MAX_VIEWABLE_RESULTS - pageLimit);
+    const totalPages = Math.trunc(viewableTotal / pageLimit) + (viewableTotal % pageLimit > 0 ? 1 : 0);
+
+    // Called when the user requests the column-selector modal.
+    const openColumnSelector = () => {
+        setSelectorOpen(true);
+    };
+
+    // Called when the user closes the column-selector modal.
+    const closeColumnSelector = () => {
+        setSelectorOpen(false);
+    };
+
+    // Called when the user selects a new set of visible columns. Generate a new set of "field="
+    // queries based on the newly selected visible columns and navigate to the new query.
+    const handleColumnSelection = React.useCallback((selectedColumns) => {
+        const sortedColumns = _(selectedColumns).sortBy(field => fieldOrder.indexOf(field));
+
+        // Convert the newly selected columns to a "field=x&field=y..." query.
+        const fieldQuery = sortedColumns.map(field => `field=${encodedURIComponent(field)}`).join('&');
+
+        // Get the existing query string and strip out any existing "field=x" elements.
+        const columnQuery = query.clone();
+        const strippedQuery = columnQuery.deleteKeyValue('field');
+
+        // Navigate to the stripped query concatenated with the new field query.
+        const href = `?${strippedQuery.format()}&${fieldQuery}`;
+        reactContext.navigate(href);
+    }, [query, reactContext, fieldOrder]);
+
+    // Called when the user selects a new page number from the pagination control. Generate a
+    // query string using a "first=x" query string parameter for the page and navigate to it.
+    const handlePagerClick = (newPageNumber) => {
+        // Map the page number to the corresponding "first=x" query string parameter.
+        const firstSearchIndex = (newPageNumber - 1) * pageLimit;
+
+        // Add the new "first=x" query string parameter, or remove it for the first page.
+        const indexQuery = query.clone();
+        if (firstSearchIndex === 0) {
+            indexQuery.deleteKeyValue('from');
+        } else {
+            indexQuery.replaceKeyValue('from', firstSearchIndex);
+        }
+
+        // Navigate to the new query string.
+        const href = `?${indexQuery.format()}`;
+        reactContext.navigate(href);
+    };
+
+    React.useEffect(() => {
+        // If we haven't yet, load the schema matching the given "type=" type to generate the
+        // columns object.
+        if (!schemaLoadInProgress.current && !allColumns) {
+            schemaLoadInProgress.current = true;
+            loadSchemaColumns(type).then((schema) => {
+                schemaLoadInProgress.current = false;
+
+                // Use the search results and the loaded schema's `properties` to generate a list
+                // of columns to display.
+                const generatedColumns = generateColumns(context, schema);
+                setAllColumns(generatedColumns);
             });
         }
-    }
+    }, [context, schemaLoadInProgress, allColumns, type]);
 
-    componentWillUnmount() {
-        if (this.state.request) this.state.request.abort();
-    }
-
-    setSort(sort) {
-        const parsedUrl = url.parse(this.context.location_href, true);
-        parsedUrl.query.sort = sort;
-        delete parsedUrl.search;
-        this.context.navigate(url.format(parsedUrl));
-    }
-
-    setColumnState(newColumns) {
-        // Gets called when the user clicks the Select button in the ColumnSelector modal.
-        // `newColumns` has the same format as `columns` returned from `columnChoices`, but
-        // `newColumns` has the user's chosen columns from the modal, while `columns` has the
-        // columns selected by the query string.
-        const parsedUrl = url.parse(this.context.location_href, true);
-        parsedUrl.query.field = Object.keys(newColumns).filter(columnPath => newColumns[columnPath].visible);
-        delete parsedUrl.search;
-        this.context.navigate(url.format(parsedUrl));
-    }
-
-    loadMore() {
-        if (this.state.request) {
-            this.state.request.abort();
+    React.useEffect(() => {
+        // If a facet selection leaves fewer pages than the current page, redirect to the same url
+        // but on the first page, by removing the "from=x" query-string parameter.
+        if (currentPage > totalPages && !redirectInProgress.current) {
+            redirectInProgress.current = true;
+            const noFromQuery = query.clone();
+            noFromQuery.deleteKeyValue('from');
+            reactContext.navigate(`?${noFromQuery.format()}`);
         }
-        const parsedUrl = url.parse(this.context.location_href, true);
-        parsedUrl.query.from = this.state.to;
-        delete parsedUrl.search;
-        const request = this.context.fetch(url.format(parsedUrl), {
-            headers: { Accept: 'application/json' },
-        });
-        request.then((response) => {
-            if (!response.ok) throw response;
-            return response.json();
-        }).catch(globals.parseAndLogError.bind(undefined, 'loadMore')).then((data) => {
-            this.setState({
-                more: this.state.more.concat(data['@graph']),
-                request: null,
-            });
-        });
+    }, [currentPage, totalPages, query, reactContext]);
 
-        this.setState({
-            request,
-            to: this.state.to + this.state.size,
-        });
-    }
+    // Compose download-TSV link by keeping the query string and replacing the path with /report.tsv.
+    const downloadTsvPath = `/report.tsv${parsedUrl.path.slice(parsedUrl.pathname.length)}`;
 
-    handleSelectorClick() {
-        // Handle click on the column selector button by opening the modal.
-        this.setState({ selectorOpen: true });
-    }
-
-    closeSelector() {
-        // Close the column selector modal.
-        this.setState({ selectorOpen: false });
-    }
-
-    render() {
-        const parsedUrl = url.parse(this.context.location_href, true);
-        if (parsedUrl.pathname.indexOf('/report') !== 0) return false; // avoid breaking on re-render when navigate changes href before context is changed
-        const context = this.props.context;
-        let searchBase = parsedUrl.search || '';
-        searchBase += searchBase ? '&' : '?';
-
-        const type = parsedUrl.query.type;
-        const schema = this.props.schemas[type];
-        let queryFields = parsedUrl.query.field;
-        if (typeof queryFields === 'string') {
-            queryFields = [queryFields];
-        }
-        const columns = columnChoices(schema, queryFields);
-
-        // Compose download-TSV link.
-        const downloadTsvPath = `/report.tsv${parsedUrl.path.slice(parsedUrl.pathname.length)}`;
-
-        /* eslint-disable jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
+    // No filled facets means no results, and we should display the notification from the back end
+    // instead of the report.
+    const facetdisplay = context.facets && context.facets.some(facet => facet.total > 0);
+    if (facetdisplay) {
         return (
-            <Panel>
-                <PanelBody>
-                    <div className="search-results">
-                        <div className="search-results__facets">
-                            <FacetList context={context} facets={context.facets} filters={context.filters} searchBase={searchBase} docTypeTitleSuffix="report" />
+            <div className="search-results">
+                <FacetList context={context} facets={context.facets} filters={context.filters} docTypeTitleSuffix="report" />
+                <div className="search-results__report-list">
+                    <div className="results-table-control">
+                        <div className="results-table-control__main">
+                            <ViewControls results={context} />
+                            <button className="btn btn-info btn-sm" title="Choose columns" onClick={openColumnSelector} disabled={!allColumns}>
+                                <i className="icon icon-columns" /> Columns
+                            </button>
+                            <a className="btn btn-info btn-sm" href={downloadTsvPath} data-bypass data-test="download-tsv">Download TSV</a>
                         </div>
-                        <div className="search-results__report-list">
-                            <h4>Showing results {this.state.from + 1} to {Math.min(context.total, this.state.to)} of {context.total}</h4>
-                            <div className="results-table-control">
-                                <div className="results-table-control__main">
-                                    <ViewControls results={context} />
-                                    <button className="btn btn-info btn-sm" title="Choose columns" onClick={this.handleSelectorClick}>
-                                        <i className="icon icon-columns" /> Columns
-                                    </button>
-                                    <a className="btn btn-info btn-sm" href={downloadTsvPath} data-bypass data-test="download-tsv">Download TSV</a>
-                                </div>
-                            </div>
-                            <Table context={context} more={this.state.more} columns={columns} setSort={this.setSort} />
-                            {this.state.to < context.total ?
-                                <button className="btn btn-info btn-sm" onClick={this.loadMore}>Load more</button>
-                            : null}
-                        </div>
-                        {this.state.selectorOpen ?
-                            <ColumnSelector
-                                columns={columns}
-                                setColumnState={this.setColumnState}
-                                closeSelector={this.closeSelector}
-                            />
+                    </div>
+                    <div className="results-table-control__pager">
+                        <PageLimitSelector pageLimit={pageLimit} query={query} />
+                        {totalPages > 1 ?
+                            <Pager.Multi currentPage={currentPage} total={totalPages} clickHandler={handlePagerClick} />
                         : null}
                     </div>
-                </PanelBody>
-            </Panel>
+                    {viewableTotal < context.total ?
+                        <div className="report-max-warning">Not all items viewable. Download TSV for all items.</div>
+                    : null}
+                    <TableItemCount count={`Showing results ${fromIndex + 1} to ${Math.min(context.total, fromIndex + pageLimit)} of ${context.total}`} />
+                    <div className="report__table">
+                        <table className="table table-striped" ref={tableRef}>
+                            <ReportHeader context={context} visibleFields={visibleFields} allColumns={allColumns} tableRef={tableRef} />
+                            <ReportData context={context} visibleFields={visibleFields} type={type} />
+                        </table>
+                    </div>
+                </div>
+                {selectorOpen ?
+                    <ColumnSelector
+                        allColumns={allColumns}
+                        visibleFields={visibleFields}
+                        setVisibleFields={handleColumnSelection}
+                        closeSelector={closeColumnSelector}
+                    />
+                : null}
+            </div>
         );
-        /* eslint-enable jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
     }
-}
-
-Report.propTypes = {
-    context: PropTypes.object.isRequired,
-    schemas: PropTypes.object, // Actually required, but comes from a GET request.
+    return <h4>{context.notification}</h4>;
 };
 
-Report.defaultProps = {
-    schemas: null,
+Report.propTypes = {
+    /** Report search results */
+    context: PropTypes.object.isRequired,
 };
 
 Report.contextTypes = {
-    location_href: PropTypes.string,
     navigate: PropTypes.func,
-    fetch: PropTypes.func,
 };
 
-
-const ReportLoader = props => (
-    <FetchedData>
-        <Param name="schemas" url="/profiles/" />
-        <Report context={props.context} />
-    </FetchedData>
-);
-
-ReportLoader.propTypes = {
-    context: PropTypes.object.isRequired,
-};
-
-globals.contentViews.register(ReportLoader, 'Report');
-
-
-// Custom cell-display function example.
-// var CustomCellDisplay = function(item, column property name) {
-//     if (displayCondition) {
-//        return (
-//            <span>{display}</span>
-//        );
-//     }
-//
-//     // No custom display necessary for the requested column
-//     return null;
-// };
-
-
-// Register cell-display components
-// globals.reportCell.register(CustomCellDisplay, @type[0] in quotes, column property name in quotes);
+globals.contentViews.register(Report, 'Report');

--- a/src/encoded/static/components/report.js
+++ b/src/encoded/static/components/report.js
@@ -211,15 +211,6 @@ const lookupColumn = (result, column) => {
     let nodes = [result];
     const names = column.split('.');
 
-    // Get the column's custom display function and call it if it exists
-    const colViewer = globals.reportCell.lookup(result, column);
-    if (colViewer) {
-        const colViewResult = colViewer(result, column);
-        if (colViewResult) {
-            return <div>{colViewResult}</div>;
-        }
-    }
-
     for (let i = 0, len = names.length; i < len && nodes.length > 0; i += 1) {
         let nextnodes = [];
         _.each(nodes.map(node => node[names[i]]), (v) => {

--- a/src/encoded/static/components/report.js
+++ b/src/encoded/static/components/report.js
@@ -250,7 +250,7 @@ const reduceComplexValue = (rawValue) => {
                 .uniq()
                 .value();
 
-            // Take care of arrays by concatenting their elements into one string.
+            // Take care of arrays by concatenating their elements into one string.
             result = flattenedValue.map((item) => {
                 if (typeof item === 'object') {
                     // The array contains objects. If each object has an @id, display that.
@@ -424,7 +424,7 @@ const ReportData = ({ context, visibleFields, type }) => (
         {context['@graph'].map(item => (
             <tr key={item['@id']}>
                 {visibleFields.map((field) => {
-                    // Get the value of the property in `item` and see if the currenet field and
+                    // Get the value of the property in `item` and see if the current field and
                     // type have a registered renderer.
                     const value = getObjectPropValue(item, field);
                     const ReportCellRenderer = ReportDataRegistry.lookup(field, type);

--- a/src/encoded/static/components/summary.js
+++ b/src/encoded/static/components/summary.js
@@ -186,17 +186,12 @@ const SummaryHorizontalFacets = ({ context, facetList }, reactContext) => {
         horizFacets = context.facets.filter(f => ['assay_title', 'biosample_ontology.term_name', 'date_released', 'date_submitted'].includes(f.field));
     }
 
-    // Calculate the searchBase, which is the current search query string fragment that can have
-    // terms added to it.
-    const searchBase = `${url.parse(reactContext.location_href).search}&` || '?';
-
     // Note: we subtract one from the horizontal facet length because "date-released" and "date-submitted" are collapsed into one facet
     return (
         <FacetList
             context={context}
             facets={horizFacets}
             filters={context.filters}
-            searchBase={searchBase}
             addClasses={`summary-horizontal-facets facet-num-${horizFacets.length - 1} ${facetList}`}
             supressTitle
             orientation="horizontal"

--- a/src/encoded/static/components/typeutils.js
+++ b/src/encoded/static/components/typeutils.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'underscore';
-import Pager from '../libs/ui/pager';
+import * as Pager from '../libs/ui/pager';
 import * as globals from './globals';
 import { requestFiles, AlternateAccession } from './objectutils';
 import { SortTablePanel, SortTable } from './sorttable';
@@ -624,7 +624,7 @@ const FileTableHeader = ({ title, currentPage, totalPageCount, control, updateCu
         {title}
         <div className="header-paged-sorttable__controls">
             {control}
-            {totalPageCount > 1 ? <Pager total={totalPageCount} current={currentPage} updateCurrentPage={updateCurrentPage} /> : null}
+            {totalPageCount > 1 ? <Pager.Simple total={totalPageCount} current={currentPage} updateCurrentPage={updateCurrentPage} /> : null}
         </div>
     </div>
 );

--- a/src/encoded/static/libs/svg-icons.js
+++ b/src/encoded/static/libs/svg-icons.js
@@ -106,6 +106,19 @@ const lockClosed = style => (
     </svg>
 );
 
+const chevronLeft = () => (
+    <svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="7.359" height="12" viewBox="0 0 7.281 12">
+        <path d="M0.192,5.534l5.341-5.341c0.258-0.258,0.676-0.258,0.931,0l0.624,0.624c0.258,0.258,0.258,0.673,0,0.931l-4.231,4.25 l4.231,4.253c0.255,0.258,0.255,0.673,0,0.931l-0.624,0.624c-0.258,0.258-0.676,0.258-0.931,0L0.192,6.466 C-0.064,6.207-0.064,5.79,0.192,5.534z" />
+    </svg>
+);
+
+const chevronRight = () => (
+    <svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="7.359" height="12" viewBox="0 0 7.359 12">
+        <path d="M7.165,6.466l-5.341,5.341c-0.258,0.258-0.676,0.258-0.931,0L0.27,11.183c-0.258-0.258-0.258-0.673,0-0.931L4.5,6.001 L0.27,1.749c-0.255-0.258-0.255-0.673,0-0.931l0.624-0.624c0.258-0.258,0.676-0.258,0.931,0l5.341,5.341 C7.423,5.79,7.423,6.207,7.165,6.466z" />
+    </svg>
+);
+
+
 const icons = {
     disclosure: style => <svg id="Disclosure" data-name="Disclosure" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 480" style={style} className="svg-icon svg-icon-disclosure"><circle cx="240" cy="240" r="240" /><polyline points="401.79 175.66 240 304.34 78.21 175.66" /></svg>,
     table,
@@ -117,6 +130,8 @@ const icons = {
     asterisk: style => <svg id="Asterisk" data-name="Asterisk" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" style={style}><polygon points="15.68 5.3 14.18 2.7 8.94 6.38 9.5 0 6.5 0 7.06 6.38 1.82 2.7 0.32 5.3 6.13 8 0.32 10.7 1.82 13.3 7.06 9.62 6.5 16 9.5 16 8.94 9.62 14.18 13.3 15.68 10.7 9.87 8 15.68 5.3" /></svg>,
     chevronDown: style => <svg id="Chevron Down" data-name="Chevron Down" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 249 124" style={style}><polygon points="249,57 124.5,124 0,57 0,0 124.5,67 249,0" /></svg>,
     chevronUp: style => <svg id="Chevron Up" data-name="Chevron Up" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 249 124" style={style}><polygon points="249,67 124.5,0 0,67 0,124 124.5,57 249,124" /></svg>,
+    chevronLeft,
+    chevronRight,
     spinner,
     largeArrow,
     genomeBrowser,

--- a/src/encoded/static/libs/ui/pager.js
+++ b/src/encoded/static/libs/ui/pager.js
@@ -83,7 +83,7 @@ export const Multi = ({ currentPage, total, clickHandler }) => {
     } else {
         // With more than nine pages, build a cluster of pages around the current page, first by
         // determining the minimum and maximum page numbers for the cluster. Allow for filling in
-        // extra numbers in the cluster for cases where the current page number approches the ends
+        // extra numbers in the cluster for cases where the current page number approaches the ends
         // of the page range, and cutting off the page numbers when the current page is within two
         // pages of either end of the page range.
         const clusterMin = Math.min(Math.max(1, currentPage - 2), total - 6);

--- a/src/encoded/static/libs/ui/pager.js
+++ b/src/encoded/static/libs/ui/pager.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import _ from 'underscore';
+import { svgIcon } from '../../libs/svg-icons';
 
 
 /**
@@ -8,7 +10,7 @@ import PropTypes from 'prop-types';
  * user clicks a page, it calls the `updateCurrentPage` callback so that the component that uses
  * <Pager> can react to the click.
  */
-const Pager = ({ total, current, updateCurrentPage }) => {
+export const Simple = ({ total, current, updateCurrentPage }) => {
     const handlePrev = () => {
         updateCurrentPage(current - 1);
     };
@@ -31,7 +33,7 @@ const Pager = ({ total, current, updateCurrentPage }) => {
     );
 };
 
-Pager.propTypes = {
+Simple.propTypes = {
     /** Total number of pages */
     total: PropTypes.number.isRequired,
     /** Current page number; 0 based */
@@ -40,4 +42,138 @@ Pager.propTypes = {
     updateCurrentPage: PropTypes.func.isRequired,
 };
 
-export default Pager;
+
+/**
+ * Displays a multi-page pager control that lets the user choose a page of data to view, with
+ * ellipses representing skipped pages to save horizontal space. Previous/next arrows on either
+ * end of the component allow the user to move to the previous and next page to the current page.
+ * We have four cases to consider based on the total page count:
+ *
+ * Nine or fewer: Straight sequence of pages with no ellipses ([x] indicates current page):
+ * <  1   2   3   4   5  [6]  7   8   9  >
+ *
+ * More than nine with the current page towards the left end ('.' indicates ellipsis):
+ * <  1   2  [3]  4   5   6   7   .   20  >
+ *
+ * More than nine with the current page towards the right end:
+ * <  1   .   14   15  [16]  17   18   19   20  >
+ *
+ * More than nine with the current page not near either end:
+ * <  1   .   11   12  [13]  14   15   .   20  >
+ *
+ * For cases with more than nine pages, Pager attempts to keep a cluster of visible page numbers
+ * surrounding the current page so that the user can see and select the two preceding and two
+ * succeeding page numbers, except when the current page gets to the extreme ends of the page
+ * range and fewer than two page numbers exist on one side of the cluster. When the current page
+ * approaches the ends of the page range, more than two visible pages appear in the cluster on the
+ * side facing the near end of the page range. This allowance keeps the width of the entire Pager
+ * component consistent regardless of the current page number, so that the previous/next buttons
+ * don't shift around horizontally.
+ */
+export const Multi = ({ currentPage, total, clickHandler }) => {
+    // Create the array of 1-based page numbers, with page 0 to represent an ellipsis before the
+    // current page and page -1 to represent an ellipsis after the current page. No real difference
+    // between these two ellipsis values, but Pager uses distinct values so we don't have duplicate
+    // React keys. No point memoizing `pageNumbers` as it needs recalculating when any prop changes.
+    let pageNumbers;
+    if (total <= 9) {
+        // A total page count of nine or fewer has no ellipses -- just a straight array of
+        // sequential numbers.
+        pageNumbers = _.range(1, total + 1); // _.range ends at max - 1
+    } else {
+        // With more than nine pages, build a cluster of pages around the current page, first by
+        // determining the minimum and maximum page numbers for the cluster. Allow for filling in
+        // extra numbers in the cluster for cases where the current page number approches the ends
+        // of the page range, and cutting off the page numbers when the current page is within two
+        // pages of either end of the page range.
+        const clusterMin = Math.min(Math.max(1, currentPage - 2), total - 6);
+        const clusterMax = Math.max(Math.min(currentPage + 2, total), 7);
+        const clusterPageNumbers = _.range(clusterMin, clusterMax + 1); // _.range ends at max - 1
+
+        // Determine whether we need an ellipsis before the cluster, or continuous page numbers. If
+        // we need an ellipsis before the cluster, then we need an array with page one and a "0" to
+        // indicate the left ellipsis
+        const prevFiller = clusterMin >= 4 ? [1, 0] : _.range(1, clusterMin);
+
+        // Determine whether we need an ellipsis after the cluster, or continuous page numbers. If
+        // we need an ellipsis after the cluster, then we need an array with a -1 to indicate the
+        // right ellipsis followed by the last page number.
+        const nextFiller = clusterMax <= total - 3 ? [-1, total] : _.range(clusterMax + 1, total + 1);
+
+        // Put together the entire sequence of displayed page numbers and ellipses:
+        // prevFiller -- clusterPageNumbers -- nextFiller
+        pageNumbers = prevFiller.concat(clusterPageNumbers, nextFiller);
+    }
+
+    // Calculate the pixel width of every page number and ellipsis based on the maximum number of
+    // digits in a page number.
+    const pageNumberWidth = 10 + (total.toString().length * 10);
+
+    // Called when the user clicks on a page number.
+    const pageNumberClick = (pageNumber) => {
+        if (pageNumber !== currentPage) {
+            clickHandler(pageNumber);
+        }
+    };
+
+    // Called when the user clicks the previous-page-number arrow.
+    const prevClick = () => {
+        if (currentPage !== 1) {
+            clickHandler(currentPage - 1);
+        }
+    };
+
+    // Called when the user clicks the next-page-number arrow.
+    const nextClick = () => {
+        if (currentPage !== total) {
+            clickHandler(currentPage + 1);
+        }
+    };
+
+    return (
+        <nav className="pager-multi" aria-label="Pagination">
+            <ul>
+                <li className={`pager-multi__page pager-multi__page--arrow${currentPage === 1 ? ' pager-multi__page--arrow-disabled' : ''}`}>
+                    <button type="button" onClick={prevClick} aria-label="Previous page" aria-disabled={currentPage === 1}>
+                        {svgIcon('chevronLeft')}
+                    </button>
+                </li>
+                {pageNumbers.map((pageNumber) => {
+                    // Ellipses pages.
+                    if (pageNumber === 0 || pageNumber === -1) {
+                        return <li key={pageNumber} className="pager-multi__page pager-multi__page--skip" style={{ width: pageNumberWidth }}>&hellip;</li>;
+                    }
+
+                    // Regular clickable pages.
+                    const isCurrentPage = pageNumber === currentPage;
+                    return (
+                        <li key={pageNumber} className={`pager-multi__page${currentPage === pageNumber ? ' pager-multi__page--current' : ''}`} style={{ width: pageNumberWidth }}>
+                            <button
+                                type="button"
+                                onClick={() => pageNumberClick(pageNumber)}
+                                aria-label={`Page ${pageNumber}${isCurrentPage ? ', current' : ''}`}
+                                aria-current={isCurrentPage ? 'page' : null}
+                            >
+                                {pageNumber}
+                            </button>
+                        </li>
+                    );
+                })}
+                <li className={`pager-multi__page pager-multi__page--arrow${currentPage === total ? ' pager-multi__page--arrow-disabled' : ''}`}>
+                    <button type="button" onClick={nextClick} aria-label="Next page" aria-disabled={currentPage === total}>
+                        {svgIcon('chevronRight')}
+                    </button>
+                </li>
+            </ul>
+        </nav>
+    );
+};
+
+Multi.propTypes = {
+    /** Currently selected page */
+    currentPage: PropTypes.number.isRequired,
+    /** Total number of pages */
+    total: PropTypes.number.isRequired,
+    /** Function to call when the user clicks a button in the pager; passes the new page number */
+    clickHandler: PropTypes.func.isRequired,
+};

--- a/src/encoded/static/scss/encoded/modules/_pager.scss
+++ b/src/encoded/static/scss/encoded/modules/_pager.scss
@@ -57,3 +57,99 @@ $pager-dimension: 24px;
     border-left: 1px solid #c0c0c0;
     border-right: 1px solid #c0c0c0;
 }
+
+
+$pager-height: 24px;
+$pager-arrow-width: 24px;
+
+.pager-multi {
+    display: flex;
+    
+    > ul {
+        display: flex;
+        margin: 0;
+        padding: 0;
+        height: $pager-height;
+
+        > li {
+            display: block;
+            list-style-type: none;
+            border-top: 1px solid #c0c0c0;
+            border-bottom: 1px solid #c0c0c0;
+            border-left: 1px solid #c0c0c0;
+
+            &:last-child {
+                border-right: 1px solid #c0c0c0;
+            }
+
+            &.pager-multi__page {
+                flex: 0 1 auto;
+                text-align: center;
+
+                button {
+                    display: block;
+                    width: 100%;
+                    height: 100%;
+                    padding-left: 5px;
+                    padding-right: 5px;
+                    line-height: 1rem;
+                    font-size: 1rem;
+                    font-weight: bold;
+                    border: none;
+                    background-color: transparent;
+                    border-radius: 0;
+                    cursor: pointer;
+
+                    svg {
+                        display: block;
+                        height: 100%;
+                        margin: 0 auto;
+                    }
+
+                    &:hover {
+                        background-color: #e0e0e0;
+                    }
+
+                    &:focus {
+                        border-radius: 0;
+                    }
+                }
+
+                &.pager-multi__page--arrow {
+                    width: $pager-arrow-width;
+
+                    button {
+                        padding: 5px 0;
+                        font-size: 0;
+                    }
+                }
+
+                &.pager-multi__page--arrow-disabled {
+                    button {
+                        fill: #c0c0c0;
+
+                        &:hover {
+                            background-color: transparent;
+                        }
+                    }
+                }
+
+                &.pager-multi__page--skip {
+                    border-top: none;
+                    border-bottom: none;
+                }
+            }
+
+            &.pager-multi__page--current {
+                button {
+                    color: #fff;
+                    background-color: #4f689e;
+
+                    &:hover {
+                        background-color: #4f689e;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/encoded/static/scss/encoded/modules/_report.scss
+++ b/src/encoded/static/scss/encoded/modules/_report.scss
@@ -12,16 +12,21 @@
         }
 
         thead {
-            background-color: #f5f5f5;
+            background-color: #e0e0e0;
 
             th {
-                padding: 5px;
-                border-left: 1px solid #e0e0e0;
+                padding: 0;
+                border-left: 1px solid #a0a0a0;
                 text-align: left;
 
                 a {
+                    padding: 10px 5px;
                     color: #000;
                     text-decoration: none;
+                }
+
+                .icon {
+                    margin-left: 5px;
                 }
 
                 &:first-child {
@@ -107,30 +112,6 @@
     }
 }
 
-
-.report__table {
-    .table {
-        height: 1px; // Allow cell <div>s to have cell full height
-
-        thead {
-            background-color: #f5f5f5;
-
-            tr {
-                height: 1px; // Allow cell <div>s to have cell full height
-
-                th, td {
-                    padding: 0;
-                }
-
-                th {
-                    .icon {
-                        margin-left: 5px;
-                    }
-                }
-            }
-        }
-    }
-}
 
 .report-header-cell {
     display: flex;

--- a/src/encoded/static/scss/encoded/modules/_report.scss
+++ b/src/encoded/static/scss/encoded/modules/_report.scss
@@ -45,6 +45,18 @@
         @at-root #{&}__selectors {
             display: flex;
             flex-wrap: wrap;
+
+            &.column-selector__selectors--extra {
+                display: block;
+                margin-top: 10px;
+                padding-top: 10px;
+                border-top: 1px solid #e0e0e0;
+
+                .column-selector__selector-item {
+                    flex: none;
+                    width: 100%;
+                }
+            }
         }
     }
 

--- a/src/encoded/static/scss/encoded/modules/_report.scss
+++ b/src/encoded/static/scss/encoded/modules/_report.scss
@@ -5,6 +5,12 @@
     @at-root #{&}__table {
         overflow-x: auto;
 
+        table {
+            border-right: 1px solid #a0a0a0;
+            border-bottom: 1px solid #a0a0a0;
+            border-left: 1px solid #a0a0a0;
+        }
+
         thead {
             background-color: #f5f5f5;
 
@@ -13,6 +19,11 @@
                 border-left: 1px solid #e0e0e0;
                 text-align: left;
 
+                a {
+                    color: #000;
+                    text-decoration: none;
+                }
+
                 &:first-child {
                     border-left: none;
                 }
@@ -20,8 +31,9 @@
         }
 
         td {
-        padding: 5px;
-        border-top: 1px solid #ddd;
+            padding: 5px;
+            border-top: 1px solid #ddd;
+            vertical-align: top;
         }
     }
 }
@@ -81,4 +93,95 @@
             height: 100%;
         }
     }
+}
+
+
+.report__table {
+    .table {
+        height: 1px; // Allow cell <div>s to have cell full height
+
+        thead {
+            background-color: #f5f5f5;
+
+            tr {
+                height: 1px; // Allow cell <div>s to have cell full height
+
+                th, td {
+                    padding: 0;
+                }
+
+                th {
+                    .icon {
+                        margin-left: 5px;
+                    }
+                }
+            }
+        }
+    }
+}
+
+.report-header-cell {
+    display: flex;
+    padding: 5px;
+    height: 100%;
+    justify-content: space-between;
+    align-items: center;
+    text-align: left;
+    white-space: nowrap;
+
+    &.report-header-cell--sortable {
+        &:hover {
+            background-color: #e0e0e0;
+        }
+    }
+}
+
+
+// Options for the number of items to display per report page.
+.page-limit-selector {
+    margin-bottom: 10px;
+
+    @media screen and (min-width: $screen-lg-min) {
+        margin-bottom: 0;
+    }
+
+    &__label {
+        margin-bottom: 2px;
+    }
+
+    &__options {
+        display: flex;
+    }
+
+    &__option {
+        display: flex;
+        height: 26px;
+        align-items: center;
+        padding: 0 10px;
+        border-top: 1px solid #c0c0c0;
+        border-bottom: 1px solid #c0c0c0;
+        border-left: 1px solid #c0c0c0;
+        font-weight: bold;
+        color: #000;
+
+        &:last-child {
+            border-right: 1px solid #c0c0c0;
+        }
+
+        &:hover {
+            background-color: #e0e0e0;
+            text-decoration: none;
+        }
+
+        &.page-limit-selector__option--selected {
+            color: #fff;
+            background-color: $brand-info;
+            pointer-events: none;
+        }
+    }
+}
+
+
+.report-max-warning {
+    margin: 10px 0 0;
 }

--- a/src/encoded/static/scss/encoded/modules/_search.scss
+++ b/src/encoded/static/scss/encoded/modules/_search.scss
@@ -320,6 +320,17 @@ $form-bg: #f3f3f3;
         }
     }
 
+    // /report/ pagination controls
+    @at-root #{&}__pager {
+        margin-bottom: 10px;
+
+        @media screen and (min-width: $screen-lg-min) {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-end;
+        }
+    }
+
     &--centered {
         justify-content: center;
     }

--- a/src/encoded/static/scss/encoded/modules/_search.scss
+++ b/src/encoded/static/scss/encoded/modules/_search.scss
@@ -322,7 +322,7 @@ $form-bg: #f3f3f3;
 
     // /report/ pagination controls
     @at-root #{&}__pager {
-        margin-bottom: 10px;
+        margin-bottom: 20px;
 
         @media screen and (min-width: $screen-lg-min) {
             display: flex;

--- a/src/encoded/static/scss/encoded/modules/_tables.scss
+++ b/src/encoded/static/scss/encoded/modules/_tables.scss
@@ -359,3 +359,12 @@ form.table-filter {
         }
     }
 }
+
+.table-item-count {
+    padding-top: 2px;
+    padding-bottom: 2px;
+    text-align: center;
+    font-size: 0.9rem;
+    color: #606060;
+    border: 1px solid #a0a0a0;
+}


### PR DESCRIPTION
* Nearly a complete rewrite of the /report/ page with these goals:
    * Document
    * Introduce a registry so alternate cell renderers can override default rendering without needing special-case code inline. Examples include the @id renderer that converts the @id of any object into a link to that object regardless of the type, and the image thumbnail renderer that only overrides the default rendering if the current report’s type is Image.
    * Include a new pagination mechanism so that users don’t need to scroll to the bottom to click the “Load More” button, and so the user can select the maximum number of items to view per page.
    * Eliminate the page blanking when making facet or sorting selections.
    * Make the data-extraction method — the process of converting property names from the schema columns to values in a displayable form — easier to maintain.
* The existing pager that only shows the current page between paging arrows still exists where it has already existed, but now both that and the new multi-page pager reside in pager.js, and you can select which pager to use within the Pager component.
* The data-extraction method now has two stages. One uses the dotted notation to extract embedded properties and flattens any array properties within. The second stage takes any complex values from the first stage and, depending on what the value looks like, displays a comma-separated list, an @id, or lists of stringified objects.
