### PR TITLE
ENCD-5623 add section breaks to glossary

### DIFF
--- a/src/encoded/static/components/app.js
+++ b/src/encoded/static/components/app.js
@@ -80,6 +80,7 @@ const portal = {
                 { id: 'references', title: 'Genome references', url: '/data-standards/reference-sequences/' },
                 { id: 'sep-mm-1' },
                 { id: 'datastandards', title: 'Assays and standards', url: '/data-standards/' },
+                { id: 'glossary', title: 'Glossary', url: '/glossary/' },
                 { id: 'fileformats', title: 'File formats', url: '/help/file-formats/' },
                 { id: 'softwaretools', title: 'Software tools', url: '/software/' },
                 { id: 'pipelines', title: 'Pipelines', url: '/pipelines/' },

--- a/src/encoded/static/components/glossary.js
+++ b/src/encoded/static/components/glossary.js
@@ -1,24 +1,77 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import _ from 'underscore';
 import * as globals from './globals';
+
+const GlossaryTerm = (props) => {
+    const term = props.glossaryEntry.term;
+    const definition = props.glossaryEntry.definition;
+    return (
+        <div className="glossary-element">
+            <h4 className="glossary-term">{term}</h4>
+            <p className="glossary-definition">{definition}</p>
+            {props.glossaryEntry.file_formats ?
+                <p className="glossary-extra-info">
+                    <span className="glossary-label">File formats: </span>
+                    <span className="glossary-field">{props.glossaryEntry.file_formats}</span>
+                </p>
+            : null}
+            {props.glossaryEntry.additional_information ?
+                <p className="glossary-extra-info">
+                    <span className="glossary-label">Additional information: </span>
+                    {props.glossaryEntry.additional_information.map(href =>
+                        <span className="glossary-field" key={href.url}>
+                            <a href={href.url}>{href.title}</a>
+                        </span>
+                    )}
+                </p>
+            : null}
+        </div>
+    );
+};
+
+GlossaryTerm.propTypes = {
+    glossaryEntry: PropTypes.object.isRequired,
+};
 
 const Glossary = (props) => {
     const { context } = props;
     const glossary = require('./glossary/glossary.json');
+    const glossaryBySection = _(glossary).groupBy(entry => entry.section || 'General terms');
 
     return (
         <div className="layout">
             <div className="layout__block layout__block--100">
-                <div className="ricktextblock block" data-pos="0,0,0">
+                <div className="richtextblock block" data-pos="0,0,0">
                     <center>
                         <h1>{context.title}</h1>
                     </center>
-                    {glossary.map(g => (
-                        <div key={g.term} className="glossary-element">
-                            <h4 className="glossary-term">{g.term}</h4>
-                            <p className="glossary-definition">{g.definition}</p>
+                    <h4 className="directory">
+                        {Object.keys(glossaryBySection).map((section, sectionIdx) =>
+                            <React.Fragment key={`${section}-link`}>
+                                <a href={`#${section.toLowerCase().split(' ').join('-')}`}>{section}</a>
+                                {(sectionIdx < Object.keys(glossaryBySection).length - 1) ?
+                                    <span> | </span>
+                                : null}
+                            </React.Fragment>
+                        )}
+                    </h4>
+                    {Object.keys(glossaryBySection).map(section =>
+                        <div className="glossary-block" key={section} id={section}>
+                            <h2 id={`${section.toLowerCase().split(' ').join('-')}`}>{section}</h2>
+                            {(section === undefined) ?
+                                <h4>{section}</h4>
+                            : null}
+                            {glossaryBySection[section]
+                                .sort((a, b) => {
+                                    if (a.term.toLowerCase() < b.term.toLowerCase()) { return -1; }
+                                    if (a.term.toLowerCase() > b.term.toLowerCase()) { return 1; }
+                                    return 0;
+                                })
+                                .map(entry => <GlossaryTerm glossaryEntry={entry} key={entry.term} id={entry.term} />)
+                            }
                         </div>
-                    ))}
+                    )}
                 </div>
             </div>
         </div>

--- a/src/encoded/static/components/navigation.js
+++ b/src/encoded/static/components/navigation.js
@@ -219,7 +219,7 @@ const GlobalSections = (props, context) => {
                         if (childAction.id.substring(0, 4) === 'sep-') {
                             return <DropdownMenuSep key={childAction.id} />;
                         }
-                        const glossaryMatch = glossary.find(def => def.term === childAction.title);
+                        const glossaryMatch = glossary.find(def => def.term.toLowerCase() === childAction.title.toLowerCase());
                         if (glossaryMatch) {
                             return (
                                 <div

--- a/src/encoded/static/scss/encoded/modules/_faq_glossary.scss
+++ b/src/encoded/static/scss/encoded/modules/_faq_glossary.scss
@@ -38,7 +38,62 @@
 }
 
 .glossary-element {
+    margin: 30px 0 0;
     h4 {
         font-size: 1.1rem;
+    }
+}
+
+.glossary-element a[href^="http"]:after {
+    content: " \f08e";
+    font-family: FontAwesome;
+    font-weight: normal;
+    font-style: normal;
+    text-decoration: none;
+    -webkit-font-smoothing: antialiased;
+
+    /* sprites.less reset */
+    display: inline;
+    line-height: normal;
+    vertical-align: baseline;
+    background-image: none;
+    background-position: 0% 0%;
+    background-repeat: repeat;
+}
+
+.block.richtextblock .glossary-element {
+    .glossary-extra-info {
+        margin: 0 0 0 25px;
+    }
+    .glossary-definition {
+        margin: 10px 0;
+        line-height: 1.3;
+    }
+}
+
+.glossary-block {
+    padding-bottom: 30px;
+}
+
+.glossary-field {
+    a {
+        padding-right: 10px;
+    }
+}
+
+.directory {
+    text-align: center;
+    font-size: 1.2rem;
+    margin-bottom: 40px;
+}
+
+hr {
+    border-color: #c0c0c0;
+}
+
+@media screen and (min-width: 960px) {
+    hr {
+        margin-left: -10%;
+        margin-right: -10%;
     }
 }


### PR DESCRIPTION
Updates:
- Glossary entries can now include lists of file formats and additional information (links) in addition to their definitions
- Definitions are grouped based on a "section" property (if there is no "section" property they are grouped under "General terms") and are alphabetized within those groups
- Section links appear as headers and are displayed at the top so you can scroll to any particular section quickly
- Navigation terms are capitalized in the navigation but not in the glossary so there was a small fix for that