### PR TITLE
ENCD-5615 Change cart search for more efficiency

### DIFF
--- a/src/encoded/static/components/app.js
+++ b/src/encoded/static/components/app.js
@@ -11,6 +11,7 @@ import jsonScriptEscape from '../libs/jsonScriptEscape';
 import origin from '../libs/origin';
 import { BrowserFeat } from './browserfeat';
 import cartStore, {
+    CartAlert,
     cartCacheSaved,
     cartIsUnsaved,
     cartSetOperationInProgress,
@@ -1242,6 +1243,7 @@ class App extends React.Component {
                                     </div>
                                     {errors}
                                     <div id="layout-footer" />
+                                    <CartAlert />
                                 </div>
                             </Provider>
                             {this.state.eulaModalVisibility ?

--- a/src/encoded/static/components/cart/actions.js
+++ b/src/encoded/static/components/cart/actions.js
@@ -15,6 +15,7 @@ export const REMOVE_MULTIPLE_FROM_CART = 'REMOVE_MULTIPLE_FROM_CART';
 export const REPLACE_CART = 'REPLACE_CART';
 export const CACHE_SAVED_CART = 'CACHE_SAVED_CART';
 export const CART_OPERATION_IN_PROGRESS = 'CART_OPERATION_IN_PROGRESS';
+export const DISPLAY_ALERT = 'DISPLAY_ALERT';
 export const SET_CURRENT = 'SET_CURRENT';
 export const SET_NAME = 'SET_NAME';
 export const SET_IDENTIFIER = 'SET_IDENTIFIER';
@@ -174,6 +175,21 @@ export const cacheSavedCart = savedCartObj => (
  */
 export const cartOperationInProgress = inProgress => (
     { type: CART_OPERATION_IN_PROGRESS, inProgress }
+);
+
+
+/**
+ * Redux action creator to indicate that <App> should display the given cart-related alert (in the
+ * form of a React component). The component that renders the alert should normally wrap it in the
+ * libs/ui/modal.js components. This is useful for cart alerts that might not appear right away,
+ * allowing the user to navigate to a different page before the alert appears. Alerts that you know
+ * appear right away should simply display them in their own React components.
+ * @param {object} alert React component to display alert modal
+ *
+ * @return {object} Redux action to display an alert.
+ */
+export const triggerAlert = alert => (
+    { type: DISPLAY_ALERT, alert }
 );
 
 

--- a/src/encoded/static/components/cart/cart_alert.js
+++ b/src/encoded/static/components/cart/cart_alert.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+
+/**
+ * Display an alert relevant to the cart, or hide an already-visible one. The alert React component
+ * gets set in the cart Redux store `alert` property.
+ */
+const CartAlertComponent = ({ alert }) => (
+    <>{alert ? <>{alert}</> : null}</>
+);
+
+CartAlertComponent.propTypes = {
+    /** React component for alert */
+    alert: PropTypes.object,
+};
+
+CartAlertComponent.defaultProps = {
+    alert: null,
+};
+
+CartAlertComponent.mapStateToProps = state => ({
+    alert: state.alert,
+});
+
+const CartAlert = connect(CartAlertComponent.mapStateToProps)(CartAlertComponent);
+
+export default CartAlert;

--- a/src/encoded/static/components/cart/index.js
+++ b/src/encoded/static/components/cart/index.js
@@ -23,6 +23,7 @@ import {
     REPLACE_CART,
     CACHE_SAVED_CART,
     CART_OPERATION_IN_PROGRESS,
+    DISPLAY_ALERT,
     SET_CURRENT,
     SET_NAME,
     SET_IDENTIFIER,
@@ -31,6 +32,7 @@ import {
     NO_ACTION,
 } from './actions';
 import cartAddElements from './add_elements';
+import CartAlert from './cart_alert';
 import { CartAddAllSearch, CartAddAllElements } from './add_multiple';
 import cartCacheSaved from './cache_saved';
 import CartBatchDownload from './batch_download';
@@ -48,7 +50,14 @@ import CartShare from './share';
 import CartStatus from './status';
 import switchCart from './switch';
 import CartToggle from './toggle';
-import { mergeCarts, cartGetAllowedTypes, cartGetAllowedObjectPathTypes } from './util';
+import {
+    cartGetAllowedObjectPathTypes,
+    cartGetAllowedTypes,
+    getCartSearchTypes,
+    getIsCartSearch,
+    mergeCarts,
+    CART_MAX_ELEMENTS,
+} from './util';
 
 
 /**
@@ -99,6 +108,8 @@ const cartModule = (state, action = { type: NO_ACTION }) => {
             });
         case CART_OPERATION_IN_PROGRESS:
             return Object.assign({}, state, { inProgress: action.inProgress });
+        case DISPLAY_ALERT:
+            return Object.assign({}, state, { alert: action.alert });
         case SET_NAME:
             return Object.assign({}, state, { name: action.name });
         case SET_IDENTIFIER:
@@ -160,6 +171,8 @@ const initializeCart = () => {
         savedCartObj: {},
         /** Indicates cart operations currently in progress */
         inProgress: false,
+        /** React component of alert to display */
+        alert: null,
     };
     return createStore(cartModule, initialCart, applyMiddleware(thunk));
 };
@@ -175,6 +188,7 @@ const cartStore = initializeCart();
 export {
     CartAddAllSearch,
     CartAddAllElements,
+    CartAlert,
     CartBatchDownload,
     cartCacheSaved,
     CartClear,
@@ -200,6 +214,9 @@ export {
     CartManager,
     cartGetAllowedTypes,
     cartGetAllowedObjectPathTypes,
+    getCartSearchTypes,
+    getIsCartSearch,
+    CART_MAX_ELEMENTS,
 };
 
 

--- a/src/encoded/static/components/cart/max_elements_warning.js
+++ b/src/encoded/static/components/cart/max_elements_warning.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { Modal, ModalHeader, ModalBody, ModalFooter } from '../../libs/ui/modal';
+import { triggerAlert } from './actions';
+import { CART_MAX_ELEMENTS } from './util';
+
+
+/**
+ * Display a modal warning the user that they cannot add any more elements to the cart because
+ * they've hit the maximum allowed number of elements in a cart.
+ */
+const CartMaxElementsWarningComponent = ({ closeMaxElementsWarning }) => {
+    /** Ref to the submit button so we can focus it on mount */
+    const submitButton = React.useRef(null);
+
+    /**
+     * Called when the use clicks the modal's Close button.
+     */
+    const handleClose = () => {
+        closeMaxElementsWarning();
+    };
+
+    React.useEffect(() => {
+        // The submit button has the title "Close" in this case.
+        submitButton.current.focus();
+    }, []);
+
+    return (
+        <Modal closeModal={handleClose}>
+            <ModalHeader title="Cart maximum size" closeModal={handleClose} />
+            <ModalBody>
+                Carts can hold a maximum of {CART_MAX_ELEMENTS} datasets.
+            </ModalBody>
+            <ModalFooter submitBtn={<button ref={submitButton} onClick={handleClose} className="btn btn-info">Close</button>} />
+        </Modal>
+    );
+};
+
+CartMaxElementsWarningComponent.propTypes = {
+    closeMaxElementsWarning: PropTypes.func.isRequired,
+};
+
+CartMaxElementsWarningComponent.mapDispatchToProps = dispatch => ({
+    closeMaxElementsWarning: () => dispatch(triggerAlert(null)),
+});
+
+const CartMaxElementsWarning = connect(null, CartMaxElementsWarningComponent.mapDispatchToProps)(CartMaxElementsWarningComponent);
+
+export default CartMaxElementsWarning;

--- a/src/encoded/static/components/cart/util.js
+++ b/src/encoded/static/components/cart/util.js
@@ -2,6 +2,15 @@
  * Small, general components and functions needed by other cart modules.
  */
 
+import _ from 'underscore';
+import url from 'url';
+
+
+/**
+ * Maximum number of items allowed in a cart.
+ */
+export const CART_MAX_ELEMENTS = 8000;
+
 
 /**
  * List of dataset types allowed in carts. Maps from collection names to corresponding data:
@@ -24,7 +33,7 @@ export const defaultDatasetType = {
 
 
 /**
- * Get a mutatable array of dataset types allowed in carts, i.e. an array of types on the right-
+ * Get a mutable array of dataset types allowed in carts, i.e. an array of types on the right-
  * hand side of "type=<dataset type>" in a query string.
  * @return {array} Copy of `allowedCartTypes` global
  */
@@ -34,7 +43,7 @@ export const cartGetAllowedTypes = () => (
 
 
 /**
- * Get a mutatable array of object path types allowed in carts, i.e. the part in an object path:
+ * Get a mutable array of object path types allowed in carts, i.e. the part in an object path:
  * /{object path type}/{accession}/ e.g. /experiments/ENCSR000AAA/
  * @return {array} Copy of `allowedCartTypes` global
  */
@@ -67,11 +76,34 @@ export const isAllowedElementsPossible = (resultFilters) => {
 
 /**
  * Return a new array containing the merged contents of two carts with no duplicates. Contains odd
- * ES6 syntax to merge, clone, and dedupe arrays in one operation.
+ * ES6 syntax to merge, clone, and de-dupe arrays in one operation.
  * https://stackoverflow.com/questions/1584370/how-to-merge-two-arrays-in-javascript-and-de-duplicate-items#answer-38940354
  * @param {array} cart0AtIds Array of @ids in one cart
  * @param {array} cart1AtIds Array of @ids to merge with `cart0AtIds`
  */
 export const mergeCarts = (cart0AtIds, cart1AtIds) => (
     [...new Set([...cart0AtIds, ...cart1AtIds])]
+);
+
+
+/**
+ * Determine whether the given search results is for a cart search or not.
+ * @param {object} context Search-results object
+ *
+ * @return {boolean} True if search results are for a cart search.
+ */
+const cartSearchPaths = ['/cart-search/', '/cart-matrix/', '/cart-report/'];
+export const getIsCartSearch = (context) => {
+    const pathName = url.parse(context['@id']).pathname;
+    return cartSearchPaths.includes(pathName);
+};
+
+/**
+ * Get array of @types of objects that exist in the given cart search results.
+ * @param {object} context /cart-search/ results
+ *
+ * @return {array} @types of all elements in the cart search results, de-duped.
+ */
+export const getCartSearchTypes = context => (
+    _.uniq(context['@graph'].map(result => result['@type'][0]))
 );

--- a/src/encoded/static/components/facets/index.js
+++ b/src/encoded/static/components/facets/index.js
@@ -17,6 +17,7 @@ import './internal_status';
 import './organism';
 import './perturbed';
 import './status';
+import './supressed';
 import './type';
 
 

--- a/src/encoded/static/components/facets/supressed.js
+++ b/src/encoded/static/components/facets/supressed.js
@@ -1,0 +1,9 @@
+import FacetRegistry from './registry';
+
+
+/**
+ * Used for all facets that need suppression unconditionally.
+ */
+const SuppressedFacet = () => null;
+
+FacetRegistry.Facet.register('cart', SuppressedFacet);

--- a/src/encoded/static/components/globals.js
+++ b/src/encoded/static/components/globals.js
@@ -44,6 +44,13 @@ documentViews.preview = new Registry();
 documentViews.file = new Registry();
 documentViews.detail = new Registry();
 
+// UNICODE entity codes, needed in JSX string templates. Each property named after the equivalent
+// HTML entity. Add new entries to this object as needed.
+export const uc = {
+    ldquo: '\u201c', // Left double quote
+    rdquo: '\u201d', // Right double quote
+};
+
 // Report-page cell components
 export const reportCell = new Registry();
 

--- a/src/encoded/static/components/view_controls.js
+++ b/src/encoded/static/components/view_controls.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import * as encoding from '../libs/query_encoding';
 import { Modal, ModalHeader, ModalBody, ModalFooter } from '../libs/ui/modal';
 import { svgIcon } from '../libs/svg-icons';
+import { getIsCartSearch } from './cart';
 
 
 /**
@@ -77,7 +78,7 @@ const modalDefaultText = (
 
 /**
  * Generate a query string from the elements of the `filters` property of search results. All
- * "type" queries come first, followed by other fields, followed by "searchTerm" quries.
+ * "type" queries come first, followed by other fields, followed by "searchTerm" queries.
  * @param {array} filters From `filters` property of search results
  *
  * @return {string} Ampersand-separated query string, not including initial question mark.
@@ -95,6 +96,11 @@ const getQueryFromFilters = (filters) => {
  * Displays view control buttons appropriate for the given search results.
  */
 export const ViewControls = ({ results, additionalFilters }) => {
+    // Don't render view controls for cart searches.
+    if (getIsCartSearch(results)) {
+        return null;
+    }
+
     const filters = results.filters.concat(additionalFilters);
     const searchPageType = getSearchPageType(results);
 

--- a/src/encoded/static/scss/encoded/_base.scss
+++ b/src/encoded/static/scss/encoded/_base.scss
@@ -245,6 +245,10 @@ $disabled-color-factor: 20%;
         @include button-size($padding-xs-vertical, $padding-xs-horizontal, $font-size-small, $btn-height-xs, $border-radius-small);
     }
 
+    @at-root button#{&} {
+        display: flex;
+    }
+
     @at-root a#{&} {
         text-decoration: none;
         display: flex;
@@ -420,7 +424,7 @@ pre code {
     @at-root #{&}__content {
         position: absolute;
         top: 100%;
-        right: 0;
+        left: 0;
         margin: 4px 0;
         padding: 0;
         width: 300px;

--- a/src/encoded/static/scss/encoded/modules/_audits.scss
+++ b/src/encoded/static/scss/encoded/modules/_audits.scss
@@ -24,6 +24,7 @@ $audit-group-height: 40px;
 
     &.audit-search {
         font-size: 0.85rem;
+        margin-left: auto;
     }
 
     // Styling when inside .item-accessories <div>

--- a/src/encoded/static/scss/encoded/modules/_cart.scss
+++ b/src/encoded/static/scss/encoded/modules/_cart.scss
@@ -1204,20 +1204,13 @@ $file-type-colors: (
     }
 }
 
-// Cart-tools buttons that stay side by side even on mobile.
-.cart-tools-extras {
+// Cart-accessories buttons.
+.cart-accessories {
     display: flex;
-    align-content: stretch;
     margin-bottom: 5px;
 
-    @media screen and (min-width: $screen-md-min) {
+    .cart-accessories__button {
         margin-right: 5px;
-        margin-bottom: 0;
-    }
-
-    .cart-tools-extras__button {
-        margin-right: 5px;
-        flex-grow: 1;
 
         &:last-child {
             margin-right: 0;
@@ -1265,5 +1258,43 @@ $file-type-colors: (
 
     @media screen and (min-width: $screen-md-min) {
         width: auto;
+    }
+}
+
+// Contents of the type-selection modal for /cart-search/ page, Report view control button.
+.cart-type-selector {
+    display: flex;
+    justify-content: center;
+
+    .btn {
+        margin-left: 2.5px;
+        margin-right: 2.55px;
+    }
+}
+
+// "Dataset report" button on the cart view page.
+.cart-dataset-report {
+    button {
+        @extend .btn-info;
+        @extend .btn-sm;
+        width: 100%;
+
+        > svg {
+            margin-left: 5px;
+            width: 8px;
+            fill: #fff;
+        }
+    }
+
+    .dropdown-button__content {
+        a {
+            font-family: Quicksand, sans-serif;
+            font-weight: 400;
+            font-size: 1rem;
+
+            &:hover {
+                text-decoration: none;
+            }
+        }
     }
 }

--- a/src/encoded/static/scss/encoded/modules/_panels.scss
+++ b/src/encoded/static/scss/encoded/modules/_panels.scss
@@ -461,7 +461,7 @@ a[href^="http://encodedcc.sdsc.edu/warehouse/"]:after {
     padding: 0 5px;
 }
 
-$file-gallery-controls-height: 34px; // Heit of controls inside file-gallery-controls
+$file-gallery-controls-height: 34px; // Height of controls inside file-gallery-controls
 
 .file-gallery-controls {
     display: flex;
@@ -485,8 +485,10 @@ $file-gallery-controls-height: 34px; // Heit of controls inside file-gallery-con
     }
 
     @at-root #{&}__visualization-selector {
+        display: flex;
+
         select {
-            display: inline-block;
+            display: block;
             height: $file-gallery-controls-height;
             width: auto;
             margin-right: 5px;


### PR DESCRIPTION
The main goals of this ticket included changing the “Dataset search” button on the cart-view page to not build a big URL containing each `@id` of the datasets in the cart, but to instead use the new /cart-search/, /cart-matrix/, and /cart-report/ endpoints. Of these, this ticket uses /cart-report/ only and renames that button “Dataset report” on the cart-view page because it now leads to a report page instead of a search-list page.

The other main goal limited the size of carts to 8000 items to go with the /cart-report/ limit of returning a maximum of 8000 items. This brought up the old issue with the modal alerting the user that they have attempted to add more than the allowed number of items, and the modal not appearing if you navigate away from the page before the cart code could determine this. I solved this by making a new `<CartAlert />` component owned by `<App>` that can display any cart-related alert in a component (`<App>`) that doesn't get dismounted when you navigate. So if you attempt to add a lot of datasets to the cart and navigate to a new page before the cart code is done figuring out if it should display an alert, you still get the alert regardless of what page you navigated to.

I ran out of room in the header of the cart-view page panel, so I moved the Merge, Lock, and Clear buttons out of the panel header and put it just below the title, in the `<CartAccessories>` component.
