### PR TITLE
ENCD-5743 add glossary link

### DIFF
--- a/src/encoded/static/components/glossary.js
+++ b/src/encoded/static/components/glossary.js
@@ -18,9 +18,10 @@ const GlossaryTerm = (props) => {
             {props.glossaryEntry.additional_information ?
                 <p className="glossary-extra-info">
                     <span className="glossary-label">Additional information: </span>
-                    {props.glossaryEntry.additional_information.map((href) => (
+                    {props.glossaryEntry.additional_information.map((href, hrefIndex) => (
                         <span className="glossary-field" key={href.url}>
                             <a href={href.url}>{href.title}</a>
+                            <span>{((props.glossaryEntry.additional_information.length > 1) && hrefIndex < (props.glossaryEntry.additional_information.length - 1)) ? ', ' : ''}</span>
                         </span>
                     ))}
                 </p>

--- a/src/encoded/static/components/glossary.js
+++ b/src/encoded/static/components/glossary.js
@@ -33,6 +33,14 @@ GlossaryTerm.propTypes = {
     glossaryEntry: PropTypes.object.isRequired,
 };
 
+// Optional links appended to section headers
+const sectionHeaderLinks = {
+    'Target categories': {
+        link: 'https://www.encodeproject.org/target-categorization/',
+        text: 'Category assignment details',
+    },
+};
+
 const Glossary = (props) => {
     const { context } = props;
     const glossary = require('./glossary/glossary.json');
@@ -57,7 +65,12 @@ const Glossary = (props) => {
                     </h4>
                     {Object.keys(glossaryBySection).map((section) => (
                         <div className="glossary-block" key={section} id={section}>
-                            <h2 id={`${section.toLowerCase().split(' ').join('-')}`}>{section}</h2>
+                            <h2 id={`${section.toLowerCase().split(' ').join('-')}`}>
+                                {section}
+                                {sectionHeaderLinks[section] ?
+                                    <span className="section-header-link"><a href={sectionHeaderLinks[section].link}>{sectionHeaderLinks[section].text}</a></span>
+                                : null}
+                            </h2>
                             {(section === undefined) ?
                                 <h4>{section}</h4>
                             : null}

--- a/src/encoded/static/scss/encoded/modules/_faq_glossary.scss
+++ b/src/encoded/static/scss/encoded/modules/_faq_glossary.scss
@@ -51,23 +51,6 @@
     }
 }
 
-.glossary-element a[href^="http"]::after, .section-header-link a[href^="http"]::after {
-    content: " \f08e";
-    font-family: FontAwesome;
-    font-weight: normal;
-    font-style: normal;
-    text-decoration: none;
-    -webkit-font-smoothing: antialiased;
-
-    /* sprites.less reset */
-    display: inline;
-    line-height: normal;
-    vertical-align: baseline;
-    background-image: none;
-    background-position: 0% 0%;
-    background-repeat: repeat;
-}
-
 .block.richtextblock .glossary-element {
     .glossary-extra-info {
         margin: 0 0 0 25px;

--- a/src/encoded/static/scss/encoded/modules/_faq_glossary.scss
+++ b/src/encoded/static/scss/encoded/modules/_faq_glossary.scss
@@ -77,12 +77,6 @@
     }
 }
 
-.glossary-field {
-    a {
-        padding-right: 10px;
-    }
-}
-
 .directory {
     text-align: center;
     font-size: 1.2rem;

--- a/src/encoded/static/scss/encoded/modules/_faq_glossary.scss
+++ b/src/encoded/static/scss/encoded/modules/_faq_glossary.scss
@@ -51,7 +51,7 @@
     }
 }
 
-.glossary-element a[href^="http"]::after {
+.glossary-element a[href^="http"]::after, .section-header-link a[href^="http"]::after {
     content: " \f08e";
     font-family: FontAwesome;
     font-weight: normal;
@@ -81,6 +81,17 @@
 
 .glossary-block {
     padding-bottom: 30px;
+
+    .section-header-link {
+        font-size: 1rem;
+        font-family: $site-font;
+        margin-left: 10px;
+        display: block;
+
+        @media screen and (min-width: $screen-sm-min) {
+            display: inline-block;
+        }
+    }
 }
 
 .glossary-field {


### PR DESCRIPTION
Adds a link to GO annotations on the target categorization page to the glossary header "Target categories". It could be extended if we want to append links to other headers as well -- not really sure if we expect to want to do that.