### PR TITLE
ENCD-5744 DOI

### DIFF
--- a/src/encoded/static/components/__tests__/cart-test.js
+++ b/src/encoded/static/components/__tests__/cart-test.js
@@ -14,7 +14,6 @@ import {
     CART_OPERATION_IN_PROGRESS,
 } from '../cart/actions';
 import { isAllowedElementsPossible } from '../cart/util';
-import { sortDatasetAnalyses } from '../cart/analysis';
 
 // Temporary use of adapter until Enzyme is compatible with React 17.
 Enzyme.configure({ adapter: new Adapter() });
@@ -435,73 +434,5 @@ describe('Cart manager while logged in as admin', () => {
         const tableRows = cartManager.find('.table.table__sortable tbody tr');
         expect(tableRows.at(0).find('.cart-manager-table__autosave-row')).toHaveLength(1);
         expect(tableRows.at(2).find('.cart-manager-table__current-row')).toHaveLength(1);
-    });
-});
-
-describe('Compiled analysis sorting', () => {
-    let analyses;
-
-    beforeAll(() => {
-        analyses = [
-            {
-                title: 'ENCODE3 v1.2.3 hg19',
-                status: 'released',
-                lab: 'ENCODE3',
-                version: '1.2.3',
-                assembly: 'hg19',
-                annotation: '',
-                assemblyAnnotationValue: 19.5,
-                files: ['/files/ENCFF101RCZ/'],
-            },
-            {
-                title: 'ENCODE3 v0.0.4 hg19 V19',
-                status: 'in progress',
-                lab: 'ENCODE3',
-                version: '0.0.4',
-                assembly: 'hg19',
-                annotation: 'V19',
-                assemblyAnnotationValue: 19.5019,
-                files: ['/files/ENCFF001RCV/', '/files/ENCFF001RCZ/'],
-            },
-            {
-                title: 'ENCODE3 GRCh38',
-                status: 'released',
-                lab: '',
-                version: '',
-                assembly: 'GRCh38',
-                annotation: '',
-                assemblyAnnotationValue: 38.5,
-                files: [
-                    '/files/ENCFF684NLR/',
-                    '/files/ENCFF651UIO/',
-                    '/files/ENCFF858ORL/',
-                    '/files/ENCFF231IAK/',
-                    '/files/ENCFF797ARJ/',
-                    '/files/ENCFF611CHF/',
-                    '/files/ENCFF873ZWP/',
-                    '/files/ENCFF953EVD/',
-                    '/files/ENCFF303HPA/',
-                    '/files/ENCFF434HLD/',
-                    '/files/ENCFF852TVX/',
-                    '/files/ENCFF547XEQ/',
-                ],
-            },
-            {
-                title: 'Lab custom v10.20.30 GRCh38 V24',
-                status: 'released',
-                lab: 'Lab custom',
-                version: '10.20.30',
-                assembly: 'GRCh38',
-                annotation: 'V24',
-                assemblyAnnotationValue: 38.5024,
-                files: ['/files/ENCFF003MRN/', '/files/ENCFF005MRN/'],
-            },
-        ];
-    });
-
-    test('Compiled analyses sort correctly', () => {
-        const sorted = sortDatasetAnalyses(analyses);
-        console.log(sorted);
-        expect([]).toHaveLength(0);
     });
 });

--- a/src/encoded/static/components/cart/share.js
+++ b/src/encoded/static/components/cart/share.js
@@ -6,74 +6,53 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import url from 'url';
 import { Modal, ModalHeader, ModalBody, ModalFooter } from '../../libs/ui/modal';
+import { CopyButton, useMount } from '../objectutils';
 
 
 /**
  * Internal component to display and process the modal used to share a cart URL. The copyable cart
  * URL gets placed into a read-only <input> element.
  */
-class CartShareComponent extends React.Component {
-    constructor() {
-        super();
-        this.copyUrl = this.copyUrl.bind(this);
-    }
+const CartShareComponent = ({ userCart, locationHref, closeShareCart, inProgress }) => {
+    /** Modal Visit Sharable Cart button */
+    const submitRef = React.useRef(null);
 
-    /**
-     * Called when the user clicks the Copy button to copy the URL to the clipboard.
-     */
-    copyUrl() {
-        // Get the URL text <input> element in the DOM and select all of the text in it to copy to
-        // the user's clipboard.
-        // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Interact_with_the_clipboard#Using_execCommand()
-        this.cartUrlBox.select();
+    // Generate the shared cart URL.
+    const parsedUrl = url.parse(locationHref);
+    Object.assign(parsedUrl, {
+        pathname: userCart['@id'],
+        search: '',
+        query: '',
+    });
+    const sharableUrl = url.format(parsedUrl);
 
-        // Execute copy command. Firefox can throw errors on rare occasion. As this is so unusual,
-        // we just show a console warning in that case.
-        try {
-            document.execCommand('copy');
-        } catch (err) {
-            console.warn('Text copy failed.');
-        }
+    useMount(() => {
+        // Focus on the Visit Sharable Cart button on mount.
+        submitRef.current.focus();
+    });
 
-        // Remove the selection after copying.
-        this.cartUrlBox.setSelectionRange(0, 0);
-    }
-
-    render() {
-        const { userCart, locationHref, closeShareCart, inProgress } = this.props;
-
-        // Generate the shared cart URL.
-        const parsedUrl = url.parse(locationHref);
-        Object.assign(parsedUrl, {
-            pathname: userCart['@id'],
-            search: '',
-            query: '',
-        });
-        const sharableUrl = url.format(parsedUrl);
-
-        return (
-            <Modal closeModal={closeShareCart} labelId="share-cart-label" descriptionId="share-cart-description" focusId="share-cart-close">
-                <ModalHeader title={`Share cart: ${userCart.name}`} labelId="share-cart-label" closeModal={closeShareCart} />
-                <ModalBody>
-                    <p id="share-cart-description" role="document">
-                        Copy the URL below to share with other people. Some items might not appear
-                        for all people depending on whether they have logged in or not.
-                    </p>
-                    <div className="cart__share-url">
-                        <input ref={(input) => { this.cartUrlBox = input; }} type="text" aria-label="Sharable cart URL" value={sharableUrl} readOnly />
-                        <button type="button" id="cart-share-url-trigger" aria-label="Copy shared cart URL" onClick={this.copyUrl} className="btn btn-sm"><i className="icon icon-clipboard" />&nbsp;Copy</button>
-                    </div>
-                </ModalBody>
-                <ModalFooter
-                    closeModal={closeShareCart}
-                    cancelTitle="Close"
-                    submitBtn={<a data-bypass="true" disabled={inProgress} target="_self" className="btn btn-info" href={sharableUrl}>Visit sharable cart</a>}
-                    closeId="share-cart-close"
-                />
-            </Modal>
-        );
-    }
-}
+    return (
+        <Modal closeModal={closeShareCart} labelId="share-cart-label" descriptionId="share-cart-description" focusId="share-cart-close">
+            <ModalHeader title={`Share cart: ${userCart.name}`} labelId="share-cart-label" closeModal={closeShareCart} />
+            <ModalBody>
+                <p id="share-cart-description" role="document">
+                    Copy the URL below to share with other people. Some items might not appear
+                    for all people depending on whether they have logged in or not.
+                </p>
+                <div className="cart__share-url">
+                    <input type="text" aria-label="Sharable cart URL" value={sharableUrl} readOnly />
+                    <CopyButton label="Copy shared cart URL" copyText={sharableUrl} css="btn-sm cart__share-button" />
+                </div>
+            </ModalBody>
+            <ModalFooter
+                closeModal={closeShareCart}
+                cancelTitle="Close"
+                submitBtn={<a data-bypass="true" ref={submitRef} disabled={inProgress} target="_self" className="btn btn-info" href={sharableUrl}>Visit sharable cart</a>}
+                closeId="share-cart-close"
+            />
+        </Modal>
+    );
+};
 
 CartShareComponent.propTypes = {
     /** Logged-in users's cart object */

--- a/src/encoded/static/components/dataset.js
+++ b/src/encoded/static/components/dataset.js
@@ -17,7 +17,7 @@ import { ProjectBadge } from './image';
 import { DocumentsPanelReq } from './doc';
 import { FileGallery, DatasetFiles } from './filegallery';
 import sortMouseArray from './matrix_mouse_development';
-import { AwardRef, ReplacementAccessions, ControllingExperiments, FileTablePaged, ExperimentTable } from './typeutils';
+import { AwardRef, ReplacementAccessions, ControllingExperiments, FileTablePaged, ExperimentTable, DoiRef } from './typeutils';
 
 // Return a summary of the given biosamples, ready to be displayed in a React component.
 export function annotationBiosampleSummary(annotation) {
@@ -83,6 +83,7 @@ const AnnotationComponent = (props, reactContext) => {
             <header>
                 <TopAccessories context={context} crumbs={crumbs} />
                 <h1>Summary for annotation file set {context.accession}</h1>
+                <DoiRef context={context} />
                 <ReplacementAccessions context={context} />
                 <ItemAccessories item={context} audit={{ auditIndicators, auditId: 'annotation-audit' }} hasCartControls />
             </header>
@@ -289,6 +290,7 @@ const PublicationDataComponent = ({ context, auditIndicators, auditDetail }, rea
             <header>
                 <TopAccessories context={context} crumbs={crumbs} />
                 <h1>Summary for publication file set {context.accession}</h1>
+                <DoiRef context={context} />
                 <div className="replacement-accessions">
                     <AlternateAccession altAcc={context.alternate_accessions} />
                 </div>
@@ -456,6 +458,7 @@ const ComputationalModelComponent = (props, reactContext) => {
             <header>
                 <TopAccessories context={context} crumbs={crumbs} />
                 <h1>Summary for computational model file set {context.accession}</h1>
+                <DoiRef context={context} />
                 <div className="replacement-accessions">
                     <AlternateAccession altAcc={context.alternate_accessions} />
                 </div>
@@ -610,6 +613,7 @@ const ReferenceComponent = (props, reactContext) => {
             <header>
                 <TopAccessories context={context} crumbs={crumbs} />
                 <h1>Summary for reference file set {context.accession}</h1>
+                <DoiRef context={context} />
                 <div className="replacement-accessions">
                     <AlternateAccession altAcc={context.alternate_accessions} />
                 </div>
@@ -808,6 +812,7 @@ const ProjectComponent = (props, reactContext) => {
             <header>
                 <TopAccessories context={context} crumbs={crumbs} />
                 <h1>Summary for project file set {context.accession}</h1>
+                <DoiRef context={context} />
                 <div className="replacement-accessions">
                     <AlternateAccession altAcc={context.alternate_accessions} />
                 </div>
@@ -987,6 +992,7 @@ const UcscBrowserCompositeComponent = (props, reactContext) => {
             <header>
                 <TopAccessories context={context} crumbs={crumbs} />
                 <h1>Summary for UCSC browser composite file set {context.accession}</h1>
+                <DoiRef context={context} />
                 <div className="replacement-accessions">
                     <AlternateAccession altAcc={context.alternate_accessions} />
                 </div>
@@ -1796,6 +1802,7 @@ export const SeriesComponent = (props, reactContext) => {
             <header>
                 <TopAccessories context={context} crumbs={crumbs} />
                 <h1>Summary for {seriesTitle} {context.accession}</h1>
+                <DoiRef context={context} />
                 <ReplacementAccessions context={context} />
                 <ItemAccessories item={context} audit={{ auditIndicators, auditId: 'series-audit' }} hasCartControls={seriesType === 'FunctionalCharacterizationSeries'} />
             </header>

--- a/src/encoded/static/components/dbxref.js
+++ b/src/encoded/static/components/dbxref.js
@@ -287,18 +287,12 @@ export function dbxrefHref(prefix, value) {
 
 
 /**
- * Internal component to display one dbxref as a string. It handles calling the pre- and post-
- * processor from `dbxrefPrefixMap` above, and looking up the URL for the given dbxref. It
- * generates either a link with the generated URL for the given dbxref and the dbxref itself as the
- * link text, o just the dbxref in a <span> if we don't have that dbxref in `dbxrefPrefixMap`.
- *
- * @prop {string} dbxref - String containing one dbxref string.
- * @prop {object} context - Object (Experiment, HumanDonor, etc.) containing the dbxref being
- *     displayed.
- * @prop {title} title - String that is displayed instead of Dbxref string. Optional.
+ * Display one dbxref. It handles calling the pre- and post- processor from `dbxrefPrefixMap`
+ * above, and looking up the URL for the given dbxref. It generates either a link with the
+ * generated URL for the given dbxref and the dbxref itself as the link text, or just the dbxref in
+ * a <span> if we don't have that dbxref in `dbxrefPrefixMap`.
  */
-const DbxrefUrl = (props) => {
-    const { dbxref, context, title } = props;
+export const DbxrefUrl = ({ dbxref, context, title, displayRef }) => {
     const displayTitle = title || dbxref;
     // Standard dbxref pattern: {prefix}:{value}. If the dbxref has more than one colon, only the
     // first colon splits the dbxref into `prefix` and `value`. The other colons get included as
@@ -333,7 +327,7 @@ const DbxrefUrl = (props) => {
         }
 
         // Return the final dbxref as a link.
-        return <a href={url}>{displayTitle}</a>;
+        return <a href={url} ref={displayRef}>{displayTitle}</a>;
     }
 
     // The dbxref prefix didn't map to anything we know about, so just display the dbxref as
@@ -342,13 +336,19 @@ const DbxrefUrl = (props) => {
 };
 
 DbxrefUrl.propTypes = {
-    dbxref: PropTypes.string.isRequired, // dbxref string
-    context: PropTypes.object.isRequired, // Object that contains the dbxref
-    title: PropTypes.string, // title string displayed instead of dbxref string
+    /** dbxref string */
+    dbxref: PropTypes.string.isRequired,
+    /** Object that contains the dbxref */
+    context: PropTypes.object.isRequired,
+    /** title string displayed instead of dbxref string */
+    title: PropTypes.string,
+    /** React ref for the dbxref link */
+    displayRef: PropTypes.object,
 };
 
 DbxrefUrl.defaultProps = {
     title: '',
+    displayRef: null,
 };
 
 

--- a/src/encoded/static/components/experiment.js
+++ b/src/encoded/static/components/experiment.js
@@ -14,7 +14,16 @@ import { singleTreatment, ItemAccessories, InternalTags, TopAccessories } from '
 import pubReferenceList from './reference';
 import { SortTablePanel, SortTable } from './sorttable';
 import Status from './status';
-import { BiosampleSummaryString, BiosampleOrganismNames, CollectBiosampleDocs, AwardRef, ReplacementAccessions, ControllingExperiments, ExperimentTable } from './typeutils';
+import {
+    AwardRef,
+    BiosampleSummaryString,
+    BiosampleOrganismNames,
+    CollectBiosampleDocs,
+    ControllingExperiments,
+    DoiRef,
+    ExperimentTable,
+    ReplacementAccessions,
+} from './typeutils';
 import Tooltip from '../libs/ui/tooltip';
 import getNumberWithOrdinal from '../libs/ordinal_suffix';
 
@@ -558,6 +567,7 @@ const ExperimentComponent = ({ context, auditIndicators, auditDetail }, reactCon
             <header>
                 <TopAccessories context={context} crumbs={crumbs} />
                 <h1>{displayType} summary for {context.accession}</h1>
+                <DoiRef context={context} />
                 <ReplacementAccessions context={context} />
                 <ItemAccessories item={context} audit={{ auditIndicators, auditId: 'experiment-audit' }} hasCartControls />
             </header>

--- a/src/encoded/static/components/experiment_series.js
+++ b/src/encoded/static/components/experiment_series.js
@@ -12,6 +12,7 @@ import * as globals from './globals';
 import { requestObjects, ItemAccessories, InternalTags, TopAccessories } from './objectutils';
 import { PickerActions, resultItemClass } from './search';
 import Status, { getObjectStatuses, sessionToAccessLevel } from './status';
+import { DoiRef } from './typeutils';
 
 
 // Only analysis on selected assembly will be used for QC reporting
@@ -649,6 +650,7 @@ class ExperimentSeriesComponent extends React.Component {
                 <header>
                     <TopAccessories context={context} crumbs={crumbs} />
                     <h1>Summary for experiment series {context.accession}</h1>
+                    <DoiRef context={context} />
                     <ItemAccessories item={context} audit={{ auditIndicators, auditId: 'series-audit' }} />
                 </header>
                 {auditDetail(context.audit, 'series-audit', { session: this.context.session, sessionProperties: this.context.session_properties })}

--- a/src/encoded/static/components/objectutils.js
+++ b/src/encoded/static/components/objectutils.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import _ from 'underscore';
 import url from 'url';
 import * as encoding from '../libs/query_encoding';
+import { svgIcon } from '../libs/svg-icons';
 import { CartToggle, cartGetAllowedTypes } from './cart';
 import * as globals from './globals';
 import { Breadcrumbs } from './navigation';
@@ -855,3 +856,61 @@ TableItemCount.propTypes = {
  * @param {function} fn
  */
 export const useMount = (fn) => React.useEffect(fn, []);
+
+
+/**
+ * Display a button that copies the given text when the user clicks the button.
+ */
+export const CopyButton = ({ label, copyText, css, titlePre, titlePost }) => {
+    /** True if browser has clipboard API */
+    const [hasClipboard, setHasClipboard] = React.useState(false);
+    /** True if user has clicked Copy */
+    const [hasCopied, setHasCopied] = React.useState(false);
+
+    /**
+     * Called when the user clicks the Copy button.
+     */
+    const handleClick = async () => {
+        // Copy given text to clipboard.
+        await navigator.clipboard.writeText(copyText);
+        setHasCopied(true);
+    };
+
+    useMount(() => {
+        // Display Copy button if browser has clipboard API.
+        if (navigator.clipboard) {
+            setHasClipboard(true);
+        }
+    });
+
+    if (hasClipboard) {
+        return (
+            <button type="button" disabled={!copyText} className={`btn btn-svgicon${css ? ` ${css}` : ''}`} onClick={handleClick} aria-label={label}>
+                {svgIcon('clipboard')} {`${hasCopied ? titlePost : titlePre}`}
+            </button>
+        );
+    }
+
+    // No clipboard API.
+    return null;
+};
+
+CopyButton.propTypes = {
+    /** A11Y label for the button */
+    label: PropTypes.string.isRequired,
+    /** Text to copy */
+    copyText: PropTypes.string,
+    /** CSS classes to add to the copy button */
+    css: PropTypes.string,
+    /** Custom title for button; "Copy" by default */
+    titlePre: PropTypes.string,
+    /** Custom title for button after Copy clicked; "Copied" by default */
+    titlePost: PropTypes.string,
+};
+
+CopyButton.defaultProps = {
+    copyText: '',
+    css: 'btn',
+    titlePre: 'Copy',
+    titlePost: 'Copied',
+};

--- a/src/encoded/static/components/typeutils.js
+++ b/src/encoded/static/components/typeutils.js
@@ -2,8 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'underscore';
 import * as Pager from '../libs/ui/pager';
+import { DbxrefUrl } from './dbxref';
 import * as globals from './globals';
-import { requestFiles, AlternateAccession } from './objectutils';
+import { requestFiles, AlternateAccession, CopyButton } from './objectutils';
 import { SortTablePanel, SortTable } from './sorttable';
 import Status from './status';
 import { BatchDownloadControls } from './view_controls';
@@ -858,4 +859,39 @@ FileTablePaged.defaultProps = {
     context: null,
     fileIds: null,
     files: null,
+};
+
+
+/**
+ * Display a DOI link and a button to copy the link to the clipboard.
+ */
+export const DoiRef = ({ context }) => {
+    /** Text to be copied */
+    const [copyText, setCopyText] = React.useState('');
+    /** Ref of dbxref link */
+    const displayRef = React.useRef(null);
+
+    React.useEffect(() => {
+        if (displayRef.current) {
+            setCopyText(displayRef.current.href);
+        }
+    }, [displayRef.current]);
+
+    /** True if browser has clipboard API */
+    if (context.doi) {
+        return (
+            <div className="doi-ref">
+                <div className="doi-ref__link">
+                    <DbxrefUrl dbxref={`doi:${context.doi}`} context={context} displayRef={displayRef} />
+                </div>
+                <CopyButton label="Copy DOI link" copyText={copyText} css="btn-xs doi-ref__copy-button" />
+            </div>
+        );
+    }
+    return null;
+};
+
+DoiRef.propTypes = {
+    /** Target of doi -- currently displayed dataset object */
+    context: PropTypes.object.isRequired,
 };

--- a/src/encoded/static/libs/svg-icons.js
+++ b/src/encoded/static/libs/svg-icons.js
@@ -115,6 +115,15 @@ const chevronRight = () => (
     </svg>
 );
 
+const clipboard = (style) => (
+    <svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 249 249" style={style} className="svg-icon svg-icon-clipboard">
+        <path d="M164,24.5h26.54c6.31,0,11.46,5.05,11.46,11.23v190.05c0,6.17-5.16,11.23-11.46,11.23H57.46
+            C51.16,237,46,231.95,46,225.77V35.73c0-6.17,5.16-11.23,11.46-11.23H84"
+        />
+        <rect x="84" y="11" width="80" height="46" />
+    </svg>
+);
+
 
 const icons = {
     disclosure: (style) => <svg id="Disclosure" data-name="Disclosure" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 480" style={style} className="svg-icon svg-icon-disclosure"><circle cx="240" cy="240" r="240" /><polyline points="401.79 175.66 240 304.34 78.21 175.66" /></svg>,
@@ -136,6 +145,7 @@ const icons = {
     expandArrows,
     lockOpen,
     lockClosed,
+    clipboard,
 };
 
 /**

--- a/src/encoded/static/scss/encoded/_base.scss
+++ b/src/encoded/static/scss/encoded/_base.scss
@@ -309,10 +309,6 @@ $disabled-color-factor: 20%;
         display: flex;
     }
 
-    &.btn-svgicon {
-        font-size: 0;
-    }
-
     &.btn-inline {
         margin-right: 5px;
     }

--- a/src/encoded/static/scss/encoded/modules/_cart.scss
+++ b/src/encoded/static/scss/encoded/modules/_cart.scss
@@ -224,16 +224,29 @@
     @at-root #{&}__share-url {
         display: flex;
         flex-wrap: nowrap;
+        align-items: stretch;
 
         > input {
             flex: 1 1 auto;
+            margin: 0;
+            height: auto;
         }
 
         > .btn {
             flex: 0 1 auto;
+            margin: 0;
+            height: auto;
             border-left: none;
             border-top-left-radius: 0;
             border-bottom-left-radius: 0;
+            background-color: #f0f0f0;
+
+            .svg-icon-clipboard {
+                height: 18px;
+                fill: transparent;
+                stroke-width: 20px;
+                stroke: #000;
+            }
         }
     }
 }

--- a/src/encoded/static/scss/encoded/modules/_common_item.scss
+++ b/src/encoded/static/scss/encoded/modules/_common_item.scss
@@ -15,3 +15,38 @@
         flex: 0 1 auto;
     }
 }
+
+// doi: (Digital Object Identifier) references, including Copy button.
+$doi-ref-border-color: #a0a0a0;
+
+.doi-ref {
+    display: flex;
+    margin: -12px 0 10px;
+
+    @at-root #{&}__link {
+        display: flex;
+        align-items: center;
+        padding: 0 5px;
+        border: 1px solid $doi-ref-border-color;
+    }
+
+    @at-root #{&}__copy-button {
+        margin: 0;
+        background-color: #f0f0f0;
+
+        &.btn {
+            background-color: #f0f0f0;
+            border: 1px solid $doi-ref-border-color;
+            border-left: none;
+            border-radius: 0;
+
+            .svg-icon-clipboard {
+                margin-right: 3px;
+                height: 14px;
+                fill: none;
+                stroke: #000;
+                stroke-width: 22px;
+            }
+        }
+    }
+}


### PR DESCRIPTION
While this ticket concerned itself with dataset pages, the Copy button it uses overlapped the functionality of the Copy button in the Share Cart modal which used an older method of copying. I decided to modify the Share Cart modal to share the new Copy button on the dataset pages.

The .btn-svgicon CSS class wasn’t used, so I deleted it.

I had a leftover Jest test experiment now in v113rc1. It affects nothing, but I’ll remove it here.