### PR TITLE
ENCD-5782 Restore assay_term_name to browser label

### DIFF
--- a/src/encoded/static/components/cart/cart.js
+++ b/src/encoded/static/components/cart/cart.js
@@ -200,6 +200,7 @@ const datasetFacets = displayedFacetFields.filter((facetField) => facetField.dat
 const requestedFacetFields = displayedFacetFields.filter((field) => !field.calculated).concat([
     { field: '@id' },
     { field: 'assembly' },
+    { field: 'assay_term_name' },
     { field: 'file_format_type' },
     { field: 'title' },
     { field: 'genome_annotation' },


### PR DESCRIPTION
I had changed the configuration object to retrieve the assay title instead, which left me feeding no assay term name to the genome browser. I now retrieve the assay term name though I don’t display it on the cart page, so I can pass it to the genome browser.