### PR TITLE
ENCD-5758 Add biological replicate to cart facets

### DIFF
--- a/src/encoded/static/components/cart/cart.js
+++ b/src/encoded/static/components/cart/cart.js
@@ -71,7 +71,7 @@ const assemblySorter = (facetTerms) => (
  *
  * @return {array} Same as `facetTerms`
  */
-const analysisSorter = (facetTerms, files, analyses) => (
+const analysisSorter = (facetTerms, analyses) => (
     _(facetTerms).sortBy((facetTerm) => (
         analyses.findIndex((analysis) => analysis.title === facetTerm.term)
     ))
@@ -1454,7 +1454,7 @@ const assembleFacets = (selectedTerms, files, analyses, usedFacetFields) => {
             // built from it, so no not-found condition needs checking.
             const facetDisplay = usedFacetFields.find((facetField) => facetField.field === facet.field);
             facet.title = facetDisplay.title;
-            facet.terms = facetDisplay.sorter ? facetDisplay.sorter(facet.terms, files, analyses) : _(facet.terms).sortBy((facetTerm) => facetTerm.term.toLowerCase());
+            facet.terms = facetDisplay.sorter ? facetDisplay.sorter(facet.terms, analyses) : _(facet.terms).sortBy((facetTerm) => facetTerm.term.toLowerCase());
         });
     }
 


### PR DESCRIPTION
I added a method to convert the biological replicate array into a displayable, comma-separated string, so I added a new `getValue` transform that any facet can use if needed. So far, we only need it for the biological replicates.