### PR TITLE
ENCD-5799 Make BDD cart tests more reliable

### DIFF
--- a/src/encoded/static/components/cart/cart.js
+++ b/src/encoded/static/components/cart/cart.js
@@ -20,6 +20,7 @@ import {
     computeAssemblyAnnotationValue,
     filterForVisualizableFiles,
     filterForPreferredFiles,
+    Checkbox,
 } from '../objectutils';
 import { ResultTableList } from '../search';
 import { compileDatasetAnalyses, sortDatasetAnalyses } from './analysis';
@@ -794,64 +795,6 @@ Facet.defaultProps = {
 
 
 /**
- * Display a checkbox and label to allow users to filter out facet terms not included in any
- * visualizable files.
- */
-const VisualizableTermsToggle = ({ visualizableOnly, handleClick }) => (
-    <div className="cart-checkbox">
-        <button type="button" id="checkbox-toggle" role="checkbox" aria-checked={visualizableOnly} onClick={handleClick}>
-            <div className={`cart-checkbox__check${visualizableOnly ? ' cart-checkbox__check--checked' : ''}`}>
-                {visualizableOnly ? <i className="icon icon-check" /> : null}
-            </div>
-            <label htmlFor="viz-terms-toggle">
-                <div className="cart-checkbox__label-text">Show visualizable data only</div>
-                <div className="cart-checkbox__icon">{svgIcon('genomeBrowser')}</div>
-            </label>
-        </button>
-    </div>
-);
-
-VisualizableTermsToggle.propTypes = {
-    /** True to display checkbox as checked */
-    visualizableOnly: PropTypes.bool,
-    /** Callback when button is clicked */
-    handleClick: PropTypes.func.isRequired,
-};
-
-VisualizableTermsToggle.defaultProps = {
-    visualizableOnly: false,
-};
-
-
-/**
- * Display a checkbox and label to allow users to select preferred_default files only.
- */
-const PreferredOnlyToggle = ({ preferredOnly, handleClick }) => (
-    <div className="cart-checkbox">
-        <button type="button" id="cart-checkbox-toggle" role="checkbox" aria-checked={preferredOnly} onClick={handleClick}>
-            <div className={`cart-checkbox__check${preferredOnly ? ' cart-checkbox__check--checked' : ''}`}>
-                {preferredOnly ? <i className="icon icon-check" /> : null}
-            </div>
-            <label htmlFor="cart-checkbox-toggle">
-                <div className="cart-checkbox__label-text">Show default data only</div>
-            </label>
-        </button>
-    </div>
-);
-
-PreferredOnlyToggle.propTypes = {
-    /** True to display checkbox as checked */
-    preferredOnly: PropTypes.bool,
-    /** Callback when button is clicked */
-    handleClick: PropTypes.func.isRequired,
-};
-
-PreferredOnlyToggle.defaultProps = {
-    preferredOnly: false,
-};
-
-
-/**
  * Display the file facets. These display the number of files involved -- not the number of
  * experiments with files matching a criteria. As the primary input to this component is currently
  * an array of experiment IDs while these facets displays all the files involved with those
@@ -919,8 +862,8 @@ const FileFacets = ({
             <FileCount fileCount={selectedFileCount} facetLoadProgress={facetLoadProgress} />
             {facetLoadProgress === -1 ?
                 <>
-                    <PreferredOnlyToggle preferredOnly={preferredOnly} handleClick={preferredOnlyChangeHandler} />
-                    {!preferredOnly ? <VisualizableTermsToggle visualizableOnly={visualizableOnly} handleClick={visualizableOnlyChangeHandler} /> : null}
+                    <Checkbox label="Show default data only" id="default-data-toggle" checked={preferredOnly} css="cart-checkbox" clickHandler={preferredOnlyChangeHandler} />
+                    {!preferredOnly ? <Checkbox label="Show visualizable data only" id="visualizable-data-toggle" checked={visualizableOnly} css="cart-checkbox" clickHandler={visualizableOnlyChangeHandler} /> : null}
                 </>
             : null}
             {facets && facets.length > 0 ?

--- a/src/encoded/static/components/objectutils.js
+++ b/src/encoded/static/components/objectutils.js
@@ -932,3 +932,35 @@ CopyButton.defaultProps = {
     copyText: '',
     css: 'btn',
 };
+
+
+/**
+ * Display a custom-styled, accessible checkbox. Loosely based on:
+ * https://webdesign.tutsplus.com/tutorials/how-to-make-custom-accessible-checkboxes-and-radio-buttons--cms-32074
+ */
+export const Checkbox = ({ label, id, checked, css, clickHandler }) => (
+    <div className={`checkbox${css ? ` ${css}` : ''}`}>
+        <input id={id} name={id} type="checkbox" checked={checked} onChange={clickHandler} />
+        <label htmlFor={id}>
+            {label}
+            {svgIcon('checkbox')}
+        </label>
+    </div>
+);
+
+Checkbox.propTypes = {
+    /** Label for the checkbox */
+    label: PropTypes.string.isRequired,
+    /** HTML ID for the checkbox <input> */
+    id: PropTypes.string.isRequired,
+    /** True if checkbox is checked */
+    checked: PropTypes.bool.isRequired,
+    /** CSS to apply to checkbox wrapper */
+    css: PropTypes.string,
+    /** Called when the user clicks the checkbox */
+    clickHandler: PropTypes.func.isRequired,
+};
+
+Checkbox.defaultProps = {
+    css: '',
+};

--- a/src/encoded/static/libs/svg-icons.js
+++ b/src/encoded/static/libs/svg-icons.js
@@ -124,6 +124,15 @@ const clipboard = (style) => (
     </svg>
 );
 
+const checkbox = (style) => (
+    <svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" style={style} className="svg-icon svg-icon-checkbox">
+        <path d="M173.898 439.404l-166.4-166.4c-9.997-9.997-9.997-26.206
+            0-36.204l36.203-36.204c9.997-9.998 26.207-9.998 36.204 0L192 312.69 432.095
+            72.596c9.997-9.997 26.207-9.997 36.204 0l36.203 36.204c9.997 9.997 9.997 26.206 0
+            36.204l-294.4 294.401c-9.998 9.997-26.207 9.997-36.204-.001z"
+        />
+    </svg>
+);
 
 const icons = {
     disclosure: (style) => <svg id="Disclosure" data-name="Disclosure" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 480" style={style} className="svg-icon svg-icon-disclosure"><circle cx="240" cy="240" r="240" /><polyline points="401.79 175.66 240 304.34 78.21 175.66" /></svg>,
@@ -146,6 +155,7 @@ const icons = {
     lockOpen,
     lockClosed,
     clipboard,
+    checkbox,
 };
 
 /**

--- a/src/encoded/static/scss/encoded/modules/_common_item.scss
+++ b/src/encoded/static/scss/encoded/modules/_common_item.scss
@@ -52,3 +52,86 @@ $doi-ref-border-color: #a0a0a0;
         }
     }
 }
+
+// Generic, custom-styled checkbox.
+$checkbox-dimensions: 18px;
+$checkbox-padding: 3px;
+
+.checkbox {
+    position: relative;
+    padding: $checkbox-padding;
+
+    // Hide default input checkbox border.
+    input {
+        position: absolute;
+        margin: 0;
+        padding: 0;
+        width: $checkbox-dimensions;
+        height: $checkbox-dimensions;
+        top: $checkbox-padding;
+        left: $checkbox-padding;
+        opacity: 0;
+        z-index: 1;
+
+        &:checked {
+            border: none;
+
+            + label {
+                &::before {
+                    background-color: #008000;
+                }
+
+                svg {
+                    opacity: 1;
+                }
+            }
+        }
+
+        &:focus {
+            + label {
+                &::before {
+                    border-color: black;
+                }
+            }
+        }
+
+        // Push label over from absolutely positioned checkbox
+        + label {
+            padding: 3px 3px 0 $checkbox-dimensions + 5px;
+            z-index: 0;
+
+            // Style custom checkbox border.
+            &::before {
+                position: absolute;
+                content: "";
+                left: $checkbox-padding;
+                top: 0;
+                width: $checkbox-dimensions;
+                height: $checkbox-dimensions;
+                background-color: transparent;
+                border: 1px solid #c0c0c0;
+                border-radius: 3px;
+            }
+
+            + label::after {
+                opacity: 1;
+            }
+
+            svg {
+                position: absolute;
+                height: $checkbox-dimensions - 4px;
+                width: $checkbox-dimensions - 4px;
+                top: 2px;
+                left: $checkbox-padding + 2px;
+                fill: white;
+                stroke: none;
+                opacity: 0;
+                z-index: 0;
+            }
+
+            &:hover {
+                cursor: pointer;
+            }
+        }
+    }
+}

--- a/src/encoded/tests/features/cart.feature
+++ b/src/encoded/tests/features/cart.feature
@@ -25,7 +25,7 @@ Feature: Cart
         And I wait for the content to load
         Then I should see 6 elements with the css selector ".result-item"
         And I should see "3 files selected"
-        When I press "cart-checkbox-toggle"
+        When I press "default-data-toggle"
         Then I should see "2 files selected"
         When I click the link to "#processeddata"
         Then I should see 2 elements with the css selector ".cart-list-item"


### PR DESCRIPTION
I found out that Firefox-based local BDD testing failed when clicking the “Show default data only” because my HTML didn’t allow Firefox to detect clicks on the label, though that worked in other browsers. So I redesigned that checkbox and use it both for that and the “Show visualizable data only” checkbox. My hope is that this allows the CircleCI BDD test, which is Chrome based, so fail less often, though we’ll still have to see. I haven’t yet seen a failure of that test with this branch.