### PR TITLE
ENCD-5819 Fix missing related-files table

### DIFF
--- a/src/encoded/static/components/dataset.js
+++ b/src/encoded/static/components/dataset.js
@@ -63,9 +63,6 @@ const AnnotationComponent = (props, reactContext) => {
     // Make a biosample summary string
     const biosampleSummary = annotationBiosampleSummary(context);
 
-    // Determine this experiment's ENCODE version
-    const encodevers = globals.encodeVersion(context);
-
     // Set up the breadcrumbs
     const datasetType = context['@type'][1];
     const filesetType = context['@type'][0];
@@ -237,7 +234,7 @@ const AnnotationComponent = (props, reactContext) => {
             </Panel>
 
             {/* Display the file widget with the facet, graph, and tables */}
-            <FileGallery context={context} encodevers={encodevers} showReplicateNumber={false} />
+            <FileGallery context={context} showReplicateNumber={false} />
 
             <FetchedItems {...props} url={experimentsUrl} Component={ControllingExperiments} />
 
@@ -755,7 +752,7 @@ const ReferenceComponent = (props, reactContext) => {
             </Panel>
 
             {/* Display the file widget with the facet, graph, and tables */}
-            <FileGallery context={context} encodevers={globals.encodeVersion(context)} hideGraph altFilterDefault />
+            <FileGallery context={context} hideGraph hideControls collapseNone />
 
             <FetchedItems {...props} url={experimentsUrl} Component={ControllingExperiments} />
 
@@ -937,7 +934,7 @@ const ProjectComponent = (props, reactContext) => {
             </Panel>
 
             {/* Display the file widget with the facet, graph, and tables */}
-            <FileGallery context={context} encodevers={globals.encodeVersion(context)} hideGraph />
+            <FileGallery context={context} hideGraph hideControls collapseNone />
 
             <FetchedItems {...props} url={experimentsUrl} Component={ControllingExperiments} />
 
@@ -1103,7 +1100,7 @@ const UcscBrowserCompositeComponent = (props, reactContext) => {
             </Panel>
 
             {/* Display the file widget with the facet, graph, and tables */}
-            <FileGallery context={context} encodevers={globals.encodeVersion(context)} hideGraph />
+            <FileGallery context={context} hideGraph hideControls collapseNone />
 
             <FetchedItems {...props} url={experimentsUrl} Component={ControllingExperiments} />
 
@@ -1949,7 +1946,6 @@ export const SeriesComponent = (props, reactContext) => {
                 url={`/search/?limit=all&type=File&dataset=${context['@id']}`}
                 Component={DatasetFiles}
                 filePanelHeader={<FilePanelHeader context={context} />}
-                encodevers={globals.encodeVersion(context)}
                 session={reactContext.session}
             />
 

--- a/src/encoded/static/components/experiment.js
+++ b/src/encoded/static/components/experiment.js
@@ -493,9 +493,6 @@ const ExperimentComponent = ({ context, auditIndicators, auditDetail }, reactCon
     analysisStepDocs = analysisStepDocs.length > 0 ? _.uniq(analysisStepDocs) : [];
     pipelineDocs = pipelineDocs.length > 0 ? _.uniq(pipelineDocs) : [];
 
-    // Determine this experiment's ENCODE version.
-    const encodevers = globals.encodeVersion(context);
-
     // Make list of statuses.
     const statuses = [{ status: context.status, title: 'Status' }];
     if (adminUser && context.internal_status) {
@@ -930,7 +927,7 @@ const ExperimentComponent = ({ context, auditIndicators, auditDetail }, reactCon
 
             {/* Display the file widget with the facet, graph, and tables for Experiment and FunctionalCharacterizationExperiment only. */}
             {!isEnhancerExperiment ?
-                <FileGallery context={context} encodevers={encodevers} anisogenic={anisogenic} />
+                <FileGallery context={context} anisogenic={anisogenic} />
             : null}
 
             {biosampleCharacterizations && biosampleCharacterizations.length > 0 ?

--- a/src/encoded/static/components/experiment_series.js
+++ b/src/encoded/static/components/experiment_series.js
@@ -858,7 +858,6 @@ class ExperimentSeriesComponent extends React.Component {
                     url={`/search/?limit=all&type=File&dataset=${context['@id']}`}
                     Component={DatasetFiles}
                     filePanelHeader={<FilePanelHeader context={context} />}
-                    encodevers={globals.encodeVersion(context)}
                     session={this.context.session}
                 />
             </div>

--- a/src/encoded/static/components/globals.js
+++ b/src/encoded/static/components/globals.js
@@ -199,18 +199,6 @@ export const browserPriority = [
     'Ensembl',
 ];
 
-// Determine the given object's ENCODE version
-export function encodeVersion(context) {
-    let encodevers = '';
-    if (context.award && context.award.rfa) {
-        encodevers = encodeVersionMap[context.award.rfa.substring(0, 7)];
-        if (typeof encodevers === 'undefined') {
-            encodevers = '';
-        }
-    }
-    return encodevers;
-}
-
 // Display a human-readable form of the file size given the size of a file in bytes. Returned as a
 // string.
 export function humanFileSize(size) {

--- a/src/encoded/tests/data/inserts/reference.json
+++ b/src/encoded/tests/data/inserts/reference.json
@@ -90,6 +90,10 @@
         "date_created": "2019-07-01T22:14:15.601240+00:00",
         "lab": "/labs/ali-mortazavi/",
         "reference_type": "sequence adapters",
+        "related_files": [
+            "/files/ENCFF026HBG/",
+            "/files/ENCFF379BCO/"
+        ],
         "submitted_by": "/users/7e944358-625c-426c-975c-7d875e22f753/",
         "status": "in progress",
         "accession": "ENCSR819DEL"
@@ -116,6 +120,10 @@
         ],
         "lab": "/labs/greg-cooper/",
         "reference_type": "functional elements",
+        "related_files": [
+            "/files/ENCFF026HBG/",
+            "/files/ENCFF027HBG/"
+        ],
         "status": "in progress"
     },
     {


### PR DESCRIPTION
* The main crux of this ticket involves the call to `requestFiles` which passes an array of files to filter out — something we don’t need anymore, and which `requestFiles` itself now interprets as a query-string key.
* Converted some boolean properties to `FileTable` to get passed in a new `options` property to try to keep the number of props under a little control. I added a `collapsedNone` boolean property which indicates no file subtables should appear collapsed by default, which I only use with Reference, Project, and UcscBrowserComposite pages. Experiment, Annotation, and FunctionalCharacteriationExperiment pages still appear with some tables collapsed by default.
* RawSequencingTable and CollapsingTitle were configured to take an object in `outputType` and `analysisObjectKey ` but these had recently become strings. This clears the “Failed prop type: Invalid prop `outputType` of type `string` supplied to `CollapsingTitle`, expected `object`” warnings seen on v114 developer builds.
* Removed `altFilterDefault` from most datasets that use FileGallery because this only affects the browser dropdown which only appears with a `visualize` property, which only appears for Experiment, Annotation, and FunctionalCharacterizationExperiment.
* Removed `encodevers` which a few years ago had been used to display extra statuses on experiments, but not since. This also involves removing the `encodeVersion` function from globals.js.

The patched demo https://encd-5819-related-files-fytanaka.demo.encodedcc.org/ has the up-to-date changes until the QA demo indexes.
