### PR TITLE
VALIS-36-remove-expander

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7401,8 +7401,8 @@
       }
     },
     "genome-visualizer": {
-      "version": "git://github.com/ENCODE-DCC/valis-hpgv.git#db49ed5c0d8c82e9fac039b36d40a0f03ed00a90",
-      "from": "git://github.com/ENCODE-DCC/valis-hpgv.git#ENCD-5770-add-legend-to-browser",
+      "version": "git://github.com/ENCODE-DCC/valis-hpgv.git#2f507425d6ff27fe380508fa3dfe271161253c78",
+      "from": "git://github.com/ENCODE-DCC/valis-hpgv.git#1.8.0",
       "requires": {
         "@material-ui/core": "^3.1.0",
         "@material-ui/icons": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "dayjs": "^1.8.16",
     "domready": "^1.0.8",
     "form-serialize": "^0.6.0",
-    "genome-visualizer": "git://github.com/ENCODE-DCC/valis-hpgv.git#ENCD-5770-add-legend-to-browser",
+    "genome-visualizer": "git://github.com/ENCODE-DCC/valis-hpgv.git#1.8.0",
     "google-analytics": "file:node_shims/google-analytics",
     "graphlib": "git://github.com/ENCODE-DCC/graphlib.git#v1.0.8",
     "immutable": "^3.7.5",

--- a/src/encoded/static/components/genome_browser.js
+++ b/src/encoded/static/components/genome_browser.js
@@ -825,7 +825,7 @@ class GenomeBrowser extends React.Component {
                 }));
             }
             let labelLength = 0;
-            const defaultHeight = 34;
+            const defaultHeight = 29;
             const extraLineHeight = 12;
             const maxCharPerLine = 26;
             // Some labels on the cart which have a target, assay name, and biosample are too long for one line (some actually extend to three lines)
@@ -856,7 +856,7 @@ class GenomeBrowser extends React.Component {
                 trackObj.type = 'signal';
                 trackObj.path = domain + file.href;
                 trackObj.heightPx = labelLength > 0 ? (defaultHeight + (extraLineHeight * labelLength)) : defaultHeight;
-                trackObj.expandedHeightPx = 140;
+                trackObj.expandedHeightPx = 135;
                 return trackObj;
             }
             if (file.file_format === 'vdna-dir') {
@@ -864,7 +864,7 @@ class GenomeBrowser extends React.Component {
                 trackObj.name = <ul className="gb-info"><li>{this.props.assembly.split(' ')[0]}</li></ul>;
                 trackObj.type = 'sequence';
                 trackObj.path = file.href;
-                trackObj.heightPx = 40;
+                trackObj.heightPx = 35;
                 trackObj.expandable = false;
                 return trackObj;
             }
@@ -873,7 +873,7 @@ class GenomeBrowser extends React.Component {
                 trackObj.name = <ul className="gb-info"><li>{file.title}</li></ul>;
                 trackObj.type = 'annotation';
                 trackObj.path = file.href;
-                trackObj.heightPx = 120;
+                trackObj.heightPx = 115;
                 trackObj.expandable = false;
                 trackObj.displayLabels = true;
                 return trackObj;
@@ -886,7 +886,7 @@ class GenomeBrowser extends React.Component {
             trackObj.expandable = true;
             trackObj.displayLabels = false;
             trackObj.heightPx = labelLength > 0 ? (defaultHeight + (extraLineHeight * labelLength)) : defaultHeight;
-            trackObj.expandedHeightPx = 140;
+            trackObj.expandedHeightPx = 135;
             trackObj.fileFormatType = file.file_format_type;
             // bigBed bedRNAElements, bigBed peptideMapping, bigBed bedExonScore, bed12, and bed9 have two tracks and need extra height
             // Convert to lower case in case of inconsistency in the capitalization of the file format in the data


### PR DESCRIPTION
Includes the following Valis updates on a Valis branch:
- an update from George, which disables the dragging expandability of the tracks when expandable = false:
VALIS-software@c5b5286
- 0 spacing between tracks
Note: I think the 0 spacing between tracks is important if we want to have some tracks as expandable with the carets but don't want them to be expandable by dragging.

I've reduced the heights of the tracks now that the heights do not include pixels of empty space.