### PR TITLE
ENCD-5842-no-encode-private-config

### DIFF
--- a/cloud-config/template-parts/runcmd_all.yml
+++ b/cloud-config/template-parts/runcmd_all.yml
@@ -2,8 +2,6 @@
 - cloud-init-per once conf-encd-pem-chmod sudo -u ubuntu chmod 0600 /home/ubuntu/.ssh/encoded-demos.pem
 - cloud-init-per once conf-encd-cfg-s3 sudo -u ubuntu aws s3 cp --region=us-west-2 s3://encoded-conf-prod/encd-pems/config /home/ubuntu/.ssh/config
 - cloud-init-per once conf-encd-cfg-chmod sudo -u ubuntu chmod 0600 /home/ubuntu/.ssh/config
-- cloud-init-per once conf-git-repo sudo -u ubuntu git clone git@github.com:ENCODE-DCC/encode-private-config.git /home/ubuntu/encode-private-config
-- cloud-init-per once conf-git-branch sudo -u ubuntu git -C /home/ubuntu/encode-private-config checkout -b encode-private-config origin/master
 
 - cloud-init-per once nagios-files-s3 aws s3 cp --region=us-west-2 --recursive s3://encoded-conf-prod/nagios-plugins /home/ubuntu/nagios-plugins
 - cloud-init-per once nagios-mv-conf mv /home/ubuntu/nagios-plugins/nrpe_local.cfg /etc/nagios/nrpe.d/nrpe_local.cfg


### PR DESCRIPTION
Cloning the private config repo is not needed. That config is not used anywhere.