### PR TITLE
ENCD-5829-allow-batch-download-from-more-dataset-pages

### DIFF
--- a/src/encoded/reports/constants.py
+++ b/src/encoded/reports/constants.py
@@ -5,6 +5,9 @@ METADATA_ALLOWED_TYPES = [
     'Experiment',
     'Annotation',
     'FunctionalCharacterizationExperiment',
+    'Reference',
+    'Project',
+    'UcscBrowserComposite',
     'PublicationData',
     'Analysis',
 ]

--- a/src/encoded/static/components/dataset.js
+++ b/src/encoded/static/components/dataset.js
@@ -752,7 +752,7 @@ const ReferenceComponent = (props, reactContext) => {
             </Panel>
 
             {/* Display the file widget with the facet, graph, and tables */}
-            <FileGallery context={context} hideGraph hideControls collapseNone />
+            <FileGallery context={context} hideGraph collapseNone />
 
             <FetchedItems {...props} url={experimentsUrl} Component={ControllingExperiments} />
 
@@ -934,7 +934,7 @@ const ProjectComponent = (props, reactContext) => {
             </Panel>
 
             {/* Display the file widget with the facet, graph, and tables */}
-            <FileGallery context={context} hideGraph hideControls collapseNone />
+            <FileGallery context={context} hideGraph collapseNone />
 
             <FetchedItems {...props} url={experimentsUrl} Component={ControllingExperiments} />
 
@@ -1100,7 +1100,7 @@ const UcscBrowserCompositeComponent = (props, reactContext) => {
             </Panel>
 
             {/* Display the file widget with the facet, graph, and tables */}
-            <FileGallery context={context} hideGraph hideControls collapseNone />
+            <FileGallery context={context} hideGraph collapseNone />
 
             <FetchedItems {...props} url={experimentsUrl} Component={ControllingExperiments} />
 

--- a/src/encoded/static/components/objectutils.js
+++ b/src/encoded/static/components/objectutils.js
@@ -133,14 +133,14 @@ export function requestSearch(query) {
  *
  * @return {promise} Array of objects requested from the server
  */
-const MAX_URL_LENGTH = 4000;
+const MAX_URL_LENGTH = 3800;
 export const requestObjects = async (identifiers, uri, queryProp = '@id') => {
     if (identifiers.length > 0) {
         // Calculate a roughly reasonable chunk size based on an estimate of how many query-string
         // elements will fit within the maximum URL size. Assume the first identifier has a length
         // typical for all the identifiers.
         const singleQuerySize = queryProp.length + identifiers[0].length;
-        const chunkLength = Math.trunc(MAX_URL_LENGTH / singleQuerySize) - Math.trunc(uri.length / singleQuerySize);
+        const chunkLength = Math.trunc(MAX_URL_LENGTH / singleQuerySize) - uri.length;
 
         // Break `identifiers` into an array of arrays of <= the calculated chunk size.
         const objectChunks = [];

--- a/src/encoded/static/components/objectutils.js
+++ b/src/encoded/static/components/objectutils.js
@@ -140,7 +140,7 @@ export const requestObjects = async (identifiers, uri, queryProp = '@id') => {
         // elements will fit within the maximum URL size. Assume the first identifier has a length
         // typical for all the identifiers.
         const singleQuerySize = queryProp.length + identifiers[0].length;
-        const chunkLength = Math.trunc(MAX_URL_LENGTH / singleQuerySize) - uri.length;
+        const chunkLength = Math.trunc((MAX_URL_LENGTH - uri.length) / singleQuerySize);
 
         // Break `identifiers` into an array of arrays of <= the calculated chunk size.
         const objectChunks = [];

--- a/src/encoded/static/components/objectutils.js
+++ b/src/encoded/static/components/objectutils.js
@@ -119,6 +119,10 @@ export function requestSearch(query) {
 }
 
 
+const SINGLE_QUERY_SIZE_PADDING = 10;
+const MAX_DOMAIN_LENGTH = 64 + 19 + 8; // Max AWS domain name + .demo.encodedcc.org + https://
+const MAX_URL_LENGTH = 4000 - MAX_DOMAIN_LENGTH;
+
 /**
  * Do a search of the specific objects whose @ids are listed in the `identifiers` parameter. Because
  * we have to specify the @id of each object in the URL of the GET request, the URL can get quite
@@ -133,13 +137,12 @@ export function requestSearch(query) {
  *
  * @return {promise} Array of objects requested from the server
  */
-const MAX_URL_LENGTH = 3800;
 export const requestObjects = async (identifiers, uri, queryProp = '@id') => {
     if (identifiers.length > 0) {
         // Calculate a roughly reasonable chunk size based on an estimate of how many query-string
         // elements will fit within the maximum URL size. Assume the first identifier has a length
         // typical for all the identifiers.
-        const singleQuerySize = queryProp.length + identifiers[0].length;
+        const singleQuerySize = queryProp.length + identifiers[0].length + SINGLE_QUERY_SIZE_PADDING;
         const chunkLength = Math.trunc((MAX_URL_LENGTH - uri.length) / singleQuerySize);
 
         // Break `identifiers` into an array of arrays of <= the calculated chunk size.


### PR DESCRIPTION
This involves both back- and front-end changes; back to allow those page types to download files, and front to enable those controls on those pages.