### PR TITLE
ENCD-5770 add legend to browser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7401,7 +7401,7 @@
       }
     },
     "genome-visualizer": {
-      "version": "git://github.com/ENCODE-DCC/valis-hpgv.git#c33788cbb8c2ff3b49aecc51f967f47ed3358f5b",
+      "version": "git://github.com/ENCODE-DCC/valis-hpgv.git#db49ed5c0d8c82e9fac039b36d40a0f03ed00a90",
       "from": "git://github.com/ENCODE-DCC/valis-hpgv.git#1.7.0",
       "requires": {
         "@material-ui/core": "^3.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7402,7 +7402,7 @@
     },
     "genome-visualizer": {
       "version": "git://github.com/ENCODE-DCC/valis-hpgv.git#db49ed5c0d8c82e9fac039b36d40a0f03ed00a90",
-      "from": "git://github.com/ENCODE-DCC/valis-hpgv.git#1.7.0",
+      "from": "git://github.com/ENCODE-DCC/valis-hpgv.git#ENCD-5770-add-legend-to-browser",
       "requires": {
         "@material-ui/core": "^3.1.0",
         "@material-ui/icons": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "dayjs": "^1.8.16",
     "domready": "^1.0.8",
     "form-serialize": "^0.6.0",
-    "genome-visualizer": "git://github.com/ENCODE-DCC/valis-hpgv.git#1.7.0",
+    "genome-visualizer": "git://github.com/ENCODE-DCC/valis-hpgv.git#ENCD-5770-add-legend-to-browser",
     "google-analytics": "file:node_shims/google-analytics",
     "graphlib": "git://github.com/ENCODE-DCC/graphlib.git#v1.0.8",
     "immutable": "^3.7.5",

--- a/src/encoded/static/components/genome_browser.js
+++ b/src/encoded/static/components/genome_browser.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import _ from 'underscore';
 import { BrowserFeat } from './browserfeat';
 import { filterForVisualizableFiles } from './objectutils';
+import Tooltip from '../libs/ui/tooltip';
 import GeneSearch from './gene_search';
 
 /**
@@ -19,6 +20,55 @@ const GV_COORDINATES_KEY = 'ENCODE-GV-coordinates';
 // used to determine if GV_COORDINATES_KEY should be used
 const GV_COORDINATES_ASSEMBLY = 'ENCODE-GV-assembly';
 const GV_COORDINATES_ANNOTATION = 'ENCODE-GV-annotation';
+
+const colorChromatinState = {
+    'Active TSS': '#ff0000',
+    'Flanking TSS': '#ff4400',
+    'Flanking TSS upstream': '#ff4500',
+    'Flanking TSS downstream': '#ff4500',
+    'Strong transcription': '#008000',
+    'Weak transcription': '#006400',
+    'Genic enhancer 1': '#c4e105',
+    'Genic enhancer 2': '#c4e105',
+    'Active enhancer 1': '#ffc44d',
+    'Active enhancer 2': '#ffc44d',
+    'Weak enhancer': '#ffff00',
+    'ZNF genes & repeats': '#66cdaa',
+    Heterochromatin: '#8a91d0',
+    'Bivalent/Poised TSS': '#cd5c5c',
+    'Bivalent enhancer': '#bdb86b',
+    'Repressed PolyComb': '#808080, #8937df',
+    'Weak Repressed PolyComb': '#c0c0c0, #9750e3',
+    'Quiescent/Low': '#ffffff',
+};
+
+const colorCCREs = {
+    'Promoter-like': '#ff0000',
+    'Proximal enhancer-like': '#ffa700',
+    'Distal enhancer-like': '#ffcd00',
+    'DNase-H3K4me3': '#ffaaaa',
+    'CTCF-only': '#00b0f0',
+    'DNase-only': '#06da93',
+    'Low-DNase': '#ffffff',
+};
+
+const colorGenome = {
+    'nucleobase A': '#0c7489',
+    'nucleobase T': '#f9ce70',
+    'nucleobase G': '#0fa3b1',
+    'nucleobase C': '#c14953',
+    'gc-banding-low': '#0c7489',
+    'gc-banding-high': '#f9ce70',
+};
+
+const colorGenes = {
+    Transcript: '#bdc5c0',
+    Coding: '#575f5a',
+    'Non-coding': '#f9ce70',
+    'Coding max score': '#575f5a',
+    'Non-coding max score': '#575f5a',
+    Untranslated: '#c14953',
+};
 
 /**
  * Returns Valis coordinates off the bar user inputs data in
@@ -382,6 +432,83 @@ const sortLookUp = (obj, param) => {
     }
 };
 
+const LegendLabel = () => (
+    <div className="legend-label">
+        <div className="legend-color-container">
+            <div className="legend-swatch" style={{ background: `${colorGenome['nucleobase A']}` }} />
+            <div className="legend-swatch" style={{ background: `${colorGenome['nucleobase T']}` }} />
+            <div className="legend-swatch" style={{ background: `${colorGenome['nucleobase C']}` }} />
+            <div className="legend-swatch" style={{ background: `${colorGenome['nucleobase G']}` }} />
+        </div>
+        <div className="legend-name">Legend</div>
+    </div>
+);
+
+/**
+ * Display a legend
+ */
+const GenomeLegend = (props) => (
+    <Tooltip
+        trigger={<LegendLabel />}
+        tooltipId="genome-legend"
+        css="legend-button"
+        size="large"
+        columnCount={props.colorBlock.length + 2}
+    >
+        <div className="legend-container">
+            <div className="legend-block">
+                <h5>Genome</h5>
+                {Object.keys(colorGenome).map((nucleobase) => (
+                    <div className="legend-element" key={nucleobase}>
+                        <div className={`legend-swatch ${colorGenome[nucleobase] === '#ffffff' ? 'with-border' : ''}`} style={{ background: `${colorGenome[nucleobase]}` }} />
+                        <div className="legend-label">{nucleobase}</div>
+                    </div>
+                ))}
+            </div>
+            <div className="legend-block">
+                <h5>Genes</h5>
+                {Object.keys(colorGenes).map((gene) => (
+                    <div className="legend-element" key={gene}>
+                        <div className={`legend-swatch ${colorGenes[gene] === '#ffffff' ? 'with-border' : ''}`} style={{ background: `${colorGenes[gene]}` }} />
+                        <div className="legend-label">{gene}</div>
+                    </div>
+                ))}
+            </div>
+            {(props.colorBlock.indexOf('ccres') > -1) ?
+                <div className="legend-block">
+                    <h5>CCREs</h5>
+                    {Object.keys(colorCCREs).map((ccre) => (
+                        <div className="legend-element" key={ccre}>
+                            <div className={`legend-swatch ${colorCCREs[ccre] === '#ffffff' ? 'with-border' : ''}`} style={{ background: `${colorCCREs[ccre]}` }} />
+                            <div className="legend-label">{ccre}</div>
+                        </div>
+                    ))}
+                </div>
+            : null}
+            {(props.colorBlock.indexOf('chromatin') > -1) ?
+                <div className="legend-block">
+                    <h5>Chromatin</h5>
+                    {Object.keys(colorChromatinState).map((state) => (
+                        <div className="legend-element" key={state}>
+                            {(colorChromatinState[state].indexOf(', ') === -1) ?
+                                <div className={`legend-swatch ${colorChromatinState[state] === '#ffffff' ? 'with-border' : ''}`} style={{ background: `${colorChromatinState[state]}` }} />
+                            :
+                                <div className={`legend-swatch ${colorChromatinState[state] === '#ffffff' ? 'with-border' : ''}`} style={{ 'background-image': `-webkit-linear-gradient(45deg, ${colorChromatinState[state].split(', ')[0]} 50%, ${colorChromatinState[state].split(', ')[1]} 50%)` }} />
+                            }
+                            <div className="legend-label">{state}</div>
+                        </div>
+                    ))}
+                </div>
+            : null}
+        </div>
+    </Tooltip>
+);
+
+GenomeLegend.propTypes = {
+    colorBlock: PropTypes.array.isRequired,
+};
+
+
 /**
  * Display a label for a file’s track.
  */
@@ -468,6 +595,7 @@ class GenomeBrowser extends React.Component {
             disableBrowserForIE: false,
             sortToggle: this.props.sortParam.map(() => true), // Indicates ascending or descending order for each sort parameter; true is descending and false is ascending
             primarySort: this.props.sortParam[0] || 'Replicates', // Indicates the final (primary) sort applied to the list of files
+            colorBlock: [], // Legend entries
         };
         this.setBrowserDefaults = this.setBrowserDefaults.bind(this);
         this.clearBrowserMemory = this.clearBrowserMemory.bind(this);
@@ -688,6 +816,16 @@ class GenomeBrowser extends React.Component {
 
     filesToTracks(files, label, domain) {
         const tracks = files.map((file) => {
+            if (file.output_type === 'candidate Cis-Regulatory Elements' && this.state.colorBlock.indexOf('ccres') === -1) {
+                this.setState((prevState) => ({
+                    colorBlock: [...prevState.colorBlock, 'ccres'],
+                }));
+            }
+            if (file.output_type === 'semi-automated genome annotation' && this.state.colorBlock.indexOf('chromatin') === -1) {
+                this.setState((prevState) => ({
+                    colorBlock: [...prevState.colorBlock, 'chromatin'],
+                }));
+            }
             let labelLength = 0;
             const defaultHeight = 34;
             const extraLineHeight = 12;
@@ -827,12 +965,15 @@ class GenomeBrowser extends React.Component {
                              handleClick={this.handleGeneSearchResultClick}
                          />
                      </div>
-                     {this.props.displaySort ?
-                      <div className="sort-control-container">
-                          <div className="sort-label">Sort by: </div>
-                          {this.props.sortParam.map((param, paramIdx) => <button type="button" className={`sort-button ${param === this.state.primarySort ? 'active' : ''}`} key={param.replace(/\s/g, '_')} onClick={() => this.sortAndRefresh(param, this.state.sortToggle[paramIdx], paramIdx, true)}><i className={this.state.sortToggle[paramIdx] ? 'tcell-desc' : 'tcell-asc'} /><div className="sort-label">{param}</div></button>)}
-                      </div>
-                      : null}
+                     <div className="horizontal-control-container">
+                         {this.props.displaySort ?
+                              <>
+                                  <div className="sort-label">Sort by: </div>
+                                  {this.props.sortParam.map((param, paramIdx) => <button type="button" className={`sort-button ${param === this.state.primarySort ? 'active' : ''}`} key={param.replace(/\s/g, '_')} onClick={() => this.sortAndRefresh(param, this.state.sortToggle[paramIdx], paramIdx, true)}><i className={this.state.sortToggle[paramIdx] ? 'tcell-desc' : 'tcell-asc'} /><div className="sort-label">{param}</div></button>)}
+                              </>
+                         : null}
+                         <GenomeLegend colorBlock={this.state.colorBlock} />
+                     </div>
                      <div className="browser-container">
                          <button type="button" className="reset-browser-button" onClick={this.resetLocation}>
                              <i className="icon icon-undo" />

--- a/src/encoded/static/components/genome_browser.js
+++ b/src/encoded/static/components/genome_browser.js
@@ -53,19 +53,19 @@ const colorCCREs = {
 };
 
 const colorGenome = {
-    'nucleobase A': '#0c7489',
-    'nucleobase T': '#f9ce70',
-    'nucleobase G': '#0fa3b1',
-    'nucleobase C': '#c14953',
-    'gc-banding-low': '#0c7489',
-    'gc-banding-high': '#f9ce70',
+    'Nucleobase A': '#0c7489',
+    'Nucleobase T': '#f9ce70',
+    'Nucleobase G': '#0fa3b1',
+    'Nucleobase C': '#c14953',
+    'GC-low': '#0c7489',
+    'GC-rich': '#f9ce70',
 };
 
 const colorGenes = {
-    Transcript: '#6b6d88',
-    Coding: '#575f5a',
-    'Non-coding': '#f9ce70',
-    Untranslated: '#c14953',
+    Transcript: '#cfd7c7',
+    'Protein coding': '#575f5a',
+    'Non-protein coding': '#f9ce70',
+    UTR: '#c14953',
 };
 
 /**
@@ -433,10 +433,10 @@ const sortLookUp = (obj, param) => {
 const LegendLabel = () => (
     <div className="legend-label">
         <div className="legend-color-container">
-            <div className="legend-swatch" style={{ background: `${colorGenome['nucleobase A']}` }} />
-            <div className="legend-swatch" style={{ background: `${colorGenome['nucleobase T']}` }} />
-            <div className="legend-swatch" style={{ background: `${colorGenome['nucleobase C']}` }} />
-            <div className="legend-swatch" style={{ background: `${colorGenome['nucleobase G']}` }} />
+            <div className="legend-swatch" style={{ background: `${colorGenome['Nucleobase A']}` }} />
+            <div className="legend-swatch" style={{ background: `${colorGenome['Nucleobase T']}` }} />
+            <div className="legend-swatch" style={{ background: `${colorGenome['Nucleobase C']}` }} />
+            <div className="legend-swatch" style={{ background: `${colorGenome['Nucleobase G']}` }} />
         </div>
         <div className="legend-name">Legend</div>
     </div>

--- a/src/encoded/static/components/genome_browser.js
+++ b/src/encoded/static/components/genome_browser.js
@@ -62,11 +62,9 @@ const colorGenome = {
 };
 
 const colorGenes = {
-    Transcript: '#bdc5c0',
+    Transcript: '#6b6d88',
     Coding: '#575f5a',
     'Non-coding': '#f9ce70',
-    'Coding max score': '#575f5a',
-    'Non-coding max score': '#575f5a',
     Untranslated: '#c14953',
 };
 

--- a/src/encoded/static/scss/encoded/modules/_genome_browser.scss
+++ b/src/encoded/static/scss/encoded/modules/_genome_browser.scss
@@ -96,9 +96,10 @@ a {
     }
 }
 
-.sort-control-container {
+.horizontal-control-container {
     display: flex;
     margin-top: 10px;
+    position: relative;
 
     .sort-label {
         margin: 2px 5px;
@@ -129,6 +130,76 @@ a {
 
     .tcell-asc {
         margin-top: 5px;
+    }
+
+    .legend-button {
+        margin-left: auto;
+        margin-right: 2px;
+    }
+}
+
+.legend-container {
+    text-align: left;
+
+    .legend-element {
+        display: flex;
+        flex-wrap: wrap;
+        margin-bottom: 3px;
+    }
+
+    .legend-swatch {
+        flex: 0 1 20px;
+    }
+
+    .legend-label {
+        flex: 0 1 auto;
+    }
+
+    .legend-swatch {
+        height: 20px;
+        width: 20px;
+        margin-right: 5px;
+
+        &.with-border {
+            border: 1px solid #bbb;
+        }
+    }
+}
+
+.legend-label {
+    display: flex;
+
+    .legend-color-container {
+        display: flex;
+        flex-wrap: wrap;
+        margin-right: 3px;
+        height: 20px;
+        width: 20px;
+
+        .legend-swatch {
+            height: 10px;
+            width: 10px;
+        }
+    }
+
+    .legend-name {
+        padding: 0 5px;
+    }
+}
+
+#genome-legend {
+    .tooltip-inner {
+        max-width: 880px;
+    }
+
+    .legend-container {
+        display: flex;
+        flex-wrap: wrap;
+        max-width: 880px;
+    }
+
+    .legend-block {
+        flex: 0 1 206px;
     }
 }
 

--- a/src/encoded/static/scss/encoded/modules/_genome_browser.scss
+++ b/src/encoded/static/scss/encoded/modules/_genome_browser.scss
@@ -100,6 +100,7 @@ a {
     display: flex;
     margin-top: 10px;
     position: relative;
+    flex-wrap: wrap;
 
     .sort-label {
         margin: 2px 5px;

--- a/src/encoded/static/scss/encoded/modules/_genome_browser.scss
+++ b/src/encoded/static/scss/encoded/modules/_genome_browser.scss
@@ -220,7 +220,7 @@ a {
 /* stylelint-disable-next-line selector-class-pattern */
 .hpgv_track-annotation {
     --transcript-arrow: rgba(0, 0, 0, 1);
-    --transcript: #bdc5c0;
+    --transcript: #cfd7c7;
     --coding: #575f5a;
     --non-coding: #f9ce70;
     --untranslated: #c14953;


### PR DESCRIPTION
- Adds legend to genome browser with 4 possible sets of defined colors: genome, gene, ccres, chromatin
- Genome and gene colors are displayed all the time, but ccre and chromatin colors are only displayed for tracks with relevant output types
- It is not optimized for mobile but should work ok
- States 16 and 17 have different colors for mouse and human files so the color blocks for those states are split diagonally and display both colors