### PR TITLE
ENCD-5685-fix-page-editor-stacked-buttons

### DIFF
--- a/src/encoded/static/components/layout.js
+++ b/src/encoded/static/components/layout.js
@@ -270,20 +270,17 @@ class BlockAddButton extends React.Component {
     render() {
         const classes = `icon-lg ${this.props.blockprops.icon}`;
         return (
-            <span>
-                <button
-                    type="button"
-                    className="btn btn-primary navbar-btn btn-sm"
-                    onClick={BlockAddButton.click}
-                    draggable="true"
-                    onDragStart={this.dragStart}
-                    onDragEnd={this.context.dragEnd}
-                    title={this.props.blockprops.label}
-                >
-                    <span className={classes} />
-                </button>
-                {' '}
-            </span>
+            <button
+                type="button"
+                className="btn btn-primary navbar-btn btn-sm"
+                onClick={BlockAddButton.click}
+                draggable="true"
+                onDragStart={this.dragStart}
+                onDragEnd={this.context.dragEnd}
+                title={this.props.blockprops.label}
+            >
+                <span className={classes} />
+            </button>
         );
     }
 }

--- a/src/encoded/static/scss/encoded/modules/_layout-editor.scss
+++ b/src/encoded/static/scss/encoded/modules/_layout-editor.scss
@@ -114,9 +114,11 @@
     z-index: 1030;
 
     @at-root #{&}__tools {
+        display: flex;
         flex: 0 1 auto;
 
         .btn {
+            margin-right: 2px;
             cursor: move;
         }
     }


### PR DESCRIPTION
The buttons now appear side-by-side as they did a while back, instead of stacked vertically as shown in the ticket. Example:

https://encd-5615-stacked-buttons-qa1-fytanaka.demo.encodedcc.org/pages/#!add