### PR TITLE
ENCD-5614-cart-dataset-filters

### DIFF
--- a/src/encoded/static/components/cart/batch_download.js
+++ b/src/encoded/static/components/cart/batch_download.js
@@ -72,6 +72,7 @@ const batchDownload = (
             }))
         );
 
+    // Form query string from currently selected datset facets.
     const datasetFormatSelections = (raw || all)
         ? []
         : (
@@ -83,8 +84,7 @@ const batchDownload = (
                     if (matchingFacetField && matchingFacetField.fieldMapper) {
                         mappedQuery = matchingFacetField.fieldMapper(selectedFileTerms[field], analyses);
                     } else {
-                        // Build the query string from `files` properties in the dataset, or from the
-                        // dataset properties itself for fields marked in `facets`.
+                        // Build the query string from the selected dataset terms.
                         subQueryString = selectedDatasetTerms[field].map((term) => (
                             `${field}=${encoding.encodedURIComponent(term)}`
                         )).join('&');
@@ -99,7 +99,7 @@ const batchDownload = (
     const visualizableOption = `${visualizable ? '&option=visualizable' : ''}`;
     const rawOption = `${raw ? '&option=raw' : ''}`;
     const preferredDefaultQuery = preferredDefault && !raw && !all ? '&files.preferred_default=true' : '';
-    const query = `${fileFormatSelections.length > 0 ? `&${fileFormatSelections.join('&')}` : ''}${datasetFormatSelections.length > 0 ? `&${datasetFormatSelections.join('&')}` : ''}`;
+    const query = `${datasetFormatSelections.length > 0 ? `&${datasetFormatSelections.join('&')}${fileFormatSelections.length > 0 ? `&${fileFormatSelections.join('&')}` : ''}` : ''}`;
     fetch(`/batch_download/?${cartId ? `&cart=${encoding.encodedURIComponent(cartId)}` : ''}${query}${visualizableOption}${rawOption}${preferredDefaultQuery}`, {
         method: 'POST',
         headers: {
@@ -205,8 +205,6 @@ const CartBatchDownloadComponent = (
             options.all = true;
         }
         options.preferredDefault = preferredDefault;
-
-        // Combine the selected file and dataset terms.
         batchDownload(cartType, elements, analyses, selectedFileTerms, selectedDatasetTerms, facetFields, savedCartObj, sharedCart, setInProgress, options, fetch);
     };
 

--- a/src/encoded/static/components/cart/cart.js
+++ b/src/encoded/static/components/cart/cart.js
@@ -93,8 +93,8 @@ const analysisFieldMap = (analysisTitles) => (
 
 
 /**
- * Field `getValue` function so that files without a `biosample_ontology` can have a "None" facet
- * term for those files lacking a biosample ontology.
+ * `getValue` function that retrieves a file's `biosample_ontology`, or returns "None" for those
+ * files lacking a biosample ontology so that we can have a "None" facet term.
  * @param {object} file ...from which to extract the `biosample_ontology` property
  * @return {object} file's biosample_ontology property, or one containing "None"
  */

--- a/src/encoded/static/components/cart/cart.js
+++ b/src/encoded/static/components/cart/cart.js
@@ -93,20 +93,6 @@ const analysisFieldMap = (analysisTitles) => (
 
 
 /**
- * `getValue` function that retrieves a file's `biosample_ontology`, or returns "None" for those
- * files lacking a biosample ontology so that we can have a "None" facet term.
- * @param {object} file ...from which to extract the `biosample_ontology` property
- * @return {object} file's biosample_ontology property, or one containing "None"
- */
-const fileBiosampleValue = (file) => {
-    if (file.biosample_ontology) {
-        return file.biosample_ontology;
-    }
-    return { term_name: 'None' };
-};
-
-
-/**
  * Field `getValue` function to extract the top @type from the given dataset.
  * @param {object} dataset ...from which to extract its @type
  * @return {string} Top-level @type of given dataset
@@ -160,7 +146,7 @@ const displayedFileFacetFields = [
         expanded: true,
     },
     {
-        field: 'analysis',
+        field: 'analyses',
         title: 'Analysis',
         dataset: true,
         sorter: analysisSorter,
@@ -168,24 +154,6 @@ const displayedFileFacetFields = [
         calculated: true,
         parent: 'assembly',
         css: 'cart-facet--analysis',
-    },
-    {
-        field: 'assay_title',
-        title: 'Assay',
-        dataset: true,
-        preferred: true,
-    },
-    {
-        field: 'biosample_ontology.term_name',
-        title: 'Biosample',
-        preferred: true,
-        getValue: fileBiosampleValue,
-    },
-    {
-        field: 'target.label',
-        title: 'Target of assay',
-        dataset: true,
-        preferred: true,
     },
     {
         field: 'annotation_type',
@@ -240,7 +208,7 @@ const displayedFileFacetFields = [
 
 const displayedDatasetFacetFields = [
     {
-        field: 'datasetType',
+        field: 'type',
         title: 'Dataset type',
         getValue: datasetTypeValue,
         termDisplay: DatasetTypeTermDisplay,
@@ -281,6 +249,7 @@ const requestedFacetFields = displayedFileFacetFields
     .filter((field) => !field.calculated).concat([
         { field: '@id' },
         { field: 'accession', dataset: true },
+        { field: 'biosample_summary', dataset: true },
         { field: 'assembly' },
         { field: 'assay_term_name' },
         { field: 'file_format_type' },
@@ -1264,7 +1233,8 @@ CartAccessories.defaultProps = {
 const CartTools = ({
     elements,
     analyses,
-    selectedTerms,
+    selectedFileTerms,
+    selectedDatasetTerms,
     selectedDatasetType,
     facetFields,
     savedCartObj,
@@ -1290,7 +1260,8 @@ const CartTools = ({
                 <CartBatchDownload
                     elements={elements}
                     analyses={analyses}
-                    selectedTerms={selectedTerms}
+                    selectedFileTerms={selectedFileTerms}
+                    selectedDatasetTerms={selectedDatasetTerms}
                     selectedType={selectedDatasetType}
                     facetFields={facetFields}
                     cartType={cartType}
@@ -1317,8 +1288,10 @@ CartTools.propTypes = {
     elements: PropTypes.array,
     /** All compiled analyses for the cart */
     analyses: PropTypes.array,
-    /** Selected facet terms */
-    selectedTerms: PropTypes.object,
+    /** Selected file facet terms */
+    selectedFileTerms: PropTypes.object,
+    /** Selected file facet terms */
+    selectedDatasetTerms: PropTypes.object,
     /** Selected dataset type */
     selectedDatasetType: PropTypes.string.isRequired,
     /** Currently used facet field definitions */
@@ -1340,7 +1313,8 @@ CartTools.propTypes = {
 CartTools.defaultProps = {
     elements: [],
     analyses: [],
-    selectedTerms: null,
+    selectedFileTerms: null,
+    selectedDatasetTerms: null,
     savedCartObj: null,
     sharedCart: null,
     fileCounts: {},
@@ -2262,8 +2236,8 @@ const CartComponent = ({ context, savedCartObj, inProgress, fetch, session }) =>
     };
 
     // Get the currently selected dataset type if the user selected exactly one.
-    const selectedDatasetType = selectedDatasetTerms.datasetType && selectedDatasetTerms.datasetType.length === 1
-        ? selectedDatasetTerms.datasetType[0]
+    const selectedDatasetType = selectedDatasetTerms.type && selectedDatasetTerms.type.length === 1
+        ? selectedDatasetTerms.type[0]
         : '';
 
     // Called when the user clicks any term in any facet.
@@ -2461,9 +2435,10 @@ const CartComponent = ({ context, savedCartObj, inProgress, fetch, session }) =>
                             elements={cartDatasets}
                             analyses={analyses}
                             savedCartObj={savedCartObj}
-                            selectedTerms={selectedFileTerms}
+                            selectedFileTerms={selectedFileTerms}
+                            selectedDatasetTerms={selectedDatasetTerms}
                             selectedDatasetType={selectedDatasetType}
-                            facetFields={usedFileFacetFields}
+                            facetFields={requestedFacetFields}
                             viewableDatasets={viewableDatasets}
                             cartType={cartType}
                             sharedCart={context}

--- a/src/encoded/static/components/cart/cart.js
+++ b/src/encoded/static/components/cart/cart.js
@@ -1093,13 +1093,14 @@ const DatasetFacets = ({
     selectedTerms,
     selectedDatasetCount,
     termClickHandler,
+    facetLoadProgress,
     clearFacetSelections,
 }) => {
     const [expandedStates, handleExpanderClick] = useExpanders(displayedDatasetFacetFields);
 
     return (
         <div className="cart__display-facets">
-            <FacetCount count={selectedDatasetCount} element="dataset" facetLoadProgress={-1} />
+            <FacetCount count={selectedDatasetCount} element="dataset" facetLoadProgress={facetLoadProgress} />
             {displayedDatasetFacetFields.map((facetField) => {
                 const facetContent = facets.find((facet) => facet.field === facetField.field);
                 if (facetContent) {
@@ -1132,6 +1133,8 @@ DatasetFacets.propTypes = {
     selectedDatasetCount: PropTypes.number,
     /** Callback when the user clicks on a file format facet item */
     termClickHandler: PropTypes.func.isRequired,
+    /** Facet-loading progress for progress bar, or null if not displayed */
+    facetLoadProgress: PropTypes.number,
     /** Callback for clearing a single facet's selections */
     clearFacetSelections: PropTypes.func.isRequired,
 };
@@ -1140,6 +1143,7 @@ DatasetFacets.defaultProps = {
     facets: [],
     selectedTerms: null,
     selectedDatasetCount: 0,
+    facetLoadProgress: null,
 };
 
 
@@ -2237,19 +2241,19 @@ const CartComponent = ({ context, savedCartObj, inProgress, fetch, session }) =>
     ), [selectedDatasetTerms, viewableDatasets]);
 
     // Build the facets based on the currently selected facet terms.
-    const datasetFiles = React.useMemo(() => filterForDatasetFiles(allFiles, selectedDatasets), [allFiles, selectedDatasets]);
+    const selectedDatasetFiles = React.useMemo(() => filterForDatasetFiles(allFiles, selectedDatasets), [allFiles, selectedDatasets]);
     const { fileFacets, selectedFiles } = React.useMemo(() => {
-        let files = defaultOnly ? filterForDefaultFiles(datasetFiles) : datasetFiles;
+        let files = defaultOnly ? filterForDefaultFiles(selectedDatasetFiles) : selectedDatasetFiles;
         files = visualizableOnly ? filterForVisualizableFiles(files) : files;
         return assembleFileFacets(selectedFileTerms, files, analyses, usedFileFacetFields);
-    }, [selectedFileTerms, selectedDatasets, visualizableOnly, defaultOnly, datasetFiles, analyses, usedFileFacetFields]);
+    }, [selectedFileTerms, selectedDatasets, visualizableOnly, defaultOnly, selectedDatasetFiles, analyses, usedFileFacetFields]);
 
     // Construct the file lists for the genome browser and raw file tabs.
-    const rawdataFiles = React.useMemo(() => datasetFiles.filter((files) => !files.assembly), [datasetFiles]);
+    const rawdataFiles = React.useMemo(() => selectedDatasetFiles.filter((files) => !files.assembly), [selectedDatasetFiles]);
     const selectedVisualizableFiles = React.useMemo(() => {
-        const files = defaultOnly ? filterForDefaultFiles(datasetFiles) : datasetFiles;
+        const files = defaultOnly ? filterForDefaultFiles(selectedDatasetFiles) : selectedDatasetFiles;
         return getSelectedVisualizableFiles(filterForVisualizableFiles(files), selectedFileTerms);
-    }, [datasetFiles, selectedFileTerms]);
+    }, [selectedDatasetFiles, selectedFileTerms]);
 
     // Called when the user selects a new page of items to view using the pager.
     const updateDisplayedPage = (newDisplayedPage) => {
@@ -2479,6 +2483,7 @@ const CartComponent = ({ context, savedCartObj, inProgress, fetch, session }) =>
                                         facets={datasetFacets}
                                         selectedTerms={selectedDatasetTerms}
                                         selectedDatasetCount={selectedDatasets.length}
+                                        facetLoadProgress={facetProgress}
                                         termClickHandler={handleDatasetTermClick}
                                         clearFacetSelections={clearDatasetFacetSelections}
                                     />

--- a/src/encoded/static/components/cart/cart.js
+++ b/src/encoded/static/components/cart/cart.js
@@ -146,7 +146,7 @@ const displayedFileFacetFields = [
         expanded: true,
     },
     {
-        field: 'analyses',
+        field: 'analysis',
         title: 'Analysis',
         dataset: true,
         sorter: analysisSorter,
@@ -258,7 +258,7 @@ const requestedFacetFields = displayedFileFacetFields
         { field: 'href' },
         { field: 'dataset' },
         { field: 'biological_replicates' },
-        { field: 'analysis_objects', dataset: true },
+        { field: 'analyses', dataset: true },
         { field: 'preferred_default' },
         { field: 'annotation_subtype', dataset: true },
         { field: 'biochemical_inputs', dataset: true },
@@ -267,7 +267,7 @@ const requestedFacetFields = displayedFileFacetFields
     ]);
 
 /** Facet `field` values for properties from dataset instead of files */
-const datasetFieldFileFacets = displayedFileFacetFields.concat(requestedFacetFields).filter((facetField) => facetField.dataset).map((facetField) => facetField.field);
+const datasetFieldFileFacets = displayedFileFacetFields.filter((facetField) => facetField.dataset).map((facetField) => facetField.field);
 
 /** Map of abbreviations for the allowed dataset types */
 const datasetTabTitles = {
@@ -2438,7 +2438,7 @@ const CartComponent = ({ context, savedCartObj, inProgress, fetch, session }) =>
                             selectedFileTerms={selectedFileTerms}
                             selectedDatasetTerms={selectedDatasetTerms}
                             selectedDatasetType={selectedDatasetType}
-                            facetFields={requestedFacetFields}
+                            facetFields={displayedFileFacetFields.concat(displayedDatasetFacetFields)}
                             viewableDatasets={viewableDatasets}
                             cartType={cartType}
                             sharedCart={context}

--- a/src/encoded/static/components/cart/cart.js
+++ b/src/encoded/static/components/cart/cart.js
@@ -2237,19 +2237,19 @@ const CartComponent = ({ context, savedCartObj, inProgress, fetch, session }) =>
     ), [selectedDatasetTerms, viewableDatasets]);
 
     // Build the facets based on the currently selected facet terms.
+    const datasetFiles = React.useMemo(() => filterForDatasetFiles(allFiles, selectedDatasets), [allFiles, selectedDatasets]);
     const { fileFacets, selectedFiles } = React.useMemo(() => {
-        let files = defaultOnly ? filterForDefaultFiles(allFiles) : allFiles;
+        let files = defaultOnly ? filterForDefaultFiles(datasetFiles) : datasetFiles;
         files = visualizableOnly ? filterForVisualizableFiles(files) : files;
-        files = filterForDatasetFiles(files, selectedDatasets);
         return assembleFileFacets(selectedFileTerms, files, analyses, usedFileFacetFields);
-    }, [selectedFileTerms, selectedDatasets, visualizableOnly, defaultOnly, allFiles, analyses, usedFileFacetFields]);
+    }, [selectedFileTerms, selectedDatasets, visualizableOnly, defaultOnly, datasetFiles, analyses, usedFileFacetFields]);
 
     // Construct the file lists for the genome browser and raw file tabs.
-    const rawdataFiles = React.useMemo(() => allFiles.filter((files) => !files.assembly), [allFiles]);
+    const rawdataFiles = React.useMemo(() => datasetFiles.filter((files) => !files.assembly), [datasetFiles]);
     const selectedVisualizableFiles = React.useMemo(() => {
-        const files = defaultOnly ? filterForDefaultFiles(allFiles) : allFiles;
+        const files = defaultOnly ? filterForDefaultFiles(datasetFiles) : datasetFiles;
         return getSelectedVisualizableFiles(filterForVisualizableFiles(files), selectedFileTerms);
-    }, [allFiles, selectedFileTerms]);
+    }, [datasetFiles, selectedFileTerms]);
 
     // Called when the user selects a new page of items to view using the pager.
     const updateDisplayedPage = (newDisplayedPage) => {

--- a/src/encoded/static/components/cart/cart.js
+++ b/src/encoded/static/components/cart/cart.js
@@ -807,7 +807,7 @@ const FacetExpander = ({ title, field, labelId, expanded, selectionCount, expand
     return (
         <div className="cart-facet__expander cart-facet__expander--non-collapsable">
             <FacetTitle title={title} />
-            <FacetSelectionControl selectionCount={selectionCount} clearSelectionHandler={controlClickHandler} />
+            <FacetSelectionControl name={field} selectionCount={selectionCount} clearSelectionHandler={controlClickHandler} />
         </div>
     );
 };

--- a/src/encoded/static/components/cart/remove_multiple.js
+++ b/src/encoded/static/components/cart/remove_multiple.js
@@ -1,0 +1,89 @@
+/**
+ * Displays a button to remove a specific set of datasets from the cart.
+ */
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { removeMultipleFromCartAndSave } from './actions';
+
+
+/**
+ * Renders a button to remove all the given datasets from the current cart.
+ */
+const CartRemoveElementsComponent = ({
+    savedCartObj,
+    elements,
+    inProgress,
+    removeMultipleItems,
+    loggedIn,
+}) => {
+    const handleClick = () => {
+        if (loggedIn && elements.length > 0) {
+            removeMultipleItems(elements);
+        }
+    };
+
+    const cartName = savedCartObj && Object.keys(savedCartObj).length > 0 ? savedCartObj.name : '';
+    return (
+        <button
+            type="button"
+            disabled={inProgress || (savedCartObj && savedCartObj.locked)}
+            className="btn btn-info btn-sm"
+            onClick={handleClick}
+            title={`Add all related experiments to cart${cartName ? `: ${cartName}` : ''}`}
+        >
+            Remove displayed items from cart
+        </button>
+    );
+};
+
+CartRemoveElementsComponent.propTypes = {
+    /** Current cart saved object */
+    savedCartObj: PropTypes.object,
+    /** New elements to add to cart as array of @ids */
+    elements: PropTypes.array.isRequired,
+    /** True if cart updating operation is in progress */
+    inProgress: PropTypes.bool.isRequired,
+    /** Function to call when Add All clicked */
+    removeMultipleItems: PropTypes.func.isRequired,
+    /** True if user has logged in */
+    loggedIn: PropTypes.bool.isRequired,
+};
+
+CartRemoveElementsComponent.defaultProps = {
+    savedCartObj: null,
+};
+
+CartRemoveElementsComponent.mapStateToProps = (state, ownProps) => ({
+    savedCartObj: state.savedCartObj,
+    elements: ownProps.elements,
+    inProgress: state.inProgress,
+    loggedIn: ownProps.loggedIn,
+});
+
+CartRemoveElementsComponent.mapDispatchToProps = (dispatch, ownProps) => ({
+    removeMultipleItems: (elements) => dispatch(removeMultipleFromCartAndSave(elements, ownProps.fetch)),
+});
+
+const CartRemoveElementsInternal = connect(CartRemoveElementsComponent.mapStateToProps, CartRemoveElementsComponent.mapDispatchToProps)(CartRemoveElementsComponent);
+
+
+// Public component used to bind to context properties.
+const CartRemoveElements = ({ elements }, reactContext) => (
+    <CartRemoveElementsInternal elements={elements} fetch={reactContext.fetch} loggedIn={!!(reactContext.session && reactContext.session['auth.userid'])} />
+);
+
+CartRemoveElements.propTypes = {
+    /** New elements to add to cart as array of @ids */
+    elements: PropTypes.array,
+};
+
+CartRemoveElements.defaultProps = {
+    elements: [],
+};
+
+CartRemoveElements.contextTypes = {
+    session: PropTypes.object,
+    fetch: PropTypes.func,
+};
+
+export default CartRemoveElements;

--- a/src/encoded/static/components/globals.js
+++ b/src/encoded/static/components/globals.js
@@ -51,6 +51,14 @@ export const uc = {
     rdquo: '\u201d', // Right double quote
 };
 
+// Used to compare keyboard event key codes.
+export const keyCode = {
+    RETURN: 13,
+    ESC: 27,
+    SPACE: 32,
+};
+
+
 // Report-page cell components
 export const reportCell = new Registry();
 

--- a/src/encoded/static/components/objectutils.js
+++ b/src/encoded/static/components/objectutils.js
@@ -879,6 +879,20 @@ export const filterForDefaultFiles = (fileList) => (
 
 
 /**
+ * Filter the given files to only include those that appear in the given datasets.
+ * @param {array} fileList Files to filter
+ *
+ * @return {array} Members of `fileList` that have preferred_default flag set.
+ */
+export const filterForDatasetFiles = (fileList, datasets) => {
+    const datasetFilePaths = datasets
+        .reduce((files, dataset) => (dataset.files ? files.concat(dataset.files) : files), [])
+        .map((file) => file['@id']);
+    return fileList.filter((file) => datasetFilePaths.includes(file['@id']));
+};
+
+
+/**
  * Displays an item count intended for the tops of table, normally reflecting a search result count.
  */
 export const TableItemCount = ({ count }) => (

--- a/src/encoded/static/libs/svg-icons.js
+++ b/src/encoded/static/libs/svg-icons.js
@@ -134,6 +134,34 @@ const checkbox = (style) => (
     </svg>
 );
 
+const dataset = (style) => (
+    <svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 500" style={style} className="svg-icon svg-icon-archive">
+        <polygon points="354.26,235.5 314.26,235.5 314.26,277.69 185.74,277.69 185.74,235.5 145.74,235.5 145.74,317.69 354.26,317.69" />
+        <path d="M500.5,37.5h-501v148h38v278h425v-278h38V37.5z M39.5,77.5h421v68h-421V77.5z M422.5,423.5h-345v-238h345V423.5z" />
+        <polygon points="354.26,317.69 145.74,317.69 145.74,235.5 185.74,235.5 185.74,277.69 314.26,277.69 314.26,235.5 354.26,235.5" />
+    </svg>
+);
+
+const file = (style) => (
+    <svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 500" style={style} className="svg-icon svg-icon-file">
+        <g>
+            <path d="M156.73,187.92c-28.12,0-44.92-18.83-44.92-50.31v-16.64c0-31.48,16.8-50.31,44.92-50.31s44.92,18.83,44.92,50.31v16.64
+                C201.65,169.09,184.85,187.92,156.73,187.92z M172.51,137.29v-16.02c0-18.44-4.92-26.88-15.78-26.88s-15.78,8.44-15.78,26.88v16.02
+                c0,18.44,4.92,26.88,15.78,26.88S172.51,155.73,172.51,137.29z"/>
+            <path d="M211.28,185.65v-22.27h28.12V98.77h-1.48l-26.64,18.36V92.45l28.12-19.53h27.89v90.47h26.72v22.27H211.28z" />
+            <path d="M343.43,187.92c-28.12,0-44.92-18.83-44.92-50.31v-16.64c0-31.48,16.8-50.31,44.92-50.31s44.92,18.83,44.92,50.31v16.64
+                C388.36,169.09,371.56,187.92,343.43,187.92z M359.22,137.29v-16.02c0-18.44-4.92-26.88-15.78-26.88s-15.78,8.44-15.78,26.88v16.02
+                c0,18.44,4.92,26.88,15.78,26.88S359.22,155.73,359.22,137.29z"/>
+            <path d="M118.68,325.65v-22.27h28.12v-64.61h-1.48l-26.64,18.36v-24.69l28.12-19.53h27.89v90.47h26.72v22.27H118.68z" />
+            <path d="M211.2,325.65v-22.27h28.12v-64.61h-1.48l-26.64,18.36v-24.69l28.12-19.53h27.89v90.47h26.72v22.27H211.2z" />
+            <path d="M343.35,327.92c-28.12,0-44.92-18.83-44.92-50.31v-16.64c0-31.48,16.8-50.31,44.92-50.31s44.92,18.83,44.92,50.31v16.64
+                C388.28,309.09,371.48,327.92,343.35,327.92z M359.14,277.29v-16.02c0-18.44-4.92-26.88-15.78-26.88s-15.78,8.44-15.78,26.88v16.02
+                c0,18.44,4.92,26.88,15.78,26.88S359.14,295.73,359.14,277.29z"/>
+        </g>
+        <path d="M0,0v500h349h40.98H390v-0.02L499.98,390H500v-0.02V350V0H0z M40,40h420v310H350v110H40V40z M390,443.41V390h53.41 L390,443.41z" />
+    </svg>
+);
+
 const icons = {
     disclosure: (style) => <svg id="Disclosure" data-name="Disclosure" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 480" style={style} className="svg-icon svg-icon-disclosure"><circle cx="240" cy="240" r="240" /><polyline points="401.79 175.66 240 304.34 78.21 175.66" /></svg>,
     table,
@@ -145,6 +173,8 @@ const icons = {
     asterisk: (style) => <svg id="Asterisk" data-name="Asterisk" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" style={style}><polygon points="15.68 5.3 14.18 2.7 8.94 6.38 9.5 0 6.5 0 7.06 6.38 1.82 2.7 0.32 5.3 6.13 8 0.32 10.7 1.82 13.3 7.06 9.62 6.5 16 9.5 16 8.94 9.62 14.18 13.3 15.68 10.7 9.87 8 15.68 5.3" /></svg>,
     chevronDown: (style) => <svg id="Chevron Down" data-name="Chevron Down" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 249 124" style={style}><polygon points="249,57 124.5,124 0,57 0,0 124.5,67 249,0" /></svg>,
     chevronUp: (style) => <svg id="Chevron Up" data-name="Chevron Up" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 249 124" style={style}><polygon points="249,67 124.5,0 0,67 0,124 124.5,57 249,124" /></svg>,
+    circle: (style) => <svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 500" style={style} className="svg-icon svg-icon-circle"><circle cx="250" cy="250" r="250" /></svg>,
+    multiplication: (style) => <svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 500" style={style} className="svg-icon svg-icon-multiplication"><polygon points="500,99 401,0 250,151.01 99,0 0,99 151.01,250 0,401 99,500 250,348.99 401,500 500,401 348.99,250" /></svg>,
     chevronLeft,
     chevronRight,
     spinner,
@@ -156,6 +186,8 @@ const icons = {
     lockClosed,
     clipboard,
     checkbox,
+    dataset,
+    file,
 };
 
 /**
@@ -178,7 +210,7 @@ export const collapseIcon = (collapsed, addClasses) => (
                 <line className="content-line" x1="151.87" y1="256" x2="360.13" y2="256" />
                 <line className="content-line" x1="256" y1="151.87" x2="256" y2="360.13" />
             </g>
-        :
+            :
             <g>
                 <title>Panel open</title>
                 <circle className="bg" cx="256" cy="256" r="240" />

--- a/src/encoded/static/scss/encoded/modules/_cart.scss
+++ b/src/encoded/static/scss/encoded/modules/_cart.scss
@@ -410,24 +410,34 @@ $cart-facet-visualizable-padding: 2px;
     // Button to expand or collapse a facet
     @at-root #{&}__expander {
         display: flex;
-        justify-content: space-between;
+        align-items: center;
+        width: 100%;
         padding: 10px 0;
-        margin: 5px 5px 10px;
+        margin: 0;
         border-bottom: 1px solid #c0c0c0;
         cursor: pointer;
+        background-color: transparent;
+        border: none;
 
         @at-root #{&}-title {
             flex: 0 1 auto;
+            position: relative;
+            top: 1px; // Offset for all uppercase lack of decenders
             text-transform: uppercase;
             font-weight: bold;
         }
 
         .icon {
             flex: 0 0 auto;
+            margin-left: auto;
         }
 
         &[aria-expanded="false"] {
             border-bottom: none;
+        }
+
+        @at-root #{&}--non-collapsable {
+            cursor: default;
         }
     }
 
@@ -444,8 +454,11 @@ $cart-facet-visualizable-padding: 2px;
         // Covers all the components within a facet term.
         @at-root #{&}__item {
             display: flex;
+            width: 100%;
             justify-content: space-between;
             cursor: pointer;
+            background-color: transparent;
+            border: none;
         }
 
         // Checkbox for a facet term
@@ -491,6 +504,7 @@ $cart-facet-visualizable-padding: 2px;
         @at-root #{&}__text {
             padding: 0 5px;
             flex: 1 0 60%;
+            text-align: left;
             font-size: 0.95rem;
         }
 
@@ -502,6 +516,7 @@ $cart-facet-visualizable-padding: 2px;
             padding: 0 5px 0;
             width: auto;
             height: $cart-facet-magnitude-size;
+            line-height: $cart-facet-magnitude-size;
             border-radius: $cart-facet-magnitude-size / 2;
 
             > span {
@@ -531,9 +546,12 @@ $cart-facet-visualizable-padding: 2px;
 }
 
 // File-count note above facet
-.cart__facet-file-count {
+.cart__facet-count {
+    display: flex;
+    align-items: center;
+    justify-content: center;
     position: relative;
-    padding: 5px;
+    padding: 2px 5px 3px;
     margin: 0 -10px 10px;
     background-color: #d8d8d8;
     text-align: center;
@@ -556,6 +574,13 @@ $cart-facet-visualizable-padding: 2px;
         z-index: 0;
         animation-duration: 0.2s;
         animation-name: change-flash;
+    }
+
+    .svg-icon {
+        margin-right: 5px;
+        width: 20px;
+        height: 20px;
+        fill: #000;
     }
 }
 
@@ -858,6 +883,14 @@ $deleted-bg: #ffe0e0;
             display: block;
         }
     }
+
+    // Icon in cart tab
+    .svg-icon {
+        margin-right: 5px;
+        width: 16px;
+        height: 16px;
+        fill: #000;
+    }
 }
 
 // Defines cart-list identifier colors based on `file_format`
@@ -1133,9 +1166,6 @@ $file-type-colors: (
 
 .cart-pager-area {
     display: flex;
-    padding: 3px;
-    justify-content: flex-end;
-    border-bottom: 1px solid #ccc;
 }
 
 .nav {
@@ -1349,6 +1379,53 @@ $file-type-colors: (
             &:hover {
                 text-decoration: none;
             }
+        }
+    }
+}
+
+// Controls at the top of search results, below the tabs.
+.cart-search-results-controls {
+    display: flex;
+    padding: 5px;
+    justify-content: space-between;
+    border-bottom: 1px solid #ccc;
+}
+
+// Control to clear all seletions within a facet.
+.cart-facet-clear {
+    position: relative;
+    margin: 0 0 0 5px;
+    padding: 0;
+    border: none;
+    background-color: transparent;
+    width: 10px;
+    height: 10px;
+
+    .cart-facet-clear__control {
+        position: absolute;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
+
+        .svg-icon-circle {
+            display: block;
+            fill: #008000;
+        }
+
+        .svg-icon-multiplication {
+            display: none;
+            fill: #b24342;
+        }
+    }
+
+    &:hover {
+        .svg-icon-circle {
+            display: none;
+        }
+
+        .svg-icon-multiplication {
+            display: block;
         }
     }
 }

--- a/src/encoded/tests/features/cart.feature
+++ b/src/encoded/tests/features/cart.feature
@@ -8,6 +8,7 @@ Feature: Cart
         When I press "/experiments/ENCSR611ZAL/"
         And I press "/experiments/ENCSR000INT/"
         And I press "/experiments/ENCSR000DZQ/"
+        And I wait for the content to load
         Then I should see 3 elements with the css selector ".cart-toggle--in-cart"
         And I should see an element with the css selector ".cart__nav-button"
 
@@ -23,25 +24,29 @@ Feature: Cart
         When I press "cart-control"
         And I click the link to "/cart-view/"
         And I wait for the content to load
-        Then I should see 7 elements with the css selector ".result-item"
-        And I should see "5 files selected"
-        When I press "default-data-toggle"
-        Then I should see "4 files selected"
+        Then I should see 6 elements with the css selector ".result-item"
+        And I should see "6 datasets selected"
+        When I press "cart-facet-term-Experiment"
+        Then I should see "3 datasets selected"
+
+    Scenario: Exercise file facets
         When I click the link to "#processeddata"
-        Then I should see 4 elements with the css selector ".cart-list-item"
+        Then I should see "3 files selected"
+        And I should see 3 elements with the css selector ".cart-list-item"
+        When I press "default-data-toggle"
+        Then I should see "3 files selected"
+        And I should see 3 elements with the css selector ".cart-list-item"
         When I click the link to "#rawdata"
         Then I should see 0 elements with the css selector ".cart-list-item"
 
     Scenario: Cart page interactions
         When I click the link to "#processeddata"
-        And I click the element with the css selector ".cart-dataset-selector"
-        And I click the element with the css selector ".cart-dataset-option.cart-dataset-option--experiments"
         And I wait for the content to load
         And I press "output_type-label"
         And I press "cart-facet-term-IDR ranked peaks"
         Then I should see "1 file selected"
         And I should see 1 elements with the css selector ".cart-list-item"
-        When I press "cart-facet-term-IDR ranked peaks"
+        When I press "cart-facet-clear-output_type"
         Then I should see "3 files selected"
         And I should see 3 elements with the css selector ".cart-list-item"
         When I press "Download processed data files"
@@ -51,11 +56,12 @@ Feature: Cart
         When I click the link to "#datasets"
         And I press "/experiments/ENCSR000INT/"
         And I wait for the content to load
-        Then I should see 2 elements with the css selector ".result-item"
-        And I should see "3 files selected"
+        Then I should see 5 elements with the css selector ".result-item"
+        And I should see "5 datasets selected"
 
     Scenario: Download menu
-        When I press "cart-download"
+        When I press "cart-facet-term-Experiment"
+        And I press "cart-download"
         Then I should see 3 elements with the css selector ".menu-item"
         When I press "raw"
         Then I should see "Download raw data files"

--- a/src/encoded/tests/features/cart.feature
+++ b/src/encoded/tests/features/cart.feature
@@ -8,7 +8,7 @@ Feature: Cart
         When I press "/experiments/ENCSR611ZAL/"
         And I press "/experiments/ENCSR000INT/"
         And I press "/experiments/ENCSR000DZQ/"
-        And I wait for the content to load
+        And I wait for 5 seconds
         Then I should see 3 elements with the css selector ".cart-toggle--in-cart"
         And I should see an element with the css selector ".cart__nav-button"
 
@@ -24,8 +24,8 @@ Feature: Cart
         When I press "cart-control"
         And I click the link to "/cart-view/"
         And I wait for the content to load
-        Then I should see 6 elements with the css selector ".result-item"
-        And I should see "6 datasets selected"
+        Then I should see 7 elements with the css selector ".result-item"
+        And I should see "7 datasets selected"
         When I press "cart-facet-term-Experiment"
         Then I should see "3 datasets selected"
 
@@ -54,10 +54,11 @@ Feature: Cart
         When I press "Close"
         Then I should not see an element with the css selector ".modal"
         When I click the link to "#datasets"
+        And I wait for 5 seconds
         And I press "/experiments/ENCSR000INT/"
         And I wait for the content to load
-        Then I should see 5 elements with the css selector ".result-item"
-        And I should see "5 datasets selected"
+        Then I should see 6 elements with the css selector ".result-item"
+        And I should see "6 datasets selected"
 
     Scenario: Download menu
         When I press "cart-facet-term-Experiment"


### PR DESCRIPTION
* Instead of tracking only the `@ids` of datasets, and retrieving a page of dataset objects every time the user wants to view a new page of datasets, I now load and keep all datasets (just a subset of their properties) just as file objects have worked. So functions like `CartSearchResults` no longer have to fetch dataset objects.
* We now load dataset descriptions on the cart-view page so that the selected annotations appear with full descriptions, just as they do on the annotation search page.
* `FileFacets` no longer resets facets when switching between showing default files only and all files, so we no longer need the useUpdate callback.
* I have a lot of duplication between file-facet code and dataset-facet code. I looked into trying to consolidate some of that, but it doesn’t look straightforward. Maybe someday.