### PR TITLE
ENCD-5808 facet for biochemical inputs

### DIFF
--- a/src/encoded/schemas/annotation.json
+++ b/src/encoded/schemas/annotation.json
@@ -254,8 +254,8 @@
             "length": "long",
             "open_on_load": true
         },
-        "annotation_type": {
-            "title": "Annotation type",
+        "annotation_subtype": {
+            "title": "Annotation subtype",
             "length": "long",
             "open_on_load": true
         },
@@ -269,6 +269,9 @@
         "organism.scientific_name": {
             "title": "Organism",
             "open_on_load": true
+        },
+        "biochemical_inputs": {
+            "title": "Biochemical inputs"
         },
         "targets.investigated_as": {
             "title": "Target category"

--- a/src/encoded/search_views.py
+++ b/src/encoded/search_views.py
@@ -51,6 +51,7 @@ from snovault.elasticsearch.searches.responses import FieldedResponse
 def includeme(config):
     config.add_route('search', '/search{slash:/?}')
     config.add_route('series_search', '/series-search{slash:/?}')
+    config.add_route('encyclopedia', '/encyclopedia{slash:/?}')
     config.add_route('searchv2_raw', '/searchv2_raw{slash:/?}')
     config.add_route('searchv2_quick', '/searchv2_quick{slash:/?}')
     config.add_route('report', '/report{slash:/?}')
@@ -128,6 +129,38 @@ def series_search(context, request):
             BasicSearchWithFacetsResponseField(
                 default_item_types=DEFAULT_ITEM_TYPES,
                 reserved_keys=RESERVED_KEYS,
+            ),
+            AllResponseField(),
+            NotificationResponseField(),
+            FiltersResponseField(),
+            ClearFiltersResponseField(),
+            ColumnsResponseField(),
+            SortResponseField(),
+            DebugQueryResponseField()
+        ]
+    )
+    return fr.render()
+
+
+@view_config(route_name='encyclopedia', request_method='GET', permission='search')
+def encyclopedia(context, request):
+    # Note the order of rendering matters for some fields, e.g. AllResponseField and
+    # NotificationResponseField depend on results from BasicSearchWithFacetsResponseField.
+    fr = FieldedResponse(
+        _meta={
+            'params_parser': ParamsParser(request)
+        },
+        response_fields=[
+            TitleResponseField(
+                title="Encyclopedia"
+            ),
+            TypeResponseField(
+                at_type=["Encyclopedia"]
+            ),
+            IDResponseField(),
+            ContextResponseField(),
+            BasicSearchWithFacetsResponseField(
+                default_item_types=DEFAULT_ITEM_TYPES
             ),
             AllResponseField(),
             NotificationResponseField(),

--- a/src/encoded/static/components/encyclopedia.js
+++ b/src/encoded/static/components/encyclopedia.js
@@ -1,0 +1,53 @@
+import PropTypes from 'prop-types';
+import url from 'url';
+import { Panel, PanelBody } from '../libs/ui/panel';
+import { ResultTable } from './search';
+import * as globals from './globals';
+
+const Encyclopedia = (props, context) => {
+    const searchBase = url.parse(context.location_href).search || '';
+
+    const currentRegion = (assembly, region) => {
+        let lastRegion = {};
+        if (assembly && region) {
+            lastRegion = {
+                assembly,
+                region,
+            };
+        }
+        return lastRegion;
+    };
+
+    return (
+        <div className="layout">
+            <div className="layout__block layout__block--100">
+                <div className="block encyclopedia" data-pos="0,0,0">
+                    <h1>{props.context.title}</h1>
+                    <Panel>
+                        <PanelBody>
+                            <ResultTable
+                                {...props}
+                                searchBase={searchBase}
+                                onChange={context.navigate}
+                                currentRegion={currentRegion}
+                                hideDocType
+                            />
+                        </PanelBody>
+                    </Panel>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+Encyclopedia.propTypes = {
+    context: PropTypes.object.isRequired,
+};
+
+Encyclopedia.contextTypes = {
+    location_href: PropTypes.string,
+    navigate: PropTypes.func,
+    fetch: PropTypes.func,
+};
+
+globals.contentViews.register(Encyclopedia, 'Encyclopedia');

--- a/src/encoded/static/components/facets/biochemical_inputs.js
+++ b/src/encoded/static/components/facets/biochemical_inputs.js
@@ -1,0 +1,204 @@
+import PropTypes from 'prop-types';
+import FacetRegistry from './registry';
+import QueryString from '../../libs/query_string';
+
+
+/**
+ * Biochemical input facet works just like a regular facet but negating is not allowed, links look more like buttons, and there is an "Any" button to select any possible terms
+ */
+const BiochemicalInputsFacet = ({ results, facet, queryString }, reactContext) => {
+    // Get query terms from url
+    const originalQuery = new QueryString(queryString);
+    const originalInputs = originalQuery.getKeyValues('advancedQuery');
+
+    // Possible query entries must be hard-coded because the facet object does not always include all terms, plus we want to exclude rDHS
+    const facetTerms = ['CTCF', 'DNase-seq', 'H3K27ac', 'H3K4me3'];
+
+    // URl should indicate toggle position, but if not, default is "only"
+    let switchState = 'only';
+    if (reactContext.location_href.indexOf('#or') > -1) {
+        switchState = 'or';
+    }
+    // If no toggle position is indicated, "or" is the position when an "AND NOT" is present or when search is not biochemical_inputs:*
+    if (originalInputs && originalInputs[0]) {
+        const defaultOnly = (originalInputs[0] === 'biochemical_inputs:*') || (originalInputs[0].toString().indexOf('AND NOT') > -1);
+        if ((reactContext.location_href.indexOf('#') === -1) && !(defaultOnly)) {
+            switchState = 'or';
+        }
+    }
+
+    // Generate array of search parameters, ones selected by AND and de-selected by AND NOT
+    let originalInputsArray = [];
+    let originalNonincludedArray = [];
+    if (originalInputs.length > 0) {
+        originalInputsArray = originalInputs[0].toString().replace('biochemical_inputs:(', '').replace(')', '').split(' AND ');
+        originalInputsArray = originalInputsArray.filter((input) => input.indexOf('NOT') === -1);
+    }
+    if (originalInputs[0] === 'biochemical_inputs:*') {
+        originalInputsArray = facetTerms;
+    }
+    originalNonincludedArray = facetTerms.filter((key) => originalInputsArray.indexOf(key) === -1);
+
+    // Generate object which includes url for each button (each button is essentially a link)
+    // The object also indicates whether the button is currently selected or not (whether the url will be adding or removing that term)
+    const facetObj = {};
+    facetTerms.forEach((term) => {
+        const query = new QueryString(queryString);
+        facetObj[term] = {};
+        // Add new term if it does not exist
+        if (originalInputsArray.indexOf(term) === -1) {
+            const newInputsArray = originalInputsArray.concat([term]);
+            const nonincludedArray = originalNonincludedArray.filter((elem) => elem !== term);
+            if (switchState === 'only') {
+                if (nonincludedArray.length === 0) {
+                    query.replaceKeyValue('advancedQuery', 'biochemical_inputs:*');
+                } else {
+                    query.replaceKeyValue('advancedQuery', `biochemical_inputs:(${(Array.isArray(newInputsArray) && (newInputsArray.length > 0)) ? newInputsArray.join(' AND ') : newInputsArray}${(Array.isArray(nonincludedArray) && (nonincludedArray.length > 0)) ? ` AND NOT ${nonincludedArray.join(' AND NOT ')}` : ''})`);
+                }
+            } else {
+                query.replaceKeyValue('advancedQuery', `biochemical_inputs:(${(Array.isArray(newInputsArray) && (newInputsArray.length > 0)) ? newInputsArray.join(' AND ') : newInputsArray})`);
+            }
+            facetObj[term].selected = false;
+            facetObj[term].link = `?${query.format()}#${switchState.toLowerCase()}`;
+        // Remove new term if it does exist
+        } else {
+            const newInputsArray = originalInputsArray.filter((input) => input !== term);
+            const nonincludedArray = originalNonincludedArray.concat([term]);
+            if (newInputsArray.length === 0) {
+                query.deleteKeyValue('advancedQuery');
+            } else if (switchState === 'only') {
+                query.replaceKeyValue('advancedQuery', `biochemical_inputs:(${(Array.isArray(newInputsArray) && (newInputsArray.length > 0)) ? newInputsArray.join(' AND ') : newInputsArray}${(Array.isArray(nonincludedArray) && (nonincludedArray.length > 0)) ? ` AND NOT ${nonincludedArray.join(' AND NOT ')}` : ''})`);
+            } else {
+                query.replaceKeyValue('advancedQuery', `biochemical_inputs:(${(Array.isArray(newInputsArray) && (newInputsArray.length > 0)) ? newInputsArray.join(' AND ') : newInputsArray})`);
+            }
+            facetObj[term].selected = true;
+            facetObj[term].link = `?${query.format()}#${switchState}`;
+        }
+    });
+
+    // The "Any" / "All" button is special and will:
+    // (1) de-select all terms if currently selected
+    // (2) "Any" executes the query advancedQuery=biochemical_inputs:*
+    // (3) "All" executes the query advancedQuery=biochemical_inputs:(CTCF AND DNase-seq AND H3K27ac AND H3K4me3)
+    facetObj.Any = {};
+    if (originalInputsArray.length === facetTerms.length) {
+        const query = new QueryString(queryString);
+        query.deleteKeyValue('advancedQuery');
+        facetObj.Any.selected = true;
+        facetObj.Any.link = `?${query.format()}#${switchState}`;
+    } else {
+        const query = new QueryString(queryString);
+        let newInputsArray = originalInputsArray;
+        facetTerms.forEach((term) => {
+            if (originalInputsArray.indexOf(term) === -1) {
+                newInputsArray = newInputsArray.concat([term]);
+            }
+        });
+        if (switchState === 'or') {
+            query.replaceKeyValue('advancedQuery', `biochemical_inputs:(${facetTerms.join(' AND ')})`);
+        } else {
+            query.replaceKeyValue('advancedQuery', 'biochemical_inputs:*');
+        }
+        facetObj.Any.selected = false;
+        facetObj.Any.link = `?${query.format()}#${switchState}`;
+    }
+
+    // Generate url for toggling "Only" switch
+    const toggleSwitchState = () => {
+        if (Array.isArray(originalInputsArray) && (originalInputsArray.length > 0)) {
+            // Generate href for toggling between "AND" and "OR"
+            const switchQuery = new QueryString(queryString);
+            let switchQueryLink;
+            if (switchState === 'or' && originalInputsArray.length === facetTerms.length) {
+                switchQuery.replaceKeyValue('advancedQuery', 'biochemical_inputs:*');
+                switchQueryLink = `?${switchQuery.format()}#only`;
+            } else if (switchState === 'or') {
+                switchQuery.replaceKeyValue('advancedQuery', `biochemical_inputs:(${originalInputsArray.join(' AND ')}${(Array.isArray(originalNonincludedArray) && (originalNonincludedArray.length > 0)) ? ` AND NOT ${originalNonincludedArray.join(' AND NOT ')}` : ''})`);
+                switchQueryLink = `?${switchQuery.format()}#only`;
+            } else {
+                switchQuery.replaceKeyValue('advancedQuery', `biochemical_inputs:(${originalInputsArray.join(' AND ')})`);
+                switchQueryLink = `?${switchQuery.format()}#or`;
+            }
+            reactContext.navigate(switchQueryLink, { noscroll: true });
+        } else if (switchState === 'only' && reactContext.location_href.indexOf('#') > -1) {
+            reactContext.navigate(reactContext.location_href.replace('#only', '#or'), { noscroll: true });
+        } else if (reactContext.location_href.indexOf('#') > -1) {
+            reactContext.navigate(reactContext.location_href.replace('#or', '#only'), { noscroll: true });
+        } else {
+            reactContext.navigate(`${reactContext.location_href}#or`, { noscroll: true });
+        }
+    };
+
+    // Styles for toggle switch
+    const DEFAULT_SWITCH_HEIGHT = 22;
+    const DEFAULT_SWITCH_WIDTH = DEFAULT_SWITCH_HEIGHT * 1.6;
+    const switchWidth = DEFAULT_SWITCH_WIDTH;
+    const switchHeight = DEFAULT_SWITCH_HEIGHT;
+    const triggerSize = switchHeight - 4;
+    const switchStyles = {
+        width: switchWidth,
+        height: switchHeight,
+        borderRadius: switchHeight / 2,
+        backgroundColor: (switchState === 'only') ? '#4183c4' : '#e9e9eb',
+    };
+    const actuatorStyles = {
+        width: triggerSize,
+        height: triggerSize,
+        borderRadius: (switchHeight / 2) - 2,
+        top: 2,
+        left: (switchState === 'only') ? (switchWidth - switchHeight) + 2 : 2,
+    };
+
+
+    return (
+        <div className={`facet ${results['@type'].indexOf('Encyclopedia') === -1 ? 'hide' : ''}`}>
+            <h5>{facet.title}</h5>
+            <div className="biochemical-toggle-description">When the toggle is on, your search results will be an exact match for your biochemical inputs selections. When the toggle is off, your selections will appear in your search results and may include additional inputs.</div>
+            <label className="boolean-switch">
+                <div style={switchStyles} className="boolean-switch__frame">
+                    <div style={actuatorStyles} className="boolean-switch__actuator" />
+                </div>
+                <input type="checkbox" checked={switchState === 'only'} onChange={toggleSwitchState} />
+                <div className="boolean-switch__title">Only</div>
+            </label>
+            <div className="facet__multiselect">
+                {(facetObj && Object.keys(facetObj).length === (facetTerms.length + 1)) ?
+                    <>
+                        {facetTerms.map((term) => (
+                            <a href={facetObj[term].link} className={facetObj[term].selected ? 'selected' : ''}>
+                                {term}
+                            </a>
+                        ))}
+                        <a href={facetObj.Any.link} className={facetObj.Any.selected ? 'selected anyall' : 'anyall'}>
+                            {(switchState === 'only') ?
+                                'Any'
+                            :
+                                'All'
+                            }
+                        </a>
+                    </>
+                : null}
+            </div>
+        </div>
+    );
+};
+
+BiochemicalInputsFacet.propTypes = {
+    /** Complete search-results object */
+    results: PropTypes.object.isRequired,
+    /** Relevant `facet` object from `facets` array in `results` */
+    facet: PropTypes.object.isRequired,
+    /** Query-string portion of current URL without initial ? */
+    queryString: PropTypes.string,
+};
+
+BiochemicalInputsFacet.defaultProps = {
+    queryString: '',
+};
+
+BiochemicalInputsFacet.contextTypes = {
+    navigate: PropTypes.func,
+    location_href: PropTypes.string,
+};
+
+FacetRegistry.Facet.register('biochemical_inputs', BiochemicalInputsFacet);

--- a/src/encoded/static/components/facets/index.js
+++ b/src/encoded/static/components/facets/index.js
@@ -11,6 +11,7 @@ import { DefaultFacet, DefaultTitle, DefaultTerm, DefaultTermName, DefaultSelect
 // Custom facet-renderer modules imported here. Keep them alphabetically sorted.
 import './audit';
 import './audit_processed_data';
+import './biochemical_inputs';
 import './date_selector';
 import './exists';
 import './internal_status';

--- a/src/encoded/static/components/index.js
+++ b/src/encoded/static/components/index.js
@@ -19,6 +19,7 @@ require('./globals');
 require('./graph');
 require('./doc');
 require('./donor');
+require('./encyclopedia');
 require('./file');
 require('./item');
 require('./page');

--- a/src/encoded/static/scss/encoded/modules/_facet.scss
+++ b/src/encoded/static/scss/encoded/modules/_facet.scss
@@ -121,6 +121,36 @@
         }
     }
 
+    @at-root #{&}__multiselect {
+        a {
+            margin: 2px;
+            font-size: 0.9rem;
+            padding: 1px 5px;
+            display: block;
+            border-radius: 3px;
+            border: 1px solid #bfbfbf;
+            background-color: rgb(239, 239, 239);
+            color: #000;
+
+            &.selected {
+                color: white;
+                background-color: #4183c4;
+                border: 1px solid #4183c4;
+            }
+
+            &.anyall {
+                margin-top: 7px;
+                font-weight: 600;
+                background-color: #cecece;
+                border: 1px solid #7d7d7d;
+
+                &.selected {
+                    background-color: #0a447d;
+                }
+            }
+        }
+    }
+
     &:last-child {
         border-bottom: none;
         padding-bottom: 0;
@@ -147,6 +177,10 @@
     }
 
     .facet-close {
+        display: none;
+    }
+
+    &.hide {
         display: none;
     }
 }
@@ -627,4 +661,58 @@ div.meta-status {
     select {
         width: 100%;
     }
+}
+
+// Styles for boolean switch
+
+.boolean-switch {
+    display: flex;
+    position: relative;
+    padding: 2px;
+    justify-content: space-between;
+    cursor: pointer;
+    border-radius: 3px;
+    border: 2px solid transparent;
+
+    input[type='checkbox'] {
+        position: absolute;
+        width: 100%;
+        height: 100%;
+        opacity: 0;
+        z-index: -1;
+    }
+
+    @at-root #{&}__title {
+        display: flex;
+        align-items: center;
+        margin-left: 5px;
+    }
+
+    // The actuator slides inside the frame.
+    @at-root #{&}__frame {
+        position: relative;
+        border: none;
+        box-shadow: 0 1px 1px inset rgba(0, 0, 0, 0.2);
+        transition: background-color 0.2s ease;
+    }
+
+    @at-root #{&}__actuator {
+        position: absolute;
+        top: 2px;
+        background-color: #fff;
+        transition: left 0.2s ease, border-radius 0.2s ease, width 0.2s ease;
+        box-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
+    }
+
+    // Focus border because opacity:0 on <input> also hides this.
+    @at-root #{&}--focused {
+        border: 2px solid #000;
+    }
+}
+
+// Style for biochemical inputs facet
+
+.biochemical-toggle-description {
+    font-size: 0.9rem;
+    padding-bottom: 5px;
 }


### PR DESCRIPTION
Adds a new "biochemical_inputs" facet for annotations with the following properties:
- Facet applies to annotations but is only present on the encyclopedia page, not the search page for annotations
- Terms work like regular facet links but have no negation and look like buttons
- An additional "All" button is present which allows you to select all biochemical inputs or de-select all biochemical inputs, and it automatically highlights/unhighlights if all terms are selected/unselected

A couple thoughts:
- I originally called the new facet a "multiselect" which made sense to me at the time but now I'm not sure. However I didn't think of anything better so I am leaving it for now.
- The facet jumps position-wise in the sidebar based on whether or not "Target" is an available facet so maybe we will want to rearrange or maybe this is ok.