### PR TITLE
ENCD-5614-cart-dataset-filters

### DIFF
--- a/src/encoded/static/components/cart/cart.js
+++ b/src/encoded/static/components/cart/cart.js
@@ -518,11 +518,11 @@ CartPager.propTypes = {
 /**
  * Displays controls at the top of search results within the tab content areas.
  */
-const CartSearchResultsControls = ({ currentTab, elements, currentPage, totalPageCount, updateCurrentPage, loading }) => {
+const CartSearchResultsControls = ({ currentTab, elements, currentPage, totalPageCount, updateCurrentPage, cartType, loading }) => {
     if (currentTab === 'datasets' || totalPageCount > 1) {
         return (
             <div className="cart-search-results-controls">
-                {currentTab === 'datasets'
+                {currentTab === 'datasets' && cartType === 'ACTIVE'
                     ? <CartRemoveElements elements={elements.map((element) => element['@id'])} loading={loading} />
                     : <div />}
                 {totalPageCount > 1
@@ -545,6 +545,8 @@ CartSearchResultsControls.propTypes = {
     totalPageCount: PropTypes.number.isRequired,
     /** Called when user clicks pager controls */
     updateCurrentPage: PropTypes.func.isRequired,
+    /** Current cart type, e.g. ACTIVE, SHARED... */
+    cartType: PropTypes.string.isRequired,
     /** True if cart still loading on page */
     loading: PropTypes.bool.isRequired,
 };
@@ -1285,6 +1287,7 @@ const CartComponent = ({ context, savedCartObj, inProgress, fetch, session }) =>
                                         currentPage={pageNumbers.datasets}
                                         totalPageCount={totalPageCount.datasets}
                                         updateCurrentPage={updateDisplayedPage}
+                                        cartType={cartType}
                                         loading={facetProgress !== -1}
                                     />
                                     <CartSearchResults
@@ -1301,6 +1304,7 @@ const CartComponent = ({ context, savedCartObj, inProgress, fetch, session }) =>
                                         currentPage={pageNumbers.browser}
                                         totalPageCount={totalPageCount.browser}
                                         updateCurrentPage={updateDisplayedPage}
+                                        cartType={cartType}
                                         loading={facetProgress !== -1}
                                     />
                                     {selectedFileTerms.assembly && selectedFileTerms.assembly.length > 0
@@ -1314,6 +1318,7 @@ const CartComponent = ({ context, savedCartObj, inProgress, fetch, session }) =>
                                         currentPage={pageNumbers.processeddata}
                                         totalPageCount={totalPageCount.processeddata}
                                         updateCurrentPage={updateDisplayedPage}
+                                        cartType={cartType}
                                         loading={facetProgress !== -1}
                                     />
                                     <CartFiles files={selectedFiles} currentPage={pageNumbers.processeddata} defaultOnly={defaultOnly} loading={facetProgress !== -1} />
@@ -1325,6 +1330,7 @@ const CartComponent = ({ context, savedCartObj, inProgress, fetch, session }) =>
                                         currentPage={pageNumbers.rawdata}
                                         totalPageCount={totalPageCount.rawdata}
                                         updateCurrentPage={updateDisplayedPage}
+                                        cartType={cartType}
                                         loading={facetProgress !== -1}
                                     />
                                     <CartFiles files={rawdataFiles} currentPage={pageNumbers.rawdata} loading={facetProgress !== -1} />

--- a/src/encoded/static/components/cart/cart.js
+++ b/src/encoded/static/components/cart/cart.js
@@ -5,31 +5,39 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import _ from 'underscore';
-import { encodedURIComponent } from '../../libs/query_encoding';
 import { svgIcon } from '../../libs/svg-icons';
 import * as DropdownButton from '../../libs/ui/button';
 import * as Pager from '../../libs/ui/pager';
 import { Panel, PanelBody, PanelHeading, TabPanel, TabPanelPane } from '../../libs/ui/panel';
-import { tintColor, isLight } from '../datacolors';
 import GenomeBrowser, { annotationTypeMap } from '../genome_browser';
 import { itemClass, atIdToType } from '../globals';
 import {
-    requestObjects,
     ItemAccessories,
-    isFileVisualizable,
     computeAssemblyAnnotationValue,
     filterForVisualizableFiles,
     filterForDefaultFiles,
-    Checkbox,
+    filterForDatasetFiles,
 } from '../objectutils';
 import { ResultTableList } from '../search';
 import { compileDatasetAnalyses, sortDatasetAnalyses } from './analysis';
 import CartBatchDownload from './batch_download';
 import CartClearButton from './clear';
+import {
+    assembleFileFacets,
+    assembleDatasetFacets,
+    datasetFieldFileFacets,
+    displayedDatasetFacetFields,
+    displayedFileFacetFields,
+    CartFacets,
+    resetDatasetFacets,
+    resetFileFacets,
+} from './facet';
 import CartLockTrigger from './lock';
 import CartMergeShared from './merge_shared';
 import Status from '../status';
-import { allowedDatasetTypes, defaultDatasetType } from './util';
+import CartRemoveElements from './remove_multiple';
+import { allowedDatasetTypes, getObjectFieldValue } from './util';
+
 
 /**
  * This file uses some shorthand terms that need some explanation.
@@ -52,216 +60,72 @@ const PAGE_FILE_COUNT = 25;
 
 
 /**
- * Sorter function to sort an array of assemblies/annotations for display in the facet according to
- * system-wide criteria.
- * @param {array} facetTerms Assembly facet terms to sort
- *
- * @return {array} Same as `facetTerms` but sorted
+ * Facet fields to request from server -- superset of those displayed in facets, minus calculated
+ * props.
  */
-const assemblySorter = (facetTerms) => (
-    // Negate the sorting value to sort from highest to lowest.
-    _(facetTerms).sortBy((facetTerm) => -computeAssemblyAnnotationValue(facetTerm.term))
-);
+const requestedFacetFields = displayedFileFacetFields
+    .concat(displayedDatasetFacetFields.map((facetField) => ({ ...facetField, dataset: true })))
+    .filter((field) => !field.calculated).concat([
+        { field: '@id' },
+        { field: 'accession', dataset: true },
+        { field: 'biosample_summary', dataset: true },
+        { field: 'assembly' },
+        { field: 'assay_term_name' },
+        { field: 'file_format_type' },
+        { field: 'title' },
+        { field: 'genome_annotation' },
+        { field: 'href' },
+        { field: 'dataset' },
+        { field: 'biological_replicates' },
+        { field: 'analyses', dataset: true },
+        { field: 'preferred_default' },
+        { field: 'annotation_subtype', dataset: true },
+        { field: 'biochemical_inputs', dataset: true },
+        { field: 'award.project', dataset: true },
+        { field: 'description', dataset: true },
+    ]);
 
 
-/**
- * Sorter function for analyses facet terms matches the order from the given analyses which have
- * already been sorted.
- * @param {array} facetTerms Analysis facet terms to sort
- *
- * @return {array} Same as `facetTerms`
- */
-const analysisSorter = (facetTerms, analyses) => (
-    _(facetTerms).sortBy((facetTerm) => (
-        analyses.findIndex((analysis) => analysis.title === facetTerm.term)
-    ))
-);
-
-
-/**
- * Field mapping transform for analyses. Generate a query string corresponding to all the selected
- * analyses with the given titles. More than one title can be selected, and more than one analysis
- * can correspond to a title, so all these get combined into one query string.
- * @param {array} analysisTitles Selected analysis titles from the facet.
- *
- * @return {string} Combined query string selecting file.analyses titles.
- */
-const analysisFieldMap = (analysisTitles) => (
-    analysisTitles.map((title) => `files.analyses.title=${encodedURIComponent(title)}`).join('&')
-);
-
-
-/**
- * List of allowed dataset types. Generally maps from collection names (e.g. '/experiments/' to a
- * displayable title.
- */
-const datasetTypes = {
-    all: { title: 'All dataset types', type: '' }, // Default always first
-    experiments: { title: 'Experiments', type: 'Experiment' },
-    annotations: { title: 'Annotations', type: 'Annotation' },
-    'functional-characterization-experiments': { title: 'Functional characterizations', type: 'FunctionalCharacterizationExperiment' },
+/** Map of abbreviations for the allowed dataset types */
+const datasetTabTitles = {
+    Experiment: 'experiments',
+    Annotation: 'annotations',
+    FunctionalCharacterizationExperiment: 'FCEs',
 };
-const DEFAULT_DATASET_TYPE = Object.keys(datasetTypes)[0];
-
-
-/**
- * File facet fields to display in order of display.
- * - field: `facet` field property
- * - title: Displayed facet title
- * - radio: True if radio-button facet; otherwise checkbox facet
- * - dataset: True to retrieve value from dataset instead of files
- * - sorter: Function to sort terms within the facet
- * - fieldMapper: Function to generate a batch download query string
- * - preferred: Facet appears when preferred_default selected
- * - calculated: True for facets displaying calculated (not requested) file/dataset props
- * - parent: Copy expanded state of this field; suppress this facet's expander title
- * - expanded: True to appear expanded by default
- */
-const displayedFacetFields = [
-    {
-        field: 'assembly',
-        title: 'Analysis/Assembly',
-        radio: true,
-        sorter: assemblySorter,
-        preferred: true,
-        expanded: true,
-    },
-    {
-        field: 'analysis',
-        title: 'Analysis',
-        dataset: true,
-        sorter: analysisSorter,
-        fieldMapper: analysisFieldMap,
-        calculated: true,
-        parent: 'assembly',
-        css: 'cart-facet--analysis',
-    },
-    {
-        field: 'assay_title',
-        title: 'Assay',
-        dataset: true,
-        preferred: true,
-    },
-    {
-        field: 'biosample_ontology.term_name',
-        title: 'Biosample',
-        dataset: true,
-        preferred: true,
-    },
-    {
-        field: 'target.label',
-        title: 'Target of assay',
-        dataset: true,
-        preferred: true,
-    },
-    {
-        field: 'annotation_type',
-        title: 'Annotation type',
-        dataset: true,
-        preferred: true,
-    },
-    {
-        field: 'output_type',
-        title: 'Output type',
-    },
-    {
-        field: 'file_type',
-        title: 'File type',
-    },
-    {
-        field: 'file_format',
-        title: 'File format',
-    },
-    {
-        field: 'lab.title',
-        title: 'Lab',
-        preferred: true,
-    },
-    {
-        field: 'status',
-        title: 'Status',
-    },
-];
-
-/**
- * File facet fields to request from server -- superset of those displayed in facets, minus
- * calculated props.
- */
-const requestedFacetFields = displayedFacetFields.filter((field) => !field.calculated).concat([
-    { field: '@id' },
-    { field: 'assembly' },
-    { field: 'assay_term_name' },
-    { field: 'file_format_type' },
-    { field: 'title' },
-    { field: 'genome_annotation' },
-    { field: 'href' },
-    { field: 'dataset' },
-    { field: 'biological_replicates' },
-    { field: 'analyses', dataset: true },
-    { field: 'preferred_default' },
-    { field: 'annotation_subtype', dataset: true },
-    { field: 'biochemical_inputs', dataset: true },
-]);
-
-/** Facet `field` values for properties from dataset instead of files */
-const datasetFacets = displayedFacetFields.concat(requestedFacetFields).filter((facetField) => facetField.dataset).map((facetField) => facetField.field);
 
 
 /**
  * Display a page of cart contents within the cart display.
  */
-class CartSearchResults extends React.Component {
-    constructor() {
-        super();
-        this.state = {
-            /** Carted elements to display as search results; includes one page of search results */
-            elementsForDisplay: null,
-        };
-        this.retrievePageElements = this.retrievePageElements.bind(this);
+const CartSearchResults = ({ elements, currentPage, cartControls, loading }) => {
+    if (elements.length > 0) {
+        const pageStartIndex = currentPage * PAGE_ELEMENT_COUNT;
+        const currentPageElements = elements.slice(pageStartIndex, pageStartIndex + PAGE_ELEMENT_COUNT);
+        return (
+            <div className="cart-search-results">
+                <ResultTableList results={currentPageElements} cartControls={cartControls} mode="cart-view" />
+            </div>
+        );
     }
 
-    componentDidMount() {
-        this.retrievePageElements();
+    // No elements and the page isn't currently loading, so indicate no datasets to view.
+    if (!loading) {
+        return <div className="nav result-table cart__empty-message">No visible datasets on this page.</div>;
     }
 
-    componentDidUpdate(prevProps) {
-        const { currentPage, elements } = this.props;
-        if (prevProps.currentPage !== currentPage || !_.isEqual(prevProps.elements, elements)) {
-            this.retrievePageElements();
-        }
-    }
-
-    /**
-     * Given the whole cart elements as a list of @ids as well as the currently displayed page
-     * number, perform a search of a page of elements. If every element in the cart is an
-     * experiment, add "?type=Experiment" to the search query. For now, this condition is always
-     * true.
-     */
-    retrievePageElements() {
-        const pageStartIndex = this.props.currentPage * PAGE_ELEMENT_COUNT;
-        const currentPageElements = this.props.elements.slice(pageStartIndex, pageStartIndex + PAGE_ELEMENT_COUNT);
-        const experimentTypeQuery = this.props.elements.every((element) => element.match(/^\/experiments\/.*?\/$/) !== null);
-        const cartQueryString = `/search/?limit=all${experimentTypeQuery ? '&type=Experiment' : ''}`;
-        requestObjects(currentPageElements, cartQueryString).then((searchResults) => {
-            this.setState({ elementsForDisplay: searchResults });
-        });
-    }
-
-    render() {
-        if (this.state.elementsForDisplay && this.state.elementsForDisplay.length === 0) {
-            return <div className="nav result-table cart__empty-message">No visible datasets on this page.</div>;
-        }
-        return <ResultTableList results={this.state.elementsForDisplay || []} cartControls={this.props.cartControls} mode="cart-view" />;
-    }
-}
+    // Page is currently loading, so don't display anything for now.
+    return <div className="nav result-table cart__empty-message">Page currently loading&hellip;</div>;
+};
 
 CartSearchResults.propTypes = {
-    /** Array of cart item @ids */
+    /** Array of cart items */
     elements: PropTypes.array,
     /** Page of results to display */
     currentPage: PropTypes.number,
     /** True if displaying an active cart */
     cartControls: PropTypes.bool,
+    /** True if cart currently loading on page */
+    loading: PropTypes.bool.isRequired,
 };
 
 CartSearchResults.defaultProps = {
@@ -274,24 +138,33 @@ CartSearchResults.defaultProps = {
 /**
  * Display browser tracks for the selected page of files.
  */
-const CartBrowser = ({ files, assembly, pageNumber }) => {
-    // Extract the current page of file objects.
-    const pageStartingIndex = pageNumber * PAGE_TRACK_COUNT;
-    const pageFiles = files.slice(pageStartingIndex, pageStartingIndex + PAGE_TRACK_COUNT).map((file) => ({ ...file }));
+const CartBrowser = ({ files, assembly, pageNumber, loading }) => {
+    if (!loading) {
+        // Extract the current page of file objects.
+        const pageStartingIndex = pageNumber * PAGE_TRACK_COUNT;
+        const pageFiles = files.slice(pageStartingIndex, pageStartingIndex + PAGE_TRACK_COUNT).map((file) => ({ ...file }));
 
-    // Shorten long annotation_type values for the Valis track label; fine to mutate `pageFiles` as
-    // it holds a copy of a segment of `files`.
-    pageFiles.forEach((file) => {
-        if (file.annotation_type) {
-            const mappedAnnotationType = annotationTypeMap[file.annotation_type];
-            if (mappedAnnotationType) {
-                file.annotation_type = mappedAnnotationType;
+        // Shorten long annotation_type values for the Valis track label; fine to mutate `pageFiles` as
+        // it holds a copy of a segment of `files`.
+        pageFiles.forEach((file) => {
+            if (file.annotation_type) {
+                const mappedAnnotationType = annotationTypeMap[file.annotation_type];
+                if (mappedAnnotationType) {
+                    file.annotation_type = mappedAnnotationType;
+                }
             }
-        }
-    });
+        });
 
-    const sortParam = ['Assay term name', 'Biosample term name', 'Output type'];
-    return <GenomeBrowser files={pageFiles} label="cart" assembly={assembly} expanded sortParam={sortParam} />;
+        const sortParam = ['Assay term name', 'Biosample term name', 'Output type'];
+        return <GenomeBrowser files={pageFiles} label="cart" assembly={assembly} expanded sortParam={sortParam} />;
+    }
+
+    // Message for page loading.
+    if (loading) {
+        return <div className="nav result-table cart__empty-message">Page currently loading&hellip;</div>;
+    }
+
+    return null;
 };
 
 CartBrowser.propTypes = {
@@ -301,13 +174,15 @@ CartBrowser.propTypes = {
     assembly: PropTypes.string.isRequired,
     /** Page of files to display */
     pageNumber: PropTypes.number.isRequired,
+    /** True if the page is currently loading */
+    loading: PropTypes.bool.isRequired,
 };
 
 
 /**
  * Display the list of files selected by the current cart facet selections.
  */
-const CartFiles = ({ files, currentPage, defaultOnly }) => {
+const CartFiles = ({ files, currentPage, defaultOnly, loading }) => {
     if (files.length > 0) {
         const pageStartIndex = currentPage * PAGE_FILE_COUNT;
         const currentPageFiles = files.slice(pageStartIndex, pageStartIndex + PAGE_ELEMENT_COUNT);
@@ -364,6 +239,13 @@ const CartFiles = ({ files, currentPage, defaultOnly }) => {
             </div>
         );
     }
+
+    // Message for page loading.
+    if (loading) {
+        return <div className="nav result-table cart__empty-message">Page currently loading&hellip;</div>;
+    }
+
+    // Page not loading and no elements.
     return <div className="nav result-table cart__empty-message">No files to view in any dataset in the cart.</div>;
 };
 
@@ -374,223 +256,12 @@ CartFiles.propTypes = {
     currentPage: PropTypes.number.isRequired,
     /** True if only displaying default files */
     defaultOnly: PropTypes.bool,
+    /** True if page currently loading */
+    loading: PropTypes.bool.isRequired,
 };
 
 CartFiles.defaultProps = {
     defaultOnly: false,
-};
-
-
-/**
- * Display a count of the total number of files selected for download given the current facet term
- * selections. Shows the facet-loading progress bar if needed.
- */
-class FileCount extends React.Component {
-    constructor() {
-        super();
-        this.state = {
-            triggerEnabled: false,
-        };
-        this.handleAnimationEnd = this.handleAnimationEnd.bind(this);
-    }
-
-    /**
-     * Inserts the <div> to show the yellow highlight when the file count changes.
-     */
-    /* eslint-disable react/no-did-update-set-state */
-    componentDidUpdate(prevProps) {
-        if (prevProps.fileCount !== this.props.fileCount) {
-            this.setState({ triggerEnabled: true });
-        }
-    }
-    /* eslint-enable react/no-did-update-set-state */
-
-    /**
-     * Called when CSS animation ends. Removes the <div> that shows the yellow highlight when the
-     * count changes.
-     */
-    handleAnimationEnd() {
-        this.setState({ triggerEnabled: false });
-    }
-
-    render() {
-        const { fileCount, facetLoadProgress } = this.props;
-        const fileCountFormatted = fileCount.toLocaleString ? fileCount.toLocaleString() : fileCount.toString();
-
-        if (facetLoadProgress === -1) {
-            return (
-                <div className="cart__facet-file-count">
-                    {this.state.triggerEnabled ? <div className="cart__facet-file-count-changer" onAnimationEnd={this.handleAnimationEnd} /> : null}
-                    {fileCount > 0 ?
-                        <span>{fileCountFormatted} {fileCount === 1 ? 'file' : 'files'} selected</span>
-                    :
-                        <span>No files selected for download</span>
-                    }
-                </div>
-            );
-        }
-
-        return <progress value={facetLoadProgress} max="100" />;
-    }
-}
-
-FileCount.propTypes = {
-    /** Number of files selected for download */
-    fileCount: PropTypes.number,
-    /** Value for the progress bar; -1 to not show it */
-    facetLoadProgress: PropTypes.number,
-};
-
-FileCount.defaultProps = {
-    fileCount: 0,
-    facetLoadProgress: 0,
-};
-
-
-/**
- * Display the selection checkbox for a single cart file facet term.
- */
-const FacetTermCheck = ({ checked }) => (
-    <div className={`cart-facet-term__check${checked ? ' cart-facet-term__check--checked' : ''}`}>
-        {checked ?
-            <i className="icon icon-check" />
-        : null}
-    </div>
-);
-
-FacetTermCheck.propTypes = {
-    /** True if facet term checkbox checked */
-    checked: PropTypes.bool,
-};
-
-FacetTermCheck.defaultProps = {
-    checked: false,
-};
-
-
-/**
- * Display the selection radio button for a single cart file facet term.
- */
-const FacetTermRadio = ({ checked }) => (
-    <div className={`cart-facet-term__radio${checked ? ' cart-facet-term__radio--checked' : ''}`}>
-        {checked ?
-            <i className="icon icon-circle" />
-        : null}
-    </div>
-);
-
-FacetTermRadio.propTypes = {
-    /** True if facet term radio button checked */
-    checked: PropTypes.bool,
-};
-
-FacetTermRadio.defaultProps = {
-    checked: false,
-};
-
-
-/**
- * Display the cart file facet term count that shows the magnitude of a facet term through its
- * color tint. The maximum value for the facet gets the full base color, and lesser values get
- * lighter tints.
- */
-const FacetTermMagnitude = ({ termCount, maxTermCount }) => {
-    const MAGNITUDE_BASE_COLOR = '#656BFF';
-    const magnitudeColor = tintColor(MAGNITUDE_BASE_COLOR, 1 - (termCount / maxTermCount));
-    const textColor = isLight(magnitudeColor) ? '#000' : '#fff';
-    return (
-        <div className="cart-facet-term__magnitude" style={{ backgroundColor: magnitudeColor }}>
-            <span style={{ color: textColor }}>{termCount}</span>
-        </div>
-    );
-};
-
-FacetTermMagnitude.propTypes = {
-    /** Number of items this facet term indicates */
-    termCount: PropTypes.number.isRequired,
-    /** Maximum count value among all terms in this facet */
-    maxTermCount: PropTypes.number.isRequired,
-};
-
-
-/**
- * Display one term of a facet.
- */
-class FacetTerm extends React.Component {
-    constructor() {
-        super();
-        this.handleTermClick = this.handleTermClick.bind(this);
-        this.handleKeyDown = this.handleKeyDown.bind(this);
-    }
-
-    /**
-     * Called when user clicks a term within a facet.
-     */
-    handleTermClick() {
-        this.props.termClickHandler(this.props.term);
-    }
-
-    /**
-     * Called when user types a key while focused on a facet term. If the user types a space or
-     * return we call the term click handler -- needed for a11y because we have a <div> acting as a
-     * button instead of an actual <button>.
-     * @param {object} e React synthetic event
-     */
-    handleKeyDown(e) {
-        if (e.keyCode === 13 || e.keyCode === 32) {
-            e.preventDefault();
-            this.props.termClickHandler(this.props.term);
-        }
-    }
-
-    render() {
-        const { term, termCount, maxTermCount, selected, visualizable, FacetTermSelectRenderer } = this.props;
-        return (
-            <li className="cart-facet-term">
-                <div
-                    className="cart-facet-term__item"
-                    role="button"
-                    tabIndex="0"
-                    id={`cart-facet-term-${term}`}
-                    onKeyDown={this.handleKeyDown}
-                    onClick={this.handleTermClick}
-                    aria-pressed={selected}
-                    aria-label={`${termCount} ${term} file${termCount === 1 ? '' : 's'}${visualizable ? ' visualizable' : ''}`}
-                >
-                    <FacetTermSelectRenderer checked={selected} />
-                    <div className="cart-facet-term__text">{term}</div>
-                    <FacetTermMagnitude termCount={termCount} maxTermCount={maxTermCount} />
-                    <div className="cart-facet-term__visualizable">
-                        {visualizable ?
-                            <div title="Selects visualizable files">{svgIcon('genomeBrowser')}</div>
-                        : null}
-                    </div>
-                </div>
-            </li>
-        );
-    }
-}
-
-FacetTerm.propTypes = {
-    /** Displayed facet term */
-    term: PropTypes.string.isRequired,
-    /** Displayed number of files for this term */
-    termCount: PropTypes.number.isRequired,
-    /** Maximum number of files for all terms in the facet */
-    maxTermCount: PropTypes.number.isRequired,
-    /** True if this term should appear selected */
-    selected: PropTypes.bool,
-    /** True if term selection results in visualizable files */
-    visualizable: PropTypes.bool,
-    /** Callback for handling clicks in the term */
-    termClickHandler: PropTypes.func.isRequired,
-    /** Facet term checkbox/radio renderer */
-    FacetTermSelectRenderer: PropTypes.elementType.isRequired,
-};
-
-FacetTerm.defaultProps = {
-    selected: false,
-    visualizable: false,
 };
 
 
@@ -639,320 +310,6 @@ const requestDatasets = (elements, fetch, session) => {
 
 
 /**
- * Extract the value of an object property based on a dotted-notation field,
- * e.g. { a: 1, b: { c: 5 }} you could retrieve the 5 by passing 'b.c' in `field`.
- * Based on https://stackoverflow.com/questions/6393943/convert-javascript-string-in-dot-notation-into-an-object-reference#answer-6394168
- * @param {object} object Object containing the value you want to extract.
- * @param {string} field  Dotted notation for the property to extract.
- *
- * @return {value} Whatever value the dotted notation specifies, or undefined.
- */
-const getObjectFieldValue = (object, field) => {
-    const parts = field.split('.');
-    if (parts.length === 1) {
-        return object[field];
-    }
-    return parts.reduce((partObject, part) => partObject && partObject[part], object);
-};
-
-
-/**
- * Display the facet title and expansion icon, and react to clicks in the button to tell the parent
- * component that a facet needs to be expanded or collapsed.
- */
-class FacetExpander extends React.Component {
-    constructor() {
-        super();
-        this.handleKeyDown = this.handleKeyDown.bind(this);
-    }
-
-    /**
-     * Called when the user types a key while a facet title expansion button has focus. If the user
-     * typed Return or Space, call the parent component to handle the expand/collapse of the facet.
-     * @param {object} e React synthetic event
-     */
-    handleKeyDown(e) {
-        if (e.keyCode === 13 || e.keyCode === 32) {
-            e.preventDefault();
-            this.props.expanderEventHandler(e);
-        }
-    }
-
-    render() {
-        const { title, field, labelId, expanded, expanderEventHandler } = this.props;
-        return (
-            <div
-                role="button"
-                tabIndex="0"
-                id={labelId}
-                className="cart-facet__expander"
-                aria-controls={field}
-                aria-expanded={expanded}
-                onKeyDown={this.handleKeyDown}
-                onClick={expanderEventHandler}
-            >
-                <div className="cart-facet__expander-title">
-                    {title}
-                </div>
-                <i className={`icon icon-chevron-${expanded ? 'up' : 'down'}`} />
-            </div>
-        );
-    }
-}
-
-FacetExpander.propTypes = {
-    /** Displayed title of the facet */
-    title: PropTypes.string.isRequired,
-    /** File facet field representing this facet */
-    field: PropTypes.string.isRequired,
-    /** Used as an id for this button corresponding to expanded component label */
-    labelId: PropTypes.string.isRequired,
-    /** True if facet is currently expanded */
-    expanded: PropTypes.bool.isRequired,
-    /** Called when the user clicks the expander button */
-    expanderEventHandler: PropTypes.func.isRequired,
-};
-
-
-/**
- * Display a single file facet.
- */
-class Facet extends React.Component {
-    constructor() {
-        super();
-        this.handleFacetTermClick = this.handleFacetTermClick.bind(this);
-        this.handleExpanderEvent = this.handleExpanderEvent.bind(this);
-    }
-
-    /**
-     * Handle a click in a facet term by calling a parent handler.
-     * @param {string} term Clicked facet term
-     */
-    handleFacetTermClick(term) {
-        this.props.facetTermClickHandler(this.props.displayedFacetField.field, term);
-    }
-
-    /**
-     * Handle a click in the facet expander by calling a parent handler.
-     * @param {object} e React synthetic event
-     */
-    handleExpanderEvent(e) {
-        this.props.expanderClickHandler(this.props.displayedFacetField.field, e.altKey);
-    }
-
-    render() {
-        const { facet, displayedFacetField, expanded, selectedFacetTerms, options } = this.props;
-        const maxTermCount = Math.max(...facet.terms.map((term) => term.count));
-        const labelId = `${displayedFacetField.field}-label`;
-        const FacetTermSelectRenderer = displayedFacetField.radio ? FacetTermRadio : FacetTermCheck;
-        return (
-            <div className="facet">
-                {!options.suppressExpander
-                    ? (
-                        <FacetExpander
-                            title={facet.title}
-                            field={displayedFacetField.field}
-                            labelId={labelId}
-                            expanded={expanded}
-                            expanderEventHandler={this.handleExpanderEvent}
-                        />
-                    )
-                : null}
-                {expanded ?
-                    <ul className={`cart-facet${displayedFacetField.css ? ` ${displayedFacetField.css}` : ''}`} role="region" id={displayedFacetField.field} aria-labelledby={labelId}>
-                        {facet.terms.map((facetTerm) => (
-                            <FacetTerm
-                                key={facetTerm.term}
-                                term={facetTerm.term}
-                                termCount={facetTerm.count}
-                                visualizable={options.suppressVisualizable ? false : facetTerm.visualizable}
-                                maxTermCount={maxTermCount}
-                                selected={selectedFacetTerms.indexOf(facetTerm.term) > -1}
-                                termClickHandler={this.handleFacetTermClick}
-                                FacetTermSelectRenderer={FacetTermSelectRenderer}
-                            />
-                        ))}
-                    </ul>
-                : null}
-            </div>
-        );
-    }
-}
-
-Facet.propTypes = {
-    /** Facet object to display */
-    facet: PropTypes.object.isRequired,
-    /** Field name representing the facet being displayed */
-    displayedFacetField: PropTypes.object.isRequired,
-    /** True if facet should appear expanded */
-    expanded: PropTypes.bool.isRequired,
-    /** Called when the expander button is clicked */
-    expanderClickHandler: PropTypes.func.isRequired,
-    /** Selected term keys */
-    selectedFacetTerms: PropTypes.array,
-    /** Called when a facet term is clicked */
-    facetTermClickHandler: PropTypes.func.isRequired,
-    /** Facet-specific options */
-    options: PropTypes.shape({
-        /** Suppress display of expander title */
-        suppressExpander: PropTypes.bool,
-        /** Suppress display of visualizable icons */
-        suppressVisualizable: PropTypes.bool,
-    }),
-};
-
-Facet.defaultProps = {
-    selectedFacetTerms: [],
-    options: {},
-};
-
-
-/**
- * Display the file facets. These display the number of files involved -- not the number of
- * experiments with files matching a criteria. As the primary input to this component is currently
- * an array of experiment IDs while these facets displays all the files involved with those
- * experiments, this component begins by retrieving information about all relevant files from the
- * DB. Each time an experiment is removed from the cart while viewing the cart page, this component
- * again retrieves all relevant files for the remaining experiments.
- */
-const FileFacets = ({
-    facets,
-    usedFacetFields,
-    selectedTerms,
-    selectedFileCount,
-    termClickHandler,
-    visualizableOnly,
-    visualizableOnlyChangeHandler,
-    preferredOnly,
-    preferredOnlyChangeHandler,
-    facetLoadProgress,
-    disabled,
-}) => {
-    /** Expanded facet fields; `usedFacetFields` array creates an entry for each field */
-    const [expandedStates, setExpandedStates] = React.useState(() => (
-        usedFacetFields.reduce((accExpanded, facetField) => (
-            ({ ...accExpanded, [facetField.field]: !!facetField.expanded })
-        ), {})
-    ));
-
-    /**
-     * Called when the user clicks a facet expander button. Updates the expander states so the
-     * facets re-render to the new expanded states.
-     * @param {string} field Field name for clicked facet expander
-     * @param {bool}   altKey True if alt/option key down at time of click
-     */
-    const handleExpanderClick = React.useCallback((field, altKey) => {
-        setExpandedStates((prevExpandedStates) => {
-            if (altKey) {
-                // Alt key held down, so expand or collapse *all* facets.
-                const allExpandedState = !prevExpandedStates[field];
-                const nextExpandedStates = {};
-                Object.keys(prevExpandedStates).forEach((facetField) => {
-                    nextExpandedStates[facetField] = allExpandedState;
-                });
-                return nextExpandedStates;
-            }
-
-            // Alt key not held down, so just expand or collapse the clicked facet.
-            const nextExpandedStates = { ...prevExpandedStates };
-            nextExpandedStates[field] = !prevExpandedStates[field];
-            return nextExpandedStates;
-        });
-    });
-
-    React.useEffect(() => {
-        // Update expanded states if fields within `usedFacetFields` changes. Copy older expanded
-        // states when possible.
-        setExpandedStates((prevExpandedStates) => (
-            usedFacetFields.reduce((accExpanded, facetField) => (
-                ({ ...accExpanded, [facetField.field]: prevExpandedStates[facetField.field] !== undefined ? prevExpandedStates[facetField.field] : false })
-            ), {})
-        ));
-    }, [usedFacetFields]);
-
-    return (
-        <div className="cart__display-facets">
-            <FileCount fileCount={selectedFileCount} facetLoadProgress={facetLoadProgress} />
-            {facetLoadProgress === -1 ?
-                <>
-                    <Checkbox label="Show default data only" id="default-data-toggle" checked={preferredOnly} css="cart-checkbox" clickHandler={preferredOnlyChangeHandler} />
-                    {!preferredOnly ? <Checkbox label="Show visualizable data only" id="visualizable-data-toggle" checked={visualizableOnly} css="cart-checkbox" clickHandler={visualizableOnlyChangeHandler} /> : null}
-                </>
-            : null}
-            {facets && facets.length > 0 ?
-                <>
-                    {usedFacetFields.map((facetField) => {
-                        const facetContent = facets.find((facet) => facet.field === facetField.field);
-                        if (facetContent) {
-                            const expanded = facetField.parent ? expandedStates[facetField.parent] : expandedStates[facetField.field];
-                            return (
-                                <Facet
-                                    key={facetField.field}
-                                    facet={facetContent}
-                                    displayedFacetField={facetField}
-                                    selectedFacetTerms={selectedTerms[facetField.field]}
-                                    facetTermClickHandler={termClickHandler}
-                                    expanded={expanded}
-                                    expanderClickHandler={handleExpanderClick}
-                                    options={{ suppressExpander: !!facetField.parent, suppressVisualizable: preferredOnly }}
-                                />
-                            );
-                        }
-                        return null;
-                    })}
-                </>
-            :
-                <>
-                    {facetLoadProgress === -1 ?
-                        <div className="cart__empty-message">No files available</div>
-                    : null}
-                </>
-            }
-            {disabled || facetLoadProgress !== -1 ?
-                <div className="cart__facet-disabled-overlay" />
-            : null}
-        </div>
-    );
-};
-
-FileFacets.propTypes = {
-    /** Array of objects for each displayed facet */
-    facets: PropTypes.array,
-    /** Currently displayed facet fields */
-    usedFacetFields: PropTypes.array,
-    /** Selected facet fields */
-    selectedTerms: PropTypes.object,
-    /** Count of the files selected by current selected facet terms */
-    selectedFileCount: PropTypes.number,
-    /** Callback when the user clicks on a file format facet item */
-    termClickHandler: PropTypes.func.isRequired,
-    /** True to check the Show Visualizable Data Only checkbox */
-    visualizableOnly: PropTypes.bool,
-    /** Call to handle clicks in the Visualize Only checkbox */
-    visualizableOnlyChangeHandler: PropTypes.func.isRequired,
-    /** True to check the Show Preferred Data Only checkbox */
-    preferredOnly: PropTypes.bool,
-    /** Call to handle clicks in the Preferred Only checkbox */
-    preferredOnlyChangeHandler: PropTypes.func.isRequired,
-    /** Facet-loading progress for progress bar, or null if not displayed */
-    facetLoadProgress: PropTypes.number,
-    /** True to disable the facets; grayed out and non-clickable */
-    disabled: PropTypes.bool,
-};
-
-FileFacets.defaultProps = {
-    facets: [],
-    usedFacetFields: [],
-    selectedTerms: null,
-    selectedFileCount: 0,
-    visualizableOnly: false,
-    preferredOnly: false,
-    facetLoadProgress: null,
-    disabled: false,
-};
-
-
-/**
  * Display a button that links to a report page showing the datasets in the currently displayed
  * cart.
  */
@@ -981,13 +338,9 @@ const CartDatasetReport = ({ savedCartObj, sharedCartObj, usedDatasetTypes, cart
                 css="cart-dataset-report"
             >
                 {usedDatasetTypes.map((type) => (
-                    <React.Fragment key={type}>
-                        {type !== DEFAULT_DATASET_TYPE ?
-                            <a href={`/cart-report/?type=${allowedDatasetTypes[type].type}&cart=${linkedCart.current['@id']}`} className={`cart-dataset-option cart-dataset-option--${type}`}>
-                                {allowedDatasetTypes[type].title}
-                            </a>
-                        : null}
-                    </React.Fragment>
+                    <a key={type} href={`/cart-report/?type=${allowedDatasetTypes[type].type}&cart=${linkedCart.current['@id']}`} className={`cart-dataset-option cart-dataset-option--${type}`}>
+                        {allowedDatasetTypes[type].title}
+                    </a>
                 ))}
             </DropdownButton.Immediate>
         );
@@ -1004,30 +357,6 @@ CartDatasetReport.propTypes = {
     usedDatasetTypes: PropTypes.array.isRequired,
     /** Type of cart to link to the button */
     cartType: PropTypes.string.isRequired,
-};
-
-
-/**
- * Selector menu to choose between dataset types to view and download.
- */
-const CartTypeSelector = ({ selectedDatasetType, usedDatasetTypes, typeChangeHandler }) => {
-    // Add the "All datasets" option to the used dataset types.
-    const displayedDatasets = Object.assign(defaultDatasetType, allowedDatasetTypes);
-
-    return (
-        <select value={selectedDatasetType} onChange={typeChangeHandler} className="cart-dataset-selector">
-            {usedDatasetTypes.map((type) => <option key={type} value={type} className={`cart-dataset-option cart-dataset-option--${type}`}>{displayedDatasets[type].title}</option>)}
-        </select>
-    );
-};
-
-CartTypeSelector.propTypes = {
-    /** Currently selected dataset type */
-    selectedDatasetType: PropTypes.string.isRequired,
-    /** Types of datasets in `elements` as collection names e.g. "experiments" */
-    usedDatasetTypes: PropTypes.array.isRequired,
-    /** Called when the user selects a new dataset type from the dropdown */
-    typeChangeHandler: PropTypes.func.isRequired,
 };
 
 
@@ -1073,10 +402,10 @@ CartAccessories.defaultProps = {
 const CartTools = ({
     elements,
     analyses,
-    selectedTerms,
+    selectedFileTerms,
+    selectedDatasetTerms,
     selectedDatasetType,
     facetFields,
-    typeChangeHandler,
     savedCartObj,
     fileCounts,
     cartType,
@@ -1086,24 +415,23 @@ const CartTools = ({
 }) => {
     // Disable the download button and show `disabledMessage` if the selected dataset matches "All
     // datasets."
-    const disabledMessage = selectedDatasetType === DEFAULT_DATASET_TYPE ? 'Select dataset type to download' : '';
-    const selectedType = datasetTypes[selectedDatasetType].type;
+    const disabledMessage = selectedDatasetType ? '' : 'Select single dataset type to download';
 
     // Make a list of all the dataset types currently in the cart.
-    const usedDatasetTypes = [Object.keys(defaultDatasetType)[0]].concat(elements.reduce((types, elementAtId) => {
+    const usedDatasetTypes = elements.reduce((types, elementAtId) => {
         const type = atIdToType(elementAtId);
         return types.includes(type) ? types : types.concat(type);
-    }, []));
+    }, []);
 
     return (
         <div className="cart-tools">
-            <CartTypeSelector selectedDatasetType={selectedDatasetType} usedDatasetTypes={usedDatasetTypes} typeChangeHandler={typeChangeHandler} />
             {elements.length > 0 ?
                 <CartBatchDownload
                     elements={elements}
                     analyses={analyses}
-                    selectedTerms={selectedTerms}
-                    selectedType={selectedType}
+                    selectedFileTerms={selectedFileTerms}
+                    selectedDatasetTerms={selectedDatasetTerms}
+                    selectedType={selectedDatasetType}
                     facetFields={facetFields}
                     cartType={cartType}
                     savedCartObj={savedCartObj}
@@ -1129,14 +457,14 @@ CartTools.propTypes = {
     elements: PropTypes.array,
     /** All compiled analyses for the cart */
     analyses: PropTypes.array,
-    /** Selected facet terms */
-    selectedTerms: PropTypes.object,
+    /** Selected file facet terms */
+    selectedFileTerms: PropTypes.object,
+    /** Selected dataset facet terms */
+    selectedDatasetTerms: PropTypes.object,
     /** Selected dataset type */
     selectedDatasetType: PropTypes.string.isRequired,
     /** Currently used facet field definitions */
     facetFields: PropTypes.array.isRequired,
-    /** Called when the user selects a new dataset type */
-    typeChangeHandler: PropTypes.func.isRequired,
     /** Cart as it exists in the database; use JSON payload method if none */
     savedCartObj: PropTypes.object,
     /** Type of cart: ACTIVE, OBJECT */
@@ -1154,7 +482,8 @@ CartTools.propTypes = {
 CartTools.defaultProps = {
     elements: [],
     analyses: [],
-    selectedTerms: null,
+    selectedFileTerms: null,
+    selectedDatasetTerms: null,
     savedCartObj: null,
     sharedCart: null,
     fileCounts: {},
@@ -1187,6 +516,68 @@ CartPager.propTypes = {
 
 
 /**
+ * Displays controls at the top of search results within the tab content areas.
+ */
+const CartSearchResultsControls = ({ currentTab, elements, currentPage, totalPageCount, updateCurrentPage, loading }) => {
+    if (currentTab === 'datasets' || totalPageCount > 1) {
+        return (
+            <div className="cart-search-results-controls">
+                {currentTab === 'datasets'
+                    ? <CartRemoveElements elements={elements.map((element) => element['@id'])} loading={loading} />
+                    : <div />}
+                {totalPageCount > 1
+                    ? <CartPager currentPage={currentPage} totalPageCount={totalPageCount} updateCurrentPage={updateCurrentPage} />
+                    : null}
+            </div>
+        );
+    }
+    return null;
+};
+
+CartSearchResultsControls.propTypes = {
+    /** Key of the currently selected tab */
+    currentTab: PropTypes.string.isRequired,
+    /** Array of currently displayed cart items */
+    elements: PropTypes.array.isRequired,
+    /** Zero-based current page to display */
+    currentPage: PropTypes.number.isRequired,
+    /** Total number of pages */
+    totalPageCount: PropTypes.number.isRequired,
+    /** Called when user clicks pager controls */
+    updateCurrentPage: PropTypes.func.isRequired,
+    /** True if cart still loading on page */
+    loading: PropTypes.bool.isRequired,
+};
+
+
+/**
+ * Add the datasets search results to the given array of datasets.
+ * @param {array} datasets Add new search results to this array
+ * @param {object} currentResults Dataset search results
+ * @return {array} `datasets` with search-result datasets added
+ */
+const addToAccumulatingDatasets = (datasets, currentResults) => {
+    if (currentResults['@graph'] && currentResults['@graph'].length > 0) {
+        currentResults['@graph'].forEach((dataset) => {
+            // Mutate the datasets for those properties that need their values altered from how
+            // they appear in search results.
+            displayedDatasetFacetFields.forEach((facetField) => {
+                if (facetField.getValue) {
+                    dataset[facetField.field] = facetField.getValue(dataset);
+                }
+            });
+        });
+
+        // Return a new array combining the existing partial files with the additional files.
+        return datasets.concat(currentResults['@graph']);
+    }
+
+    // No search results; just return unchanged list of datasets.
+    return datasets;
+};
+
+
+/**
  * Adds partial file objects from a dataset search-result object to an existing array of partial
  * file objects. Mutate the file objects to include faceted properties from the relevant datasets.
  * @param {object} files Partial file objects being collected
@@ -1203,11 +594,20 @@ const addToAccumulatingFiles = (files, currentResults) => {
                     if (!file.restricted) {
                         // Mutate the files to include faceted properties from the dataset
                         // object before adding it to the accumulating list of files.
-                        datasetFacets.forEach((datasetFacet) => {
+                        datasetFieldFileFacets.forEach((datasetFacet) => {
                             const [experimentProp] = datasetFacet.split('.');
                             file[experimentProp] = dataset[experimentProp];
                         });
                         currentFilesPartial.push(file);
+
+                        // Mutate the files for any properties whose values need altering through
+                        // their `getValue` properties from the facet definitions.
+                        displayedFileFacetFields.forEach((facetField) => {
+                            if (facetField.getValue) {
+                                const [fileProp] = facetField.field.split('.');
+                                file[fileProp] = facetField.getValue(file);
+                            }
+                        });
                     }
                 });
             }
@@ -1219,231 +619,6 @@ const addToAccumulatingFiles = (files, currentResults) => {
 
     // No search results; just return unchanged list of partial files.
     return files;
-};
-
-
-/**
- * Update the `facets` array by incrementing the count of the term within it selected by the
- * `field` within the given `file`.
- * @param {array} facets Facet array to update - mutated!
- * @param {string} field Field key within the facet to update
- * @param {object} file File containing the term to add to the facet
- */
-const addFileTermToFacet = (facets, field, file) => {
-    const facetTerm = getObjectFieldValue(file, field);
-    const visualizable = isFileVisualizable(file);
-    if (facetTerm !== undefined) {
-        const matchingFacet = facets.find((facet) => facet.field === field);
-        if (matchingFacet) {
-            // The facet has been seen in this loop before, so add to or initialize
-            // the relevant term within this facet.
-            const matchingTerm = matchingFacet.terms.find((matchingFacetTerm) => matchingFacetTerm.term === facetTerm);
-            if (matchingTerm) {
-                // Facet term has been counted before, so add to its count. Mark the term as
-                // visualizable if any file contributing to this term is visualizable.
-                matchingTerm.count += 1;
-                if (visualizable) {
-                    matchingTerm.visualizable = visualizable;
-                }
-            } else {
-                // Facet term has not been counted before, so initialize a new facet term entry.
-                matchingFacet.terms.push({ term: facetTerm, count: 1, visualizable });
-            }
-        } else {
-            // The facet has not been seen in this loop before, so initialize it as
-            // well as the value of the relevant term within the facet.
-            facets.push({ field, terms: [{ term: facetTerm, count: 1, visualizable }] });
-        }
-    }
-};
-
-
-/**
- * Extract the file @ids of the analyses selected by the given analysis titles.
- * @param {array} availableAnalyses Compiled analysis objects.
- * @param {array} analysisTitles Titles of analyses from which to extract file @ids.
- *
- * @return {array} Combined @ids of selected analysis files.
- */
-const getAnalysesFileIds = (availableAnalyses, analysisTitles = []) => {
-    const selectedFileIds = availableAnalyses.reduce((fileIds, analysis) => {
-        if (analysisTitles.length === 0 || analysisTitles.includes(analysis.title)) {
-            return fileIds.concat(analysis.files);
-        }
-        return fileIds;
-    }, []);
-    return _.uniq(selectedFileIds);
-};
-
-
-/**
- * Based on the currently selected facet terms and the files collected from the datasets in the
- * cart, generate the simplified facets and the subset of files these facets select. `analyses` not
- * needed when `assembleFacets` called simply to reset the facets.
- * @param {object} selectedTerms Currently selected terms within each facet
- * @param {array} files Partial files to consider when building these facets.
- * @param {array} analyses Compiled analysis objects from experiments in cart.
- * @param {array} usedFacetFields Facet fields to consider when assembling.
- *
- * @return {object}
- *     {array} facets - Array of simplified facet objects including fields and terms;
- *                               empty array if none
- *     {array} selectedFiles - Array of partial files selected by currently selected facets
- */
-const assembleFacets = (selectedTerms, files, analyses, usedFacetFields) => {
-    const assembledFacets = [];
-    const selectedFiles = [];
-
-    // Get complete list of files to consider -- processed files, and those associated with all
-    // available analyses if any selected.
-    let consideredFiles;
-    consideredFiles = files.filter((file) => file.assembly);
-    if (selectedTerms.analysis && selectedTerms.analysis.length > 0) {
-        // Consider all files the selected analyses corresponds to.
-        const fileIds = getAnalysesFileIds(analyses);
-        consideredFiles = _.compact(fileIds.map((id) => files.find((file) => id === file['@id'])));
-    }
-    if (consideredFiles.length > 0) {
-        const selectedFacetKeys = Object.keys(selectedTerms).filter((term) => selectedTerms[term].length > 0);
-        consideredFiles.forEach((file) => {
-            // Determine whether the file passes the currently selected facet terms. Properties
-            // within the file have to match any of the terms within a facet, and across all
-            // facets that include selected terms. This is the "first test" I refer to later.
-            let match = selectedFacetKeys.every((selectedFacetKey) => {
-                // `selectedFacetKey` is one facet field, e.g. "output_type".
-                // `filePropValue` is the file's value for that field.
-                const filePropValue = getObjectFieldValue(file, selectedFacetKey);
-
-                // Determine if the file's `selectedFacetKey` prop has been selected by at
-                // least one facet term.
-                return selectedTerms[selectedFacetKey].indexOf(filePropValue) !== -1;
-            });
-
-            // Files that pass the first test add their properties to the relevant facet term
-            // counts. Files that don't pass go through a second test to see if their properties
-            // should appear unselected within a facet. Files that fail both tests get ignored for
-            // facets.
-            if (match) {
-                // The file passed the first test, so its terms appear selected in their facets.
-                // Add all its properties to the relevant facet terms.
-                Object.keys(selectedTerms).forEach((facetField) => {
-                    addFileTermToFacet(assembledFacets, facetField, file);
-                });
-                selectedFiles.push(file);
-            } else {
-                // The file didn't pass the first test, so run the same test repeatedly but
-                // with one facet removed from the test each time. For each easier test the
-                // file passes, add to the corresponding term count for the removed facet,
-                // allowing the user to select it to extend the set of selected files.
-                selectedFacetKeys.forEach((selectedFacetField) => {
-                    // Remove one facet containing a selection from the test.
-                    const filteredSelectedFacetKeys = selectedFacetKeys.filter((key) => key !== selectedFacetField);
-                    match = filteredSelectedFacetKeys.every((filteredSelectedFacetKey) => {
-                        const filePropValue = getObjectFieldValue(file, filteredSelectedFacetKey);
-                        return selectedTerms[filteredSelectedFacetKey].indexOf(filePropValue) !== -1;
-                    });
-
-                    // A match means to add to the count of the current facet field file term
-                    // only.
-                    if (match) {
-                        addFileTermToFacet(assembledFacets, selectedFacetField, file);
-                    }
-                });
-            }
-        });
-
-        // We need to include selected terms that happen to have a zero count, so add all
-        // selected facet terms not yet included in `facets`.
-        Object.keys(selectedTerms).forEach((field) => {
-            const matchingFacet = assembledFacets.find((facet) => facet.field === field);
-            if (matchingFacet) {
-                // Find selected terms NOT in facets and add them with a zero count.
-                const matchingFacetTerms = matchingFacet.terms.map((facetTerm) => facetTerm.term);
-                const missingTerms = selectedTerms[field].filter((term) => matchingFacetTerms.indexOf(term) === -1);
-                if (missingTerms.length > 0) {
-                    missingTerms.forEach((term) => {
-                        matchingFacet.terms.push({ term, count: 0, visualizable: false });
-                    });
-                }
-            }
-        });
-
-        // Sort each facet's terms either alphabetically or by some criteria specific to a
-        // facet. `facets` and `usedFacetFields` have the same order, but `facets` might
-        // not have all possible facets -- just currently relevant ones.
-        assembledFacets.forEach((facet) => {
-            // We know a corresponding `usedFacetFields` entry exists because `facets` gets
-            // built from it, so no not-found condition needs checking.
-            const facetDisplay = usedFacetFields.find((facetField) => facetField.field === facet.field);
-            facet.title = facetDisplay.title;
-            facet.terms = facetDisplay.sorter ? facetDisplay.sorter(facet.terms, analyses) : _(facet.terms).sortBy((facetTerm) => facetTerm.term.toLowerCase());
-        });
-    }
-
-    return { facets: assembledFacets.length > 0 ? assembledFacets : [], selectedFiles, defaultFiles: filterForDefaultFiles(selectedFiles) };
-};
-
-
-/**
- * For any radio-button facets, select the first term if no items within them have been selected.
- * @param {array} facets Simplified facet object
- * @param {object} selectedTerms Selected terms within the facets
- *
- * @return {object} Same as `selectedTerms` but with radio-button facet terms selected
- */
-const initRadioFacets = (facets, selectedTerms, usedFacetFields) => {
-    const newSelectedTerms = {};
-    usedFacetFields.forEach((facetField) => {
-        if (facetField.radio && selectedTerms[facetField.field].length === 0) {
-            // Assign the first term of the radio-button facet as the sole selection. In the
-            // unusual case that no facet terms for this radio-button facet have been collected,
-            // just copy the existing selection for the facet.
-            const matchingFacet = facets.find((facet) => facet.field === facetField.field);
-            newSelectedTerms[facetField.field] = (
-                matchingFacet ? [matchingFacet.terms[0].term] : selectedTerms[facetField.field].slice(0)
-            );
-        } else {
-            // Not a radio-button facet, or radio-button facet has selected terms; copy existing
-            // selected terms.
-            newSelectedTerms[facetField.field] = selectedTerms[facetField.field].slice(0);
-        }
-    });
-    return newSelectedTerms;
-};
-
-
-/**
- * Make a selected-terms object showing no selections based on the given facet properties.
- * @param {array} usedFacetFields Currently used subset of `displayedFacetFields`.
- *
- * @return {object} Selected facet showing no selections; used with `assembleFacets`
- */
-const initSelectedTerms = (usedFacetFields) => {
-    const emptySelectedTerms = {};
-    usedFacetFields.forEach((facetField) => {
-        emptySelectedTerms[facetField.field] = [];
-    });
-    return emptySelectedTerms;
-};
-
-
-/**
- * Reset the facets to no selections, and select the first term of radio-button facets, all as if
- * the page has just been loaded.
- * @param {array} files Files to consider when building facets.
- * @param {array} usedFacetFields Facet fields to consider
- *
- * @return {object} Initial facet-term selections
- */
-const resetFacets = (files, analyses, usedFacetFields) => {
-    // Make an empty selected-terms object so `assembleFacets` can generate fresh simplified
-    // facets.
-    const emptySelectedTerms = initSelectedTerms(usedFacetFields);
-
-    // Build the facets based on no selections, then select the first term of any radio-button
-    // facets.
-    const { facets } = assembleFacets(emptySelectedTerms, files, analyses, usedFacetFields);
-    return initRadioFacets(facets, emptySelectedTerms, usedFacetFields);
 };
 
 
@@ -1466,8 +641,9 @@ const getSelectedVisualizableFiles = (visualizableFiles, selectedTerms) => (
 /**
  * Content of the tabs with counters.
  */
-const CounterTab = ({ title, count, voice }) => (
+const CounterTab = ({ title, count, icon, voice }) => (
     <div className="cart-tab" aria-label={`${count} ${voice}`}>
+        {icon ? svgIcon(icon) : null}
         {title} <div className="cart-tab__count">{count}</div>
     </div>
 );
@@ -1477,11 +653,14 @@ CounterTab.propTypes = {
     title: PropTypes.string.isRequired,
     /** Counter value to display next to the tab */
     count: PropTypes.number.isRequired,
+    /** ID of icon to display, if any */
+    icon: PropTypes.string,
     /** Screen reader text */
     voice: PropTypes.string,
 };
 
 CounterTab.defaultProps = {
+    icon: '',
     voice: 'items',
 };
 
@@ -1505,8 +684,8 @@ CounterTab.defaultProps = {
  */
 const getCartInfo = (context, savedCartObj) => {
     let cartType = '';
-    let cartName;
-    let cartDatasets;
+    let cartName = '';
+    let cartDatasets = [];
     if (context['@type'][0] === 'cart-view' && savedCartObj && Object.keys(savedCartObj).length > 0) {
         cartType = 'ACTIVE';
         cartName = savedCartObj.name;
@@ -1570,7 +749,7 @@ const processFilesAnalyses = (files, analyses) => {
 
 
 /**
- * Use the following order when sortnig files by status for evaluating pseudo-default files.
+ * Use the following order when sorting files by status for evaluating pseudo-default files.
  */
 const pseudoDefaultFileStatusOrder = ['released', 'archived', 'in progress'];
 
@@ -1686,7 +865,7 @@ const retrieveDatasetsFiles = (datasetsIds, facetProgressHandler, fetch, session
     // Break incoming array of dataset @ids into manageable chunks of arrays, each with
     // CHUNK_SIZE elements. Search results from all these chunks get consolidated before returning
     // a promise.
-    const CHUNK_SIZE = 500;
+    const CHUNK_SIZE = 100;
     const chunks = [];
     for (let datasetIndex = 0; datasetIndex < datasetsIds.length; datasetIndex += CHUNK_SIZE) {
         chunks.push(datasetsIds.slice(datasetIndex, datasetIndex + CHUNK_SIZE));
@@ -1714,7 +893,7 @@ const retrieveDatasetsFiles = (datasetsIds, facetProgressHandler, fetch, session
                 // we're accumulating.
                 return {
                     datasetFiles: addToAccumulatingFiles(accumulatingResults.datasetFiles, currentResults),
-                    datasets: accumulatingResults.datasets.concat(currentResults['@graph'].map((experiment) => experiment['@id'])),
+                    datasets: addToAccumulatingDatasets(accumulatingResults.datasets, currentResults),
                     datasetAnalyses: addToAccumulatingAnalyses(accumulatingResults.datasetAnalyses, currentResults),
                 };
             })
@@ -1781,12 +960,12 @@ const calcTotalPageCount = (itemCount, maxCount) => Math.floor(itemCount / maxCo
  * of these files, complete file objects get retrieved.
  */
 const CartComponent = ({ context, savedCartObj, inProgress, fetch, session }) => {
-    // Keeps track of currently selected facet terms keyed by facet fields.
-    const [selectedTerms, setSelectedTerms] = React.useState({});
-    // Currently selected dataset type.
-    const [selectedDatasetType, setSelectedDatasetType] = React.useState(DEFAULT_DATASET_TYPE);
-    // Array of dataset @ids the user has access to view; subset of `cartDatasets`.
-    const [viewableDatasets, setViewableDatasets] = React.useState(null);
+    // Keeps track of currently selected dataset facet terms keyed by facet fields.
+    const [selectedDatasetTerms, setSelectedDatasetTerms] = React.useState({});
+    // Keeps track of currently selected file facet terms keyed by facet fields.
+    const [selectedFileTerms, setSelectedFileTerms] = React.useState({});
+    // Array of datasets the user has access to view; subset of `cartDatasets`.
+    const [viewableDatasets, setViewableDatasets] = React.useState([]);
     // Compiled analyses applicable to the current datasets.
     const [analyses, setAnalyses] = React.useState([]);
     // Currently displayed page number for each tab panes; for pagers.
@@ -1803,45 +982,43 @@ const CartComponent = ({ context, savedCartObj, inProgress, fetch, session }) =>
     const [defaultOnly, setDefaultOnly] = React.useState(true);
     // All partial file objects in the cart datasets. Not affected by currently selected facets.
     const [allFiles, setAllFiles] = React.useState([]);
+    // Tracks previous contents of `cartDatasets` to know if the cart contents have changed.
+    const cartDatasetsRef = React.useRef([]);
 
     // Retrieve current unfiltered cart information regardless of its source (object or active).
-    const { cartType, cartName, cartDatasets } = React.useMemo(() => (
-        getCartInfo(context, savedCartObj)
-    ), [context, savedCartObj]);
-
-    // Get the cart datasets subject to the dataset-type dropdown. Empty array if cart type not yet
-    // determined.
-    const cartDatasetsForType = React.useMemo(() => {
-        if (cartType) {
-            return (
-                selectedDatasetType === 'all'
-                    ? cartDatasets
-                    : cartDatasets.filter((datasetAtId) => atIdToType(datasetAtId) === selectedDatasetType)
-            );
-        }
-        return [];
-    }, [selectedDatasetType, cartDatasets, cartType]);
+    // Determine if the cart contents have changed.
+    const { cartType, cartName, cartDatasets } = getCartInfo(context, savedCartObj);
+    const isCartDatasetsChanged = !_.isEqual(cartDatasetsRef.current, cartDatasets);
+    if (isCartDatasetsChanged) {
+        cartDatasetsRef.current = cartDatasets;
+    }
 
     // Filter out conditional facets.
-    const usedFacetFields = React.useMemo(() => (
+    const usedFileFacetFields = React.useMemo(() => (
         defaultOnly
-            ? displayedFacetFields.filter((facetField) => facetField.preferred)
-            : displayedFacetFields
+            ? displayedFileFacetFields.filter((facetField) => facetField.preferred)
+            : displayedFileFacetFields
     ), [defaultOnly]);
 
-    // Build the facets based on the currently selected facet terms.
-    const { facets, selectedFiles } = React.useMemo(() => {
-        let files = defaultOnly ? filterForDefaultFiles(allFiles) : allFiles;
+    // Build the dataset facets based on the currently selected facet terms.
+    const { datasetFacets, selectedDatasets } = React.useMemo(() => (
+        assembleDatasetFacets(selectedDatasetTerms, viewableDatasets, displayedDatasetFacetFields)
+    ), [selectedDatasetTerms, viewableDatasets]);
+
+    // Build the file facets based on the currently selected facet terms.
+    const selectedDatasetFiles = React.useMemo(() => filterForDatasetFiles(allFiles, selectedDatasets), [allFiles, selectedDatasets]);
+    const { fileFacets, selectedFiles } = React.useMemo(() => {
+        let files = defaultOnly ? filterForDefaultFiles(selectedDatasetFiles) : selectedDatasetFiles;
         files = visualizableOnly ? filterForVisualizableFiles(files) : files;
-        return assembleFacets(selectedTerms, files, analyses, usedFacetFields);
-    }, [selectedTerms, visualizableOnly, defaultOnly, allFiles, analyses, usedFacetFields]);
+        return assembleFileFacets(selectedFileTerms, files, analyses, usedFileFacetFields);
+    }, [selectedFileTerms, selectedDatasets, visualizableOnly, defaultOnly, selectedDatasetFiles, analyses, usedFileFacetFields]);
 
     // Construct the file lists for the genome browser and raw file tabs.
-    const rawdataFiles = React.useMemo(() => allFiles.filter((files) => !files.assembly), [allFiles]);
+    const rawdataFiles = React.useMemo(() => selectedDatasetFiles.filter((files) => !files.assembly), [selectedDatasetFiles]);
     const selectedVisualizableFiles = React.useMemo(() => {
-        const files = defaultOnly ? filterForDefaultFiles(allFiles) : allFiles;
-        return getSelectedVisualizableFiles(filterForVisualizableFiles(files), selectedTerms);
-    }, [allFiles, selectedTerms]);
+        const files = defaultOnly ? filterForDefaultFiles(selectedDatasetFiles) : selectedDatasetFiles;
+        return getSelectedVisualizableFiles(filterForVisualizableFiles(files), selectedFileTerms);
+    }, [selectedDatasetFiles, selectedFileTerms]);
 
     // Called when the user selects a new page of items to view using the pager.
     const updateDisplayedPage = (newDisplayedPage) => {
@@ -1849,46 +1026,93 @@ const CartComponent = ({ context, savedCartObj, inProgress, fetch, session }) =>
         dispatchPageNumbers({ tab: displayedTab, pageNumber: newDisplayedPage });
     };
 
+    // Get the currently selected dataset type if the user selected exactly one.
+    const selectedDatasetType = selectedDatasetTerms.type && selectedDatasetTerms.type.length === 1
+        ? selectedDatasetTerms.type[0]
+        : '';
+
     // Called when the user clicks any term in any facet.
-    const handleTermClick = (clickedField, clickedTerm) => {
+    const handleDatasetTermClick = (clickedField, clickedTerm) => {
         const newSelectedTerms = {};
-        const matchingFacetField = usedFacetFields.find((facetField) => facetField.field === clickedField);
+        const matchingFacetField = displayedDatasetFacetFields.find((facetField) => facetField.field === clickedField);
         if (matchingFacetField && matchingFacetField.radio) {
             // The user clicked a radio-button facet.
-            usedFacetFields.forEach((facetField) => {
+            displayedDatasetFacetFields.usedFileFacetFields.forEach((facetField) => {
                 // Set new term for the clicked radio button, or copy the array for other
                 // terms within this as well as other facets.
-                newSelectedTerms[facetField.field] = facetField.field === clickedField ? [clickedTerm] : selectedTerms[facetField.field].slice(0);
+                newSelectedTerms[facetField.field] = facetField.field === clickedField ? [clickedTerm] : selectedDatasetTerms[facetField.field].slice(0);
             });
         } else {
             // The user clicked a checkbox facet. Determine whether we need to add or subtract
             // a term from the facet selections.
-            const addTerm = selectedTerms[clickedField].indexOf(clickedTerm) === -1;
+            const addTerm = selectedDatasetTerms[clickedField].indexOf(clickedTerm) === -1;
+            if (addTerm) {
+                // Adding a selected term. Copy the previous selectedDatasetTerms, adding the newly
+                // selected term in its facet in sorted position.
+                displayedDatasetFacetFields.forEach((facetField) => {
+                    if (clickedField === facetField.field) {
+                        // Clicked term belongs to this field's facet. Insert it into its
+                        // sorted position in a copy of the selectedDatasetTerms array.
+                        const sortedIndex = _(selectedDatasetTerms[facetField.field]).sortedIndex(clickedTerm);
+                        newSelectedTerms[facetField.field] = [...selectedDatasetTerms[facetField.field].slice(0, sortedIndex), clickedTerm, ...selectedDatasetTerms[facetField.field].slice(sortedIndex)];
+                    } else {
+                        // Clicked term doesn't belong to this field's facet. Just copy the
+                        // `selectedDatasetTerms` array unchanged.
+                        newSelectedTerms[facetField.field] = selectedDatasetTerms[facetField.field].slice(0);
+                    }
+                });
+            } else {
+                // Removing a selected term. Copy the previous selectedDatasetTerms, filtering out
+                // the unselected term in its facet.
+                displayedDatasetFacetFields.forEach((facetField) => {
+                    newSelectedTerms[facetField.field] = selectedDatasetTerms[facetField.field].filter((term) => term !== clickedTerm);
+                });
+            }
+        }
+
+        setSelectedDatasetTerms(newSelectedTerms);
+    };
+
+    // Called when the user clicks any term in any facet.
+    const handleFileTermClick = (clickedField, clickedTerm) => {
+        const newSelectedTerms = {};
+        const matchingFacetField = displayedFileFacetFields.find((facetField) => facetField.field === clickedField);
+        if (matchingFacetField && matchingFacetField.radio) {
+            // The user clicked a radio-button facet.
+            displayedFileFacetFields.forEach((facetField) => {
+                // Set new term for the clicked radio button, or copy the array for other
+                // terms within this as well as other facets.
+                newSelectedTerms[facetField.field] = facetField.field === clickedField ? [clickedTerm] : selectedFileTerms[facetField.field].slice(0);
+            });
+        } else {
+            // The user clicked a checkbox facet. Determine whether we need to add or subtract
+            // a term from the facet selections.
+            const addTerm = selectedFileTerms[clickedField].indexOf(clickedTerm) === -1;
             if (addTerm) {
                 // Adding a selected term. Copy the previous selectedFacetTerms, adding the newly
                 // selected term in its facet in sorted position.
-                usedFacetFields.forEach((facetField) => {
+                displayedFileFacetFields.forEach((facetField) => {
                     if (clickedField === facetField.field) {
                         // Clicked term belongs to this field's facet. Insert it into its
                         // sorted position in a copy of the selectedTerms array.
-                        const sortedIndex = _(selectedTerms[facetField.field]).sortedIndex(clickedTerm);
-                        newSelectedTerms[facetField.field] = [...selectedTerms[facetField.field].slice(0, sortedIndex), clickedTerm, ...selectedTerms[facetField.field].slice(sortedIndex)];
+                        const sortedIndex = _(selectedFileTerms[facetField.field]).sortedIndex(clickedTerm);
+                        newSelectedTerms[facetField.field] = [...selectedFileTerms[facetField.field].slice(0, sortedIndex), clickedTerm, ...selectedFileTerms[facetField.field].slice(sortedIndex)];
                     } else {
                         // Clicked term doesn't belong to this field's facet. Just copy the
                         // `selectedTerms` array unchanged.
-                        newSelectedTerms[facetField.field] = selectedTerms[facetField.field].slice(0);
+                        newSelectedTerms[facetField.field] = selectedFileTerms[facetField.field].slice(0);
                     }
                 });
             } else {
                 // Removing a selected term. Copy the previous selectedFacetTerms, filtering out
                 // the unselected term in its facet.
-                usedFacetFields.forEach((facetField) => {
-                    newSelectedTerms[facetField.field] = selectedTerms[facetField.field].filter((term) => term !== clickedTerm);
+                displayedFileFacetFields.forEach((facetField) => {
+                    newSelectedTerms[facetField.field] = selectedFileTerms[facetField.field].filter((term) => term !== clickedTerm);
                 });
             }
         }
 
-        setSelectedTerms(newSelectedTerms);
+        setSelectedFileTerms(newSelectedTerms);
     };
 
     // Called when the user clicks the Show Visualizable Only checkbox.
@@ -1900,7 +1124,6 @@ const CartComponent = ({ context, savedCartObj, inProgress, fetch, session }) =>
     const handlePreferredOnlyChange = React.useCallback(() => {
         setDefaultOnly((prevPreferredOnly) => !prevPreferredOnly);
         setVisualizableOnly(false);
-        setSelectedTerms({});
     }, []);
 
     // Called when the user clicks a tab.
@@ -1908,25 +1131,40 @@ const CartComponent = ({ context, savedCartObj, inProgress, fetch, session }) =>
         setDisplayedTab(newTab);
     };
 
-    // Called when the user changes the currently selected dataset type.
-    const handleTypeChange = (e) => {
-        setSelectedDatasetType(e.target.value);
+    // Clear all selected dataset terms within the facet specified by the given field.
+    const clearDatasetFacetSelections = (field) => {
+        const newSelectedDatasetTerms = { ...selectedDatasetTerms };
+        newSelectedDatasetTerms[field] = [];
+        setSelectedDatasetTerms(newSelectedDatasetTerms);
     };
 
-    // Use the file information to build the facets and its initial selections.
+    // Clear all selected file terms within the facet specified by the given field.
+    const clearFileFacetSelections = (field) => {
+        const newSelectedFileTerms = { ...selectedFileTerms };
+        newSelectedFileTerms[field] = [];
+        setSelectedFileTerms(newSelectedFileTerms);
+    };
+
+    // Use the file information to build the facets and its initial selections. Resetting the
+    // facets to their initial states should only happen with a change to files.
     React.useEffect(() => {
+        // Reset file terms.
         const files = defaultOnly ? filterForDefaultFiles(allFiles) : allFiles;
         const allVisualizableFiles = filterForVisualizableFiles(files);
         const consideredFiles = visualizableOnly ? allVisualizableFiles : files;
-        const newSelectedTerms = resetFacets(consideredFiles, analyses, usedFacetFields);
-        setSelectedTerms(newSelectedTerms);
-    }, [visualizableOnly, defaultOnly, analyses, usedFacetFields, allFiles]);
+        const newSelectedFileTerms = resetFileFacets(consideredFiles, analyses, displayedFileFacetFields);
+        setSelectedFileTerms(newSelectedFileTerms);
+
+        // Reset dataset terms.
+        const newSelectedDatasetTerms = resetDatasetFacets(viewableDatasets, displayedDatasetFacetFields);
+        setSelectedDatasetTerms(newSelectedDatasetTerms);
+    }, [allFiles]);
 
     // After mount, we can fetch all datasets in the cart that are viewable at the user's
     // permission level and from them extract all their files.
     React.useEffect(() => {
-        if (cartDatasetsForType.length > 0) {
-            retrieveDatasetsFiles(cartDatasetsForType, setFacetProgress, fetch, session).then(({ datasetFiles, datasets, datasetAnalyses }) => {
+        if (isCartDatasetsChanged) {
+            retrieveDatasetsFiles(cartDatasets, setFacetProgress, fetch, session).then(({ datasetFiles, datasets, datasetAnalyses }) => {
                 // Mutate files for special cases.
                 datasetFiles.forEach((file) => {
                     // De-embed any embedded datasets.files.dataset.
@@ -1940,11 +1178,11 @@ const CartComponent = ({ context, savedCartObj, inProgress, fetch, session }) =>
                 setAnalyses(datasetAnalyses);
             });
         }
-    }, [cartDatasetsForType, fetch, session]);
+    }, [isCartDatasetsChanged]);
 
     // Data changes or initial load need a total-page-count calculation.
     React.useEffect(() => {
-        const datasetPageCount = calcTotalPageCount(cartDatasetsForType.length, PAGE_ELEMENT_COUNT);
+        const datasetPageCount = calcTotalPageCount(selectedDatasets.length, PAGE_ELEMENT_COUNT);
         const browserPageCount = calcTotalPageCount(selectedVisualizableFiles.length, PAGE_TRACK_COUNT);
         const processedDataPageCount = calcTotalPageCount(selectedFiles.length, PAGE_FILE_COUNT);
         const rawdataPageCount = calcTotalPageCount(rawdataFiles.length, PAGE_FILE_COUNT);
@@ -1966,7 +1204,7 @@ const CartComponent = ({ context, savedCartObj, inProgress, fetch, session }) =>
         if (pageNumbers.rawdata >= rawdataPageCount) {
             dispatchPageNumbers({ tab: 'rawdata', pageNumber: 0 });
         }
-    }, [cartDatasetsForType, selectedVisualizableFiles, selectedFiles, rawdataFiles, pageNumbers.datasets, pageNumbers.browser, pageNumbers.processeddata, pageNumbers.rawdata]);
+    }, [selectedDatasets, selectedVisualizableFiles, selectedFiles, rawdataFiles, pageNumbers.datasets, pageNumbers.browser, pageNumbers.processeddata, pageNumbers.rawdata]);
 
     return (
         <div className={itemClass(context, 'view-item')}>
@@ -1982,16 +1220,16 @@ const CartComponent = ({ context, savedCartObj, inProgress, fetch, session }) =>
                 {cartType === 'OBJECT' ? <ItemAccessories item={context} /> : null}
             </header>
             <Panel addClasses="cart__result-table">
-                {cartDatasetsForType.length > 0 ?
+                {selectedDatasets.length > 0 ?
                     <PanelHeading addClasses="cart__header">
                         <CartTools
                             elements={cartDatasets}
                             analyses={analyses}
                             savedCartObj={savedCartObj}
-                            selectedTerms={selectedTerms}
+                            selectedFileTerms={selectedFileTerms}
+                            selectedDatasetTerms={selectedDatasetTerms}
                             selectedDatasetType={selectedDatasetType}
-                            facetFields={usedFacetFields}
-                            typeChangeHandler={handleTypeChange}
+                            facetFields={displayedFileFacetFields.concat(displayedDatasetFacetFields)}
                             viewableDatasets={viewableDatasets}
                             cartType={cartType}
                             sharedCart={context}
@@ -1999,74 +1237,97 @@ const CartComponent = ({ context, savedCartObj, inProgress, fetch, session }) =>
                             visualizable={visualizableOnly}
                             preferredDefault={defaultOnly}
                         />
-                        {selectedTerms.assembly && selectedTerms.assembly[0] ? <div className="cart-assembly-indicator">{selectedTerms.assembly[0]}</div> : null}
+                        {selectedFileTerms.assembly && selectedFileTerms.assembly[0] ? <div className="cart-assembly-indicator">{selectedFileTerms.assembly[0]}</div> : null}
                     </PanelHeading>
                 : null}
                 <PanelBody>
-                    {cartDatasetsForType.length > 0 ?
+                    {cartDatasets.length > 0 ?
                         <div className="cart__display">
-                            <FileFacets
-                                facets={facets}
-                                usedFacetFields={usedFacetFields}
-                                elements={cartDatasetsForType}
-                                selectedTerms={selectedTerms}
-                                termClickHandler={handleTermClick}
-                                selectedFileCount={selectedFiles.length}
-                                visualizableOnly={visualizableOnly}
-                                visualizableOnlyChangeHandler={handleVisualizableOnlyChange}
-                                preferredOnly={defaultOnly}
-                                preferredOnlyChangeHandler={handlePreferredOnlyChange}
-                                facetLoadProgress={facetProgress}
-                                disabled={displayedTab === 'rawdata'}
+                            <CartFacets
+                                datasetProps={{
+                                    facets: datasetFacets,
+                                    selectedTerms: selectedDatasetTerms,
+                                    termClickHandler: handleDatasetTermClick,
+                                    clearFacetSelections: clearDatasetFacetSelections,
+                                }}
+                                fileProps={{
+                                    facets: fileFacets,
+                                    selectedTerms: selectedFileTerms,
+                                    termClickHandler: handleFileTermClick,
+                                    clearFacetSelections: clearFileFacetSelections,
+                                    usedFacetFields: usedFileFacetFields,
+                                }}
+                                options={{
+                                    visualizableOnly,
+                                    visualizableOnlyChangeHandler: handleVisualizableOnlyChange,
+                                    preferredOnly: defaultOnly,
+                                    preferredOnlyChangeHandler: handlePreferredOnlyChange,
+                                }}
+                                datasets={selectedDatasets}
+                                files={selectedFiles}
+                                facetProgress={facetProgress}
                             />
                             <TabPanel
                                 tabPanelCss="cart__display-content"
                                 tabs={{ datasets: 'All datasets', browser: 'Genome browser', processeddata: 'Processed data', rawdata: 'Raw data' }}
                                 tabDisplay={{
-                                    datasets: <CounterTab title={datasetTypes[selectedDatasetType].title} count={cartDatasetsForType.length} voice="datasets" />,
-                                    browser: <CounterTab title="Genome browser" count={selectedVisualizableFiles.length} voice="visualizable tracks" />,
-                                    processeddata: <CounterTab title="Processed data" count={selectedFiles.length} voice="processed data files" />,
-                                    rawdata: <CounterTab title="Raw data" count={rawdataFiles.length} voice="raw data files" />,
+                                    datasets: <CounterTab title={`Selected ${selectedDatasetType ? datasetTabTitles[selectedDatasetType] : 'datasets'}`} count={selectedDatasets.length} icon="dataset" voice="selected datasets" />,
+                                    browser: <CounterTab title="Genome browser" count={selectedVisualizableFiles.length} icon="file" voice="visualizable tracks" />,
+                                    processeddata: <CounterTab title="Processed data" count={selectedFiles.length} icon="file" voice="processed data files" />,
+                                    rawdata: <CounterTab title="Raw data" count={rawdataFiles.length} icon="file" voice="raw data files" />,
                                 }}
                                 handleTabClick={handleTabClick}
                             >
                                 <TabPanelPane key="datasets">
-                                    <CartPager
+                                    <CartSearchResultsControls
+                                        currentTab={displayedTab}
+                                        elements={selectedDatasets}
                                         currentPage={pageNumbers.datasets}
                                         totalPageCount={totalPageCount.datasets}
                                         updateCurrentPage={updateDisplayedPage}
+                                        loading={facetProgress !== -1}
                                     />
                                     <CartSearchResults
-                                        elements={cartDatasetsForType}
+                                        elements={selectedDatasets}
                                         currentPage={pageNumbers.datasets}
                                         cartControls={cartType !== 'OBJECT'}
+                                        loading={facetProgress !== -1}
                                     />
                                 </TabPanelPane>
                                 <TabPanelPane key="browser">
-                                    <CartPager
+                                    <CartSearchResultsControls
+                                        currentTab={displayedTab}
+                                        elements={selectedDatasets}
                                         currentPage={pageNumbers.browser}
                                         totalPageCount={totalPageCount.browser}
                                         updateCurrentPage={updateDisplayedPage}
+                                        loading={facetProgress !== -1}
                                     />
-                                    {selectedTerms.assembly && selectedTerms.assembly.length > 0
-                                        ? <CartBrowser files={selectedVisualizableFiles} assembly={selectedTerms.assembly[0]} pageNumber={pageNumbers.browser} />
+                                    {selectedFileTerms.assembly && selectedFileTerms.assembly.length > 0
+                                        ? <CartBrowser files={selectedVisualizableFiles} assembly={selectedFileTerms.assembly[0]} pageNumber={pageNumbers.browser} loading={facetProgress !== -1} />
                                         : null}
                                 </TabPanelPane>
                                 <TabPanelPane key="processeddata">
-                                    <CartPager
+                                    <CartSearchResultsControls
+                                        currentTab={displayedTab}
+                                        elements={selectedDatasets}
                                         currentPage={pageNumbers.processeddata}
                                         totalPageCount={totalPageCount.processeddata}
                                         updateCurrentPage={updateDisplayedPage}
+                                        loading={facetProgress !== -1}
                                     />
-                                    <CartFiles files={selectedFiles} currentPage={pageNumbers.processeddata} defaultOnly={defaultOnly} />
+                                    <CartFiles files={selectedFiles} currentPage={pageNumbers.processeddata} defaultOnly={defaultOnly} loading={facetProgress !== -1} />
                                 </TabPanelPane>
                                 <TabPanelPane key="rawdata">
-                                    <CartPager
+                                    <CartSearchResultsControls
+                                        currentTab={displayedTab}
+                                        elements={selectedDatasets}
                                         currentPage={pageNumbers.rawdata}
                                         totalPageCount={totalPageCount.rawdata}
                                         updateCurrentPage={updateDisplayedPage}
+                                        loading={facetProgress !== -1}
                                     />
-                                    <CartFiles files={rawdataFiles} currentPage={pageNumbers.rawdata} />
+                                    <CartFiles files={rawdataFiles} currentPage={pageNumbers.rawdata} loading={facetProgress !== -1} />
                                 </TabPanelPane>
                             </TabPanel>
                         </div>

--- a/src/encoded/static/components/cart/facet.js
+++ b/src/encoded/static/components/cart/facet.js
@@ -1,0 +1,1418 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import _ from 'underscore';
+import { Modal, ModalHeader, ModalBody } from '../../libs/ui/modal';
+import { encodedURIComponent } from '../../libs/query_encoding';
+import { svgIcon } from '../../libs/svg-icons';
+import { tintColor, isLight } from '../datacolors';
+import { keyCode } from '../globals';
+import {
+    isFileVisualizable,
+    computeAssemblyAnnotationValue,
+    filterForDefaultFiles,
+    Checkbox,
+} from '../objectutils';
+import { getAnalysesFileIds, getObjectFieldValue } from './util';
+
+
+/**
+ * Sorter function to sort an array of assemblies/annotations for display in the facet according to
+ * system-wide criteria.
+ * @param {array} facetTerms Assembly facet terms to sort
+ *
+ * @return {array} Same as `facetTerms` but sorted
+ */
+const assemblySorter = (facetTerms) => (
+    // Negate the sorting value to sort from highest to lowest.
+    _(facetTerms).sortBy((facetTerm) => -computeAssemblyAnnotationValue(facetTerm.term))
+);
+
+
+/**
+ * Sorter function for analyses facet terms matches the order from the given analyses which have
+ * already been sorted.
+ * @param {array} facetTerms Analysis facet terms to sort
+ *
+ * @return {array} Same as `facetTerms`
+ */
+const analysisSorter = (facetTerms, analyses) => (
+    _(facetTerms).sortBy((facetTerm) => (
+        analyses.findIndex((analysis) => analysis.title === facetTerm.term)
+    ))
+);
+
+
+/**
+ * Field mapping transform for analyses. Generate a query string corresponding to all the selected
+ * analyses with the given titles. More than one title can be selected, and more than one analysis
+ * can correspond to a title, so all these get combined into one query string.
+ * @param {array} analysisTitles Selected analysis titles from the facet.
+ *
+ * @return {string} Combined query string selecting file.analyses titles.
+ */
+const analysisFieldMap = (analysisTitles) => (
+    analysisTitles.map((title) => `files.analyses.title=${encodedURIComponent(title)}`).join('&')
+);
+
+
+/**
+ * Field `getValue` function to extract the top @type from the given dataset.
+ * @param {object} dataset ...from which to extract its @type
+ * @return {string} Top-level @type of given dataset
+ */
+const datasetTypeValue = (dataset) => dataset['@type'][0];
+
+
+/**
+ * Display a term of the Dataset Term facets mapped to the English-language equivalent from the
+ * profile titles from <App> page load, e.g. "Functional Characterization Experiment" instead of
+ * "FunctionalCharacterizationExperiment."
+ */
+const DatasetTypeTermDisplay = ({ term }, { profilesTitles }) => {
+    if (profilesTitles && profilesTitles[term]) {
+        return <div className="cart-facet-term__text">{profilesTitles[term]}</div>;
+    }
+    return <div className="cart-facet-term__text">{term}</div>;
+};
+
+DatasetTypeTermDisplay.propTypes = {
+    /** Displayed facet term */
+    term: PropTypes.string.isRequired,
+};
+
+DatasetTypeTermDisplay.contextTypes = {
+    profilesTitles: PropTypes.object,
+};
+
+
+/**
+ * File facet fields to display in order of display.
+ * - field: `facet` field property
+ * - title: Displayed facet title
+ * - radio: True if radio-button facet; otherwise checkbox facet
+ * - dataset: True to retrieve value from dataset instead of files
+ * - sorter: Function to sort terms within the facet
+ * - fieldMapper: Function to generate a batch download query string
+ * - preferred: Facet appears when preferred_default selected
+ * - calculated: True for facets displaying calculated (not requested) file/dataset props
+ * - parent: Copy expanded state of this field; suppress this facet's expander title
+ * - expanded: True to appear expanded by default
+ * - nonCollapsable: True for the facet to always appear expanded; no expander trigger
+ * - persistent: True if the facet should appear on the main page, not only in the modal
+ */
+export const displayedFileFacetFields = [
+    {
+        field: 'assembly',
+        title: 'Analysis/Assembly',
+        radio: true,
+        sorter: assemblySorter,
+        preferred: true,
+        expanded: true,
+        persistent: true,
+    },
+    {
+        field: 'analysis',
+        title: 'Analysis',
+        dataset: true,
+        sorter: analysisSorter,
+        fieldMapper: analysisFieldMap,
+        persistent: true,
+        calculated: true,
+        parent: 'assembly',
+        css: 'cart-facet--analysis',
+    },
+    {
+        field: 'output_type',
+        title: 'Output type',
+    },
+    {
+        field: 'file_type',
+        title: 'File type',
+    },
+    {
+        field: 'file_format',
+        title: 'File format',
+    },
+    {
+        field: 'lab.title',
+        title: 'Lab',
+        preferred: true,
+    },
+    {
+        field: 'status',
+        title: 'Status',
+    },
+];
+
+export const displayedDatasetFacetFields = [
+    {
+        field: 'type',
+        title: 'Dataset type',
+        getValue: datasetTypeValue,
+        termDisplay: DatasetTypeTermDisplay,
+        nonCollapsable: true,
+        persistent: true,
+    },
+    {
+        field: 'assay_title',
+        title: 'Assay title',
+    },
+    {
+        field: 'biosample_ontology.term_name',
+        title: 'Biosample',
+    },
+    {
+        field: 'target.label',
+        title: 'Target',
+    },
+    {
+        field: 'annotation_type',
+        title: 'Annotation type',
+    },
+    {
+        field: 'replicates.library.biosample.organism.scientific_name',
+        title: 'Organism',
+    },
+    {
+        field: 'lab.title',
+        title: 'Lab',
+    },
+    {
+        field: 'status',
+        title: 'Status',
+    },
+];
+
+
+/** Get all the facet fields with the `persistent` flag set */
+const displayedPersistentFacetFields = displayedDatasetFacetFields.filter((fieldConfig) => fieldConfig.persistent)
+    .concat(displayedFileFacetFields.filter((fieldConfig) => fieldConfig.persistent));
+
+/** Facet `field` values for properties from dataset instead of files */
+export const datasetFieldFileFacets = ['biosample_ontology.term_name', 'target.label'];
+
+
+/**
+ * Display a count of the total number of elements selected in the facet, given the current facet term
+ * selections. Shows the facet-loading progress bar if needed.
+ */
+const FacetCount = ({ count, element, facetLoadProgress }) => {
+    const [triggerEnabled, setTriggerEnabled] = React.useState(false);
+
+    /**
+     * Called when CSS animation ends. Removes the <div> that shows the yellow highlight when the
+     * count changes.
+     */
+    const handleAnimationEnd = () => {
+        setTriggerEnabled(false);
+    };
+
+    React.useEffect(() => {
+        // Inserts the <div> to show the yellow highlight when the file count changes.
+        setTriggerEnabled(true);
+    }, [count]);
+
+    if (facetLoadProgress === -1) {
+        const fileCountFormatted = count.toLocaleString ? count.toLocaleString() : count.toString();
+        return (
+            <div className="cart__facet-count">
+                {triggerEnabled ? <div className="cart__facet-count-changer" onAnimationEnd={handleAnimationEnd} /> : null}
+                {count > 0 ?
+                    <>{svgIcon(element)} {fileCountFormatted} {element}{count !== 1 ? 's' : ''} selected</>
+                :
+                    <>No files selected for download</>
+                }
+            </div>
+        );
+    }
+
+    return <progress value={facetLoadProgress} max="100" />;
+};
+
+FacetCount.propTypes = {
+    /** Number of files selected for download */
+    count: PropTypes.number,
+    /** What sort of element to document in the display, e.g. "dataset" */
+    element: PropTypes.string.isRequired,
+    /** Value for the progress bar; -1 to not show it */
+    facetLoadProgress: PropTypes.number,
+};
+
+FacetCount.defaultProps = {
+    count: 0,
+    facetLoadProgress: -1,
+};
+
+
+/**
+ * Renders one button showing a current facet selection, and allowing the user to clear the
+ * selection.
+ */
+const SelectionItem = ({ selection, term, selectionType, clickHandler }) => (
+    <button
+        type="button"
+        key={selection}
+        onClick={() => clickHandler(term, selection)}
+        className="btn btn-xs facet-selections-button"
+        aria-label={`Remove ${selection} from filters`}
+    >
+        <div className="facet-selections-button__icon">{svgIcon(selectionType)}</div>
+        <div className="facet-selections-button__label">
+            {selection}
+        </div>
+    </button>
+);
+
+SelectionItem.propTypes = {
+    selection: PropTypes.string.isRequired,
+    term: PropTypes.string.isRequired,
+    selectionType: PropTypes.oneOf(['dataset', 'file']).isRequired,
+    clickHandler: PropTypes.func.isRequired,
+};
+
+
+/**
+ * Renders the buttons that show all the currently selected facet terms.
+ */
+const Selections = ({ datasetTerms, datasetTermClickHandler, fileTerms, fileTermClickHandler }) => (
+    <div className="facet-selections">
+        {Object.keys(datasetTerms).map((term) => {
+            // Render the selected dataset facet terms first.
+            if (datasetTerms[term].length > 0) {
+                return (
+                    datasetTerms[term].map((selection) => (
+                        <SelectionItem key={selection} selection={selection} term={term} selectionType="dataset" clickHandler={datasetTermClickHandler} />
+                    ))
+                );
+            }
+            return null;
+        })}
+        {Object.keys(fileTerms).map((term) => {
+            // Render the selected file facet terms second.
+            const matchingDisplayField = displayedFileFacetFields.find((fieldDef) => (
+                fieldDef.field === term
+            ));
+            if (!matchingDisplayField.radio && fileTerms[term].length > 0) {
+                return (
+                    fileTerms[term].map((selection) => (
+                        <SelectionItem key={selection} selection={selection} term={term} selectionType="file" clickHandler={fileTermClickHandler} />
+                    ))
+                );
+            }
+            return null;
+        })}
+    </div>
+);
+
+Selections.propTypes = {
+    datasetTerms: PropTypes.object.isRequired,
+    datasetTermClickHandler: PropTypes.func.isRequired,
+    fileTerms: PropTypes.object.isRequired,
+    fileTermClickHandler: PropTypes.func.isRequired,
+};
+
+
+/**
+ * Display the selection checkbox for a single cart file facet term.
+ */
+const FacetTermCheck = ({ checked }) => (
+    <div className={`cart-facet-term__check${checked ? ' cart-facet-term__check--checked' : ''}`}>
+        {checked ?
+            <i className="icon icon-check" />
+        : null}
+    </div>
+);
+
+FacetTermCheck.propTypes = {
+    /** True if facet term checkbox checked */
+    checked: PropTypes.bool,
+};
+
+FacetTermCheck.defaultProps = {
+    checked: false,
+};
+
+
+/**
+ * Display the selection radio button for a single cart file facet term.
+ */
+const FacetTermRadio = ({ checked }) => (
+    <div className={`cart-facet-term__radio${checked ? ' cart-facet-term__radio--checked' : ''}`}>
+        {checked ?
+            <i className="icon icon-circle" />
+        : null}
+    </div>
+);
+
+FacetTermRadio.propTypes = {
+    /** True if facet term radio button checked */
+    checked: PropTypes.bool,
+};
+
+FacetTermRadio.defaultProps = {
+    checked: false,
+};
+
+
+/**
+ * Render the text contents of a facet term, using custom displays from the `termDisplay` property
+ * of a facet definition if provided.
+ */
+const FacetTermContent = ({ term, displayedFacetField }) => {
+    if (displayedFacetField.termDisplay) {
+        return <displayedFacetField.termDisplay term={term} displayedFacetField={displayedFacetField} />;
+    }
+    return <div className="cart-facet-term__text">{term}</div>;
+};
+
+FacetTermContent.propTypes = {
+    /** Displayed facet term */
+    term: PropTypes.string.isRequired,
+    /** Field definition representing the facet being displayed */
+    displayedFacetField: PropTypes.object.isRequired,
+};
+
+
+/**
+ * Display the cart file facet term count that shows the magnitude of a facet term through its
+ * color tint. The maximum value for the facet gets the full base color, and lesser values get
+ * lighter tints.
+ */
+const FacetTermMagnitude = ({ termCount, maxTermCount }) => {
+    const MAGNITUDE_BASE_COLOR = '#656BFF';
+    const magnitudeColor = tintColor(MAGNITUDE_BASE_COLOR, 1 - (termCount / maxTermCount));
+    const textColor = isLight(magnitudeColor) ? '#000' : '#fff';
+    return (
+        <div className="cart-facet-term__magnitude" style={{ backgroundColor: magnitudeColor }}>
+            <span style={{ color: textColor }}>{termCount}</span>
+        </div>
+    );
+};
+
+FacetTermMagnitude.propTypes = {
+    /** Number of items this facet term indicates */
+    termCount: PropTypes.number.isRequired,
+    /** Maximum count value among all terms in this facet */
+    maxTermCount: PropTypes.number.isRequired,
+};
+
+
+/**
+ * Display one term of a facet.
+ */
+const FacetTerm = ({
+    term,
+    displayedFacetField,
+    termCount,
+    maxTermCount,
+    selected,
+    visualizable,
+    termClickHandler,
+    FacetTermSelectRenderer,
+}) => {
+    /**
+     * Called when user clicks a term within a facet.
+     */
+    const handleTermClick = () => {
+        termClickHandler(term);
+    };
+
+    return (
+        <li className="cart-facet-term">
+            <button
+                className="cart-facet-term__item"
+                type="button"
+                id={`cart-facet-term-${term}`}
+                onClick={handleTermClick}
+                aria-pressed={selected}
+                aria-label={`${termCount} ${term} file${termCount === 1 ? '' : 's'}${visualizable ? ' visualizable' : ''}`}
+            >
+                <FacetTermSelectRenderer checked={selected} />
+                <FacetTermContent term={term} displayedFacetField={displayedFacetField} />
+                <FacetTermMagnitude termCount={termCount} maxTermCount={maxTermCount} />
+                <div className="cart-facet-term__visualizable">
+                    {visualizable ?
+                        <div title="Selects visualizable files">{svgIcon('genomeBrowser')}</div>
+                    : null}
+                </div>
+            </button>
+        </li>
+    );
+};
+
+FacetTerm.propTypes = {
+    /** Displayed facet term */
+    term: PropTypes.string.isRequired,
+    /** Field definition representing the facet being displayed */
+    displayedFacetField: PropTypes.object.isRequired,
+    /** Displayed number of files for this term */
+    termCount: PropTypes.number.isRequired,
+    /** Maximum number of files for all terms in the facet */
+    maxTermCount: PropTypes.number.isRequired,
+    /** True if this term should appear selected */
+    selected: PropTypes.bool,
+    /** True if term selection results in visualizable files */
+    visualizable: PropTypes.bool,
+    /** Callback for handling clicks in the term */
+    termClickHandler: PropTypes.func.isRequired,
+    /** Facet term checkbox/radio renderer */
+    FacetTermSelectRenderer: PropTypes.elementType.isRequired,
+};
+
+FacetTerm.defaultProps = {
+    selected: false,
+    visualizable: false,
+};
+
+
+/**
+ * Display the title inside the facet expander.
+ */
+const FacetTitle = ({ title }) => (
+    <div className="cart-facet__expander-title">
+        {title}
+    </div>
+);
+
+FacetTitle.propTypes = {
+    /** Text title to display */
+    title: PropTypes.string.isRequired,
+};
+
+
+/**
+ * Display a button that shows an indicator when the user has selected at least one term in the
+ * facet, and allows the user to click the indicator to clear all selections within that facet.
+ */
+const FacetSelectionControl = ({ selectionCount, name, clearSelectionHandler }) => {
+    /**
+     * Called when the user types a key while the control holds the current selection.
+     */
+    const handleKeyPress = (e) => {
+        if (e.keyCode === keyCode.RETURN || e.keyCode === keyCode.SPACE) {
+            e.preventDefault();
+            clearSelectionHandler(e);
+        }
+    };
+
+    if (selectionCount > 0) {
+        return (
+            <div role="button" tabIndex="0" id={`cart-facet-clear-${name}`} className="cart-facet-clear" onKeyDown={handleKeyPress} onClick={clearSelectionHandler}>
+                <div className="cart-facet-clear__control cart-facet-clear__control--has-selections">{svgIcon('circle')}</div>
+                <div className="cart-facet-clear__control cart-facet-clear__control--clear-selections">{svgIcon('multiplication')}</div>
+                <span className="sr-only">
+                    Clear {selectionCount} {selectionCount === 1 ? 'selection' : 'selections'}
+                </span>
+            </div>
+        );
+    }
+    return null;
+};
+
+FacetSelectionControl.propTypes = {
+    /** Number of selected terms in the facet */
+    selectionCount: PropTypes.number.isRequired,
+    /** Used as part of the ID to uniquely identify the button on the page */
+    name: PropTypes.string.isRequired,
+    /** Function to call when someone clicks the control */
+    clearSelectionHandler: PropTypes.func.isRequired,
+};
+
+
+/**
+ * Display the facet title and expansion icon, and react to clicks in the button to tell the parent
+ * component that a facet needs to be expanded or collapsed.
+ */
+const FacetExpander = ({ title, field, labelId, expanded, selectionCount, expanderEventHandler, clearFacetSelections }) => {
+    /**
+     * Called when the user clicks the control to clear all selected terms in the facet.
+     */
+    const controlClickHandler = (e) => {
+        e.stopPropagation();
+        clearFacetSelections(field);
+    };
+
+    // Use an expander button if the caller provides an event handler to expand or collapse
+    // the facet.
+    if (expanderEventHandler) {
+        return (
+            <button
+                type="button"
+                id={labelId}
+                className="cart-facet__expander"
+                aria-controls={field}
+                aria-expanded={expanded}
+                onClick={expanderEventHandler}
+            >
+                <FacetTitle title={title} />
+                {clearFacetSelections ? <FacetSelectionControl name={field} selectionCount={selectionCount} clearSelectionHandler={controlClickHandler} /> : null}
+                <i className={`icon icon-chevron-${expanded ? 'up' : 'down'}`} />
+            </button>
+        );
+    }
+
+    // Just display the title without an expander button if no event handler given.
+    return (
+        <div className="cart-facet__expander cart-facet__expander--non-collapsable">
+            <FacetTitle title={title} />
+            {clearFacetSelections ? <FacetSelectionControl name={field} selectionCount={selectionCount} clearSelectionHandler={controlClickHandler} /> : null}
+        </div>
+    );
+};
+
+FacetExpander.propTypes = {
+    /** Displayed title of the facet */
+    title: PropTypes.string.isRequired,
+    /** File facet field representing this facet */
+    field: PropTypes.string.isRequired,
+    /** Used as an id for this button corresponding to expanded component label */
+    labelId: PropTypes.string.isRequired,
+    /** True if facet is currently expanded */
+    expanded: PropTypes.bool.isRequired,
+    /** Number of selected terms */
+    selectionCount: PropTypes.number.isRequired,
+    /** Called when the user clicks the expander button; null for always-open */
+    expanderEventHandler: PropTypes.func,
+    /** Called when the user clears all selections in a facet */
+    clearFacetSelections: PropTypes.func,
+};
+
+FacetExpander.defaultProps = {
+    expanderEventHandler: null,
+    clearFacetSelections: null,
+};
+
+
+/**
+ * Display a single file facet.
+ */
+class Facet extends React.Component {
+    constructor() {
+        super();
+        this.handleFacetTermClick = this.handleFacetTermClick.bind(this);
+        this.handleExpanderEvent = this.handleExpanderEvent.bind(this);
+    }
+
+    /**
+     * Handle a click in a facet term by calling a parent handler.
+     * @param {string} term Clicked facet term
+     */
+    handleFacetTermClick(term) {
+        this.props.facetTermClickHandler(this.props.displayedFacetField.field, term);
+    }
+
+    /**
+     * Handle a click in the facet expander by calling a parent handler.
+     * @param {object} e React synthetic event
+     */
+    handleExpanderEvent(e) {
+        this.props.expanderClickHandler(this.props.displayedFacetField.field, e.altKey);
+    }
+
+    render() {
+        const {
+            facet,
+            displayedFacetField,
+            expanded,
+            expanderClickHandler,
+            selectedFacetTerms,
+            clearFacetSelections,
+            options,
+        } = this.props;
+        const maxTermCount = Math.max(...facet.terms.map((term) => term.count));
+        const labelId = `${displayedFacetField.field}-label`;
+        const FacetTermSelectRenderer = displayedFacetField.radio ? FacetTermRadio : FacetTermCheck;
+        return (
+            <div className="facet">
+                {!options.supressTitle
+                    ? (
+                        <FacetExpander
+                            title={facet.title}
+                            field={displayedFacetField.field}
+                            labelId={labelId}
+                            expanded={expanded}
+                            expanderEventHandler={displayedFacetField.nonCollapsable || !expanderClickHandler ? null : this.handleExpanderEvent}
+                            selectionCount={selectedFacetTerms.length}
+                            clearFacetSelections={displayedFacetField.radio ? null : clearFacetSelections}
+                        />
+                    )
+                : null}
+                {expanded || displayedFacetField.nonCollapsable ?
+                    <ul className={`cart-facet${displayedFacetField.css ? ` ${displayedFacetField.css}` : ''}`} role="region" id={displayedFacetField.field} aria-labelledby={labelId}>
+                        {facet.terms.map((facetTerm) => (
+                            <FacetTerm
+                                key={facetTerm.term}
+                                displayedFacetField={displayedFacetField}
+                                term={facetTerm.term}
+                                termCount={facetTerm.count}
+                                visualizable={options.suppressVisualizable ? false : facetTerm.visualizable}
+                                maxTermCount={maxTermCount}
+                                selected={selectedFacetTerms.indexOf(facetTerm.term) > -1}
+                                termClickHandler={this.handleFacetTermClick}
+                                FacetTermSelectRenderer={FacetTermSelectRenderer}
+                            />
+                        ))}
+                    </ul>
+                : null}
+            </div>
+        );
+    }
+}
+
+Facet.propTypes = {
+    /** Facet object to display */
+    facet: PropTypes.object.isRequired,
+    /** Field definition representing the facet being displayed */
+    displayedFacetField: PropTypes.object.isRequired,
+    /** True if facet should appear expanded */
+    expanded: PropTypes.bool.isRequired,
+    /** Called when the expander button is clicked */
+    expanderClickHandler: PropTypes.func,
+    /** Selected term keys */
+    selectedFacetTerms: PropTypes.array,
+    /** Called when a facet term is clicked */
+    facetTermClickHandler: PropTypes.func.isRequired,
+    /** Called when the user clears all selections in a facet */
+    clearFacetSelections: PropTypes.func,
+    /** Facet-specific options */
+    options: PropTypes.shape({
+        /** Suppress display of facet title */
+        supressTitle: PropTypes.bool,
+        /** Suppress display of visualizable icons */
+        suppressVisualizable: PropTypes.bool,
+    }),
+};
+
+Facet.defaultProps = {
+    expanderClickHandler: null,
+    clearFacetSelections: null,
+    selectedFacetTerms: [],
+    options: {},
+};
+
+
+/**
+ * Manage the expanded states of collapsable facets in a facet list.
+ * @param {object} facetFields Definitions for facet list
+ * @return {array} expanded states of each facet; callback when user clicks an expander
+ */
+const useExpanders = (facetFields) => {
+    /** Expanded facet fields; `displayedFileFacetFields` array creates an entry for each field */
+    const [expandedStates, setExpandedStates] = React.useState(() => (
+        facetFields.reduce((accExpanded, facetField) => (
+            ({ ...accExpanded, [facetField.field]: !!facetField.expanded })
+        ), {})
+    ));
+
+    /**
+     * Called when the user clicks a facet expander button. Updates the expander states so the
+     * facets re-render to the new expanded states.
+     * @param {string} field Field name for clicked facet expander
+     * @param {boolean} altKey True if alt/option key down at time of click
+     */
+    const handleExpanderClick = (field, altKey) => {
+        setExpandedStates((prevExpandedStates) => {
+            if (altKey) {
+                // Alt key held down, so expand or collapse *all* facets.
+                const allExpandedState = !prevExpandedStates[field];
+                const nextExpandedStates = {};
+                Object.keys(prevExpandedStates).forEach((facetField) => {
+                    nextExpandedStates[facetField] = allExpandedState;
+                });
+                return nextExpandedStates;
+            }
+
+            // Alt key not held down, so just expand or collapse the clicked facet.
+            const nextExpandedStates = { ...prevExpandedStates };
+            nextExpandedStates[field] = !prevExpandedStates[field];
+            return nextExpandedStates;
+        });
+    };
+
+    return [expandedStates, handleExpanderClick];
+};
+
+
+/**
+ * Display the file facets. These display the number of files involved -- not the number of
+ * experiments with files matching a criteria. As the primary input to this component is currently
+ * an array of experiment IDs while these facets displays all the files involved with those
+ * experiments, this component begins by retrieving information about all relevant files from the
+ * DB. Each time an experiment is removed from the cart while viewing the cart page, this component
+ * again retrieves all relevant files for the remaining experiments.
+ */
+export const FileFacets = ({
+    facets,
+    usedFacetFields,
+    selectedTerms,
+    selectedFileCount,
+    termClickHandler,
+    visualizableOnly,
+    visualizableOnlyChangeHandler,
+    preferredOnly,
+    preferredOnlyChangeHandler,
+    facetLoadProgress,
+    clearFacetSelections,
+}) => {
+    const [expandedStates, handleExpanderClick] = useExpanders(displayedFileFacetFields);
+
+    return (
+        <div className="cart-facet-modal-column">
+            <FacetCount count={selectedFileCount} element="file" />
+            <div className="cart-facet-list">
+                <Checkbox label="Show default data only" id="default-data-toggle" checked={preferredOnly} css="cart-checkbox" clickHandler={preferredOnlyChangeHandler} />
+                {!preferredOnly ? <Checkbox label="Show visualizable data only" id="visualizable-data-toggle" checked={visualizableOnly} css="cart-checkbox" clickHandler={visualizableOnlyChangeHandler} /> : null}
+                {facets && facets.length > 0 ?
+                    <>
+                        {usedFacetFields.map((facetField) => {
+                            const facetContent = facets.find((facet) => facet.field === facetField.field);
+                            if (facetContent) {
+                                const expanded = facetField.parent ? expandedStates[facetField.parent] : expandedStates[facetField.field];
+                                return (
+                                    <Facet
+                                        key={facetField.field}
+                                        facet={facetContent}
+                                        displayedFacetField={facetField}
+                                        selectedFacetTerms={selectedTerms[facetField.field]}
+                                        facetTermClickHandler={termClickHandler}
+                                        expanded={expanded}
+                                        expanderClickHandler={handleExpanderClick}
+                                        options={{ supressTitle: !!facetField.parent, suppressVisualizable: preferredOnly }}
+                                        clearFacetSelections={clearFacetSelections}
+                                    />
+                                );
+                            }
+                            return null;
+                        })}
+                    </>
+                :
+                    <>
+                        {facetLoadProgress === -1 ?
+                            <div className="cart__empty-message">No files available</div>
+                        : null}
+                    </>
+                }
+            </div>
+        </div>
+    );
+};
+
+FileFacets.propTypes = {
+    /** Array of objects for each displayed facet */
+    facets: PropTypes.array,
+    /** Currently displayed facet fields */
+    usedFacetFields: PropTypes.array,
+    /** Selected facet fields */
+    selectedTerms: PropTypes.object,
+    /** Number of files currently selected */
+    selectedFileCount: PropTypes.number,
+    /** Callback when the user clicks on a file format facet item */
+    termClickHandler: PropTypes.func.isRequired,
+    /** True to check the Show Visualizable Data Only checkbox */
+    visualizableOnly: PropTypes.bool,
+    /** Call to handle clicks in the Visualize Only checkbox */
+    visualizableOnlyChangeHandler: PropTypes.func.isRequired,
+    /** True to check the Show Preferred Data Only checkbox */
+    preferredOnly: PropTypes.bool,
+    /** Call to handle clicks in the Preferred Only checkbox */
+    preferredOnlyChangeHandler: PropTypes.func.isRequired,
+    /** Facet-loading progress for progress bar, or null if not displayed */
+    facetLoadProgress: PropTypes.number,
+    /** Called when the user clears all selections in a facet */
+    clearFacetSelections: PropTypes.func.isRequired,
+};
+
+FileFacets.defaultProps = {
+    facets: [],
+    usedFacetFields: [],
+    selectedTerms: null,
+    selectedFileCount: 0,
+    visualizableOnly: false,
+    preferredOnly: false,
+    facetLoadProgress: null,
+};
+
+
+/**
+ * Display the dataset facets relevant to the currently selected facet terms and datasets in the
+ * cart.
+ */
+export const DatasetFacets = ({
+    facets,
+    selectedTerms,
+    selectedDatasetCount,
+    termClickHandler,
+    clearFacetSelections,
+}) => {
+    const [expandedStates, handleExpanderClick] = useExpanders(displayedDatasetFacetFields);
+
+    return (
+        <div className="cart-facet-modal-column">
+            <FacetCount count={selectedDatasetCount} element="dataset" />
+            <div className="cart-facet-list">
+                {displayedDatasetFacetFields.map((facetField) => {
+                    const facetContent = facets.find((facet) => facet.field === facetField.field);
+                    if (facetContent) {
+                        const expanded = facetField.parent ? expandedStates[facetField.parent] : expandedStates[facetField.field];
+                        return (
+                            <Facet
+                                key={facetField.field}
+                                facet={facetContent}
+                                displayedFacetField={facetField}
+                                selectedFacetTerms={selectedTerms[facetField.field]}
+                                facetTermClickHandler={termClickHandler}
+                                expanded={expanded}
+                                expanderClickHandler={handleExpanderClick}
+                                clearFacetSelections={clearFacetSelections}
+                            />
+                        );
+                    }
+                    return null;
+                })}
+            </div>
+        </div>
+    );
+};
+
+DatasetFacets.propTypes = {
+    /** Array of objects for each displayed facet */
+    facets: PropTypes.array,
+    /** Selected facet fields */
+    selectedTerms: PropTypes.object,
+    /** Number of datasets currently selected */
+    selectedDatasetCount: PropTypes.number,
+    /** Callback when the user clicks on a file format facet item */
+    termClickHandler: PropTypes.func.isRequired,
+    /** Callback for clearing a single facet's selections */
+    clearFacetSelections: PropTypes.func.isRequired,
+};
+
+DatasetFacets.defaultProps = {
+    facets: [],
+    selectedTerms: null,
+    selectedDatasetCount: 0,
+};
+
+
+/**
+ * Main entry point to render the facet column contents. It displays the checkbox options, the
+ * persistent facets, the button to display the modal with all facets, and the current facet
+ * selections.
+ */
+export const CartFacets = ({
+    datasetProps,
+    fileProps,
+    options,
+    datasets,
+    files,
+    facetProgress,
+}) => {
+    const [isModalOpen, setIsModalOpen] = React.useState(false);
+    const closeRef = React.useRef(null);
+
+    const handleClick = () => {
+        setIsModalOpen(true);
+    };
+
+    const handleClose = () => {
+        setIsModalOpen(false);
+    };
+
+    React.useEffect(() => {
+        // Make sure the user can type into this field as soon as the modal appears without having
+        // to click in the field.
+        if (closeRef.current) {
+            closeRef.current.focus();
+            closeRef.current.select();
+        }
+    }, []);
+
+    return (
+        <div className="cart__display-facets">
+            <FacetCount count={files.length} element="file" facetLoadProgress={facetProgress} />
+            <Checkbox label="Show default data only" id="default-data-toggle" checked={options.preferredOnly} css="cart-checkbox" clickHandler={options.preferredOnlyChangeHandler} />
+            {!options.preferredOnly ? <Checkbox label="Show visualizable data only" id="visualizable-data-toggle" checked={options.visualizableOnly} css="cart-checkbox" clickHandler={options.visualizableOnlyChangeHandler} /> : null}
+            <div className="cart-facet-list">
+                {displayedPersistentFacetFields.map((facetField) => {
+                    const datasetFacetContent = datasetProps.facets.find((facet) => facet.field === facetField.field);
+                    if (datasetFacetContent) {
+                        return (
+                            <Facet
+                                key={facetField.field}
+                                facet={datasetFacetContent}
+                                displayedFacetField={facetField}
+                                selectedFacetTerms={datasetProps.selectedTerms[facetField.field]}
+                                facetTermClickHandler={datasetProps.termClickHandler}
+                                expanded
+                            />
+                        );
+                    }
+                    const fileFacetContent = fileProps.facets.find((facet) => facet.field === facetField.field);
+                    if (fileFacetContent) {
+                        return (
+                            <Facet
+                                key={facetField.field}
+                                facet={fileFacetContent}
+                                displayedFacetField={facetField}
+                                selectedFacetTerms={fileProps.selectedTerms[facetField.field]}
+                                facetTermClickHandler={fileProps.termClickHandler}
+                                options={{ supressTitle: !!facetField.parent, suppressVisualizable: options.preferredOnly }}
+                                expanded
+                            />
+                        );
+                    }
+                    return null;
+                })}
+            </div>
+            <div className="facet-selections-section">
+                <button type="button" className="btn btn-info btn-sm facet-selections-actuator" onClick={handleClick} disabled={facetProgress !== -1}>More filters</button>
+                <Selections
+                    datasetTerms={datasetProps.selectedTerms}
+                    datasetTermClickHandler={datasetProps.termClickHandler}
+                    fileTerms={fileProps.selectedTerms}
+                    fileTermClickHandler={fileProps.termClickHandler}
+                />
+            </div>
+            {isModalOpen ?
+                <Modal closeModal={handleClose}>
+                    <ModalHeader title="Dataset and file filters" labelId="selection-modal" closeModal={handleClose} focusClose />
+                    <ModalBody>
+                        <div className="cart-facet-modal">
+                            <DatasetFacets
+                                facets={datasetProps.facets}
+                                selectedTerms={datasetProps.selectedTerms}
+                                selectedDatasetCount={datasets.length}
+                                termClickHandler={datasetProps.termClickHandler}
+                                clearFacetSelections={datasetProps.clearFacetSelections}
+                            />
+                            <FileFacets
+                                facets={fileProps.facets}
+                                selectedTerms={fileProps.selectedTerms}
+                                selectedFileCount={files.length}
+                                usedFacetFields={fileProps.usedFacetFields}
+                                elements={datasets}
+                                termClickHandler={fileProps.termClickHandler}
+                                visualizableOnly={options.visualizableOnly}
+                                visualizableOnlyChangeHandler={options.visualizableOnlyChangeHandler}
+                                preferredOnly={options.preferredOnly}
+                                preferredOnlyChangeHandler={options.preferredOnlyChangeHandler}
+                                clearFacetSelections={fileProps.clearFacetSelections}
+                            />
+                        </div>
+                    </ModalBody>
+                </Modal>
+            : null}
+        </div>
+    );
+};
+
+CartFacets.propTypes = {
+    /** Properties specific to the dataset facets */
+    datasetProps: PropTypes.exact({
+        /** Currently displayed dataset facets */
+        facets: PropTypes.array,
+        /** Currently selected facet terms */
+        selectedTerms: PropTypes.object,
+        /** Called when the user clicks a facet term on or off */
+        termClickHandler: PropTypes.func,
+        /** Called when the user clears all selections within a single facet */
+        clearFacetSelections: PropTypes.func,
+    }).isRequired,
+    /** Properties specific to the file facets */
+    fileProps: PropTypes.exact({
+        /** Currently displayed file facets */
+        facets: PropTypes.array,
+        /** Currently selected facet terms */
+        selectedTerms: PropTypes.object,
+        /** Function to call when the user clicks a facet term on or off */
+        termClickHandler: PropTypes.func,
+        /** Called when the user clears all selections within a single facet */
+        clearFacetSelections: PropTypes.func,
+        /** Facets currently enabled based on options */
+        usedFacetFields: PropTypes.array,
+    }).isRequired,
+    /** Other options controlled by the main cart-page code */
+    options: PropTypes.exact({
+        /** True if user has chosen to view visualizable facet terms only */
+        visualizableOnly: PropTypes.bool,
+        /** Called when the user changes the Visualizable Only checkbox */
+        visualizableOnlyChangeHandler: PropTypes.func,
+        /** True if user has chosen to view default files only */
+        preferredOnly: PropTypes.bool,
+        /** Called when the user changes the checkbox for viewing default files only */
+        preferredOnlyChangeHandler: PropTypes.func,
+    }).isRequired,
+    /** Currently selected datasets */
+    datasets: PropTypes.array.isRequired,
+    /** Currently selected files */
+    files: PropTypes.array.isRequired,
+    /** Current progress of loading the datasets/files for the facets */
+    facetProgress: PropTypes.number,
+};
+
+CartFacets.defaultProps = {
+    facetProgress: null,
+};
+
+
+/**
+ * Update the `facets` array by incrementing the count of the term within it selected by the
+ * `field` within the given `dataset`.
+ * @param {array} facets Facet array to update - mutated!
+ * @param {string} field Field key within the facet to update
+ * @param {object} dataset Contains the term to add to the facet
+ */
+const addDatasetTermToFacet = (facets, field, dataset) => {
+    const facetTerm = getObjectFieldValue(dataset, field);
+    if (facetTerm !== undefined) {
+        const matchingFacet = facets.find((facet) => facet.field === field);
+        if (matchingFacet) {
+            // The facet has been seen in this loop before, so add to or initialize
+            // the relevant term within this facet.
+            const matchingTerm = matchingFacet.terms.find((matchingFacetTerm) => matchingFacetTerm.term === facetTerm);
+            if (matchingTerm) {
+                // Facet term has been counted before, so add to its count. Mark the term as
+                // visualizable if any file contributing to this term is visualizable.
+                matchingTerm.count += 1;
+            } else {
+                // Facet term has not been counted before, so initialize a new facet term entry.
+                matchingFacet.terms.push({ term: facetTerm, count: 1 });
+            }
+        } else {
+            // The facet has not been seen in this loop before, so initialize it as
+            // well as the value of the relevant term within the facet.
+            facets.push({ field, terms: [{ term: facetTerm, count: 1 }] });
+        }
+    }
+};
+
+
+/**
+ * Update the `facets` array by incrementing the count of the term within it selected by the
+ * `field` within the given `file`.
+ * @param {array} facets Facet array to update - mutated!
+ * @param {string} field Field key within the facet to update
+ * @param {object} file File containing the term to add to the facet
+ */
+const addFileTermToFacet = (facets, field, file) => {
+    const facetTerm = getObjectFieldValue(file, field);
+    const visualizable = isFileVisualizable(file);
+    if (facetTerm !== undefined) {
+        const matchingFacet = facets.find((facet) => facet.field === field);
+        if (matchingFacet) {
+            // The facet has been seen in this loop before, so add to or initialize
+            // the relevant term within this facet.
+            const matchingTerm = matchingFacet.terms.find((matchingFacetTerm) => matchingFacetTerm.term === facetTerm);
+            if (matchingTerm) {
+                // Facet term has been counted before, so add to its count. Mark the term as
+                // visualizable if any file contributing to this term is visualizable.
+                matchingTerm.count += 1;
+                if (visualizable) {
+                    matchingTerm.visualizable = visualizable;
+                }
+            } else {
+                // Facet term has not been counted before, so initialize a new facet term entry.
+                matchingFacet.terms.push({ term: facetTerm, count: 1, visualizable });
+            }
+        } else {
+            // The facet has not been seen in this loop before, so initialize it as
+            // well as the value of the relevant term within the facet.
+            facets.push({ field, terms: [{ term: facetTerm, count: 1, visualizable }] });
+        }
+    }
+};
+
+
+/**
+ * Based on the currently selected facet terms and the current set of datasets in the cart,
+ * generate the simplified facets and the subset of datasets these facets select.
+ * @param {object} selectedTerms Currently selected terms within each facet
+ * @param {array} datasets Datasets to consider when building these facets.
+ * @param {array} usedFacetFields Facet fields to consider when assembling.
+ *
+ * @return {object}
+ *     {array} facets - Array of simplified facet objects including fields and terms;
+ *                               empty array if none
+ *     {array} selectedFiles - Array of datasets selected by currently selected facets
+ */
+export const assembleDatasetFacets = (selectedTerms, datasets, usedFacetFields) => {
+    const assembledFacets = [];
+    const selectedDatasets = [];
+
+    if (datasets.length > 0) {
+        const selectedFacetKeys = Object.keys(selectedTerms).filter((term) => selectedTerms[term].length > 0);
+        datasets.forEach((dataset) => {
+            // Determine whether the dataset passes the currently selected facet terms. Properties
+            // within the dataset have to match any of the terms within a facet, and across all
+            // facets that include selected terms. This is the "first test" I refer to later.
+            let match = selectedFacetKeys.every((selectedFacetKey) => {
+                // `selectedFacetKey` is one facet field, e.g. "assay_title".
+                // `propValue` is the dataset's value for that field.
+                const propValue = getObjectFieldValue(dataset, selectedFacetKey);
+
+                // Determine if the dataset's `selectedFacetKey` prop has been selected by at
+                // least one facet term.
+                return selectedTerms[selectedFacetKey].indexOf(propValue) !== -1;
+            });
+
+            // Datasets that pass the first test add their properties to the relevant facet term
+            // counts. Datasets that don't pass go through a second test to see if their properties
+            // should appear unselected within a facet. Datasets that fail both tests get ignored
+            // for facets.
+            if (match) {
+                // The dataset passed the first test, so its terms appear selected in their facets.
+                // Add all its properties to the relevant facet terms.
+                Object.keys(selectedTerms).forEach((facetField) => {
+                    addDatasetTermToFacet(assembledFacets, facetField, dataset);
+                });
+                selectedDatasets.push(dataset);
+            } else {
+                // The dataset didn't pass the first test, so run the same test repeatedly but
+                // with one facet removed from the test each time. For each easier test the
+                // dataset passes, add to the corresponding term count for the removed facet,
+                // allowing the user to select it to extend the set of selected datasets.
+                selectedFacetKeys.forEach((selectedFacetField) => {
+                    // Remove one facet containing a selection from the test.
+                    const filteredSelectedFacetKeys = selectedFacetKeys.filter((key) => key !== selectedFacetField);
+                    match = filteredSelectedFacetKeys.every((filteredSelectedFacetKey) => {
+                        const datasetPropValue = getObjectFieldValue(dataset, filteredSelectedFacetKey);
+                        return selectedTerms[filteredSelectedFacetKey].indexOf(datasetPropValue) !== -1;
+                    });
+
+                    // A match means to add to the count of the current facet field dataset term
+                    // only.
+                    if (match) {
+                        addDatasetTermToFacet(assembledFacets, selectedFacetField, dataset);
+                    }
+                });
+            }
+        });
+
+        // We need to include selected terms that happen to have a zero count, so add all
+        // selected facet terms not yet included in `facets`.
+        Object.keys(selectedTerms).forEach((field) => {
+            const matchingFacet = assembledFacets.find((facet) => facet.field === field);
+            if (matchingFacet) {
+                // Find selected terms NOT in facets and add them with a zero count.
+                const matchingFacetTerms = matchingFacet.terms.map((facetTerm) => facetTerm.term);
+                const missingTerms = selectedTerms[field].filter((term) => matchingFacetTerms.indexOf(term) === -1);
+                if (missingTerms.length > 0) {
+                    missingTerms.forEach((term) => {
+                        matchingFacet.terms.push({ term, count: 0, visualizable: false });
+                    });
+                }
+            }
+        });
+
+        // Sort each facet's terms either alphabetically or by some criteria specific to a
+        // facet. `facets` and `usedFacetFields` have the same order, but `facets` might
+        // not have all possible facets -- just currently relevant ones.
+        assembledFacets.forEach((facet) => {
+            // We know a corresponding `usedFacetFields` entry exists because `facets` gets
+            // built from it, so no not-found condition needs checking.
+            const facetDisplay = usedFacetFields.find((facetField) => facetField.field === facet.field);
+            facet.title = facetDisplay.title;
+            facet.terms = _(facet.terms).sortBy((facetTerm) => facetTerm.term.toLowerCase());
+        });
+    }
+
+    return { datasetFacets: assembledFacets.length > 0 ? assembledFacets : [], selectedDatasets };
+};
+
+
+/**
+ * Based on the currently selected facet terms and the files collected from the datasets in the
+ * cart, generate the simplified facets and the subset of files these facets select. `analyses` not
+ * needed when `assembleFileFacets` called simply to reset the facets.
+ * @param {object} selectedTerms Currently selected terms within each facet
+ * @param {array} files Partial files to consider when building these facets.
+ * @param {array} analyses Compiled analysis objects from experiments in cart.
+ * @param {array} usedFacetFields Facet fields to consider when assembling.
+ *
+ * @return {object}
+ *     {array} facets - Array of simplified facet objects including fields and terms;
+ *                               empty array if none
+ *     {array} selectedFiles - Array of partial files selected by currently selected facets
+ */
+export const assembleFileFacets = (selectedTerms, files, analyses, usedFacetFields) => {
+    const assembledFacets = [];
+    const selectedFiles = [];
+    const usedSelectedTerms = {};
+    const usedFieldValues = usedFacetFields.map((facetField) => facetField.field);
+    Object.keys(selectedTerms).forEach((term) => {
+        if (usedFieldValues.includes(term)) {
+            usedSelectedTerms[term] = selectedTerms[term];
+        }
+    });
+
+    // Get complete list of files to consider -- processed files, and those associated with all
+    // available analyses if any selected.
+    let consideredFiles;
+    consideredFiles = files.filter((file) => file.assembly);
+    if (usedSelectedTerms.analysis && usedSelectedTerms.analysis.length > 0) {
+        // Consider all files the selected analyses corresponds to.
+        const fileIds = getAnalysesFileIds(analyses);
+        consideredFiles = _.compact(fileIds.map((id) => files.find((file) => id === file['@id'])));
+    }
+    if (consideredFiles.length > 0) {
+        const selectedFacetKeys = Object.keys(usedSelectedTerms).filter((term) => usedSelectedTerms[term].length > 0);
+        consideredFiles.forEach((file) => {
+            // Determine whether the file passes the currently selected facet terms. Properties
+            // within the file have to match any of the terms within a facet, and across all
+            // facets that include selected terms. This is the "first test" I refer to later.
+            let match = selectedFacetKeys.every((selectedFacetKey) => {
+                // `selectedFacetKey` is one facet field, e.g. "output_type".
+                // `filePropValue` is the file's value for that field.
+                const filePropValue = getObjectFieldValue(file, selectedFacetKey);
+
+                // Determine if the file's `selectedFacetKey` prop has been selected by at
+                // least one facet term.
+                return usedSelectedTerms[selectedFacetKey].indexOf(filePropValue) !== -1;
+            });
+
+            // Files that pass the first test add their properties to the relevant facet term
+            // counts. Files that don't pass go through a second test to see if their properties
+            // should appear unselected within a facet. Files that fail both tests get ignored for
+            // facets.
+            if (match) {
+                // The file passed the first test, so its terms appear selected in their facets.
+                // Add all its properties to the relevant facet terms.
+                Object.keys(usedSelectedTerms).forEach((facetField) => {
+                    addFileTermToFacet(assembledFacets, facetField, file);
+                });
+                selectedFiles.push(file);
+            } else {
+                // The file didn't pass the first test, so run the same test repeatedly but
+                // with one facet removed from the test each time. For each easier test the
+                // file passes, add to the corresponding term count for the removed facet,
+                // allowing the user to select it to extend the set of selected files.
+                selectedFacetKeys.forEach((selectedFacetField) => {
+                    // Remove one facet containing a selection from the test.
+                    const filteredSelectedFacetKeys = selectedFacetKeys.filter((key) => key !== selectedFacetField);
+                    match = filteredSelectedFacetKeys.every((filteredSelectedFacetKey) => {
+                        const filePropValue = getObjectFieldValue(file, filteredSelectedFacetKey);
+                        return selectedTerms[filteredSelectedFacetKey].indexOf(filePropValue) !== -1;
+                    });
+
+                    // A match means to add to the count of the current facet field file term
+                    // only.
+                    if (match) {
+                        addFileTermToFacet(assembledFacets, selectedFacetField, file);
+                    }
+                });
+            }
+        });
+
+        // We need to include selected terms that happen to have a zero count, so add all
+        // selected facet terms not yet included in `facets`.
+        Object.keys(usedSelectedTerms).forEach((field) => {
+            const matchingFacet = assembledFacets.find((facet) => facet.field === field);
+            if (matchingFacet) {
+                // Find selected terms NOT in facets and add them with a zero count.
+                const matchingFacetTerms = matchingFacet.terms.map((facetTerm) => facetTerm.term);
+                const missingTerms = selectedTerms[field].filter((term) => matchingFacetTerms.indexOf(term) === -1);
+                if (missingTerms.length > 0) {
+                    missingTerms.forEach((term) => {
+                        matchingFacet.terms.push({ term, count: 0, visualizable: false });
+                    });
+                }
+            }
+        });
+
+        // Sort each facet's terms either alphabetically or by some criteria specific to a
+        // facet. `facets` and `usedFacetFields` have the same order, but `facets` might
+        // not have all possible facets -- just currently relevant ones.
+        assembledFacets.forEach((facet) => {
+            // We know a corresponding `usedFacetFields` entry exists because `facets` gets
+            // built from it, so no not-found condition needs checking.
+            const facetDisplay = usedFacetFields.find((facetField) => facetField.field === facet.field);
+            facet.title = facetDisplay.title;
+            facet.terms = facetDisplay.sorter ? facetDisplay.sorter(facet.terms, analyses) : _(facet.terms).sortBy((facetTerm) => facetTerm.term.toLowerCase());
+        });
+    }
+
+    return { fileFacets: assembledFacets.length > 0 ? assembledFacets : [], selectedFiles, defaultFiles: filterForDefaultFiles(selectedFiles) };
+};
+
+
+/**
+ * For any radio-button facets, select the first term if no items within them have been selected.
+ * @param {array} facets Simplified facet object
+ * @param {object} selectedTerms Selected terms within the facets
+ *
+ * @return {object} Same as `selectedTerms` but with radio-button facet terms selected
+ */
+const initRadioFacets = (facets, selectedTerms, usedFacetFields) => {
+    const newSelectedTerms = {};
+    usedFacetFields.forEach((facetField) => {
+        if (facetField.radio && selectedTerms[facetField.field].length === 0) {
+            // Assign the first term of the radio-button facet as the sole selection. In the
+            // unusual case that no facet terms for this radio-button facet have been collected,
+            // just copy the existing selection for the facet.
+            const matchingFacet = facets.find((facet) => facet.field === facetField.field);
+            newSelectedTerms[facetField.field] = (
+                matchingFacet ? [matchingFacet.terms[0].term] : selectedTerms[facetField.field].slice(0)
+            );
+        } else {
+            // Not a radio-button facet, or radio-button facet has selected terms; copy existing
+            // selected terms.
+            newSelectedTerms[facetField.field] = selectedTerms[facetField.field].slice(0);
+        }
+    });
+    return newSelectedTerms;
+};
+
+
+/**
+ * Make a selected-terms object showing no selections based on the given facet properties.
+ * @param {array} usedFacetFields Currently used subset of `displayedFileFacetFields`.
+ *
+ * @return {object} Selected facet showing no selections; used with `assembleFileFacets`
+ */
+const initSelectedTerms = (usedFacetFields) => {
+    const emptySelectedTerms = {};
+    usedFacetFields.forEach((facetField) => {
+        emptySelectedTerms[facetField.field] = [];
+    });
+    return emptySelectedTerms;
+};
+
+
+/**
+ * Reset the facets to no selections as if the page has just been loaded.
+ * @param {array} files Files to consider when building facets.
+ * @param {array} usedFacetFields Facet fields to consider
+ *
+ * @return {object} Initial facet-term selections
+ */
+export const resetDatasetFacets = (datasets, usedFacetFields) => {
+    // Make an empty selected-terms object so `assembleDatasetFacets` can generate fresh simplified
+    // facets.
+    const emptySelectedTerms = initSelectedTerms(usedFacetFields);
+
+    // Build the facets based on no selections, then select the first term of any radio-button
+    // facets.
+    const { datasetFacets } = assembleDatasetFacets(emptySelectedTerms, datasets, usedFacetFields);
+    return initRadioFacets(datasetFacets, emptySelectedTerms, usedFacetFields);
+};
+
+
+/**
+ * Reset the facets to no selections, and select the first term of radio-button facets, all as if
+ * the page has just been loaded.
+ * @param {array} files Files to consider when building facets.
+ * @param {array} usedFacetFields Facet fields to consider
+ *
+ * @return {object} Initial facet-term selections
+ */
+export const resetFileFacets = (files, analyses, usedFacetFields) => {
+    // Make an empty selected-terms object so `assembleFileFacets` can generate fresh simplified
+    // facets.
+    const emptySelectedTerms = initSelectedTerms(usedFacetFields);
+
+    // Build the facets based on no selections, then select the first term of any radio-button
+    // facets.
+    const { fileFacets } = assembleFileFacets(emptySelectedTerms, files, analyses, usedFacetFields);
+    return initRadioFacets(fileFacets, emptySelectedTerms, usedFacetFields);
+};
+

--- a/src/encoded/static/components/cart/remove_multiple.js
+++ b/src/encoded/static/components/cart/remove_multiple.js
@@ -1,0 +1,174 @@
+/**
+ * Displays a button to remove a specific set of datasets from the cart.
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { removeMultipleFromCartAndSave } from './actions';
+import { Modal, ModalHeader, ModalBody, ModalFooter } from '../../libs/ui/modal';
+
+
+/**
+ * Display the modal dialog to confirm a user wants to remove the selected datasets from their
+ * cart, and initiate that action if they do.
+ */
+const CartRemoveElementsModalComponent = ({ elements, closeClickHandler, removeMultipleItems, loggedIn, inProgress }) => {
+    /**
+     * Called when a user clicks the modal button to confirm removing the selected elements from the
+     * cart.
+     */
+    const handleConfirmRemoveClick = () => {
+        if (loggedIn && elements.length > 0) {
+            removeMultipleItems(elements);
+            closeClickHandler();
+        }
+    };
+
+    return (
+        <Modal labelId="label-remove-selected" descriptionId="description-remove-selected" focusId="close-remove-items">
+            <ModalHeader labelId="label-remove-selected" title="Remove selected datasets from cart" closeModal={closeClickHandler} />
+            <ModalBody>
+                <p id="description-remove-selected">Remove the {elements.length} currently selected datasets from the cart. This action is not reversible.</p>
+            </ModalBody>
+            <ModalFooter
+                closeModal={<button type="button" id="close-remove-items" onClick={closeClickHandler} className="btn btn-default">Cancel</button>}
+                submitBtn={<button type="button" onClick={handleConfirmRemoveClick} disabled={inProgress} className="btn btn-danger" id="submit-remote-selected">Remove selected</button>}
+                dontClose
+            />
+        </Modal>
+    );
+};
+
+CartRemoveElementsModalComponent.propTypes = {
+    /** Items in the current cart */
+    elements: PropTypes.array.isRequired,
+    /** Function to call to close the Clear Cart modal */
+    closeClickHandler: PropTypes.func.isRequired,
+    /** True if user has logged in */
+    loggedIn: PropTypes.bool.isRequired,
+    /** True if cart operation in progress */
+    inProgress: PropTypes.bool.isRequired,
+    /** Function to call to clear the selected datasets from the Redux store */
+    removeMultipleItems: PropTypes.func.isRequired,
+};
+
+CartRemoveElementsModalComponent.mapStateToProps = (state, ownProps) => ({
+    elements: ownProps.elements,
+    closeClickHandler: ownProps.closeClickHandler,
+    loggedIn: ownProps.loggedIn,
+    inProgress: state.inProgress,
+});
+
+CartRemoveElementsModalComponent.mapDispatchToProps = (dispatch, ownProps) => ({
+    removeMultipleItems: (elements) => dispatch(removeMultipleFromCartAndSave(elements, ownProps.fetch)),
+});
+
+const CartRemoveElementsModalInternal = connect(CartRemoveElementsModalComponent.mapStateToProps, CartRemoveElementsModalComponent.mapDispatchToProps)(CartRemoveElementsModalComponent);
+
+export const CartRemoveElementsModal = ({ elements, closeClickHandler }, reactContext) => (
+    <CartRemoveElementsModalInternal elements={elements} closeClickHandler={closeClickHandler} loggedIn={!!(reactContext.session && reactContext.session['auth.userid'])} fetch={reactContext.fetch} />
+);
+
+CartRemoveElementsModal.propTypes = {
+    /** Currently selected datasets to remove from cart as array of @ids */
+    elements: PropTypes.array.isRequired,
+    /** Function to call to close the Cart Clear modal */
+    closeClickHandler: PropTypes.func.isRequired,
+};
+
+CartRemoveElementsModal.contextTypes = {
+    fetch: PropTypes.func,
+    session: PropTypes.object,
+};
+
+
+/**
+ * Renders a button to remove all the given datasets from the current cart.
+ */
+const CartRemoveElementsComponent = ({
+    elements,
+    loading,
+    savedCartObj,
+    inProgress,
+}) => {
+    /** True if the alert modal is visible */
+    const [isModalVisible, setIsModalVisible] = React.useState(false);
+
+    /**
+     * Handle a click in the actuator button to open the alert modal.
+     */
+    const handleOpenClick = () => {
+        setIsModalVisible(true);
+    };
+
+    /**
+     * Handle a click for closing the modal without doing anything.
+     */
+    const handleCloseClick = () => {
+        setIsModalVisible(false);
+    };
+
+    return (
+        <>
+            <button
+                type="button"
+                disabled={loading || inProgress || (savedCartObj && savedCartObj.locked)}
+                className="btn btn-info btn-sm"
+                onClick={handleOpenClick}
+            >
+                Remove selected items from cart
+            </button>
+            {isModalVisible
+                ? <CartRemoveElementsModal elements={elements} closeClickHandler={handleCloseClick} />
+                : null}
+        </>
+    );
+};
+
+CartRemoveElementsComponent.propTypes = {
+    /** Currently selected datasets to remove from cart as array of @ids */
+    elements: PropTypes.array.isRequired,
+    /** True if cart currently loading on the page */
+    loading: PropTypes.bool.isRequired,
+    /** Current cart saved object */
+    savedCartObj: PropTypes.object,
+    /** True if cart updating operation is in progress */
+    inProgress: PropTypes.bool.isRequired,
+};
+
+CartRemoveElementsComponent.defaultProps = {
+    savedCartObj: null,
+};
+
+CartRemoveElementsComponent.mapStateToProps = (state, ownProps) => ({
+    elements: ownProps.elements,
+    loading: ownProps.loading,
+    savedCartObj: state.savedCartObj,
+    inProgress: state.inProgress,
+});
+
+const CartRemoveElementsInternal = connect(CartRemoveElementsComponent.mapStateToProps)(CartRemoveElementsComponent);
+
+
+// Public component used to bind to context properties.
+const CartRemoveElements = ({ elements, loading }, reactContext) => (
+    <CartRemoveElementsInternal elements={elements} loading={loading} fetch={reactContext.fetch} />
+);
+
+CartRemoveElements.propTypes = {
+    /** Elements to remove from the cart as array of @ids */
+    elements: PropTypes.array,
+    /** True if cart currently loading on the page */
+    loading: PropTypes.bool,
+};
+
+CartRemoveElements.defaultProps = {
+    elements: [],
+    loading: false,
+};
+
+CartRemoveElements.contextTypes = {
+    fetch: PropTypes.func,
+};
+
+export default CartRemoveElements;

--- a/src/encoded/static/components/cart/util.js
+++ b/src/encoded/static/components/cart/util.js
@@ -107,3 +107,39 @@ export const getIsCartSearch = (context) => {
 export const getCartSearchTypes = (context) => (
     _.uniq(context['@graph'].map((result) => result['@type'][0]))
 );
+
+
+/**
+ * Extract the file @ids of the analyses selected by the given analysis titles.
+ * @param {array} availableAnalyses Compiled analysis objects.
+ * @param {array} analysisTitles Titles of analyses from which to extract file @ids.
+ *
+ * @return {array} Combined @ids of selected analysis files.
+ */
+export const getAnalysesFileIds = (availableAnalyses, analysisTitles = []) => {
+    const selectedFileIds = availableAnalyses.reduce((fileIds, analysis) => {
+        if (analysisTitles.length === 0 || analysisTitles.includes(analysis.title)) {
+            return fileIds.concat(analysis.files);
+        }
+        return fileIds;
+    }, []);
+    return _.uniq(selectedFileIds);
+};
+
+
+/**
+ * Extract the value of an object property based on a dotted-notation field,
+ * e.g. { a: 1, b: { c: 5 }} you could retrieve the 5 by passing 'b.c' in `field`.
+ * Based on https://stackoverflow.com/questions/6393943/convert-javascript-string-in-dot-notation-into-an-object-reference#answer-6394168
+ * @param {object} object Object containing the value you want to extract.
+ * @param {string} field  Dotted notation for the property to extract.
+ *
+ * @return {value} Whatever value the dotted notation specifies, or undefined.
+ */
+export const getObjectFieldValue = (object, field) => {
+    const parts = field.split('.');
+    if (parts.length === 1) {
+        return object[field];
+    }
+    return parts.reduce((partObject, part) => partObject && partObject[part], object);
+};

--- a/src/encoded/static/components/globals.js
+++ b/src/encoded/static/components/globals.js
@@ -51,6 +51,14 @@ export const uc = {
     rdquo: '\u201d', // Right double quote
 };
 
+// Used to compare keyboard event key codes.
+export const keyCode = {
+    RETURN: 13,
+    ESC: 27,
+    SPACE: 32,
+};
+
+
 // Report-page cell components
 export const reportCell = new Registry();
 

--- a/src/encoded/static/components/objectutils.js
+++ b/src/encoded/static/components/objectutils.js
@@ -922,6 +922,21 @@ export const filterForDefaultFiles = (fileList) => (
 
 
 /**
+ * Filter the given files to only include those that appear in the given datasets.
+ * @param {array} fileList Files to filter
+ * @param {array} datasets Datasets to check against
+ *
+ * @return {array} Members of `fileList` that the given datasets include
+ */
+export const filterForDatasetFiles = (fileList, datasets) => {
+    const datasetFilePaths = datasets
+        .reduce((files, dataset) => (dataset.files ? files.concat(dataset.files) : files), [])
+        .map((file) => file['@id']);
+    return fileList.filter((file) => datasetFilePaths.includes(file['@id']));
+};
+
+
+/**
  * Displays an item count intended for the tops of table, normally reflecting a search result count.
  */
 export const TableItemCount = ({ count }) => (

--- a/src/encoded/static/libs/svg-icons.js
+++ b/src/encoded/static/libs/svg-icons.js
@@ -134,6 +134,34 @@ const checkbox = (style) => (
     </svg>
 );
 
+const dataset = (style) => (
+    <svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 500" style={style} className="svg-icon svg-icon-archive">
+        <polygon points="354.26,235.5 314.26,235.5 314.26,277.69 185.74,277.69 185.74,235.5 145.74,235.5 145.74,317.69 354.26,317.69" />
+        <path d="M500.5,37.5h-501v148h38v278h425v-278h38V37.5z M39.5,77.5h421v68h-421V77.5z M422.5,423.5h-345v-238h345V423.5z" />
+        <polygon points="354.26,317.69 145.74,317.69 145.74,235.5 185.74,235.5 185.74,277.69 314.26,277.69 314.26,235.5 354.26,235.5" />
+    </svg>
+);
+
+const file = (style) => (
+    <svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 500" style={style} className="svg-icon svg-icon-file">
+        <g>
+            <path d="M156.73,187.92c-28.12,0-44.92-18.83-44.92-50.31v-16.64c0-31.48,16.8-50.31,44.92-50.31s44.92,18.83,44.92,50.31v16.64
+                C201.65,169.09,184.85,187.92,156.73,187.92z M172.51,137.29v-16.02c0-18.44-4.92-26.88-15.78-26.88s-15.78,8.44-15.78,26.88v16.02
+                c0,18.44,4.92,26.88,15.78,26.88S172.51,155.73,172.51,137.29z"/>
+            <path d="M211.28,185.65v-22.27h28.12V98.77h-1.48l-26.64,18.36V92.45l28.12-19.53h27.89v90.47h26.72v22.27H211.28z" />
+            <path d="M343.43,187.92c-28.12,0-44.92-18.83-44.92-50.31v-16.64c0-31.48,16.8-50.31,44.92-50.31s44.92,18.83,44.92,50.31v16.64
+                C388.36,169.09,371.56,187.92,343.43,187.92z M359.22,137.29v-16.02c0-18.44-4.92-26.88-15.78-26.88s-15.78,8.44-15.78,26.88v16.02
+                c0,18.44,4.92,26.88,15.78,26.88S359.22,155.73,359.22,137.29z"/>
+            <path d="M118.68,325.65v-22.27h28.12v-64.61h-1.48l-26.64,18.36v-24.69l28.12-19.53h27.89v90.47h26.72v22.27H118.68z" />
+            <path d="M211.2,325.65v-22.27h28.12v-64.61h-1.48l-26.64,18.36v-24.69l28.12-19.53h27.89v90.47h26.72v22.27H211.2z" />
+            <path d="M343.35,327.92c-28.12,0-44.92-18.83-44.92-50.31v-16.64c0-31.48,16.8-50.31,44.92-50.31s44.92,18.83,44.92,50.31v16.64
+                C388.28,309.09,371.48,327.92,343.35,327.92z M359.14,277.29v-16.02c0-18.44-4.92-26.88-15.78-26.88s-15.78,8.44-15.78,26.88v16.02
+                c0,18.44,4.92,26.88,15.78,26.88S359.14,295.73,359.14,277.29z"/>
+        </g>
+        <path d="M0,0v500h349h40.98H390v-0.02L499.98,390H500v-0.02V350V0H0z M40,40h420v310H350v110H40V40z M390,443.41V390h53.41 L390,443.41z" />
+    </svg>
+);
+
 const icons = {
     disclosure: (style) => <svg id="Disclosure" data-name="Disclosure" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 480" style={style} className="svg-icon svg-icon-disclosure"><circle cx="240" cy="240" r="240" /><polyline points="401.79 175.66 240 304.34 78.21 175.66" /></svg>,
     table,
@@ -145,6 +173,8 @@ const icons = {
     asterisk: (style) => <svg id="Asterisk" data-name="Asterisk" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" style={style}><polygon points="15.68 5.3 14.18 2.7 8.94 6.38 9.5 0 6.5 0 7.06 6.38 1.82 2.7 0.32 5.3 6.13 8 0.32 10.7 1.82 13.3 7.06 9.62 6.5 16 9.5 16 8.94 9.62 14.18 13.3 15.68 10.7 9.87 8 15.68 5.3" /></svg>,
     chevronDown: (style) => <svg id="Chevron Down" data-name="Chevron Down" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 249 124" style={style}><polygon points="249,57 124.5,124 0,57 0,0 124.5,67 249,0" /></svg>,
     chevronUp: (style) => <svg id="Chevron Up" data-name="Chevron Up" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 249 124" style={style}><polygon points="249,67 124.5,0 0,67 0,124 124.5,57 249,124" /></svg>,
+    circle: (style) => <svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 500" style={style} className="svg-icon svg-icon-circle"><circle cx="250" cy="250" r="250" /></svg>,
+    multiplication: (style) => <svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 500" style={style} className="svg-icon svg-icon-multiplication"><polygon points="500,99 401,0 250,151.01 99,0 0,99 151.01,250 0,401 99,500 250,348.99 401,500 500,401 348.99,250" /></svg>,
     chevronLeft,
     chevronRight,
     spinner,
@@ -156,6 +186,8 @@ const icons = {
     lockClosed,
     clipboard,
     checkbox,
+    dataset,
+    file,
 };
 
 /**
@@ -178,7 +210,7 @@ export const collapseIcon = (collapsed, addClasses) => (
                 <line className="content-line" x1="151.87" y1="256" x2="360.13" y2="256" />
                 <line className="content-line" x1="256" y1="151.87" x2="256" y2="360.13" />
             </g>
-        :
+            :
             <g>
                 <title>Panel open</title>
                 <circle className="bg" cx="256" cy="256" r="240" />

--- a/src/encoded/static/scss/encoded/modules/_cart.scss
+++ b/src/encoded/static/scss/encoded/modules/_cart.scss
@@ -360,6 +360,7 @@
     &-facets {
         @media screen and (min-width: $screen-sm-min) {
             flex: 0 0 300px;
+            width: 300px;
             margin-right: 20px;
         }
 
@@ -405,36 +406,47 @@ $cart-facet-visualizable-size: 18px;
 $cart-facet-visualizable-padding: 2px;
 
 .cart-facet {
+    margin-top: 0;
     padding: 0;
 
     // Button to expand or collapse a facet
     @at-root #{&}__expander {
         display: flex;
-        justify-content: space-between;
+        align-items: center;
+        width: 100%;
         padding: 10px 0;
-        margin: 5px 5px 10px;
+        margin: 0;
         border-bottom: 1px solid #c0c0c0;
         cursor: pointer;
+        background-color: transparent;
+        border: none;
 
         @at-root #{&}-title {
             flex: 0 1 auto;
+            position: relative;
+            top: 1px; // Offset for all uppercase lack of decenders
             text-transform: uppercase;
             font-weight: bold;
         }
 
         .icon {
             flex: 0 0 auto;
+            margin-left: auto;
         }
 
         &[aria-expanded="false"] {
             border-bottom: none;
+        }
+
+        @at-root #{&}--non-collapsable {
+            cursor: default;
         }
     }
 
     // One term within a facet
     @at-root #{&}-term {
         margin: 0 4px;
-        padding: 4px 0;
+        padding: 2px 0;
         font-size: 0; // Edge/IE11 fix for too-tall <li>
 
         &:hover {
@@ -444,8 +456,11 @@ $cart-facet-visualizable-padding: 2px;
         // Covers all the components within a facet term.
         @at-root #{&}__item {
             display: flex;
+            width: 100%;
             justify-content: space-between;
             cursor: pointer;
+            background-color: transparent;
+            border: none;
         }
 
         // Checkbox for a facet term
@@ -491,6 +506,7 @@ $cart-facet-visualizable-padding: 2px;
         @at-root #{&}__text {
             padding: 0 5px;
             flex: 1 0 60%;
+            text-align: left;
             font-size: 0.95rem;
         }
 
@@ -502,6 +518,7 @@ $cart-facet-visualizable-padding: 2px;
             padding: 0 5px 0;
             width: auto;
             height: $cart-facet-magnitude-size;
+            line-height: $cart-facet-magnitude-size;
             border-radius: $cart-facet-magnitude-size / 2;
 
             > span {
@@ -531,9 +548,12 @@ $cart-facet-visualizable-padding: 2px;
 }
 
 // File-count note above facet
-.cart__facet-file-count {
+.cart__facet-count {
+    display: flex;
+    align-items: center;
+    justify-content: center;
     position: relative;
-    padding: 5px;
+    padding: 2px 5px 3px;
     margin: 0 -10px 10px;
     background-color: #d8d8d8;
     text-align: center;
@@ -556,6 +576,13 @@ $cart-facet-visualizable-padding: 2px;
         z-index: 0;
         animation-duration: 0.2s;
         animation-name: change-flash;
+    }
+
+    .svg-icon {
+        margin-right: 5px;
+        width: 20px;
+        height: 20px;
+        fill: #000;
     }
 }
 
@@ -785,7 +812,7 @@ $deleted-bg: #ffe0e0;
 
 // Checkbox for filtering out facet terms not included in visualizable files.
 .cart-checkbox {
-    margin: 0 0 10px;
+    margin: 10px 0;
     padding: 0;
 
     > button {
@@ -857,6 +884,14 @@ $deleted-bg: #ffe0e0;
         @media screen and (min-width: $screen-sm-min) {
             display: block;
         }
+    }
+
+    // Icon in cart tab
+    .svg-icon {
+        margin-right: 5px;
+        width: 16px;
+        height: 16px;
+        fill: #000;
     }
 }
 
@@ -1133,9 +1168,6 @@ $file-type-colors: (
 
 .cart-pager-area {
     display: flex;
-    padding: 3px;
-    justify-content: flex-end;
-    border-bottom: 1px solid #ccc;
 }
 
 .nav {
@@ -1349,6 +1381,128 @@ $file-type-colors: (
             &:hover {
                 text-decoration: none;
             }
+        }
+    }
+}
+
+// Controls at the top of search results, below the tabs.
+.cart-search-results-controls {
+    display: flex;
+    padding: 5px;
+    justify-content: space-between;
+    border-bottom: 1px solid #ccc;
+}
+
+// Control to clear all selections within a facet.
+.cart-facet-clear {
+    position: relative;
+    margin: 0 0 0 5px;
+    padding: 0;
+    border: none;
+    background-color: transparent;
+    width: 10px;
+    height: 10px;
+
+    .cart-facet-clear__control {
+        position: absolute;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
+
+        .svg-icon-circle {
+            display: block;
+            fill: #008000;
+        }
+
+        .svg-icon-multiplication {
+            display: none;
+            fill: #b24342;
+        }
+    }
+
+    &:hover {
+        .svg-icon-circle {
+            display: none;
+        }
+
+        .svg-icon-multiplication {
+            display: block;
+        }
+    }
+}
+
+// Modal to display dataset and file facets.
+.cart-facet-modal {
+    display: flex;
+    gap: 10px;
+
+    .cart__facet-count {
+        margin: 0 0 0 -10px;
+    }
+}
+
+// Each column (dataset and file) of facets within the modal.
+.cart-facet-modal-column {
+    flex: 0 0 calc(50% - 5px);
+    padding: 0 0 10px 10px;
+    border: 1px solid #e0e0e0;
+
+    .cart-facet-list {
+        max-height: 500px;
+        overflow-y: auto;
+
+        .facet {
+            margin-right: 10px;
+        }
+    }
+}
+
+// Area showing "More filters" actuator and tags allowing user to clear selections.
+.facet-selections-section {
+    padding-top: 10px;
+    border-top: 1px solid #eee;
+}
+
+// Button to bring up the facet modal.
+.facet-selections-actuator {
+    margin: 0 auto;
+}
+
+// Buttons that display the current facet selections and allows the user to clear them.
+.facet-selections {
+    display: flex;
+    margin: 0 -2px;
+    flex-wrap: wrap;
+    justify-content: space-between;
+
+    .facet-selections-button {
+        display: flex;
+        margin: 2px;
+        padding: 0 5px;
+        flex-grow: 1;
+        align-items: center;
+        justify-content: left;
+        overflow: hidden;
+        font-weight: normal;
+        background-color: #fff;
+
+        .facet-selections-button__icon {
+            width: 14px;
+            margin-right: 5px;
+            padding: 0;
+
+            svg {
+                width: 14px;
+                fill: #000;
+            }
+        }
+
+        .facet-selections-button__label {
+            overflow: hidden;
+            line-height: 1rem;
+            text-overflow: ellipsis;
+            font-size: 0.8rem;
         }
     }
 }

--- a/src/encoded/tests/features/cart.feature
+++ b/src/encoded/tests/features/cart.feature
@@ -6,8 +6,11 @@ Feature: Cart
         Then I should see 25 elements with the css selector ".result-item__cart-control"
 
         When I press "/experiments/ENCSR611ZAL/"
+        And I wait for 3 seconds
         And I press "/experiments/ENCSR000INT/"
+        And I wait for 3 seconds
         And I press "/experiments/ENCSR000DZQ/"
+        And I wait for 3 seconds
         Then I should see 3 elements with the css selector ".cart-toggle--in-cart"
         And I should see an element with the css selector ".cart__nav-button"
 
@@ -25,23 +28,29 @@ Feature: Cart
         And I wait for the content to load
         Then I should see 7 elements with the css selector ".result-item"
         And I should see "5 files selected"
-        When I press "default-data-toggle"
-        Then I should see "4 files selected"
+        When I press "cart-facet-term-Experiment"
+        Then I should see "3 files selected"
+
+    Scenario: Exercise file facets
         When I click the link to "#processeddata"
-        Then I should see 4 elements with the css selector ".cart-list-item"
+        Then I should see 3 elements with the css selector ".cart-list-item"
+        When I press "default-data-toggle"
+        Then I should see "3 files selected"
+        And I should see 3 elements with the css selector ".cart-list-item"
         When I click the link to "#rawdata"
         Then I should see 0 elements with the css selector ".cart-list-item"
 
     Scenario: Cart page interactions
         When I click the link to "#processeddata"
-        And I click the element with the css selector ".cart-dataset-selector"
-        And I click the element with the css selector ".cart-dataset-option.cart-dataset-option--experiments"
-        And I wait for the content to load
+        And I press "More filters"
         And I press "output_type-label"
         And I press "cart-facet-term-IDR ranked peaks"
+        And I press "close-modal"
         Then I should see "1 file selected"
         And I should see 1 elements with the css selector ".cart-list-item"
-        When I press "cart-facet-term-IDR ranked peaks"
+        When I press "More filters"
+        And I press "cart-facet-clear-output_type"
+        And I press "close-modal"
         Then I should see "3 files selected"
         And I should see 3 elements with the css selector ".cart-list-item"
         When I press "Download processed data files"
@@ -49,13 +58,15 @@ Feature: Cart
         When I press "Close"
         Then I should not see an element with the css selector ".modal"
         When I click the link to "#datasets"
+        And I wait for 5 seconds
         And I press "/experiments/ENCSR000INT/"
         And I wait for the content to load
-        Then I should see 2 elements with the css selector ".result-item"
-        And I should see "3 files selected"
+        Then I should see 6 elements with the css selector ".result-item"
+        And I should see "4 files selected"
 
     Scenario: Download menu
-        When I press "cart-download"
+        When I press "cart-facet-term-Experiment"
+        And I press "cart-download"
         Then I should see 3 elements with the css selector ".menu-item"
         When I press "raw"
         Then I should see "Download raw data files"


### PR DESCRIPTION
* Instead of tracking only the @ids of datasets, and retrieving a page of dataset objects every time the user wants to view a new page of datasets, I now load and keep all datasets (just a subset of their properties) just as file objects have worked. So functions like `CartSearchResults` no longer have to fetch dataset objects.
* We now load dataset descriptions on the cart-view page so that the selected annotations appear with full descriptions, just as they do on the annotation search page.
* `FileFacets` no longer resets facets when switching between showing default files only and all files, so we no longer need the useUpdate callback.
* I have a lot of duplication between file-facet code and dataset-facet code. I looked into trying to consolidate some of that, but it doesn’t look straightforward. Maybe someday.
* All facet-specific code has moved out of cart.js to a new facet.js file.
* When retrieving datasets, I now use a 100-dataset chunk size instead of 500 so that the progress bar makes more sense, at a small cost of overall performance.
