### PR TITLE
ENCD-5945-index-annotations-logging

### DIFF
--- a/src/encoded/commands/index_annotations.py
+++ b/src/encoded/commands/index_annotations.py
@@ -59,19 +59,17 @@ def run(app):
     # bulk index of annotations
     annotations = json_from_path(registry.settings.get('annotations_path'), {})
 
-    base_timeout = 45 
+    base_timeout = 45
     additional_timeout = 0
     annotation_indexing_success = False
 
     while not annotation_indexing_success:
         try:
-            print(f"Sending annotation indexing request with timeout {base_timeout + additional_timeout}")
             es.bulk(index=index, body=annotations, refresh=True, request_timeout=base_timeout+additional_timeout)
             annotation_indexing_success = True
         except:
             log.error("Unable to index the annotations.", exc_info=True)
             additional_timeout += 10
-            print(f"Retrying with timeout {base_timeout + additional_timeout}")
 
 
 

--- a/src/encoded/commands/index_annotations.py
+++ b/src/encoded/commands/index_annotations.py
@@ -61,7 +61,9 @@ def run(app):
 
     base_timeout = 45
     additional_timeout = 0
-    while True:
+    retries = 5
+
+    for _ in range(retries):
         try:
             es.bulk(index=index, body=annotations, refresh=True, request_timeout=base_timeout+additional_timeout)
             break

--- a/src/encoded/commands/index_annotations.py
+++ b/src/encoded/commands/index_annotations.py
@@ -58,10 +58,21 @@ def run(app):
 
     # bulk index of annotations
     annotations = json_from_path(registry.settings.get('annotations_path'), {})
-    try:
-        es.bulk(index=index, body=annotations, refresh=True, request_timeout=30)
-    except:
-        log.error("Unable to index the annotations", exc_info=True)
+
+    base_timeout = 30
+    additional_timeout = 0
+    annotation_indexing_success = False
+
+    while not annotation_indexing_success:
+        try:
+            print(f"Sending annotation indexing request with timeout {base_timeout + additional_timeout}")
+            es.bulk(index=index, body=annotations, refresh=True, request_timeout=base_timeout+additional_timeout)
+            annotation_indexing_success = True
+        except:
+            log.error("Unable to index the annotations.", exc_info=True)
+            additional_timeout += 10
+            print(f"Retrying with timeout {base_timeout + additional_timeout}")
+
 
 
 def main():

--- a/src/encoded/commands/index_annotations.py
+++ b/src/encoded/commands/index_annotations.py
@@ -61,12 +61,10 @@ def run(app):
 
     base_timeout = 45
     additional_timeout = 0
-    annotation_indexing_success = False
-
-    while not annotation_indexing_success:
+    while True:
         try:
             es.bulk(index=index, body=annotations, refresh=True, request_timeout=base_timeout+additional_timeout)
-            annotation_indexing_success = True
+            break
         except:
             log.error("Unable to index the annotations.", exc_info=True)
             additional_timeout += 10

--- a/src/encoded/commands/index_annotations.py
+++ b/src/encoded/commands/index_annotations.py
@@ -59,7 +59,7 @@ def run(app):
     # bulk index of annotations
     annotations = json_from_path(registry.settings.get('annotations_path'), {})
 
-    base_timeout = 30
+    base_timeout = 45 
     additional_timeout = 0
     annotation_indexing_success = False
 

--- a/src/encoded/commands/index_annotations.py
+++ b/src/encoded/commands/index_annotations.py
@@ -61,7 +61,7 @@ def run(app):
     try:
         es.bulk(index=index, body=annotations, refresh=True, request_timeout=30)
     except:
-        print("Unable index the annotations")
+        log.error("Unable to index the annotations", exc_info=True)
 
 
 def main():


### PR DESCRIPTION
Increases initial timeout to 45s (was 30s), which seems to be enough. Logs possible exception and retries with 10s more.