### PR TITLE
ENCD-5951-annotation-labels

### DIFF
--- a/src/encoded/static/components/cart/cart.js
+++ b/src/encoded/static/components/cart/cart.js
@@ -71,6 +71,8 @@ const requestedFacetFields = displayedFileFacetFields
         { field: 'biosample_summary', dataset: true },
         { field: 'assembly' },
         { field: 'assay_term_name' },
+        { field: 'annotation_subtype' },
+        { field: 'annotation_type' },
         { field: 'file_format_type' },
         { field: 'title' },
         { field: 'genome_annotation' },


### PR DESCRIPTION
Add new file props to request to populate the file objects for the genome browser.

Patched demo: https://encd-5951-annotation-labels-fytanaka.demo.encodedcc.org/