### PR TITLE
ENCD-5720-add-target-facet-to-cart-view-page

### DIFF
--- a/src/encoded/static/components/cart/cart.js
+++ b/src/encoded/static/components/cart/cart.js
@@ -80,6 +80,8 @@ const requestedFacetFields = displayedFileFacetFields
         { field: 'dataset' },
         { field: 'biological_replicates' },
         { field: 'analyses', dataset: true },
+        { field: 'target', dataset: true },
+        { field: 'targets', dataset: true },
         { field: 'preferred_default' },
         { field: 'annotation_subtype', dataset: true },
         { field: 'biochemical_inputs', dataset: true },
@@ -406,6 +408,7 @@ const CartTools = ({
     elements,
     selectedFileTerms,
     selectedDatasetTerms,
+    selectedDatasetType,
     facetFields,
     savedCartObj,
     cartType,
@@ -425,6 +428,7 @@ const CartTools = ({
                     cartType={cartType}
                     selectedFileTerms={selectedFileTerms}
                     selectedDatasetTerms={selectedDatasetTerms}
+                    selectedDatasetType={selectedDatasetType}
                     facetFields={facetFields}
                     savedCartObj={savedCartObj}
                     sharedCart={sharedCart}
@@ -448,6 +452,8 @@ CartTools.propTypes = {
     selectedFileTerms: PropTypes.object,
     /** Selected dataset facet terms */
     selectedDatasetTerms: PropTypes.object,
+    /** Currently selected dataset type */
+    selectedDatasetType: PropTypes.string.isRequired,
     /** Currently used facet field definitions */
     facetFields: PropTypes.array.isRequired,
     /** Cart as it exists in the database; use JSON payload method if none */
@@ -729,6 +735,25 @@ const processFilesAnalyses = (files, analyses) => {
 
 
 /**
+ * After retrieving the dataset objects, they get passed to this function to extract the Annotation
+ * `targets` property or other datasets' `target` property, and then mutate each dataset to contain
+ * the calculated `targetList` array property so it can generate a facet.
+ * @param {array} datasets Datasets to process for `targetList` property; each dataset mutated
+ */
+const processDatasetTargetList = (datasets) => {
+    datasets.forEach((dataset) => {
+        let targetList = [];
+        if (dataset['@type'][0] === 'Annotation' && dataset.targets.length > 0) {
+            targetList = dataset.targets.map((target) => target.label);
+        } else if (dataset.target) {
+            targetList = [dataset.target.label];
+        }
+        dataset.targetList = targetList;
+    });
+};
+
+
+/**
  * Use the following order when sorting files by status for evaluating pseudo-default files.
  */
 const pseudoDefaultFileStatusOrder = ['released', 'archived', 'in progress'];
@@ -881,8 +906,9 @@ const retrieveDatasetsFiles = (datasetsIds, facetProgressHandler, fetch, session
     ), Promise.resolve({ datasetFiles: [], datasets: [], datasetAnalyses: [] })).then(({ datasetFiles, datasets, datasetAnalyses }) => {
         facetProgressHandler(-1);
 
-        // Mutate the files to refer to their relevant analyses.
+        // Mutate the files or datasets for their calculated properties.
         processFilesAnalyses(datasetFiles, datasetAnalyses);
+        processDatasetTargetList(datasets);
         return { datasetFiles, datasets, datasetAnalyses: sortDatasetAnalyses(datasetAnalyses) };
     });
 };
@@ -1205,6 +1231,7 @@ const CartComponent = ({ context, savedCartObj, inProgress, fetch, session }) =>
                         <CartTools
                             elements={cartDatasets}
                             analyses={analyses}
+                            selectedDatasetType={selectedDatasetType}
                             savedCartObj={savedCartObj}
                             selectedFileTerms={selectedFileTerms}
                             selectedDatasetTerms={selectedDatasetTerms}

--- a/src/encoded/static/components/cart/util.js
+++ b/src/encoded/static/components/cart/util.js
@@ -141,5 +141,9 @@ export const getObjectFieldValue = (object, field) => {
     if (parts.length === 1) {
         return object[field];
     }
-    return parts.reduce((partObject, part) => partObject && partObject[part], object);
+    const value = parts.reduce((partObject, part) => partObject && partObject[part], object);
+    if (Array.isArray(value)) {
+        return value.length > 0 ? value : undefined;
+    }
+    return value;
 };


### PR DESCRIPTION
This adds a calculated property to datasets for their targets; one in the case of Experiment and FunctionalCharacterizationExperiment, or an array of targets in the case of Annotations. Must of the changes in this branch involve populating facets when a property for the term can be an array.