### PR TITLE
ENCD-6003 redirecting region search to data services

### DIFF
--- a/src/encoded/genomic_data_service.py
+++ b/src/encoded/genomic_data_service.py
@@ -14,6 +14,7 @@ RNA_GET_FACETS = [
 ]
 RNA_GET_EXPRESSIONS = '/expressions/bytes'
 RNA_GET_AUTOCOMPLETE = '/autocomplete'
+REGION_SEARCH = '/region-search'
 
 # react component orders columns by "the position" in the hash map
 RNA_GET_COLUMNS = {
@@ -262,3 +263,20 @@ class GenomicDataService():
             }
 
         return response
+
+
+    def region_search(self, assembly, chromosome, start, end):
+        params = {
+            'assembly': assembly,
+            'chr': chromosome.replace('chr', ''),
+            'start': start,
+            'end': end
+        }
+
+        query_params = '&'.join([f'{k}={params[k]}' for k in params.keys()])
+
+        url = f'{self.path}{REGION_SEARCH}?{query_params}'
+
+        results = requests.get(url, timeout=3).json()
+
+        return results

--- a/src/encoded/region_search.py
+++ b/src/encoded/region_search.py
@@ -354,9 +354,16 @@ def region_search(context, request):
         used_filters['files.uuid'] = file_uuids
         query['aggs'] = set_facets(_FACETS, used_filters, principals, ['Experiment'])
         schemas = (types[item_type].schema for item_type in ['Experiment'])
+
+        ######################### DO NOT MERGE THIS
+        from elasticsearch import Elasticsearch
+        es = Elasticsearch(hosts=['34.208.231.246'], port=9201) ### IP FROM ENCODE DEMO
+        ###########################################
+
         es_results = es.search(
             body=query, index='experiment', doc_type='experiment', size=size, request_timeout=60
         )
+
         result['@graph'] = list(format_results(request, es_results['hits']['hits']))
         result['total'] = total = es_results['hits']['total']
         result['facets'] = format_facets(es_results, _FACETS, used_filters, schemas, total, principals)

--- a/src/encoded/static/scss/encoded/modules/_search.scss
+++ b/src/encoded/static/scss/encoded/modules/_search.scss
@@ -35,6 +35,7 @@ $form-bg: #f3f3f3;
             display: flex;
             flex-direction: column;
         }
+
     }
 
     @at-root #{&}__report-list {


### PR DESCRIPTION
https://encodedcc.atlassian.net/browse/ENCD-6003

Redirecting peak searches to data services. All remaining ES lookups and coordinates resolution remain at Encode. They should be moved in the future to the Data Services in the future.

We need to either add a feature flag for this PR or turn it into a Draft PR, as we need to QA the data before making the change in production.