### PR TITLE
ENCD-5982-cart-file-views-feature

### DIFF
--- a/src/encoded/schemas/cart.json
+++ b/src/encoded/schemas/cart.json
@@ -16,7 +16,7 @@
     ],
     "properties": {
         "schema_version": {
-            "default": "1"
+            "default": "2"
         },
         "name": {
             "title": "Name",
@@ -47,6 +47,33 @@
                 "description": "Reference to one element in the cart",
                 "type":  "string",
                 "linkTo": "Dataset"
+            }
+        },
+        "file_views": {
+            "title": "Cart file views",
+            "description": "Views of subsets of files within a cart",
+            "type": "array",
+            "items": {
+                "title": "Single cart file view",
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "title": "File view title",
+                        "description": "Title of one file view",
+                        "type": "string"
+                    },
+                    "files": {
+                        "title": "File view contents",
+                        "description": "Files within a file view",
+                        "type": "array",
+                        "items": {
+                            "title": "File within a view",
+                            "description": "Reference to a file within a view",
+                            "type": "string",
+                            "linkTo": "File"
+                        }
+                    }
+                }
             }
         }
     },

--- a/src/encoded/schemas/changelogs/cart.md
+++ b/src/encoded/schemas/changelogs/cart.md
@@ -1,9 +1,12 @@
 ## Changelog for cart.json
 
+### Schema version 2
+
+* Added *file_views* array property.
+
 ### Minor changes since schema version 1
 
 * Added optional *identifier* property.
-
 
 ### Schema version 1
 

--- a/src/encoded/static/components/cart/batch_download.js
+++ b/src/encoded/static/components/cart/batch_download.js
@@ -103,10 +103,16 @@ const CartBatchDownloadComponent = (
         sharedCart,
         cartInProgress,
         visualizable,
+        isFileViewOnly,
     }
 ) => {
-    const disabled = !selectedDatasetType || cartInProgress;
-    const actuatorTitle = selectedDatasetType ? 'Download' : 'Select single dataset type to download';
+    const disabled = !selectedDatasetType || cartInProgress || isFileViewOnly;
+    let actuatorTitle;
+    if (isFileViewOnly) {
+        actuatorTitle = 'Turn off file view to download';
+    } else {
+        actuatorTitle = selectedDatasetType ? 'Download' : 'Select single dataset type to download';
+    }
 
     // Build the cart batch-download controller from the user selections.
     const cart = cartType === 'ACTIVE' ? savedCartObj : sharedCart;
@@ -160,6 +166,8 @@ CartBatchDownloadComponent.propTypes = {
     cartInProgress: PropTypes.bool,
     /** True to download only visualizable files */
     visualizable: PropTypes.bool,
+    /** True if file view selected */
+    isFileViewOnly: PropTypes.bool,
 };
 
 CartBatchDownloadComponent.defaultProps = {
@@ -169,6 +177,7 @@ CartBatchDownloadComponent.defaultProps = {
     sharedCart: null,
     cartInProgress: false,
     visualizable: false,
+    isFileViewOnly: false,
 };
 
 const mapStateToProps = (state, ownProps) => ({

--- a/src/encoded/static/components/cart/database.js
+++ b/src/encoded/static/components/cart/database.js
@@ -91,7 +91,11 @@ export default cartSave;
  * @return {Promise} Resolves to newly created cart object, or reject with error code.
  */
 export const cartCreate = ({ name, identifier, status }, fetch) => {
-    const body = { name, locked: false };
+    const body = {
+        name,
+        locked: false,
+        file_views: [],
+    };
     if (identifier) {
         body.identifier = identifier;
     }

--- a/src/encoded/static/components/cart/facet.js
+++ b/src/encoded/static/components/cart/facet.js
@@ -1064,6 +1064,77 @@ CartFacets.defaultProps = {
 
 
 /**
+ * Displays a message about facets being disabled when the user has selected "File view."
+ */
+export const CartFacetsStandin = ({ files, facetProgress }) => (
+    <div className="cart__display-facets">
+        {files.length > 0 ? <FacetCount count={files.length} element="file" facetLoadProgress={facetProgress} /> : null}
+        <div className={`${files.length === 0 ? 'cart-facet-standin-message' : null}`}>
+            Dataset and file filtering disabled while file view selected.
+        </div>
+    </div>
+);
+
+CartFacetsStandin.propTypes = {
+    /** Currently selected files */
+    files: PropTypes.array.isRequired,
+    /** Current progress of loading the datasets/files for the facets */
+    facetProgress: PropTypes.number,
+};
+
+CartFacetsStandin.defaultProps = {
+    facetProgress: null,
+};
+
+
+/**
+ * Displays only an assembly facet when the user has selected "File view."
+ */
+export const CartFacetsFileView = ({ fileProps, files, facetProgress }) => {
+    const fileFacetContent = fileProps.facets.find((facet) => facet.field === 'assembly');
+    const displayedFacetField = displayedFileFacetFields.find((facetField) => facetField.field === 'assembly');
+    if (fileFacetContent) {
+        return (
+            <div className="cart__display-facets">
+                <FacetCount count={files.length} element="file" facetLoadProgress={facetProgress} />
+                <div className="cart-facet-list">
+                    <Facet
+                        facet={fileFacetContent}
+                        displayedFacetField={displayedFacetField}
+                        selectedFacetTerms={fileProps.selectedTerms.assembly}
+                        facetTermClickHandler={fileProps.termClickHandler}
+                        expanded
+                    />
+                </div>
+            </div>
+        );
+    }
+
+    return <CartFacetsStandin files={files} facetProgress={facetProgress} />;
+};
+
+CartFacetsFileView.propTypes = {
+    /** Properties specific to the file facets */
+    fileProps: PropTypes.exact({
+        /** Currently displayed file facets */
+        facets: PropTypes.array,
+        /** Currently selected facet terms */
+        selectedTerms: PropTypes.object,
+        /** Function to call when the user clicks a facet term on or off */
+        termClickHandler: PropTypes.func,
+    }).isRequired,
+    /** Currently selected files */
+    files: PropTypes.array.isRequired,
+    /** Current progress of loading the datasets/files for the facets */
+    facetProgress: PropTypes.number,
+};
+
+CartFacetsFileView.defaultProps = {
+    facetProgress: null,
+};
+
+
+/**
  * This merges a facet term into a facet object. If the term already exists in the facet, its term
  * count gets incremented. Otherwise, the term gets added to the facet terms with an initial count.
  * @param {object} facet Facet to merge term into
@@ -1072,8 +1143,7 @@ CartFacets.defaultProps = {
 const mergeTermIntoFacet = (facet, term) => {
     const matchingTerm = facet.terms.find((matchingFacetTerm) => matchingFacetTerm.term === term);
     if (matchingTerm) {
-        // Facet term has been counted before, so add to its count. Mark the term as
-        // visualizable if any file contributing to this term is visualizable.
+        // Facet term has been counted before, so add to its count.
         matchingTerm.count += 1;
     } else {
         // Facet term has not been counted before, so initialize a new facet term entry.

--- a/src/encoded/static/components/cart/file_view.js
+++ b/src/encoded/static/components/cart/file_view.js
@@ -1,0 +1,163 @@
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { Checkbox, isFileVisualizable } from '../objectutils';
+import { addToFileViewAndSave, removeFromFileViewAndSave } from './actions';
+
+
+/**
+ * Displays and reacts to clicks in the 'In file view' checkbox.
+ */
+const CartFileViewToggleComponent = ({
+    filePath,
+    selected,
+    disabled,
+    inProgress,
+    cartLocked,
+    onAddToFileViewClick,
+    onRemoveFromFileViewClick,
+}) => {
+    const handleClick = (e) => {
+        // Checkbox lies on top of the link to the file, so have to stop the click here.
+        e.stopPropagation();
+        if (selected) {
+            onRemoveFromFileViewClick();
+        } else {
+            onAddToFileViewClick();
+        }
+    };
+
+    return (
+        <Checkbox
+            label="In file view"
+            id={`file-view-check-${filePath}`}
+            checked={selected}
+            disabled={disabled || inProgress || cartLocked}
+            clickHandler={handleClick}
+            css="cart-file-view-checkbox"
+        />
+    );
+};
+
+CartFileViewToggleComponent.propTypes = {
+    /** @id of the file this toggle controls */
+    filePath: PropTypes.string.isRequired,
+    /** True if file's view is selected */
+    selected: PropTypes.bool.isRequired,
+    /** True if file view toggle should appear disabled */
+    disabled: PropTypes.bool.isRequired,
+    /** True if cart operation in progress */
+    inProgress: PropTypes.bool.isRequired,
+    /** True if cart is locked */
+    cartLocked: PropTypes.bool.isRequired,
+    /** Called when the user clicks the file-view checkbox to add file to file view */
+    onAddToFileViewClick: PropTypes.func.isRequired,
+    /** Called when the user clicks the file-view checkbox to remove file from file view */
+    onRemoveFromFileViewClick: PropTypes.func.isRequired,
+};
+
+CartFileViewToggleComponent.mapStateToProps = (state, ownProps) => ({
+    filePath: ownProps.file['@id'],
+    fileViewName: ownProps.fileViewName,
+    inProgress: state.inProgress,
+    cartLocked: state.locked,
+});
+
+CartFileViewToggleComponent.mapDispatchToProps = (dispatch, ownProps) => ({
+    onAddToFileViewClick: () => dispatch(addToFileViewAndSave(ownProps.fileViewName, [ownProps.file['@id']], ownProps.fetch)),
+    onRemoveFromFileViewClick: () => dispatch(removeFromFileViewAndSave(ownProps.fileViewName, [ownProps.file['@id']], ownProps.fetch)),
+});
+
+const CartFileViewToggleInternal = connect(
+    CartFileViewToggleComponent.mapStateToProps,
+    CartFileViewToggleComponent.mapDispatchToProps,
+)(CartFileViewToggleComponent);
+
+export const CartFileViewToggle = ({ file, fileViewName, selected, disabled }, reactContext) => (
+    <CartFileViewToggleInternal
+        file={file}
+        fileViewName={fileViewName}
+        selected={selected}
+        disabled={disabled}
+        fetch={reactContext.fetch}
+    />
+);
+
+CartFileViewToggle.propTypes = {
+    /** File being added */
+    file: PropTypes.object.isRequired,
+    /** Name of the current file view */
+    fileViewName: PropTypes.string.isRequired,
+    /** True if file's view is selected */
+    selected: PropTypes.bool.isRequired,
+    /** True if file view control should appear disabled */
+    disabled: PropTypes.bool.isRequired,
+};
+
+CartFileViewToggle.contextTypes = {
+    fetch: PropTypes.func,
+};
+
+
+/**
+ * Displays and reacts to clicks in the 'Add selected files to file view' button.
+ */
+const CartFileViewAddAllComponent = ({ locked, inProgress, disabled, onAddAllToFileViewClick }) => (
+    <button type="button" className="btn btn-info btn-sm file-view-controls__add" disabled={disabled || locked || inProgress} onClick={onAddAllToFileViewClick}>
+        Add selected files to file view
+    </button>
+);
+
+CartFileViewAddAllComponent.propTypes = {
+    /** True if button should appear disabled for higher-level reasons */
+    disabled: PropTypes.bool.isRequired,
+    /** True if cart is locked */
+    locked: PropTypes.bool.isRequired,
+    /** True if cart operation in progress */
+    inProgress: PropTypes.bool.isRequired,
+    /** Function to call when the user clicks the 'Add all to file view' button */
+    onAddAllToFileViewClick: PropTypes.func.isRequired,
+};
+
+CartFileViewAddAllComponent.mapStateToProps = (state) => ({
+    inProgress: state.inProgress,
+    locked: state.locked,
+});
+
+CartFileViewAddAllComponent.mapDispatchToProps = (dispatch, ownProps) => ({
+    onAddAllToFileViewClick: () => dispatch(addToFileViewAndSave(
+        ownProps.fileViewName,
+        ownProps.filePaths,
+        ownProps.fetch,
+    )),
+});
+
+const CartFileViewAddAllInternal = connect(
+    CartFileViewAddAllComponent.mapStateToProps,
+    CartFileViewAddAllComponent.mapDispatchToProps
+)(CartFileViewAddAllComponent);
+
+export const CartFileViewAddAll = ({ files, fileViewName, disabled }, reactContext) => {
+    const filePaths = files.filter((file) => isFileVisualizable(file)).map((file) => file['@id']);
+    return (
+        <CartFileViewAddAllInternal
+            filePaths={filePaths}
+            fileViewName={fileViewName}
+            fetch={reactContext.fetch}
+            disabled={disabled}
+        />
+    );
+};
+
+CartFileViewAddAll.propTypes = {
+    files: PropTypes.array.isRequired,
+    fileViewName: PropTypes.string.isRequired,
+    disabled: PropTypes.bool,
+};
+
+CartFileViewAddAll.defaultProps = {
+    disabled: false,
+};
+
+CartFileViewAddAll.contextTypes = {
+    fetch: PropTypes.func,
+};

--- a/src/encoded/static/components/cart/switch.js
+++ b/src/encoded/static/components/cart/switch.js
@@ -1,6 +1,7 @@
 import {
     cacheSavedCart,
     replaceCart,
+    replaceFileViews,
     setCartIdentifier,
     setCartLocked,
     setCartName,
@@ -28,6 +29,7 @@ const switchCart = (currentCartAtId, fetch) => (
                 dispatch(setCartIdentifier(savedCartObj.identifier));
                 dispatch(setCartLocked(savedCartObj.locked));
                 dispatch(setCartStatus(savedCartObj.status));
+                dispatch(replaceFileViews(savedCartObj.file_views));
                 dispatch(cacheSavedCart(savedCartObj));
                 cartSetOperationInProgress(false, dispatch);
                 resolve(savedCartObj);

--- a/src/encoded/static/components/objectutils.js
+++ b/src/encoded/static/components/objectutils.js
@@ -1054,9 +1054,9 @@ CopyButton.defaultProps = {
  * Display a custom-styled, accessible checkbox. Loosely based on:
  * https://webdesign.tutsplus.com/tutorials/how-to-make-custom-accessible-checkboxes-and-radio-buttons--cms-32074
  */
-export const Checkbox = ({ label, id, checked, css, clickHandler }) => (
-    <div className={`checkbox${css ? ` ${css}` : ''}`}>
-        <input id={id} name={id} type="checkbox" checked={checked} onChange={clickHandler} />
+export const Checkbox = ({ label, id, checked, disabled, css, clickHandler }) => (
+    <div className={`checkbox${disabled ? ' checkbox--disabled' : ''}${css ? ` ${css}` : ''}`}>
+        <input id={id} name={id} type="checkbox" checked={checked} disabled={disabled} onChange={clickHandler} />
         <label htmlFor={id}>
             {label}
             {svgIcon('checkbox')}
@@ -1071,6 +1071,8 @@ Checkbox.propTypes = {
     id: PropTypes.string.isRequired,
     /** True if checkbox is checked */
     checked: PropTypes.bool.isRequired,
+    /** True if checkbox is disabled */
+    disabled: PropTypes.bool,
     /** CSS to apply to checkbox wrapper */
     css: PropTypes.string,
     /** Called when the user clicks the checkbox */
@@ -1078,6 +1080,7 @@ Checkbox.propTypes = {
 };
 
 Checkbox.defaultProps = {
+    disabled: false,
     css: '',
 };
 

--- a/src/encoded/static/scss/encoded/modules/_cart.scss
+++ b/src/encoded/static/scss/encoded/modules/_cart.scss
@@ -328,6 +328,7 @@
     @media screen and (min-width: $screen-md-min) {
         display: flex;
         flex: 0 1 auto;
+        align-items: center;
     }
 }
 
@@ -386,6 +387,11 @@
             border: none;
         }
     }
+}
+
+// Adjusts message if no file count header exists in the facet.
+.cart-facet-standin-message {
+    padding: 10px;
 }
 
 // Defines check boxes and radio button on the cart facets.
@@ -927,9 +933,25 @@ $file-type-colors: (
 
 // Contains list of cart-related objects, sort of like search results.
 .cart-list {
-    // Contains one item in the cart list.
     @at-root #{&}-item {
+        position: relative;
+
+        &.cart-list-item--no-dl {
+            .cart-list-link__file-type {
+                background-color: #606060;
+                color: white;
+            }
+
+            .cart-file-view-checkbox {
+                color: white;
+            }
+        }
+    }
+
+    // Contains one item in the cart list.
+    @at-root #{&}-link {
         display: flex;
+        flex: 1 0 auto;
         position: relative;
         border-bottom: 1px solid #ccc;
         color: #000;
@@ -976,7 +998,7 @@ $file-type-colors: (
                 flex-basis: 10%;
             }
 
-            .cart-list-item--no-dl & {
+            .cart-list-link--no-dl & {
                 background-color: #606060;
                 color: white;
             }
@@ -1019,8 +1041,8 @@ $file-type-colors: (
 
         @at-root #{&}__no-dl {
             position: absolute;
+            top: 3px;
             right: 0;
-            bottom: 3px;
             left: 0;
             font-size: 0.75rem;
             color: white;
@@ -1120,10 +1142,6 @@ $file-type-colors: (
             @media screen and (min-width: $screen-md-min) {
                 flex-basis: 25%;
             }
-
-            @media screen and (min-width: $screen-lg-min) {
-                flex-basis: 15%;
-            }
         }
 
         @at-root #{&}__assay {
@@ -1133,10 +1151,6 @@ $file-type-colors: (
             @media screen and (min-width: $screen-md-min) {
                 flex-basis: 25%;
             }
-
-            @media screen and (min-width: $screen-lg-min) {
-                flex-basis: 30%;
-            }
         }
 
         @at-root #{&}__biosample {
@@ -1145,10 +1159,6 @@ $file-type-colors: (
 
             @media screen and (min-width: $screen-md-min) {
                 flex-basis: 25%;
-            }
-
-            @media screen and (min-width: $screen-lg-min) {
-                flex-basis: 30%;
             }
         }
 
@@ -1164,6 +1174,63 @@ $file-type-colors: (
         text-align: center;
         font-size: 0.9rem;
     }
+}
+
+$file-view-checkbox-size: 14px;
+
+// Used on the checkbox for each file to include or remove from the file view.
+.cart-file-view-checkbox {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    font-size: 0.9rem;
+    z-index: 1;
+
+    input {
+        width: $file-view-checkbox-size;
+        height: $file-view-checkbox-size;
+
+        + label {
+            padding-left: 15px;
+
+            &::before {
+                top: 4px;
+                width: $file-view-checkbox-size;
+                height: $file-view-checkbox-size;
+            }
+
+            svg {
+                top: 6px;
+                width: $file-view-checkbox-size - 4;
+                height: $file-view-checkbox-size - 4;
+            }
+        }
+    }
+}
+
+// Used for the checkbox to select whether to view only file view files.
+.file-view-toggle {
+    margin: 3px 0 0 0;
+
+    input {
+        + label {
+            padding: 0 0 0 23px;
+            line-height: 1.6;
+
+            &::before {
+                top: 3px;
+            }
+
+            svg {
+                top: 5px;
+            }
+        }
+    }
+}
+
+.file-view-controls {
+    display: flex;
+    align-items: center;
 }
 
 .cart-pager-area {
@@ -1349,7 +1416,13 @@ $file-type-colors: (
     display: flex;
     padding: 5px;
     justify-content: space-between;
+    align-items: center;
     border-bottom: 1px solid #ccc;
+
+    .cart-checkbox {
+        margin-top: 0;
+        margin-bottom: 0;
+    }
 }
 
 // Control to clear all selections within a facet.

--- a/src/encoded/static/scss/encoded/modules/_common_item.scss
+++ b/src/encoded/static/scss/encoded/modules/_common_item.scss
@@ -72,6 +72,7 @@ $checkbox-padding: 3px;
         left: $checkbox-padding;
         opacity: 0;
         z-index: 1;
+        cursor: pointer;
 
         &:checked {
             border: none;
@@ -108,7 +109,7 @@ $checkbox-padding: 3px;
                 top: 0;
                 width: $checkbox-dimensions;
                 height: $checkbox-dimensions;
-                background-color: transparent;
+                background-color: white;
                 border: 1px solid #c0c0c0;
                 border-radius: 3px;
             }
@@ -131,6 +132,14 @@ $checkbox-padding: 3px;
 
             &:hover {
                 cursor: pointer;
+            }
+        }
+    }
+
+    &.checkbox--disabled {
+        input {
+            + label {
+                color: #808080;
             }
         }
     }

--- a/src/encoded/tests/data/inserts/cart.json
+++ b/src/encoded/tests/data/inserts/cart.json
@@ -8,6 +8,12 @@
             "/experiments/ENCSR002CON/",
             "/experiments/ENCSR706IDL/"
         ],
+        "file_views": [
+            {
+                "title": "View",
+                "files": []
+            }
+        ],
         "identifier": "ali-mortazavi-first-cart",
         "submitted_by": "netus.lorem@risus.lobortis",
         "status": "current",

--- a/src/encoded/tests/fixtures/schemas/cart.py
+++ b/src/encoded/tests/fixtures/schemas/cart.py
@@ -65,3 +65,20 @@ def other_cart_submitter_testapp(app, remc_member):
         'REMOTE_USER': remc_member['uuid'],
     }
     return TestApp(app, environ)
+
+
+@pytest.fixture
+def cart_0_0():
+    return{
+        'name': 'Test Cart',
+        'elements': []
+    }
+
+
+@pytest.fixture
+def cart_1(cart_0_0):
+    item = cart_0_0.copy()
+    item.update({
+        'schema_version': '1',
+    })
+    return item

--- a/src/encoded/tests/test_upgrade_cart.py
+++ b/src/encoded/tests/test_upgrade_cart.py
@@ -1,0 +1,7 @@
+import pytest
+
+
+def test_cart_upgrade_1_2(upgrader, cart_1):
+    value = upgrader.upgrade('cart', cart_1, current_version='1', target_version='2')
+    assert value['schema_version'] == '2'
+    assert 'file_views' in value

--- a/src/encoded/types/cart.py
+++ b/src/encoded/types/cart.py
@@ -65,7 +65,8 @@ def _create_cart(request, user, name=None, identifier=None, status=None):
         'status': status or 'current',
         'name': cart_name,
         'locked': False,
-        'elements': []
+        'elements': [],
+        'file_views': [],
     }
     if identifier:
         initial_cart['identifier'] = identifier

--- a/src/encoded/upgrade/cart.py
+++ b/src/encoded/upgrade/cart.py
@@ -1,0 +1,7 @@
+from snovault import upgrade_step
+
+
+@upgrade_step('cart', '1', '2')
+def cart_1_2(value, system):
+    if 'file_views' not in value:
+        value['file_views'] = []


### PR DESCRIPTION
* The new file_views property of the cart object comprises an array of objects, one for each of the user’s file views. For now, we have no UI for the user to create and delete file views, so each user gets only one with the name “View.” Most file-view related Redux functions can work with multiple file views for future expansion.
* While I have a Redux action to remove a file view, I didn’t implement a function to remove the file view from a cart and save that updated cart to the database because we currently have no way to remove a cart view via the UI, nor does it make sense to until we support multiple cart views in one cart in the UI.
