### PR TITLE
ENCD-6024-make-search-results-targets-into-links

### DIFF
--- a/src/encoded/schemas/aggregate_series.json
+++ b/src/encoded/schemas/aggregate_series.json
@@ -147,6 +147,10 @@
             "title": "Status",
             "type": "string"
         },
+        "target.@id": {
+            "title": "Targets",
+            "type": "string"
+        },
         "target.label": {
             "title": "Target",
             "type": "string"

--- a/src/encoded/schemas/annotation.json
+++ b/src/encoded/schemas/annotation.json
@@ -344,6 +344,9 @@
             "title": "Accession",
             "type": "string"
         },
+        "targets.@id": {
+            "title": "Targets"
+        },
         "targets.label":{
             "title": "Target",
             "type": "string"

--- a/src/encoded/schemas/differentiation_series.json
+++ b/src/encoded/schemas/differentiation_series.json
@@ -133,6 +133,10 @@
             "title": "Status",
             "type": "string"
         },
+        "target.@id": {
+            "title": "Targets",
+            "type": "string"
+        },
         "target.label": {
             "title": "Target",
             "type": "string"

--- a/src/encoded/schemas/disease_series.json
+++ b/src/encoded/schemas/disease_series.json
@@ -147,6 +147,10 @@
             "title": "Status",
             "type": "string"
         },
+        "target.@id": {
+            "title": "Targets",
+            "type": "string"
+        },
         "target.label": {
             "title": "Target",
             "type": "string"

--- a/src/encoded/schemas/experiment.json
+++ b/src/encoded/schemas/experiment.json
@@ -327,6 +327,9 @@
         "assay_title": {
             "title": "Assay title"
         },
+        "target.@id": {
+            "title": "Target"
+        },
         "target.label": {
             "title": "Target of assay"
         },

--- a/src/encoded/schemas/experiment_series.json
+++ b/src/encoded/schemas/experiment_series.json
@@ -141,6 +141,9 @@
         "status": {
             "title": "Status"
         },
+        "target.@id": {
+            "title": "Targets"
+        },
         "target.genes.symbol": {
             "title": "Target gene symbol"
         },

--- a/src/encoded/schemas/functional_characterization_experiment.json
+++ b/src/encoded/schemas/functional_characterization_experiment.json
@@ -441,6 +441,9 @@
         "assay_title": {
             "title": "Assay title"
         },
+        "target.@id": {
+            "title": "Target"
+        },
         "target.label": {
             "title": "Target of assay"
         },

--- a/src/encoded/schemas/functional_characterization_series.json
+++ b/src/encoded/schemas/functional_characterization_series.json
@@ -178,6 +178,10 @@
             "title": "Status",
             "type": "string"
         },
+        "target.@id": {
+            "title": "Targets",
+            "type": "string"
+        },
         "target.label": {
             "title": "Target",
             "type": "string"

--- a/src/encoded/schemas/gene_silencing_series.json
+++ b/src/encoded/schemas/gene_silencing_series.json
@@ -133,6 +133,10 @@
             "title": "Status",
             "type": "string"
         },
+        "target.@id": {
+            "title": "Targets",
+            "type": "string"
+        },
         "target.label": {
             "title": "Target",
             "type": "string"

--- a/src/encoded/schemas/matched_set.json
+++ b/src/encoded/schemas/matched_set.json
@@ -150,6 +150,10 @@
             "title": "Status",
             "type": "string"
         },
+        "target.@id": {
+            "title": "Targets",
+            "type": "string"
+        },
         "target.label": {
             "title": "Target",
             "type": "string"

--- a/src/encoded/schemas/multiomics_series.json
+++ b/src/encoded/schemas/multiomics_series.json
@@ -145,6 +145,10 @@
             "title": "Status",
             "type": "string"
         },
+        "target.@id": {
+            "title": "Targets",
+            "type": "string"
+        },
         "target.label": {
             "title": "Target",
             "type": "string"

--- a/src/encoded/schemas/organism_development_series.json
+++ b/src/encoded/schemas/organism_development_series.json
@@ -122,6 +122,10 @@
             "title": "Biosample term name",
             "type": "string"
         },
+        "target.@id": {
+            "title": "Targets",
+            "type": "string"
+        },
         "target.label": {
             "title": "Target",
             "type": "string"

--- a/src/encoded/schemas/pulse_chase_time_series.json
+++ b/src/encoded/schemas/pulse_chase_time_series.json
@@ -133,6 +133,10 @@
             "title": "Status",
             "type": "string"
         },
+        "target.@id": {
+            "title": "Targets",
+            "type": "string"
+        },
         "target.label": {
             "title": "Target",
             "type": "string"

--- a/src/encoded/schemas/reference_epigenome.json
+++ b/src/encoded/schemas/reference_epigenome.json
@@ -179,6 +179,10 @@
             "title": "Status",
             "type": "string"
         },
+        "target.@id": {
+            "title": "Targets",
+            "type": "string"
+        },
         "target.label": {
             "title": "Target",
             "type": "string"

--- a/src/encoded/schemas/replication_timing_series.json
+++ b/src/encoded/schemas/replication_timing_series.json
@@ -155,6 +155,10 @@
             "title": "Status",
             "type": "string"
         },
+        "target.@id": {
+            "title": "Targets",
+            "type": "string"
+        },
         "target.label": {
             "title": "Target",
             "type": "string"

--- a/src/encoded/schemas/single_cell_rna_series.json
+++ b/src/encoded/schemas/single_cell_rna_series.json
@@ -160,6 +160,10 @@
             "title": "Status",
             "type": "string"
         },
+        "target.@id": {
+            "title": "Targets",
+            "type": "string"
+        },
         "target.label": {
             "title": "Target",
             "type": "string"

--- a/src/encoded/schemas/treatment_concentration_series.json
+++ b/src/encoded/schemas/treatment_concentration_series.json
@@ -128,6 +128,10 @@
             "title": "Status",
             "type": "string"
         },
+        "target.@id": {
+            "title": "Targets",
+            "type": "string"
+        },
         "target.label": {
             "title": "Target",
             "type": "string"

--- a/src/encoded/schemas/treatment_time_series.json
+++ b/src/encoded/schemas/treatment_time_series.json
@@ -133,6 +133,10 @@
             "title": "Status",
             "type": "string"
         },
+        "target.@id": {
+            "title": "Targets",
+            "type": "string"
+        },
         "target.label": {
             "title": "Target",
             "type": "string"

--- a/src/encoded/static/components/experiment_series.js
+++ b/src/encoded/static/components/experiment_series.js
@@ -10,7 +10,7 @@ import { FetchedItems } from './fetched';
 import { DatasetFiles } from './filegallery';
 import * as globals from './globals';
 import { requestObjects, ItemAccessories, InternalTags, TopAccessories } from './objectutils';
-import { PickerActions, resultItemClass } from './search';
+import { PickerActions, resultItemClass, TargetsDataLine } from './search';
 import Status, { getObjectStatuses, sessionToAccessLevel } from './status';
 import { DoiRef } from './typeutils';
 
@@ -499,7 +499,7 @@ class ExperimentSeriesComponent extends React.Component {
         this.state = {
             /** Dataset objects with audit keyed by dataset @id which are
              * retrieved through a series of requests. For each dataset objects
-             * there are two key prpoperies, selectedAnalysis and selectedFiles.
+             * there are two key properties, selectedAnalysis and selectedFiles.
              * selectedAnalysis is one analysis objects selected based on lab,
              * award, etc. selectedFiles is a filtered list of experiment files
              * belonging to the selectedAnalysis.
@@ -893,7 +893,6 @@ const searchableDatasetStatusQuery = searchableDatasetStatuses.reduce((query, st
 
 const ListingComponent = (props, reactContext) => {
     const result = props.context;
-    let targets = [];
     let lifeStages = [];
     let ages = [];
 
@@ -923,11 +922,6 @@ const ListingComponent = (props, reactContext) => {
     ages = _.uniq(ages);
     const lifeSpec = [lifeStages.length === 1 ? lifeStages[0] : null, ages.length === 1 ? ages[0] : null].filter(Boolean);
 
-    // Get list of target labels.
-    if (result.target) {
-        targets = _.uniq(result.target.map((target) => target.label));
-    }
-
     const contributors = _.uniq(result.contributors.map((lab) => lab.title));
     const contributingAwards = _.uniq(result.contributing_awards.map((award) => award.project));
 
@@ -955,7 +949,7 @@ const ListingComponent = (props, reactContext) => {
                     </a>
                     <div className="result-item__data-row">
                         {result.dataset_type ? <div><strong>Dataset type: </strong>{result.dataset_type}</div> : null}
-                        {targets.length > 0 ? <div><strong>Target: </strong>{targets.join(', ')}</div> : null}
+                        <TargetsDataLine result={result} targetPropertyName="target" />
                         <div><strong>Lab: </strong>{contributors.join(', ')}</div>
                         <div><strong>Project: </strong>{contributingAwards.join(', ')}</div>
                     </div>

--- a/src/encoded/tests/test_batch_download.py
+++ b/src/encoded/tests/test_batch_download.py
@@ -38,7 +38,7 @@ def test_batch_download_report_download(testapp, index_workbook, threadlocals):
     lines = res.body.splitlines()
     assert b'/report/' in lines[0]
     assert lines[1].split(b'\t') == [
-        b'ID', b'Accession', b'Assay name', b'Assay title', b'Target of assay',
+        b'ID', b'Accession', b'Assay name', b'Assay title', b'Target', b'Target of assay',
         b'Target gene symbol', b'Biosample summary', b'Biosample term name', b'Dbxrefs', b'Description', b'Lab',
         b'Project', b'Status', b'Files', b'Related series', b'Biosample accession', b'Biological replicate',
         b'Technical replicate', b'Linked antibody', b'Organism', b'Life stage', b'Biosample age',
@@ -58,7 +58,7 @@ def test_batch_download_report_download_with_cart(testapp, index_workbook, threa
     lines = res.body.splitlines()
     assert b'/cart-report/' in lines[0]
     assert lines[1].split(b'\t') == [
-        b'ID', b'Accession', b'Assay name', b'Assay title', b'Target of assay',
+        b'ID', b'Accession', b'Assay name', b'Assay title', b'Target', b'Target of assay',
         b'Target gene symbol', b'Biosample summary', b'Biosample term name', b'Dbxrefs', b'Description', b'Lab',
         b'Project', b'Status', b'Files', b'Related series', b'Biosample accession', b'Biological replicate',
         b'Technical replicate', b'Linked antibody', b'Organism', b'Life stage', b'Biosample age',


### PR DESCRIPTION
The vast majority of file changes involve adding `target.@id` to various dataset schemas’ `columns` property so that search results can retrieve a link to the target objects, as all dataset targets in search results now link to the target page. Links with factorbook dbxrefs now link to both our own target page as well as the factorbook link.