### PR TITLE
ENCD-6065 fix post diff table crash

### DIFF
--- a/src/encoded/static/components/dataset.js
+++ b/src/encoded/static/components/dataset.js
@@ -1744,8 +1744,8 @@ const differentiationTableColumnsWithTime = {
             );
         },
         objSorter: (a, b) => {
-            const aTime = computeDifferentiation(a) ? computeDifferentiation(a).split(' ')[0] : 0;
-            const bTime = computeDifferentiation(b) ? computeDifferentiation(b).split(' ')[0] : 0;
+            const aTime = computeDifferentiation(a)?.split(' ')[0] || 0;
+            const bTime = computeDifferentiation(b)?.split(' ')[0] || 0;
             if (aTime < bTime) { return -1; }
             if (aTime > bTime) { return 1; }
             return 0;

--- a/src/encoded/static/components/dataset.js
+++ b/src/encoded/static/components/dataset.js
@@ -1744,8 +1744,8 @@ const differentiationTableColumnsWithTime = {
             );
         },
         objSorter: (a, b) => {
-            const aTime = computeDifferentiation(a).split(' ')[0];
-            const bTime = computeDifferentiation(b).split(' ')[0];
+            const aTime = computeDifferentiation(a) ? computeDifferentiation(a).split(' ')[0] : 0;
+            const bTime = computeDifferentiation(b) ? computeDifferentiation(b).split(' ')[0] : 0;
             if (aTime < bTime) { return -1; }
             if (aTime > bTime) { return 1; }
             return 0;


### PR DESCRIPTION
We needed to account for experiments without a post-differentiation time.
I thought about updating the computeDifferentiation() function instead of the fix below, but the result of computeDifferentiation() is used for the display so I didn't want to change that.