### PR TITLE
ENCD-5981-change-filegallery-defaults

### DIFF
--- a/src/encoded/static/components/filegallery.js
+++ b/src/encoded/static/components/filegallery.js
@@ -2984,7 +2984,7 @@ class FileGalleryRendererComponent extends React.Component {
             /** Filters for files */
             fileFilters: {},
             /** Current tab: 'browser', 'graph', or 'tables' */
-            currentTab: 'tables',
+            currentTab: 'browser',
             /** Sorted compiled dataset analysis objects filtered by available assemblies */
             compiledAnalyses: compileAnalyses(props.analyses, datasetFiles, 'choose analysis'),
             /** Index of currently/last selected `compiledAnalyses`. */
@@ -3039,28 +3039,12 @@ class FileGalleryRendererComponent extends React.Component {
         // Determine how many visualizable files there are
         const vizFiles = filterForVisualizableFiles(this.props.context.files);
 
-        if (!this.props.hideGraph && vizFiles.length > 0) {
-            this.setState({ currentTab: 'browser' }, () => {
-                // Determine available assemblies
-                const assemblyList = this.setAssemblyList(this.state.files);
-                // We want to get the assembly with the highest assembly number (but not 'All assemblies')
-                const newAssembly = Object.keys(assemblyList).reduce((a, b) => (((assemblyList[a] > assemblyList[b]) && (a !== 'All assemblies')) ? a : b));
-                this.filterFiles(newAssembly, 'assembly');
-            });
+        if (vizFiles.length > 0) {
+            this.setState({ currentTab: 'browser' });
         } else if (this.props.context.files?.some((file) => file.analysis_step_version)) {
-            // Display graph as default if there are no visualizable files
-            let assemblyList = [];
-            this.setState({ currentTab: 'graph' }, () => {
-                // Determine available assemblies
-                assemblyList = this.setAssemblyList(this.state.files);
-                // We want to get the assembly with the highest assembly number (but not 'All assemblies')
-                const newAssembly = Object.keys(assemblyList).reduce((a, b) => (((assemblyList[a] > assemblyList[b]) && (a !== 'All assemblies')) ? a : b));
-                this.filterFiles(newAssembly, 'assembly');
-            });
+            this.setState({ currentTab: 'graph' });
         } else {
-            this.setState({ currentTab: 'tables' }, () => {
-                this.filterFiles('All assemblies', 'assembly');
-            });
+            this.setState({ currentTab: 'tables' });
         }
     }
 

--- a/src/encoded/static/components/filegallery.js
+++ b/src/encoded/static/components/filegallery.js
@@ -2984,7 +2984,7 @@ class FileGalleryRendererComponent extends React.Component {
             /** Filters for files */
             fileFilters: {},
             /** Current tab: 'browser', 'graph', or 'tables' */
-            currentTab: 'tables',
+            currentTab: 'browser',
             /** Sorted compiled dataset analysis objects filtered by available assemblies */
             compiledAnalyses: compileAnalyses(props.analyses, datasetFiles, 'choose analysis'),
             /** Index of currently/last selected `compiledAnalyses`. */
@@ -3035,17 +3035,16 @@ class FileGalleryRendererComponent extends React.Component {
         if (!this.props.altFilterDefault) {
             this.setState({ selectedFilterValue: '0' });
         }
+
         // Determine how many visualizable files there are
-        // const tempFiles = filterForVisualizableFiles(this.state.files);
+        const vizFiles = filterForVisualizableFiles(this.props.context.files);
         // If the graph is hidden and there are no visualizable files, set default tab to be table and set default assembly to be 'All assemblies'
-        // if (this.props.hideGraph && tempFiles.length < 1) {
-        if (this.props.hideGraph) {
+        if (this.props.hideGraph && vizFiles.length < 1) {
             this.setState({ currentTab: 'tables' }, () => {
                 this.filterFiles('All assemblies', 'assembly');
             });
         // If the graph is not hidden and there are no visualizable files, set default tab to be graph and set default assembly to be the most recent assembly
-        } else {
-        // } else if (tempFiles.length < 1) {
+        } else if (vizFiles.length < 1) {
             // Display graph as default if there are no visualizable files
             let assemblyList = [];
             this.setState({ currentTab: 'graph' }, () => {
@@ -3056,14 +3055,13 @@ class FileGalleryRendererComponent extends React.Component {
                 this.filterFiles(newAssembly, 'assembly');
             });
         // If there are visualizable files, set default tab to be browser and set default assembly to be the most recent assembly
+        } else {
+            // Determine available assemblies
+            const assemblyList = this.setAssemblyList(this.state.files);
+            // We want to get the assembly with the highest assembly number (but not 'All assemblies')
+            const newAssembly = Object.keys(assemblyList).reduce((a, b) => (((assemblyList[a] > assemblyList[b]) && (a !== 'All assemblies')) ? a : b));
+            this.filterFiles(newAssembly, 'assembly');
         }
-        //  else {
-        //     // Determine available assemblies
-        //     const assemblyList = this.setAssemblyList(this.state.files);
-        //     // We want to get the assembly with the highest assembly number (but not 'All assemblies')
-        //     const newAssembly = Object.keys(assemblyList).reduce((a, b) => (((assemblyList[a] > assemblyList[b]) && (a !== 'All assemblies')) ? a : b));
-        //     this.filterFiles(newAssembly, 'assembly');
-        // }
     }
 
 

--- a/src/encoded/static/components/filegallery.js
+++ b/src/encoded/static/components/filegallery.js
@@ -2984,7 +2984,7 @@ class FileGalleryRendererComponent extends React.Component {
             /** Filters for files */
             fileFilters: {},
             /** Current tab: 'browser', 'graph', or 'tables' */
-            currentTab: 'browser',
+            currentTab: 'tables',
             /** Sorted compiled dataset analysis objects filtered by available assemblies */
             compiledAnalyses: compileAnalyses(props.analyses, datasetFiles, 'choose analysis'),
             /** Index of currently/last selected `compiledAnalyses`. */
@@ -3056,11 +3056,13 @@ class FileGalleryRendererComponent extends React.Component {
             });
         // If there are visualizable files, set default tab to be browser and set default assembly to be the most recent assembly
         } else {
-            // Determine available assemblies
-            const assemblyList = this.setAssemblyList(this.state.files);
-            // We want to get the assembly with the highest assembly number (but not 'All assemblies')
-            const newAssembly = Object.keys(assemblyList).reduce((a, b) => (((assemblyList[a] > assemblyList[b]) && (a !== 'All assemblies')) ? a : b));
-            this.filterFiles(newAssembly, 'assembly');
+            this.setState({ currentTab: 'browser' }, () => {
+                // Determine available assemblies
+                const assemblyList = this.setAssemblyList(this.state.files);
+                // We want to get the assembly with the highest assembly number (but not 'All assemblies')
+                const newAssembly = Object.keys(assemblyList).reduce((a, b) => (((assemblyList[a] > assemblyList[b]) && (a !== 'All assemblies')) ? a : b));
+                this.filterFiles(newAssembly, 'assembly');
+            });
         }
     }
 

--- a/src/encoded/static/components/filegallery.js
+++ b/src/encoded/static/components/filegallery.js
@@ -3038,13 +3038,16 @@ class FileGalleryRendererComponent extends React.Component {
 
         // Determine how many visualizable files there are
         const vizFiles = filterForVisualizableFiles(this.props.context.files);
-        // If the graph is hidden and there are no visualizable files, set default tab to be table and set default assembly to be 'All assemblies'
-        if (this.props.hideGraph && vizFiles.length < 1) {
-            this.setState({ currentTab: 'tables' }, () => {
-                this.filterFiles('All assemblies', 'assembly');
+
+        if (!this.props.hideGraph && vizFiles.length > 0) {
+            this.setState({ currentTab: 'browser' }, () => {
+                // Determine available assemblies
+                const assemblyList = this.setAssemblyList(this.state.files);
+                // We want to get the assembly with the highest assembly number (but not 'All assemblies')
+                const newAssembly = Object.keys(assemblyList).reduce((a, b) => (((assemblyList[a] > assemblyList[b]) && (a !== 'All assemblies')) ? a : b));
+                this.filterFiles(newAssembly, 'assembly');
             });
-        // If the graph is not hidden and there are no visualizable files, set default tab to be graph and set default assembly to be the most recent assembly
-        } else if (vizFiles.length < 1) {
+        } else if (this.props.context.files?.some((file) => file.analysis_step_version)) {
             // Display graph as default if there are no visualizable files
             let assemblyList = [];
             this.setState({ currentTab: 'graph' }, () => {
@@ -3054,14 +3057,9 @@ class FileGalleryRendererComponent extends React.Component {
                 const newAssembly = Object.keys(assemblyList).reduce((a, b) => (((assemblyList[a] > assemblyList[b]) && (a !== 'All assemblies')) ? a : b));
                 this.filterFiles(newAssembly, 'assembly');
             });
-        // If there are visualizable files, set default tab to be browser and set default assembly to be the most recent assembly
         } else {
-            this.setState({ currentTab: 'browser' }, () => {
-                // Determine available assemblies
-                const assemblyList = this.setAssemblyList(this.state.files);
-                // We want to get the assembly with the highest assembly number (but not 'All assemblies')
-                const newAssembly = Object.keys(assemblyList).reduce((a, b) => (((assemblyList[a] > assemblyList[b]) && (a !== 'All assemblies')) ? a : b));
-                this.filterFiles(newAssembly, 'assembly');
+            this.setState({ currentTab: 'tables' }, () => {
+                this.filterFiles('All assemblies', 'assembly');
             });
         }
     }

--- a/src/encoded/static/components/filegallery.js
+++ b/src/encoded/static/components/filegallery.js
@@ -2984,7 +2984,7 @@ class FileGalleryRendererComponent extends React.Component {
             /** Filters for files */
             fileFilters: {},
             /** Current tab: 'browser', 'graph', or 'tables' */
-            currentTab: 'browser',
+            currentTab: 'tables',
             /** Sorted compiled dataset analysis objects filtered by available assemblies */
             compiledAnalyses: compileAnalyses(props.analyses, datasetFiles, 'choose analysis'),
             /** Index of currently/last selected `compiledAnalyses`. */


### PR DESCRIPTION
Set default tab on file gallery to be the browser, as long as there is at least one visualizable file.