### PR TITLE
ENCD-6084-fix-mouse-development-matrix-crash

### DIFF
--- a/src/encoded/static/components/matrix_mouse_development.js
+++ b/src/encoded/static/components/matrix_mouse_development.js
@@ -100,7 +100,10 @@ const analyzeSubCategoryData = (subCategoryData, columnCategory, colMap, colCoun
     let subCategorySums = Array(colCount).fill(0);
     subCategoryData.forEach((rowData) => {
         // `rowData` has all the data for one row. Collect sums of all data for each column.
-        rowData[columnCategory].buckets.forEach((value) => {
+        const allowedRowDataBuckets = rowData[columnCategory].buckets.filter((bucket) => (
+            !excludedAssays.includes(bucket.key)
+        ));
+        allowedRowDataBuckets.forEach((value) => {
             if (stageFilter) {
                 stageFilter.forEach((singleFilter) => {
                     const filterString = singleFilter.replace('embryo', 'embryonic');


### PR DESCRIPTION
This matrix filters out “Control ChIP-seq” experiments, but one part of the code still expected to find all received assay types, and crashed when it didn’t find “Control ChIP-seq” from the filtered data.

It would probably be better to simply use the already-filtered data throughout the code instead of filtering twice as I do here, but that seemed like a large change at this stage.

“Control ChIP-seq” data was recently added, which caused this crash.