### PR TITLE
ENCD-6100-remvoing trailing slash for rnaget link

### DIFF
--- a/src/encoded/static/components/app.js
+++ b/src/encoded/static/components/app.js
@@ -67,7 +67,7 @@ const portal = {
                 { id: 'sep-mm-3' },
                 { id: 'region-search', title: 'Search by region', url: '/region-search/' },
                 { id: 'publications', title: 'Publications', url: '/publications/' },
-                { id: 'rna-get', title: 'RNA-Get (gene expression)', url: '/rnaget/' },
+                { id: 'rna-get', title: 'RNA-Get (gene expression)', url: '/rnaget' },
             ],
         },
         {


### PR DESCRIPTION
In sum, if you reach the page with a trailing ‘/', the links don’t build correctly:

encodeproject.org/rnaget  works

encodeproject.org/rnaget/  doesn't work

as we will change the interface very soon, I will just remove the trailing space from the dropdown menu as it’s how most people reach the page