### PR TITLE
ENCD-5908-add-formatted-biorep-property-to-experiments-and-fcc-experiments

### DIFF
--- a/src/encoded/tests/test_types_experiment.py
+++ b/src/encoded/tests/test_types_experiment.py
@@ -511,7 +511,7 @@ def test_experiment_biosample_replicates_1_2(testapp, base_experiment, biosample
     testapp.patch_json(replicate_1_1['@id'], {'library': library_1['@id']})
     testapp.patch_json(replicate_2_1['@id'], {'library': library_2['@id']})
     testapp.patch_json(base_experiment['@id'], {'replicates': [replicate_1_1['@id'], replicate_2_1['@id']]})
-    res = testapp.get(base_experiment['@id']+'@@index-data') 
+    res = testapp.get(base_experiment['@id'] + '@@index-data') 
     assert res.json['object']['biological_replicates'] == '1, 2' 
 
 def test_experiment_biosample_replicates_2_1(testapp, base_experiment, biosample_1, biosample_2, library_1, library_2, replicate_1_1, replicate_1_2):
@@ -520,16 +520,16 @@ def test_experiment_biosample_replicates_2_1(testapp, base_experiment, biosample
     testapp.patch_json(replicate_1_1['@id'], {'library': library_1['@id']})
     testapp.patch_json(replicate_1_2['@id'], {'library': library_2['@id']})
     testapp.patch_json(base_experiment['@id'], {'replicates': [replicate_1_1['@id'], replicate_1_2['@id']]})
-    res = testapp.get(base_experiment['@id']+'@@index-data') 
+    res = testapp.get(base_experiment['@id'] + '@@index-data') 
     assert res.json['object']['biological_replicates'] == '1' 
 
 def test_experiment_biosample_replicates_1(testapp, base_experiment, biosample_1, library_1, replicate_1_1):
     testapp.patch_json(library_1['@id'], {'biosample': biosample_1['@id']})
     testapp.patch_json(replicate_1_1['@id'], {'library': library_1['@id']})
     testapp.patch_json(base_experiment['@id'], {'replicates': [replicate_1_1['@id']]})
-    res = testapp.get(base_experiment['@id']+'@@index-data') 
+    res = testapp.get(base_experiment['@id'] + '@@index-data') 
     assert res.json['object']['biological_replicates'] == '1' 
 
 def test_experiment_biosample_replicates_0(testapp, base_experiment):
-    res = testapp.get(base_experiment['@id']+'@@index-data') 
-    assert not 'biological_replicates' in res.json['object']
+    res = testapp.get(base_experiment['@id'] + '@@index-data') 
+    assert 'biological_replicates' not in res.json['object']

--- a/src/encoded/tests/test_types_experiment.py
+++ b/src/encoded/tests/test_types_experiment.py
@@ -504,3 +504,32 @@ def test_experiment_default_analysis(
                for experiment_audit in experiment_audits.get(audit_type))
 
     assert res.json['object']['default_analysis'] == analysis_2['@id']
+
+def test_experiment_biosample_replicates_1_2(testapp, base_experiment, biosample_1, biosample_2, library_1, library_2, replicate_1_1, replicate_2_1):
+    testapp.patch_json(library_1['@id'], {'biosample': biosample_1['@id']})
+    testapp.patch_json(library_2['@id'], {'biosample': biosample_2['@id']})
+    testapp.patch_json(replicate_1_1['@id'], {'library': library_1['@id']})
+    testapp.patch_json(replicate_2_1['@id'], {'library': library_2['@id']})
+    testapp.patch_json(base_experiment['@id'], {'replicates': [replicate_1_1['@id'], replicate_2_1['@id']]})
+    res = testapp.get(base_experiment['@id']+'@@index-data') 
+    assert res.json['object']['biological_replicates'] == '1, 2' 
+
+def test_experiment_biosample_replicates_2_1(testapp, base_experiment, biosample_1, biosample_2, library_1, library_2, replicate_1_1, replicate_1_2):
+    testapp.patch_json(library_1['@id'], {'biosample': biosample_1['@id']})
+    testapp.patch_json(library_2['@id'], {'biosample': biosample_2['@id']})
+    testapp.patch_json(replicate_1_1['@id'], {'library': library_1['@id']})
+    testapp.patch_json(replicate_1_2['@id'], {'library': library_2['@id']})
+    testapp.patch_json(base_experiment['@id'], {'replicates': [replicate_1_1['@id'], replicate_1_2['@id']]})
+    res = testapp.get(base_experiment['@id']+'@@index-data') 
+    assert res.json['object']['biological_replicates'] == '1' 
+
+def test_experiment_biosample_replicates_1(testapp, base_experiment, biosample_1, library_1, replicate_1_1):
+    testapp.patch_json(library_1['@id'], {'biosample': biosample_1['@id']})
+    testapp.patch_json(replicate_1_1['@id'], {'library': library_1['@id']})
+    testapp.patch_json(base_experiment['@id'], {'replicates': [replicate_1_1['@id']]})
+    res = testapp.get(base_experiment['@id']+'@@index-data') 
+    assert res.json['object']['biological_replicates'] == '1' 
+
+def test_experiment_biosample_replicates_0(testapp, base_experiment):
+    res = testapp.get(base_experiment['@id']+'@@index-data') 
+    assert not 'biological_replicates' in res.json['object']

--- a/src/encoded/tests/test_types_functional_characterization_experiment.py
+++ b/src/encoded/tests/test_types_functional_characterization_experiment.py
@@ -63,3 +63,24 @@ def test_fcc_crispr_assay_readout_method(testapp, functional_characterization_ex
     testapp.patch_json(functional_characterization_experiment_disruption_screen['@id'], {'control_type': 'control'})
     res = testapp.get(functional_characterization_experiment_disruption_screen['@id']+'@@index-data')
     assert 'crispr_screen_readout' not in res.json['object']
+
+def test_fcc_biosample_replicates_1_2(testapp, functional_characterization_experiment_disruption_screen, biosample_1, biosample_2, library_1, library_2, replicate_1_fce, replicate_2_fce, disruption_genetic_modification):
+    testapp.patch_json(biosample_1['@id'], {'genetic_modifications': [disruption_genetic_modification['@id']]})
+    testapp.patch_json(biosample_2['@id'], {'genetic_modifications': [disruption_genetic_modification['@id']]})
+    testapp.patch_json(library_1['@id'], {'biosample': biosample_1['@id']})
+    testapp.patch_json(library_2['@id'], {'biosample': biosample_2['@id']})
+    testapp.patch_json(replicate_1_fce['@id'], {'library': library_1['@id']})
+    testapp.patch_json(replicate_2_fce['@id'], {'library': library_2['@id']})
+    res = testapp.get(functional_characterization_experiment_disruption_screen['@id']+'@@index-data')
+    assert res.json['object']['biological_replicates'] == '1, 2' 
+
+def test_fcc_biosample_replicates_1(testapp, functional_characterization_experiment_disruption_screen, biosample_1, library_1, replicate_1_fce, disruption_genetic_modification):
+    testapp.patch_json(biosample_1['@id'], {'genetic_modifications': [disruption_genetic_modification['@id']]})
+    testapp.patch_json(library_1['@id'], {'biosample': biosample_1['@id']})
+    testapp.patch_json(replicate_1_fce['@id'], {'library': library_1['@id']})
+    res = testapp.get(functional_characterization_experiment_disruption_screen['@id']+'@@index-data')
+    assert res.json['object']['biological_replicates'] == '1' 
+
+def test_fcc_biosample_replicates_0(testapp, functional_characterization_experiment_disruption_screen):
+    res = testapp.get(functional_characterization_experiment_disruption_screen['@id']+'@@index-data') 
+    assert not 'biological_replicates' in res.json['object']

--- a/src/encoded/tests/test_types_functional_characterization_experiment.py
+++ b/src/encoded/tests/test_types_functional_characterization_experiment.py
@@ -71,16 +71,16 @@ def test_fcc_biosample_replicates_1_2(testapp, functional_characterization_exper
     testapp.patch_json(library_2['@id'], {'biosample': biosample_2['@id']})
     testapp.patch_json(replicate_1_fce['@id'], {'library': library_1['@id']})
     testapp.patch_json(replicate_2_fce['@id'], {'library': library_2['@id']})
-    res = testapp.get(functional_characterization_experiment_disruption_screen['@id']+'@@index-data')
+    res = testapp.get(functional_characterization_experiment_disruption_screen['@id'] + '@@index-data')
     assert res.json['object']['biological_replicates'] == '1, 2' 
 
 def test_fcc_biosample_replicates_1(testapp, functional_characterization_experiment_disruption_screen, biosample_1, library_1, replicate_1_fce, disruption_genetic_modification):
     testapp.patch_json(biosample_1['@id'], {'genetic_modifications': [disruption_genetic_modification['@id']]})
     testapp.patch_json(library_1['@id'], {'biosample': biosample_1['@id']})
     testapp.patch_json(replicate_1_fce['@id'], {'library': library_1['@id']})
-    res = testapp.get(functional_characterization_experiment_disruption_screen['@id']+'@@index-data')
+    res = testapp.get(functional_characterization_experiment_disruption_screen['@id'] + '@@index-data')
     assert res.json['object']['biological_replicates'] == '1' 
 
 def test_fcc_biosample_replicates_0(testapp, functional_characterization_experiment_disruption_screen):
-    res = testapp.get(functional_characterization_experiment_disruption_screen['@id']+'@@index-data') 
-    assert not 'biological_replicates' in res.json['object']
+    res = testapp.get(functional_characterization_experiment_disruption_screen['@id'] + '@@index-data') 
+    assert 'biological_replicates' not in res.json['object']

--- a/src/encoded/types/experiment.py
+++ b/src/encoded/types/experiment.py
@@ -24,7 +24,8 @@ from .shared_calculated_properties import (
     CalculatedCategorySlims,
     CalculatedTypeSlims,
     CalculatedObjectiveSlims,
-    CalculatedReplicationType
+    CalculatedReplicationType,
+    CalculatedBiologicalReplicates
 )
 
 from .assay_data import assay_terms
@@ -48,7 +49,8 @@ class Experiment(Dataset,
                  CalculatedCategorySlims,
                  CalculatedTypeSlims,
                  CalculatedObjectiveSlims,
-                 CalculatedReplicationType):
+                 CalculatedReplicationType,
+                 CalculatedBiologicalReplicates):
     item_type = 'experiment'
     schema = load_schema('encoded:schemas/experiment.json')
     embedded = Dataset.embedded + [

--- a/src/encoded/types/functional_characterization_experiment.py
+++ b/src/encoded/types/functional_characterization_experiment.py
@@ -20,7 +20,8 @@ from .shared_calculated_properties import (
     CalculatedCategorySlims,
     CalculatedTypeSlims,
     CalculatedObjectiveSlims,
-    CalculatedReplicationType
+    CalculatedReplicationType,
+    CalculatedBiologicalReplicates
 )
 
 from .assay_data import assay_terms
@@ -45,7 +46,8 @@ class FunctionalCharacterizationExperiment(
     CalculatedCategorySlims,
     CalculatedTypeSlims,
     CalculatedObjectiveSlims,
-    CalculatedReplicationType):
+    CalculatedReplicationType,
+    CalculatedBiologicalReplicates):
     item_type = 'functional_characterization_experiment'
     schema = load_schema('encoded:schemas/functional_characterization_experiment.json')
     embedded = Dataset.embedded + [

--- a/src/encoded/types/shared_calculated_properties.py
+++ b/src/encoded/types/shared_calculated_properties.py
@@ -517,17 +517,17 @@ class CalculatedReplicationType:
 
 
 class CalculatedBiologicalReplicates:
-    @calculated_property(schema={
+    @calculated_property(condition='replicates', schema={
         "title": "Formatted biological replicates",
         "description": "The biological replicate numbers associated with this dataset as formatted text.",
         "comment": "Do not submit. This field is calculated through the experiment replicates.",
         "type": "string"
     })
-    def biological_replicates(self, request, replicates=None):
+    def biological_replicates(self, request, replicates):
         replicate_numbers = set()
         for rep in replicates:
-            replicateObject = request.embed(rep, '@@object')
-            if replicateObject['status'] == 'deleted':
+            replicate_object = request.embed(rep, '@@object')
+            if replicate_object['status'] == 'deleted':
                 continue
-            replicate_numbers.add(replicateObject['biological_replicate_number'])
+            replicate_numbers.add(replicate_object['biological_replicate_number'])
         return ', '.join([str(v) for v in sorted(replicate_numbers)]) if replicate_numbers else None

--- a/src/encoded/types/shared_calculated_properties.py
+++ b/src/encoded/types/shared_calculated_properties.py
@@ -514,3 +514,20 @@ class CalculatedReplicationType:
                 return 'isogenic'
 
         return 'anisogenic'
+
+
+class CalculatedBiologicalReplicates:
+    @calculated_property(schema={
+        "title": "Formatted biological replicates",
+        "description": "The biological replicate numbers associated with this dataset as formatted text.",
+        "comment": "Do not submit. This field is calculated through the experiment replicates.",
+        "type": "string"
+    })
+    def biological_replicates(self, request, replicates=None):
+        replicate_numbers = set()
+        for rep in replicates:
+            replicateObject = request.embed(rep, '@@object')
+            if replicateObject['status'] == 'deleted':
+                continue
+            replicate_numbers.add(replicateObject['biological_replicate_number'])
+        return ', '.join([str(v) for v in sorted(replicate_numbers)]) if replicate_numbers else None


### PR DESCRIPTION
I put this new shared calculated property on the two objects that can have replicates: Experiment and FunctionalCharacterizationExperiment. Another option involved adding this property to the dataset object, so let me know if you feel that would work better.