### PR TITLE
ENCD-6135-cart-view-update

### DIFF
--- a/src/encoded/static/components/__tests__/cart-test.js
+++ b/src/encoded/static/components/__tests__/cart-test.js
@@ -68,13 +68,14 @@ describe('Cart actions', () => {
             state = {
                 elements: ['/experiment/ENCSR000AAA/', '/experiment/ENCSR001AAA/', '/experiment/ENCSR002AAA/'],
                 name: 'Untitled',
+                fileViews: [],
                 savedCartObj: {},
                 inProgress: false,
             };
         });
 
         test('REMOVE_FROM_CART works and does not mutate state', () => {
-            const newState = cartModule(state, { type: REMOVE_FROM_CART, elementAtId: '/experiment/ENCSR001AAA/' });
+            const newState = cartModule(state, { type: REMOVE_FROM_CART, elementAtId: '/experiment/ENCSR001AAA/', filePaths: [] });
             expect(newState.elements).toHaveLength(2);
             expect(newState.elements[0]).toEqual('/experiment/ENCSR000AAA/');
             expect(newState.elements[1]).toEqual('/experiment/ENCSR002AAA/');
@@ -82,7 +83,7 @@ describe('Cart actions', () => {
         });
 
         test('Failed REMOVE_FROM_CART does not modify contents', () => {
-            const newState = cartModule(state, { type: REMOVE_FROM_CART, elementAtId: '/experiment/ENCSR004AAA/' });
+            const newState = cartModule(state, { type: REMOVE_FROM_CART, elementAtId: '/experiment/ENCSR004AAA/', filePaths: [] });
             expect(_.isEqual(state.elements, newState.elements)).toEqual(true);
         });
 

--- a/src/encoded/static/components/cart/cart.js
+++ b/src/encoded/static/components/cart/cart.js
@@ -42,10 +42,7 @@ import CartLockTrigger from './lock';
 import CartMergeShared from './merge_shared';
 import Status from '../status';
 import CartRemoveElements from './remove_multiple';
-import { allowedDatasetTypes } from './util';
-
-
-const DEFAULT_FILE_VIEW_NAME = 'View';
+import { allowedDatasetTypes, DEFAULT_FILE_VIEW_NAME } from './util';
 
 
 /**
@@ -570,7 +567,7 @@ const CartSearchResultsControls = ({
     return (
         <div className="cart-search-results-controls">
             {currentTab === 'datasets' && cartType === 'ACTIVE'
-                ? <CartRemoveElements elements={elements.map((element) => element['@id'])} loading={loading} />
+                ? <CartRemoveElements elements={elements} loading={loading} />
                 : (currentTab === 'processeddata' ?
                     <FileViewControl
                         files={filesToAddToFileView}

--- a/src/encoded/static/components/cart/clear.js
+++ b/src/encoded/static/components/cart/clear.js
@@ -5,8 +5,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { removeMultipleFromCartAndSave } from './actions';
 import { Modal, ModalHeader, ModalBody, ModalFooter } from '../../libs/ui/modal';
+import { clearCartAndSave } from './actions';
 
 
 /**
@@ -22,8 +22,8 @@ class CartClearModalComponent extends React.Component {
      * Called when a user clicks the modal button to confirm clearing the cart.
      */
     handleConfirmClearClick() {
-        const { elements, onClearCartClick, closeClickHandler } = this.props;
-        onClearCartClick(elements);
+        const { onClearCartClick, closeClickHandler } = this.props;
+        onClearCartClick();
         closeClickHandler();
     }
 
@@ -46,8 +46,6 @@ class CartClearModalComponent extends React.Component {
 }
 
 CartClearModalComponent.propTypes = {
-    /** Items in the current cart */
-    elements: PropTypes.array.isRequired,
     /** Name of current cart */
     cartName: PropTypes.string,
     /** True if cart operation in progress */
@@ -64,13 +62,12 @@ CartClearModalComponent.defaultProps = {
 };
 
 CartClearModalComponent.mapStateToProps = (state) => ({
-    elements: state.elements,
     cartName: state.savedCartObj && state.savedCartObj.name,
     inProgress: state.inProgress,
 });
 
 CartClearModalComponent.mapDispatchToProps = (dispatch, ownProps) => ({
-    onClearCartClick: (elements) => dispatch(removeMultipleFromCartAndSave(elements, ownProps.fetch)),
+    onClearCartClick: () => dispatch(clearCartAndSave(ownProps.fetch)),
 });
 
 const CartClearModalInternal = connect(CartClearModalComponent.mapStateToProps, CartClearModalComponent.mapDispatchToProps)(CartClearModalComponent);

--- a/src/encoded/static/components/cart/database.js
+++ b/src/encoded/static/components/cart/database.js
@@ -63,16 +63,20 @@ const getWriteableCartObject = (cartAtId, fetch) => (
  * Save the in-memory cart to the database. The user object has the @id of the user's cart, but not
  * the cart object itself which must be provided in `savedCartObj`.
  * @param {array} elements Array of @ids contained in the in-memory cart to be saved
+ * @param {array} fileViews Array of file views to save; falsy to not save
  * @param {object} savedCartObj User's saved cart object
  * @param {func} fetch System-wide fetch operation
  * @return {object} Promise with new or updated cart object
  */
-const cartSave = (elements, savedCartObj, fetch) => {
+const cartSave = (elements, fileViews, savedCartObj, fetch) => {
     const cartAtId = savedCartObj && savedCartObj['@id'];
     if (cartAtId) {
         return getWriteableCartObject(cartAtId, fetch).then((writeableCart) => {
             // Copy the in-memory cart to the writeable cart object and then update it in the DB.
             writeableCart.elements = elements;
+            if (fileViews) {
+                writeableCart.file_views = fileViews;
+            }
             return updateCartObject(writeableCart, cartAtId, fetch);
         });
     }

--- a/src/encoded/static/components/cart/remove_multiple.js
+++ b/src/encoded/static/components/cart/remove_multiple.js
@@ -4,8 +4,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { removeMultipleFromCartAndSave } from './actions';
 import { Modal, ModalHeader, ModalBody, ModalFooter } from '../../libs/ui/modal';
+import { removeMultipleFromCartAndSave } from './actions';
+import { DEFAULT_FILE_VIEW_NAME } from './util';
 
 
 /**
@@ -60,13 +61,19 @@ CartRemoveElementsModalComponent.mapStateToProps = (state, ownProps) => ({
 });
 
 CartRemoveElementsModalComponent.mapDispatchToProps = (dispatch, ownProps) => ({
-    removeMultipleItems: (elements) => dispatch(removeMultipleFromCartAndSave(elements, ownProps.fetch)),
+    removeMultipleItems: (elements) => dispatch(removeMultipleFromCartAndSave(elements, ownProps.fileViewTitle, ownProps.fetch)),
 });
 
 const CartRemoveElementsModalInternal = connect(CartRemoveElementsModalComponent.mapStateToProps, CartRemoveElementsModalComponent.mapDispatchToProps)(CartRemoveElementsModalComponent);
 
 export const CartRemoveElementsModal = ({ elements, closeClickHandler }, reactContext) => (
-    <CartRemoveElementsModalInternal elements={elements} closeClickHandler={closeClickHandler} loggedIn={!!(reactContext.session && reactContext.session['auth.userid'])} fetch={reactContext.fetch} />
+    <CartRemoveElementsModalInternal
+        elements={elements}
+        closeClickHandler={closeClickHandler}
+        fileViewTitle={DEFAULT_FILE_VIEW_NAME}
+        loggedIn={!!(reactContext.session && reactContext.session['auth.userid'])}
+        fetch={reactContext.fetch}
+    />
 );
 
 CartRemoveElementsModal.propTypes = {

--- a/src/encoded/static/components/cart/toggle.js
+++ b/src/encoded/static/components/cart/toggle.js
@@ -7,7 +7,7 @@ import { svgIcon } from '../../libs/svg-icons';
 import { addToCartAndSave, removeFromCartAndSave, triggerAlert } from './actions';
 import CartLoggedOutWarning, { useLoggedOutWarning } from './loggedout_warning';
 import CartMaxElementsWarning from './max_elements_warning';
-import { CART_MAX_ELEMENTS } from './util';
+import { CART_MAX_ELEMENTS, DEFAULT_FILE_VIEW_NAME } from './util';
 import { truncateString, uc } from '../globals';
 
 
@@ -122,7 +122,7 @@ const mapStateToProps = (state, ownProps) => ({
 
 const mapDispatchToProps = (dispatch, ownProps) => ({
     onAddToCartClick: () => dispatch(addToCartAndSave(ownProps.element['@id'], ownProps.fetch)),
-    onRemoveFromCartClick: () => dispatch(removeFromCartAndSave(ownProps.element['@id'], ownProps.fetch)),
+    onRemoveFromCartClick: () => dispatch(removeFromCartAndSave(ownProps.element, ownProps.fileViewTitle, ownProps.fetch)),
     showMaxElementsWarning: () => dispatch(triggerAlert(<CartMaxElementsWarning />)),
 });
 
@@ -133,6 +133,7 @@ const CartToggle = (props, reactContext) => (
     <CartToggleInternal
         element={props.element}
         displayName={props.displayName}
+        fileViewTitle={DEFAULT_FILE_VIEW_NAME}
         css={props.css}
         loggedIn={!!(reactContext.session && reactContext.session['auth.userid'])}
         fetch={reactContext.fetch}

--- a/src/encoded/static/components/cart/util.js
+++ b/src/encoded/static/components/cart/util.js
@@ -11,6 +11,11 @@ import url from 'url';
  */
 export const CART_MAX_ELEMENTS = 8000;
 
+/**
+ * Default title of file view.
+ */
+export const DEFAULT_FILE_VIEW_NAME = 'View';
+
 
 /**
  * List of dataset types allowed in carts. Maps from collection names to corresponding data:


### PR DESCRIPTION
Summary: If you remove datasets from the cart that include files saved in the file view, the file_views[x].files array of files in the file view doesn’t get updated with the files in the removed datasets removed from the file view.

This affects removing one dataset, removing many datasets, and clearing the cart.

The fix largely involves the actions in index.js also removing files from the fileViews that match files from datasets being removed.