### PR TITLE
ENCD-6005-region-search-display-bug-fixes

### DIFF
--- a/src/encoded/region_search.py
+++ b/src/encoded/region_search.py
@@ -215,7 +215,7 @@ def region_search(context, request):
         return result
 
     expand = True
-    if region and (re.match('chr\d+:\d+-\d+', region) or re.match('rs\d+', region)):
+    if region and (re.match('chr\w:\d+-\d+', region) or re.match('rs\d+', region)):
         expand = False
 
     try:

--- a/src/encoded/region_search.py
+++ b/src/encoded/region_search.py
@@ -215,7 +215,7 @@ def region_search(context, request):
         return result
 
     expand = True
-    if region and (re.match('chr\w:\d+-\d+', region) or re.match('rs\d+', region)):
+    if region and (re.match(r'chr\w:\d+-\d+', region) or re.match(r'rs\d+', region)):
         expand = False
 
     try:

--- a/src/encoded/region_search.py
+++ b/src/encoded/region_search.py
@@ -215,7 +215,7 @@ def region_search(context, request):
         return result
 
     expand = True
-    if region and region.startswith('chr'):
+    if region and (re.match('chr\d+:\d+-\d+', region) or re.match('rs\d+', region)):
         expand = False
 
     try:

--- a/src/encoded/static/components/region_search.js
+++ b/src/encoded/static/components/region_search.js
@@ -199,10 +199,10 @@ class SearchBox extends React.Component {
     handleOnFocus(e) {
         this.setState({ showAutoSuggest: false });
 
-        const query = e.currentTarget.getElementsByClassName('form-control')[0].value;
+        const query = e.currentTarget.getElementsByClassName('form-control')[0].value || '';
         const annotation = e.currentTarget.elements.annotation[0].value;
         const assembly = this.state.genome;
-        this.props.handleSearch(query, annotation, assembly);
+        this.props.handleSearch(query.trim(), annotation, assembly);
 
         e.stopPropagation();
         e.preventDefault();

--- a/src/encoded/static/components/region_search.js
+++ b/src/encoded/static/components/region_search.js
@@ -299,28 +299,22 @@ const RegionSearch = (props, context) => {
     const GV_COORDINATES_ASSEMBLY = 'ENCODE-GV-assembly';
     const GV_COORDINATES_ANNOTATION = 'ENCODE-GV-annotation';
     const GV_FILE_TYPE = 'ENCODE-GV-file-type';
-    const GV_VIEW = 'ENCODE-GV-view';
 
     const initialGBrowserFiles = (props.context.gbrowser || []).filter((file) => supportedFileTypes.indexOf(file.file_format) > -1);
     const availableFileTypes = [...new Set(initialGBrowserFiles.map((file) => file.file_format))];
 
     const { columns, filters, facets, total, coordinates } = props.context;
 
-    let visualization = defaultVisualization;
     let fileTypes = availableFileTypes;
-    if (typeof window !== 'undefined' && window.sessionStorage) {
-        const lastView = window.sessionStorage.getItem(GV_VIEW);
-        if (lastView && lastView.split(',')[0] === coordinates) {
-            visualization = lastView.split(',')[1];
-        }
 
+    if (typeof window !== 'undefined' && window.sessionStorage) {
         const lastFileTypesSelection = window.sessionStorage.getItem(GV_FILE_TYPE);
         if (lastFileTypesSelection && lastFileTypesSelection.split(',')[0] === coordinates) {
             fileTypes = lastFileTypesSelection.split(',')[1];
         }
     }
 
-    const [selectedVisualization, setSelectedVisualization] = React.useState(visualization);
+    const [selectedVisualization, setSelectedVisualization] = React.useState(defaultVisualization);
     const [selectedFileTypes, setSelectedFileTypes] = React.useState(fileTypes);
     const [gBrowserFiles, setGBrowserFiles] = React.useState(initialGBrowserFiles);
 
@@ -390,12 +384,6 @@ const RegionSearch = (props, context) => {
 
     const handleVisualization = (tab) => {
         setGenomeBrowserStorageVariables(props.context.coordinates);
-        if (selectedVisualization === 'Genome Browser') {
-            window.sessionStorage.setItem(GV_VIEW, [props.context.coordinates, 'Genome Browser']);
-        } else {
-            window.sessionStorage.removeItem(GV_VIEW);
-        }
-
         setSelectedVisualization(tab);
     };
 

--- a/src/encoded/static/components/region_search.js
+++ b/src/encoded/static/components/region_search.js
@@ -57,25 +57,27 @@ const AutocompleteBox = (props) => {
 
                     let title = term.title || term.text;
 
-		    if (term.dbxrefs) {
-			if (userTerm.startsWith('hgnc')) {
-			    for (let xref in term.dbxrefs) {
-				if (term.dbxrefs[xref].toLowerCase().startsWith('hgnc')) {
-				    title = term.dbxrefs[xref];
-				}
-			    }
-			} else if (userTerm.startsWith('ensg')) {
-			    for (let xref in term.dbxrefs) {
-				const ensgTerm = term.dbxrefs[xref].split(':').pop();
-				if (ensgTerm.toLowerCase().startsWith('ensg')) {
-				    title = ensgTerm;
-				    if (title == userTerm) {
-					break;
-				    }
-				}
-			    }
-			}
-		    }
+                    if (term.dbxrefs) {
+                        if (userTerm.startsWith('hgnc')) {
+                            Object.keys(term.dbxrefs).forEach((xref) => {
+                                if (term.dbxrefs[xref].toLowerCase().startsWith('hgnc')) {
+                                    title = term.dbxrefs[xref];
+                                }
+                            });
+                        } else if (userTerm.startsWith('ensg')) {
+                            Object.keys(term.dbxrefs).forEach((xref) => {
+                                const ensgTerm = term.dbxrefs[xref].split(':').pop();
+                                if (ensgTerm.toLowerCase().startsWith('ensg')) {
+                                    title = ensgTerm;
+                                    if (title === userTerm) {
+                                        /* eslint-disable no-useless-return */
+                                        return;
+                                        /* eslint-enable no-useless-return */
+                                    }
+                                }
+                            });
+                        }
+                    }
 
                     const locations = term.locations || term._source.annotations;
 
@@ -230,7 +232,7 @@ class SearchBox extends React.Component {
             }
         }
 
-        let suggest = `https://www.encodeproject.org${makeSearchUrl(this.state.searchTerm, this.state.genome)}`;
+        const suggest = `https://www.encodeproject.org${makeSearchUrl(this.state.searchTerm, this.state.genome)}`;
 
         return (
             <Panel>
@@ -317,9 +319,6 @@ const RegionSearch = (props, context) => {
 
     const selectedAssembly = url.parse(context.location_href, true).query.genome || defaultAssembly;
 
-    const searchBase = url.parse(context.location_href).search || '';
-    const trimmedSearchBase = searchBase.replace(/[?|&]limit=all/, '');
-
     const results = props.context['@graph'];
 
     const setGenomeBrowserStorageVariables = (coords) => {
@@ -396,13 +395,6 @@ const RegionSearch = (props, context) => {
         window.location = `/region-search/?region=${encodeURIComponent(query)}&annotation=${annotation}&genome=${assembly}`;
     };
 
-    const handlePagination = (e) => {
-        e.preventDefault();
-        e.stopPropagation();
-
-        window.location = e.currentTarget.getAttribute('href');
-    };
-
     const resultsList = (
         <Panel>
             <PanelBody>
@@ -429,55 +421,48 @@ const RegionSearch = (props, context) => {
     );
 
     const genomeBrowserView = (
-        <div className="outer-tab-container">
-            <div className="tab-body">
-                <Panel>
-                    <PanelBody>
-                        <div className="search-results">
-                            <div className="search-results__facets">
-                                <FacetList
-                                    context={props.context}
-                                    facets={facets}
-                                    filters={filters}
-                                    onFilter={onFilter}
-                                    additionalFacet={
-                                        <>
-                                            <div className="facet ">
-                                                <h5>File Type</h5>
-                                                {availableFileTypes.map((type) => (
-                                                    <button type="button" name={type} className="facet-term annotation-type" onClick={chooseFileType}>
-                                                        {(selectedFileTypes.indexOf(type) > -1) ?
+        <Panel>
+            <PanelBody>
+                <div className="search-results">
+                    <FacetList
+                        context={props.context}
+                        facets={facets}
+                        filters={filters}
+                        onFilter={onFilter}
+                        additionalFacet={
+                            <>
+                                <div className="facet ">
+                                    <h5>File Type</h5>
+                                    {availableFileTypes.map((type) => (
+                                        <button type="button" name={type} className="facet-term annotation-type" onClick={chooseFileType}>
+                                            {(selectedFileTypes.indexOf(type) > -1) ?
                                                             <span className="full-dot dot" />
                                                         :
                                                             <span className="empty-dot dot" />
-                                                        }
-                                                        <div className="facet-term__text">
-                                                            {type}
-                                                        </div>
-                                                    </button>
-                                                ))}
+                                            }
+                                            <div className="facet-term__text">
+                                                {type}
                                             </div>
-                                        </>
-                                    }
-                                />
-                            </div>
-
-                            <div className="search-results__result-list" style={{ display: 'block' }}>
-                                <GenomeBrowser
-                                    files={gBrowserFiles}
-                                    label="cart"
-                                    assembly={selectedAssembly}
-                                    expanded
-                                    annotation={selectedAssembly === 'mm10' ? 'M21' : 'V29'}
-                                    displaySort
-                                    maxCharPerLine={30}
-                                />
-                            </div>
-                        </div>
-                    </PanelBody>
-                </Panel>
-            </div>
-        </div>
+                                        </button>
+                                    ))}
+                                </div>
+                            </>
+                        }
+                    />
+                    <div className="search-results__result-list region-search__gbrowser">
+                        <GenomeBrowser
+                            files={gBrowserFiles}
+                            label="cart"
+                            assembly={selectedAssembly}
+                            expanded
+                            annotation={selectedAssembly === 'mm10' ? 'M21' : 'V29'}
+                            displaySort
+                            maxCharPerLine={30}
+                        />
+                    </div>
+                </div>
+            </PanelBody>
+        </Panel>
     );
 
     return (

--- a/src/encoded/static/components/region_search.js
+++ b/src/encoded/static/components/region_search.js
@@ -298,6 +298,7 @@ const RegionSearch = (props, context) => {
     const GV_COORDINATES_KEY = 'ENCODE-GV-coordinates';
     const GV_COORDINATES_ASSEMBLY = 'ENCODE-GV-assembly';
     const GV_COORDINATES_ANNOTATION = 'ENCODE-GV-annotation';
+    const GV_FILE_TYPE = 'ENCODE-GV-file-type';
     const GV_VIEW = 'ENCODE-GV-view';
 
     const initialGBrowserFiles = (props.context.gbrowser || []).filter((file) => supportedFileTypes.indexOf(file.file_format) > -1);
@@ -306,15 +307,21 @@ const RegionSearch = (props, context) => {
     const { columns, filters, facets, total, coordinates } = props.context;
 
     let visualization = defaultVisualization;
+    let fileTypes = availableFileTypes;
     if (typeof window !== 'undefined' && window.sessionStorage) {
         const lastView = window.sessionStorage.getItem(GV_VIEW);
         if (lastView && lastView.split(',')[0] === coordinates) {
             visualization = lastView.split(',')[1];
         }
+
+        const lastFileTypesSelection = window.sessionStorage.getItem(GV_FILE_TYPE);
+        if (lastFileTypesSelection && lastFileTypesSelection.split(',')[0] === coordinates) {
+            fileTypes = lastFileTypesSelection.split(',')[1];
+        }
     }
 
     const [selectedVisualization, setSelectedVisualization] = React.useState(visualization);
-    const [selectedFileTypes, setSelectedFileTypes] = React.useState(availableFileTypes);
+    const [selectedFileTypes, setSelectedFileTypes] = React.useState(fileTypes);
     const [gBrowserFiles, setGBrowserFiles] = React.useState(initialGBrowserFiles);
 
     const selectedAssembly = url.parse(context.location_href, true).query.genome || defaultAssembly;
@@ -357,6 +364,10 @@ const RegionSearch = (props, context) => {
 
         setSelectedFileTypes(newSelectedTypes);
 
+        if (typeof window !== 'undefined' && window.sessionStorage) {
+            window.sessionStorage.setItem(GV_FILE_TYPE, [props.context.coordinates, newSelectedTypes]);
+        }
+
         e.stopPropagation();
         e.preventDefault();
     };
@@ -377,14 +388,16 @@ const RegionSearch = (props, context) => {
         }
     };
 
-    React.useEffect(() => {
+    const handleVisualization = (tab) => {
         setGenomeBrowserStorageVariables(props.context.coordinates);
         if (selectedVisualization === 'Genome Browser') {
             window.sessionStorage.setItem(GV_VIEW, [props.context.coordinates, 'Genome Browser']);
         } else {
             window.sessionStorage.removeItem(GV_VIEW);
         }
-    }, [selectedVisualization]);
+
+        setSelectedVisualization(tab);
+    };
 
     const visualizationTabs = {};
     visualizationOptions.forEach((visualizationName) => {
@@ -482,7 +495,7 @@ const RegionSearch = (props, context) => {
                         <TabPanel
                             tabs={visualizationTabs}
                             selectedTab={selectedVisualization}
-                            handleTabClick={(tab) => setSelectedVisualization(tab)}
+                            handleTabClick={(tab) => handleVisualization(tab)}
                             tabCss="tab-button"
                             tabPanelCss="tab-container encyclopedia-tabs"
                         >

--- a/src/encoded/static/components/region_search.js
+++ b/src/encoded/static/components/region_search.js
@@ -309,7 +309,7 @@ const RegionSearch = (props, context) => {
     if (typeof window !== 'undefined' && window.sessionStorage) {
         const lastView = window.sessionStorage.getItem(GV_VIEW);
         if (lastView && lastView.split(',')[0] === coordinates) {
-            visualization = lastView[1];
+            visualization = lastView.split(',')[1];
         }
     }
 

--- a/src/encoded/static/scss/encoded/modules/_search.scss
+++ b/src/encoded/static/scss/encoded/modules/_search.scss
@@ -463,7 +463,6 @@ $form-bg: #f3f3f3;
 
 .region-search {
     @at-root #{&}__gbrowser {
-	display: block;
+        display: block;
     }
 }
-

--- a/src/encoded/static/scss/encoded/modules/_search.scss
+++ b/src/encoded/static/scss/encoded/modules/_search.scss
@@ -460,3 +460,10 @@ $form-bg: #f3f3f3;
         display: none;
     }
 }
+
+.region-search {
+    @at-root #{&}__gbrowser {
+	display: block;
+    }
+}
+


### PR DESCRIPTION
Bug fixes:

* HGNC and ENSG autocomplete using gene search endpoint
* Rsid should not expand 2kb
* "View All" button removed
* Genome Browser display bug fixed
* File types selection persisted after filtering facets
* Treated situations where coordinates come in different string cases from search endpoint
* Trailing spaces won't prevent queries from returning empty