### PR TITLE
ENCD-6150 Removing both lifestage and run_type from facets

### DIFF
--- a/src/encoded/schemas/functional_characterization_experiment.json
+++ b/src/encoded/schemas/functional_characterization_experiment.json
@@ -370,9 +370,6 @@
             "title": "Cell",
             "type": "typeahead"
         },
-        "replicates.library.biosample.life_stage": {
-            "title": "Life stage"
-        },
         "replicates.library.biosample.disease_term_name": {
             "title": "Disease"
         },
@@ -394,9 +391,6 @@
         },
         "files.platform.term_name": {
             "title": "Platform"
-        },
-        "files.run_type": {
-            "title": "Run type"
         },
         "replicates.library.nucleic_acid_term_name": {
             "title": "Library material"

--- a/src/encoded/schemas/functional_characterization_series.json
+++ b/src/encoded/schemas/functional_characterization_series.json
@@ -111,17 +111,11 @@
         "related_datasets.replicates.library.biosample.applied_modifications.MOI": {
             "title": "Multiplicity of infection"
         },
-        "related_datasets.replicates.library.biosample.life_stage": {
-            "title": "Life stage"
-        },
         "treatment_term_name": {
             "title": "Biosample treatment"
         },
         "related_datasets.files.file_type": {
             "title": "Available file types"
-        },
-        "related_datsets.files.run_type": {
-            "title": "Run type"
         },
         "related_datasets.replicates.library.nucleic_acid_term_name": {
             "title": "Library material"


### PR DESCRIPTION
ENCD-6150 Removing run_type and life_stage from the functional characterization data types.  They were already missing from transgenic_enhancer_experiment