### PR TITLE
ENCD-6097-allow-series-and-related-datasets-in-cart

### DIFF
--- a/src/encoded/schemas/aggregate_series.json
+++ b/src/encoded/schemas/aggregate_series.json
@@ -155,6 +155,10 @@
             "title": "Target",
             "type": "string"
         },
+        "related_datasets.@id": {
+            "title": "Additional datasets",
+            "type": "string"
+        },
         "related_datasets.replicates.antibody.accession": {
             "title": "Linked antibody",
             "type": "string"

--- a/src/encoded/schemas/differentiation_series.json
+++ b/src/encoded/schemas/differentiation_series.json
@@ -141,6 +141,10 @@
             "title": "Target",
             "type": "string"
         },
+        "related_datasets.@id": {
+            "title": "Additional datasets",
+            "type": "string"
+        },
         "related_datasets.replicates.antibody.accession": {
             "title": "Linked antibody",
             "type": "string"

--- a/src/encoded/schemas/disease_series.json
+++ b/src/encoded/schemas/disease_series.json
@@ -155,6 +155,10 @@
             "title": "Target",
             "type": "string"
         },
+        "related_datasets.@id": {
+            "title": "Additional datasets",
+            "type": "string"
+        },
         "related_datasets.replicates.antibody.accession": {
             "title": "Linked antibody",
             "type": "string"

--- a/src/encoded/schemas/functional_characterization_series.json
+++ b/src/encoded/schemas/functional_characterization_series.json
@@ -245,6 +245,10 @@
             "title": "Target",
             "type": "string"
         },
+        "related_datasets.@id": {
+            "title": "Additional datasets",
+            "type": "string"
+        },
         "related_datasets.replicates.antibody.accession": {
             "title": "Linked antibody",
             "type": "string"

--- a/src/encoded/schemas/gene_silencing_series.json
+++ b/src/encoded/schemas/gene_silencing_series.json
@@ -141,6 +141,10 @@
             "title": "Target",
             "type": "string"
         },
+        "related_datasets.@id": {
+            "title": "Additional datasets",
+            "type": "string"
+        },
         "related_datasets.replicates.antibody.accession": {
             "title": "Linked antibody",
             "type": "string"

--- a/src/encoded/schemas/matched_set.json
+++ b/src/encoded/schemas/matched_set.json
@@ -158,6 +158,10 @@
             "title": "Target",
             "type": "string"
         },
+        "related_datasets.@id": {
+            "title": "Additional datasets",
+            "type": "string"
+        },
         "related_datasets.replicates.antibody.accession": {
             "title": "Linked antibody",
             "type": "string"

--- a/src/encoded/schemas/multiomics_series.json
+++ b/src/encoded/schemas/multiomics_series.json
@@ -153,6 +153,10 @@
             "title": "Target",
             "type": "string"
         },
+        "related_datasets.@id": {
+            "title": "Additional datasets",
+            "type": "string"
+        },
         "related_datasets.replicates.antibody.accession": {
             "title": "Linked antibody",
             "type": "string"

--- a/src/encoded/schemas/organism_development_series.json
+++ b/src/encoded/schemas/organism_development_series.json
@@ -130,6 +130,10 @@
             "title": "Target",
             "type": "string"
         },
+        "related_datasets.@id": {
+            "title": "Additional datasets",
+            "type": "string"
+        },
         "related_datasets.replicates.antibody.accession": {
             "title": "Linked antibody",
             "type": "string"

--- a/src/encoded/schemas/pulse_chase_time_series.json
+++ b/src/encoded/schemas/pulse_chase_time_series.json
@@ -141,6 +141,10 @@
             "title": "Target",
             "type": "string"
         },
+        "related_datasets.@id": {
+            "title": "Additional datasets",
+            "type": "string"
+        },
         "related_datasets.replicates.antibody.accession": {
             "title": "Linked antibody",
             "type": "string"

--- a/src/encoded/schemas/reference_epigenome.json
+++ b/src/encoded/schemas/reference_epigenome.json
@@ -187,6 +187,10 @@
             "title": "Target",
             "type": "string"
         },
+        "related_datasets.@id": {
+            "title": "Additional datasets",
+            "type": "string"
+        },
         "related_datasets.replicates.antibody.accession": {
             "title": "Linked antibody",
             "type": "string"

--- a/src/encoded/schemas/replication_timing_series.json
+++ b/src/encoded/schemas/replication_timing_series.json
@@ -163,6 +163,10 @@
             "title": "Target",
             "type": "string"
         },
+        "related_datasets.@id": {
+            "title": "Additional datasets",
+            "type": "string"
+        },
         "related_datasets.replicates.antibody.accession": {
             "title": "Linked antibody",
             "type": "string"

--- a/src/encoded/schemas/single_cell_rna_series.json
+++ b/src/encoded/schemas/single_cell_rna_series.json
@@ -183,6 +183,10 @@
             "title": "Target",
             "type": "string"
         },
+        "related_datasets.@id": {
+            "title": "Additional datasets",
+            "type": "string"
+        },
         "related_datasets.replicates.antibody.accession": {
             "title": "Linked antibody",
             "type": "string"

--- a/src/encoded/schemas/treatment_concentration_series.json
+++ b/src/encoded/schemas/treatment_concentration_series.json
@@ -136,6 +136,10 @@
             "title": "Target",
             "type": "string"
         },
+        "related_datasets.@id": {
+            "title": "Additional datasets",
+            "type": "string"
+        },
         "related_datasets.replicates.antibody.accession": {
             "title": "Linked antibody",
             "type": "string"

--- a/src/encoded/schemas/treatment_time_series.json
+++ b/src/encoded/schemas/treatment_time_series.json
@@ -141,6 +141,10 @@
             "title": "Target",
             "type": "string"
         },
+        "related_datasets.@id": {
+            "title": "Additional datasets",
+            "type": "string"
+        },
         "related_datasets.replicates.antibody.accession": {
             "title": "Linked antibody",
             "type": "string"

--- a/src/encoded/static/components/antibody.js
+++ b/src/encoded/static/components/antibody.js
@@ -662,7 +662,7 @@ const ListingComponent = (props, reactContext) => {
     }
 
     return (
-        <li className={resultItemClass(result)}>
+        <div className={resultItemClass(result)}>
             <div className="result-item">
                 <div className="result-item__data">
                     {Object.keys(targetTree).map((target) => (
@@ -688,7 +688,7 @@ const ListingComponent = (props, reactContext) => {
                 <PickerActions context={result} />
             </div>
             {props.auditDetail(result.audit, result['@id'], { session: reactContext.session, sessionProperties: reactContext.session_properties })}
-        </li>
+        </div>
     );
 };
 

--- a/src/encoded/static/components/award.js
+++ b/src/encoded/static/components/award.js
@@ -2244,7 +2244,7 @@ Award.contextTypes = {
 globals.contentViews.register(Award, 'Award');
 
 const Listing = ({ context: result }) => (
-    <li className={resultItemClass(result)}>
+    <div className={resultItemClass(result)}>
         <div className="result-item">
             <div className="result-item__data">
                 <a href={result['@id']} className="result-item__link">{result.title}</a>
@@ -2259,7 +2259,7 @@ const Listing = ({ context: result }) => (
             </div>
             <PickerActions context={result} />
         </div>
-    </li>
+    </div>
 );
 
 Listing.propTypes = {

--- a/src/encoded/static/components/biosample_type.js
+++ b/src/encoded/static/components/biosample_type.js
@@ -104,7 +104,7 @@ globals.contentViews.register(BiosampleType, 'BiosampleType');
 
 
 const ListingComponent = ({ context: result, auditIndicators, auditDetail }, reactContext) => (
-    <li className={resultItemClass(result)}>
+    <div className={resultItemClass(result)}>
         <div className="result-item">
             <div className="result-item__data">
                 <a href={result['@id']} className="result-item__link">
@@ -121,7 +121,7 @@ const ListingComponent = ({ context: result, auditIndicators, auditDetail }, rea
             <PickerActions context={result} />
         </div>
         {auditDetail(result.audit, result['@id'], { session: reactContext.session, sessionProperties: reactContext.session_properties, except: result['@id'], forcedEditLink: true })}
-    </li>
+    </div>
 );
 
 ListingComponent.propTypes = {

--- a/src/encoded/static/components/cart/actions.js
+++ b/src/encoded/static/components/cart/actions.js
@@ -93,6 +93,19 @@ export const addMultipleToCartAndSave = (elementAtIds, fetch) => (
 
 
 /**
+ * Manually set the cart state to show an operation is in progress or not. This mostly gets set
+ * automatically when other operations are performed. Use this to set it for other reasons.
+ * @param {boolean} operationInProgress True to set operation in progress
+ * @returns {object} Promise from initiating the operation; probably instantaneous
+ */
+export const cartManualSetOperationInProgress = (operationInProgress) => (
+    (dispatch) => {
+        cartSetOperationInProgress(operationInProgress, dispatch);
+    }
+);
+
+
+/**
  * Redux action creator to remove an element from the cart.
  * @param {string} elementAtId `@id` of element to remove from the cart
  * @param {string} title Title of current file view

--- a/src/encoded/static/components/cart/cart.js
+++ b/src/encoded/static/components/cart/cart.js
@@ -1456,6 +1456,7 @@ const CartComponent = ({ context, savedCartObj, inProgress, fetch, session, loca
                                                 visualizableOnlyChangeHandler: handleVisualizableOnlyChange,
                                                 preferredOnly: defaultOnly,
                                                 preferredOnlyChangeHandler: handlePreferredOnlyChange,
+                                                disabled: displayedTab === 'series',
                                             }}
                                             datasets={selectedDatasets}
                                             files={selectedFiles}

--- a/src/encoded/static/components/cart/cart.js
+++ b/src/encoded/static/components/cart/cart.js
@@ -619,7 +619,7 @@ const addToAccumulatingDatasets = (datasets, currentResults) => {
  * @return {array} `series` with search-result series added
  */
 const addToAccumulatingSeries = (series, currentResults) => {
-    if (currentResults['@graph'] && currentResults['@graph'].length > 0) {
+    if (currentResults['@graph']?.length > 0) {
         const seriesDatasets = currentResults['@graph'].filter((dataset) => hasType(dataset, 'Series'));
 
         // Return a new array combining the existing partial files with the additional files.

--- a/src/encoded/static/components/cart/cart.js
+++ b/src/encoded/static/components/cart/cart.js
@@ -11,7 +11,7 @@ import * as DropdownButton from '../../libs/ui/button';
 import * as Pager from '../../libs/ui/pager';
 import { Panel, PanelBody, PanelHeading, TabPanel, TabPanelPane } from '../../libs/ui/panel';
 import GenomeBrowser, { annotationTypeMap } from '../genome_browser';
-import { itemClass, atIdToType } from '../globals';
+import { itemClass, atIdToType, hasType } from '../globals';
 import {
     ItemAccessories,
     computeAssemblyAnnotationValue,
@@ -21,10 +21,11 @@ import {
     filterForReleasedAnalyses,
     isFileVisualizable,
 } from '../objectutils';
-import { ResultTableList } from '../search';
 import { compileDatasetAnalyses, sortDatasetAnalyses } from './analysis';
 import CartBatchDownload from './batch_download';
 import CartClearButton from './clear';
+import * as constants from './constants';
+import CartViewContext from './context';
 import {
     assembleFileFacets,
     assembleDatasetFacets,
@@ -40,9 +41,11 @@ import {
 import { CartFileViewToggle, CartFileViewOnlyToggle, FileViewControl } from './file_view';
 import CartLockTrigger from './lock';
 import CartMergeShared from './merge_shared';
+import { CartSearchResults } from './search_results';
 import Status from '../status';
 import CartRemoveElements from './remove_multiple';
-import { allowedDatasetTypes, DEFAULT_FILE_VIEW_NAME } from './util';
+import { ManageSeriesModal, useSeriesManager } from './series';
+import { allowedDatasetTypes, calcTotalPageCount, DEFAULT_FILE_VIEW_NAME } from './util';
 
 
 /**
@@ -57,12 +60,12 @@ import { allowedDatasetTypes, DEFAULT_FILE_VIEW_NAME } from './util';
  */
 
 
-/** Number of dataset elements to display per page */
-const PAGE_ELEMENT_COUNT = 25;
-/** Number of genome-browser tracks to display per page */
-const PAGE_TRACK_COUNT = 20;
-/** Number of files to display per page */
-const PAGE_FILE_COUNT = 25;
+/**
+ * Get the value of the dataset `target` property. For series, return the empty string because its `target` is an array.
+ * @param {object} dataset - Dataset object whose target we need
+ * @returns {string} - The value of the `target` property
+ */
+const datasetTarget = (dataset) => (hasType(dataset, 'Series') ? '' : dataset.target);
 
 
 /**
@@ -73,6 +76,7 @@ const requestedFacetFields = displayedFileFacetFields
     .concat(displayedDatasetFacetFields.map((facetField) => ({ ...facetField, dataset: true })))
     .filter((field) => !field.calculated).concat([
         { field: '@id' },
+        { field: 'related_datasets', dataset: true },
         { field: 'accession', dataset: true },
         { field: 'biosample_summary', dataset: true },
         { field: 'assembly' },
@@ -88,7 +92,7 @@ const requestedFacetFields = displayedFileFacetFields
         { field: 'simple_biosample_summary' },
         { field: 'origin_batches' },
         { field: 'analyses', dataset: true },
-        { field: 'target', dataset: true },
+        { field: 'target', dataset: true, getValue: datasetTarget },
         { field: 'targets', dataset: true },
         { field: 'preferred_default' },
         { field: 'annotation_subtype', dataset: true },
@@ -109,54 +113,13 @@ const datasetTabTitles = {
 
 
 /**
- * Display a page of cart contents within the cart display.
- */
-const CartSearchResults = ({ elements, currentPage, cartControls, loading }) => {
-    if (elements.length > 0) {
-        const pageStartIndex = currentPage * PAGE_ELEMENT_COUNT;
-        const currentPageElements = elements.slice(pageStartIndex, pageStartIndex + PAGE_ELEMENT_COUNT);
-        return (
-            <div className="cart-search-results">
-                <ResultTableList results={currentPageElements} cartControls={cartControls} mode="cart-view" />
-            </div>
-        );
-    }
-
-    // No elements and the page isn't currently loading, so indicate no datasets to view.
-    if (!loading) {
-        return <div className="nav result-table cart__empty-message">No visible datasets on this page.</div>;
-    }
-
-    // Page is currently loading, so don't display anything for now.
-    return <div className="nav result-table cart__empty-message">Page currently loading&hellip;</div>;
-};
-
-CartSearchResults.propTypes = {
-    /** Array of cart items */
-    elements: PropTypes.array,
-    /** Page of results to display */
-    currentPage: PropTypes.number,
-    /** True if displaying an active cart */
-    cartControls: PropTypes.bool,
-    /** True if cart currently loading on page */
-    loading: PropTypes.bool.isRequired,
-};
-
-CartSearchResults.defaultProps = {
-    elements: [],
-    currentPage: 0,
-    cartControls: false,
-};
-
-
-/**
  * Display browser tracks for the selected page of files.
  */
 const CartBrowser = ({ files, assembly, pageNumber, loading }) => {
     if (!loading) {
         // Extract the current page of file objects.
-        const pageStartingIndex = pageNumber * PAGE_TRACK_COUNT;
-        const pageFiles = files.slice(pageStartingIndex, pageStartingIndex + PAGE_TRACK_COUNT).map((file) => ({ ...file }));
+        const pageStartingIndex = pageNumber * constants.PAGE_TRACK_COUNT;
+        const pageFiles = files.slice(pageStartingIndex, pageStartingIndex + constants.PAGE_TRACK_COUNT).map((file) => ({ ...file }));
 
         // Shorten long annotation_type values for the Valis track label; fine to mutate `pageFiles` as
         // it holds a copy of a segment of `files`.
@@ -206,8 +169,8 @@ const CartFiles = ({
     loading,
 }) => {
     if (files.length > 0) {
-        const pageStartIndex = currentPage * PAGE_FILE_COUNT;
-        const currentPageFiles = files.slice(pageStartIndex, pageStartIndex + PAGE_ELEMENT_COUNT);
+        const pageStartIndex = currentPage * constants.PAGE_FILE_COUNT;
+        const currentPageFiles = files.slice(pageStartIndex, pageStartIndex + constants.PAGE_ELEMENT_COUNT);
         const pseudoDefaultFiles = files.filter((file) => file.pseudo_default);
         return (
             <div className="cart-list cart-list--file">
@@ -460,8 +423,8 @@ const CartTools = ({
     isFileViewOnly,
 }) => {
     // Make a list of all the dataset types currently in the cart.
-    const usedDatasetTypes = elements.reduce((types, elementAtId) => {
-        const type = atIdToType(elementAtId);
+    const usedDatasetTypes = elements.reduce((types, element) => {
+        const type = atIdToType(element['@id']);
         return types.includes(type) ? types : types.concat(type);
     }, []);
 
@@ -619,29 +582,52 @@ CartSearchResultsControls.defaultProps = {
 };
 
 /**
- * Add the datasets search results to the given array of datasets.
- * @param {array} datasets Add new search results to this array
+ * Add the datasets search results to the given array of datasets, only including individual
+ * datasets -- not series objects.
+ * @param {array} datasets Add new search result individual datasets to this array
  * @param {object} currentResults Dataset search results
  * @return {array} `datasets` with search-result datasets added
  */
 const addToAccumulatingDatasets = (datasets, currentResults) => {
     if (currentResults['@graph'] && currentResults['@graph'].length > 0) {
-        currentResults['@graph'].forEach((dataset) => {
+        // Filter out series datasets; only consider individual datasets.
+        const individualDatasets = currentResults['@graph'].filter((dataset) => !hasType(dataset, 'Series'));
+        individualDatasets.forEach((dataset) => {
             // Mutate the datasets for those properties that need their values altered from how
             // they appear in search results.
-            displayedDatasetFacetFields.forEach((facetField) => {
+            requestedFacetFields.forEach((facetField) => {
                 if (facetField.getValue) {
                     dataset[facetField.field] = facetField.getValue(dataset);
                 }
             });
         });
 
-        // Return a new array combining the existing partial files with the additional files.
-        return datasets.concat(currentResults['@graph']);
+        // Return a new array combining the existing individual datasets with the datasets from
+        // the given search results.
+        return datasets.concat(individualDatasets);
     }
 
     // No search results; just return unchanged list of datasets.
     return datasets;
+};
+
+
+/**
+ * Add the series search results to the given array of series.
+ * @param {array} series Add new search results to this array
+ * @param {object} currentResults Dataset search results
+ * @return {array} `series` with search-result series added
+ */
+const addToAccumulatingSeries = (series, currentResults) => {
+    if (currentResults['@graph'] && currentResults['@graph'].length > 0) {
+        const seriesDatasets = currentResults['@graph'].filter((dataset) => hasType(dataset, 'Series'));
+
+        // Return a new array combining the existing partial files with the additional files.
+        return series.concat(seriesDatasets);
+    }
+
+    // No search results; just return unchanged list of datasets.
+    return series;
 };
 
 
@@ -828,6 +814,33 @@ const processDatasetTargetList = (datasets) => {
 
 
 /**
+ * Fill in a `_relatedSeries` property of each of the given `datasets` objects with an array of the
+ * @ids of the given `series` objects that include each dataset. That allows you to see what series
+ * objects include a given dataset, if any.
+ * @param {object} series Array of series objects in cart to apply to their related datasets
+ * @param {object} datasets Array of dataset objects in cart to apply their related series
+ */
+const processSeriesDatasets = (series, datasets) => {
+    if (series && series.length > 0) {
+        series.forEach((singleSeries) => {
+            if (singleSeries.related_datasets && singleSeries.related_datasets.length > 0) {
+                singleSeries.related_datasets.forEach((relatedDataset) => {
+                    const matchingRelatedDataset = datasets.find((dataset) => relatedDataset['@id'] === dataset['@id']);
+                    if (matchingRelatedDataset) {
+                        if (matchingRelatedDataset._relatedSeries) {
+                            matchingRelatedDataset._relatedSeries.push(singleSeries['@id']);
+                        } else {
+                            matchingRelatedDataset._relatedSeries = [singleSeries['@id']];
+                        }
+                    }
+                });
+            }
+        });
+    }
+};
+
+
+/**
  * Use the following order when sorting files by status for evaluating pseudo-default files.
  */
 const pseudoDefaultFileStatusOrder = ['released', 'archived', 'in progress'];
@@ -973,17 +986,19 @@ const retrieveDatasetsFiles = (datasetsIds, facetProgressHandler, fetch, session
                 return {
                     datasetFiles: addToAccumulatingFiles(accumulatingResults.datasetFiles, currentResults),
                     datasets: addToAccumulatingDatasets(accumulatingResults.datasets, currentResults),
+                    series: addToAccumulatingSeries(accumulatingResults.series, currentResults),
                     datasetAnalyses: addToAccumulatingAnalyses(accumulatingResults.datasetAnalyses, currentResults),
                 };
             })
         ))
-    ), Promise.resolve({ datasetFiles: [], datasets: [], datasetAnalyses: [] })).then(({ datasetFiles, datasets, datasetAnalyses }) => {
+    ), Promise.resolve({ datasetFiles: [], datasets: [], series: [], datasetAnalyses: [] })).then(({ datasetFiles, datasets, series, datasetAnalyses }) => {
         facetProgressHandler(-1);
 
         // Mutate the files or datasets for their calculated properties.
         processFilesAnalyses(datasetFiles, datasetAnalyses);
         processDatasetTargetList(datasets);
-        return { datasetFiles, datasets, datasetAnalyses: sortDatasetAnalyses(datasetAnalyses) };
+        processSeriesDatasets(series, datasets);
+        return { datasetFiles, datasets, series, datasetAnalyses: sortDatasetAnalyses(datasetAnalyses) };
     });
 };
 
@@ -1033,17 +1048,6 @@ const reducerTabPaneTotalPageCount = (state, action) => {
 
 
 /**
- * Calculate the total number of pages needed to display all items in any of the tab panes
- * (datasets, files, etc.).
- * @param {number} itemCount Total number of items being displayed on pages
- * @param {number} maxCount Maximum number of items per page
- *
- * @return {number} Number of pages to contain all items
- */
-const calcTotalPageCount = (itemCount, maxCount) => Math.floor(itemCount / maxCount) + (itemCount % maxCount !== 0 ? 1 : 0);
-
-
-/**
  * Renders the cart search results page. Display either:
  * 1. OBJECT (/carts/<uuid>)
  *    * context contains items to display (shared cart).
@@ -1060,14 +1064,16 @@ const CartComponent = ({ context, savedCartObj, inProgress, fetch, session, loca
     const [selectedFileTerms, setSelectedFileTerms] = React.useState({});
     // Array of datasets the user has access to view; subset of `cartDatasets`.
     const [viewableDatasets, setViewableDatasets] = React.useState([]);
+    // Array of series objects in the cart.
+    const [allSeries, setAllSeries] = React.useState([]);
     // True if the user has selected viewing only file view files
     const [isFileViewOnly, setIsFileViewOnly] = React.useState(false);
     // Compiled analyses applicable to the current datasets.
     const [analyses, setAnalyses] = React.useState([]);
     // Currently displayed page number for each tab panes; for pagers.
-    const [pageNumbers, dispatchPageNumbers] = React.useReducer(reducerTabPanePageNumber, { datasets: 0, browser: 0, processeddata: 0, rawdata: 0 });
+    const [pageNumbers, dispatchPageNumbers] = React.useReducer(reducerTabPanePageNumber, { series: 0, datasets: 0, browser: 0, processeddata: 0, rawdata: 0 });
     // Total number of displayed pages for each tab pane; for pagers.
-    const [totalPageCount, dispatchTotalPageCounts] = React.useReducer(reducerTabPaneTotalPageCount, { datasets: 0, browser: 0, processeddata: 0, rawdata: 0 });
+    const [totalPageCount, dispatchTotalPageCounts] = React.useReducer(reducerTabPaneTotalPageCount, { series: 0, datasets: 0, browser: 0, processeddata: 0, rawdata: 0 });
     // Currently displayed tab; match key of first TabPanelPane initially.
     const [displayedTab, setDisplayedTab] = React.useState('datasets');
     // Facet-loading progress bar value; null=indeterminate; -1=disable
@@ -1080,6 +1086,8 @@ const CartComponent = ({ context, savedCartObj, inProgress, fetch, session, loca
     const [allFiles, setAllFiles] = React.useState([]);
     // Tracks previous contents of `cartDatasets` to know if the cart contents have changed.
     const cartDatasetsRef = React.useRef([]);
+    // Series manager states and actions.
+    const seriesManager = useSeriesManager();
 
     // Retrieve current unfiltered cart information regardless of its source (object or active).
     // Determine if the cart contents have changed.
@@ -1117,7 +1125,7 @@ const CartComponent = ({ context, savedCartObj, inProgress, fetch, session, loca
             return assembleDatasetFacets(selectedDatasetTerms, viewableDatasets, displayedDatasetFacetFields);
         }
         return { datasetFacets: null, selectedDatasets: viewableDatasets };
-    }, [selectedDatasetTerms, viewableDatasets, isFileViewOnly]);
+    }, [selectedDatasetTerms, viewableDatasets, isFileViewOnly, isCartDatasetsChanged]);
 
     // Build the file facets based on the currently selected facet terms.
     const selectedDatasetFiles = React.useMemo(() => filterForDatasetFiles(allFiles, selectedDatasets), [allFiles, selectedDatasets]);
@@ -1334,7 +1342,7 @@ const CartComponent = ({ context, savedCartObj, inProgress, fetch, session, loca
     // permission level and from them extract all their files.
     React.useEffect(() => {
         if (isCartDatasetsChanged) {
-            retrieveDatasetsFiles(cartDatasets, setFacetProgress, fetch, session).then(({ datasetFiles, datasets, datasetAnalyses }) => {
+            retrieveDatasetsFiles(cartDatasets, setFacetProgress, fetch, session).then(({ datasetFiles, datasets, series, datasetAnalyses }) => {
                 // Mutate files for special cases.
                 datasetFiles.forEach((file) => {
                     // De-embed any embedded datasets.files.dataset.
@@ -1345,6 +1353,7 @@ const CartComponent = ({ context, savedCartObj, inProgress, fetch, session, loca
 
                 setAllFiles(datasetFiles);
                 setViewableDatasets(datasets);
+                setAllSeries(series);
                 setAnalyses(datasetAnalyses);
             });
         }
@@ -1352,16 +1361,21 @@ const CartComponent = ({ context, savedCartObj, inProgress, fetch, session, loca
 
     // Data changes or initial load need a total-page-count calculation.
     React.useEffect(() => {
-        const datasetPageCount = calcTotalPageCount(selectedDatasets.length, PAGE_ELEMENT_COUNT);
-        const browserPageCount = calcTotalPageCount(selectedVisualizableFiles.length, PAGE_TRACK_COUNT);
-        const processedDataPageCount = calcTotalPageCount(selectedFiles.length, PAGE_FILE_COUNT);
-        const rawdataPageCount = calcTotalPageCount(rawdataFiles.length, PAGE_FILE_COUNT);
+        const seriesPageCount = calcTotalPageCount(allSeries.length, constants.PAGE_ELEMENT_COUNT);
+        const datasetPageCount = calcTotalPageCount(selectedDatasets.length, constants.PAGE_ELEMENT_COUNT);
+        const browserPageCount = calcTotalPageCount(selectedVisualizableFiles.length, constants.PAGE_TRACK_COUNT);
+        const processedDataPageCount = calcTotalPageCount(selectedFiles.length, constants.PAGE_FILE_COUNT);
+        const rawdataPageCount = calcTotalPageCount(rawdataFiles.length, constants.PAGE_FILE_COUNT);
+        dispatchTotalPageCounts({ tab: 'series', totalPageCount: seriesPageCount });
         dispatchTotalPageCounts({ tab: 'datasets', totalPageCount: datasetPageCount });
         dispatchTotalPageCounts({ tab: 'browser', totalPageCount: browserPageCount });
         dispatchTotalPageCounts({ tab: 'processeddata', totalPageCount: processedDataPageCount });
         dispatchTotalPageCounts({ tab: 'rawdata', totalPageCount: rawdataPageCount });
 
         // Go to first page if current page number goes out of range of new page count.
+        if (pageNumbers.series >= seriesPageCount) {
+            dispatchPageNumbers({ tab: 'series', pageNumber: 0 });
+        }
         if (pageNumbers.datasets >= datasetPageCount) {
             dispatchPageNumbers({ tab: 'datasets', pageNumber: 0 });
         }
@@ -1377,196 +1391,218 @@ const CartComponent = ({ context, savedCartObj, inProgress, fetch, session, loca
     }, [selectedDatasets, selectedVisualizableFiles, selectedFiles, rawdataFiles, pageNumbers.datasets, pageNumbers.browser, pageNumbers.processeddata, pageNumbers.rawdata]);
 
     return (
-        <div className={itemClass(context, 'view-item')}>
-            <header>
-                <h1>{cartName}</h1>
-                <CartAccessories
-                    savedCartObj={savedCartObj}
-                    viewableDatasets={viewableDatasets}
-                    sharedCart={context}
-                    cartType={cartType}
-                    inProgress={inProgress}
-                />
-                {cartType === 'OBJECT' ? <ItemAccessories item={context} /> : null}
-            </header>
-            <Panel addClasses="cart__result-table">
-                {selectedDatasets.length > 0 ?
-                    <PanelHeading addClasses="cart__header">
-                        <CartTools
-                            elements={cartDatasets}
-                            analyses={analyses}
-                            selectedDatasetType={selectedDatasetType}
-                            savedCartObj={savedCartObj}
-                            selectedFileTerms={selectedFileTerms}
-                            selectedDatasetTerms={selectedDatasetTerms}
-                            facetFields={displayedFileFacetFields.concat(displayedDatasetFacetFields)}
-                            viewableDatasets={viewableDatasets}
-                            cartType={cartType}
-                            sharedCart={context}
-                            fileCounts={{ processed: selectedFiles.length, raw: rawdataFiles.length, all: allFiles.length }}
-                            visualizable={visualizableOnly}
-                            preferredDefault={defaultOnly}
-                            isFileViewOnly={isFileViewOnly}
-                        />
-                        <CartFileViewOnlyToggle
-                            isFileViewOnly={isFileViewOnly}
-                            updateFileViewOnly={handleFileViewOnlyClick}
-                            selectedFilesInFileView={selectedFilesInFileView}
-                        />
-                    </PanelHeading>
-                : null}
-                <PanelBody>
-                    {cartDatasets.length > 0 ?
-                        <div className="cart__display">
-                            {!isFileViewOnly
-                                ?
-                                    <CartFacets
-                                        datasetProps={{
-                                            facets: datasetFacets,
-                                            selectedTerms: selectedDatasetTerms,
-                                            termClickHandler: handleDatasetTermClick,
-                                            clearFacetSelections: clearDatasetFacetSelections,
-                                        }}
-                                        fileProps={{
-                                            facets: fileFacets,
-                                            selectedTerms: selectedFileTerms,
-                                            termClickHandler: handleFileTermClick,
-                                            clearFacetSelections: clearFileFacetSelections,
-                                            usedFacetFields: usedFileFacetFields,
-                                        }}
-                                        options={{
-                                            visualizableOnly,
-                                            visualizableOnlyChangeHandler: handleVisualizableOnlyChange,
-                                            preferredOnly: defaultOnly,
-                                            preferredOnlyChangeHandler: handlePreferredOnlyChange,
-                                        }}
-                                        datasets={selectedDatasets}
-                                        files={selectedFiles}
-                                        facetProgress={facetProgress}
-                                    />
-                                : (
-                                    displayedTab === 'browser'
-                                        ?
-                                            <CartFacetsFileView
-                                                files={selectedVisualizableFiles}
-                                                facetProgress={facetProgress}
-                                                fileProps={{
-                                                    facets: fileFacets,
-                                                    selectedTerms: selectedFileTerms,
-                                                    termClickHandler: handleFileTermClick,
-                                                }}
+        <CartViewContext.Provider
+            value={{
+                allSeriesInCart: allSeries,
+                allDatasetsInCart: viewableDatasets,
+                setManagedSeries: seriesManager.setManagedSeries,
+            }}
+        >
+            <div className={itemClass(context, 'view-item')}>
+                <header>
+                    <h1>{cartName}</h1>
+                    <CartAccessories
+                        savedCartObj={savedCartObj}
+                        viewableDatasets={viewableDatasets}
+                        sharedCart={context}
+                        cartType={cartType}
+                        inProgress={inProgress}
+                    />
+                    {cartType === 'OBJECT' ? <ItemAccessories item={context} /> : null}
+                </header>
+                <Panel addClasses="cart__result-table">
+                    {selectedDatasets.length > 0 ?
+                        <PanelHeading addClasses="cart__header">
+                            <CartTools
+                                elements={viewableDatasets}
+                                selectedFileTerms={selectedFileTerms}
+                                selectedDatasetTerms={selectedDatasetTerms}
+                                selectedDatasetType={selectedDatasetType}
+                                facetFields={displayedFileFacetFields.concat(displayedDatasetFacetFields)}
+                                savedCartObj={savedCartObj}
+                                cartType={cartType}
+                                sharedCart={context}
+                                visualizable={visualizableOnly}
+                                isFileViewOnly={isFileViewOnly}
+                            />
+                            <CartFileViewOnlyToggle
+                                isFileViewOnly={isFileViewOnly}
+                                updateFileViewOnly={handleFileViewOnlyClick}
+                                selectedFilesInFileView={selectedFilesInFileView}
+                            />
+                        </PanelHeading>
+                    : null}
+                    <PanelBody>
+                        {cartDatasets.length > 0 || allSeries.length > 0 ?
+                            <div className="cart__display">
+                                {!isFileViewOnly
+                                    ?
+                                        <CartFacets
+                                            datasetProps={{
+                                                facets: datasetFacets,
+                                                selectedTerms: selectedDatasetTerms,
+                                                termClickHandler: handleDatasetTermClick,
+                                                clearFacetSelections: clearDatasetFacetSelections,
+                                            }}
+                                            fileProps={{
+                                                facets: fileFacets,
+                                                selectedTerms: selectedFileTerms,
+                                                termClickHandler: handleFileTermClick,
+                                                clearFacetSelections: clearFileFacetSelections,
+                                                usedFacetFields: usedFileFacetFields,
+                                            }}
+                                            options={{
+                                                visualizableOnly,
+                                                visualizableOnlyChangeHandler: handleVisualizableOnlyChange,
+                                                preferredOnly: defaultOnly,
+                                                preferredOnlyChangeHandler: handlePreferredOnlyChange,
+                                            }}
+                                            datasets={selectedDatasets}
+                                            files={selectedFiles}
+                                            facetProgress={facetProgress}
+                                        />
+                                    : (
+                                        displayedTab === 'browser'
+                                            ?
+                                                <CartFacetsFileView
+                                                    files={selectedVisualizableFiles}
+                                                    facetProgress={facetProgress}
+                                                    fileProps={{
+                                                        facets: fileFacets,
+                                                        selectedTerms: selectedFileTerms,
+                                                        termClickHandler: handleFileTermClick,
+                                                    }}
+                                                />
+                                            : <CartFacetsStandin files={displayedTab === 'processeddata' ? selectedFiles : []} facetProgress={facetProgress} />
+                                    )
+                                }
+                                <TabPanel
+                                    tabPanelCss="cart__display-content"
+                                    tabs={!isFileViewOnly
+                                        ? {
+                                            series: 'Series',
+                                            datasets: 'All datasets',
+                                            browser: 'Genome browser',
+                                            processeddata: 'Processed data',
+                                            rawdata: 'Raw data',
+                                        } : {
+                                            browser: 'Genome browser',
+                                            processeddata: 'Processed data',
+                                        }
+                                    }
+                                    tabDisplay={!isFileViewOnly
+                                        ? {
+                                            series: <CounterTab title="Series" count={allSeries.length} icon="dataset" voice="series" />,
+                                            datasets: <CounterTab title={`Selected ${selectedDatasetType ? datasetTabTitles[selectedDatasetType] : 'datasets'}`} count={selectedDatasets.length} icon="dataset" voice="selected datasets" />,
+                                            browser: <CounterTab title="Genome browser" count={selectedVisualizableFiles.length} icon="file" voice="visualizable tracks" />,
+                                            processeddata: <CounterTab title="Processed" count={selectedFiles.length} icon="file" voice="processed data files" />,
+                                            rawdata: <CounterTab title="Raw" count={rawdataFiles.length} icon="file" voice="raw data files" />,
+                                        } : {
+                                            browser: <CounterTab title="Genome browser" count={selectedVisualizableFiles.length} icon="file" voice="visualizable tracks" />,
+                                            processeddata: <CounterTab title="Processed" count={selectedFiles.length} icon="file" voice="processed data files" />,
+                                        }
+                                    }
+                                    selectedTab={displayedTab}
+                                    handleTabClick={handleTabClick}
+                                >
+                                    {!isFileViewOnly ?
+                                        <TabPanelPane key="series">
+                                            <CartSearchResults
+                                                elements={allSeries}
+                                                currentPage={pageNumbers.series}
+                                                cartControls={cartType !== 'OBJECT'}
+                                                loading={facetProgress !== -1}
                                             />
-                                        : <CartFacetsStandin files={displayedTab === 'processeddata' ? selectedFiles : []} facetProgress={facetProgress} />
-                                )
-                            }
-                            <TabPanel
-                                tabPanelCss="cart__display-content"
-                                tabs={!isFileViewOnly
-                                    ? {
-                                        datasets: 'All datasets',
-                                        browser: 'Genome browser',
-                                        processeddata: 'Processed data',
-                                        rawdata: 'Raw data',
-                                    } : {
-                                        browser: 'Genome browser',
-                                        processeddata: 'Processed data',
-                                    }
-                                }
-                                tabDisplay={!isFileViewOnly
-                                    ? {
-                                        datasets: <CounterTab title={`Selected ${selectedDatasetType ? datasetTabTitles[selectedDatasetType] : 'datasets'}`} count={selectedDatasets.length} icon="dataset" voice="selected datasets" />,
-                                        browser: <CounterTab title="Genome browser" count={selectedVisualizableFiles.length} icon="file" voice="visualizable tracks" />,
-                                        processeddata: <CounterTab title="Processed data" count={selectedFiles.length} icon="file" voice="processed data files" />,
-                                        rawdata: <CounterTab title="Raw data" count={rawdataFiles.length} icon="file" voice="raw data files" />,
-                                    } : {
-                                        browser: <CounterTab title="Genome browser" count={selectedVisualizableFiles.length} icon="file" voice="visualizable tracks" />,
-                                        processeddata: <CounterTab title="Processed data" count={selectedFiles.length} icon="file" voice="processed data files" />,
-                                    }
-                                }
-                                selectedTab={displayedTab}
-                                handleTabClick={handleTabClick}
-                            >
-                                {!isFileViewOnly ?
-                                    <TabPanelPane key="datasets">
+                                        </TabPanelPane>
+                                    : null}
+                                    {!isFileViewOnly ?
+                                        <TabPanelPane key="datasets">
+                                            <CartSearchResultsControls
+                                                currentTab={displayedTab}
+                                                elements={selectedDatasets}
+                                                currentPage={pageNumbers.datasets}
+                                                totalPageCount={totalPageCount.datasets}
+                                                updateCurrentPage={updateDisplayedPage}
+                                                cartType={cartType}
+                                                loading={facetProgress !== -1}
+                                            />
+                                            <CartSearchResults
+                                                elements={selectedDatasets}
+                                                currentPage={pageNumbers.datasets}
+                                                cartControls={cartType !== 'OBJECT'}
+                                                loading={facetProgress !== -1}
+                                            />
+                                        </TabPanelPane>
+                                    : null}
+                                    <TabPanelPane key="browser">
                                         <CartSearchResultsControls
                                             currentTab={displayedTab}
                                             elements={selectedDatasets}
-                                            currentPage={pageNumbers.datasets}
-                                            totalPageCount={totalPageCount.datasets}
+                                            currentPage={pageNumbers.browser}
+                                            totalPageCount={totalPageCount.browser}
                                             updateCurrentPage={updateDisplayedPage}
                                             cartType={cartType}
                                             loading={facetProgress !== -1}
                                         />
-                                        <CartSearchResults
-                                            elements={selectedDatasets}
-                                            currentPage={pageNumbers.datasets}
-                                            cartControls={cartType !== 'OBJECT'}
-                                            loading={facetProgress !== -1}
-                                        />
+                                        {selectedFileTerms.assembly && selectedFileTerms.assembly.length > 0
+                                            ? <CartBrowser files={selectedVisualizableFiles} assembly={selectedFileTerms.assembly[0]} pageNumber={pageNumbers.browser} loading={facetProgress !== -1} />
+                                            : null}
                                     </TabPanelPane>
-                                : null}
-                                <TabPanelPane key="browser">
-                                    <CartSearchResultsControls
-                                        currentTab={displayedTab}
-                                        elements={selectedDatasets}
-                                        currentPage={pageNumbers.browser}
-                                        totalPageCount={totalPageCount.browser}
-                                        updateCurrentPage={updateDisplayedPage}
-                                        cartType={cartType}
-                                        loading={facetProgress !== -1}
-                                    />
-                                    {selectedFileTerms.assembly && selectedFileTerms.assembly.length > 0
-                                        ? <CartBrowser files={selectedVisualizableFiles} assembly={selectedFileTerms.assembly[0]} pageNumber={pageNumbers.browser} loading={facetProgress !== -1} />
-                                        : null}
-                                </TabPanelPane>
-                                <TabPanelPane key="processeddata">
-                                    <CartSearchResultsControls
-                                        currentTab={displayedTab}
-                                        elements={selectedDatasets}
-                                        currentPage={pageNumbers.processeddata}
-                                        totalPageCount={totalPageCount.processeddata}
-                                        updateCurrentPage={updateDisplayedPage}
-                                        fileViewOptions={{
-                                            filesToAddToFileView: filterForVisualizableFiles(selectedFiles),
-                                            fileViewName: DEFAULT_FILE_VIEW_NAME,
-                                            fileViewControlsEnabled: true,
-                                            isFileViewOnly,
-                                        }}
-                                        cartType={cartType}
-                                        loading={facetProgress !== -1}
-                                    />
-                                    <CartFiles
-                                        files={selectedFiles}
-                                        isFileViewOnly={isFileViewOnly}
-                                        selectedFilesInFileView={selectedFilesInFileView}
-                                        currentPage={pageNumbers.processeddata}
-                                        defaultOnly={defaultOnly}
-                                        cartType={cartType}
-                                        loading={facetProgress !== -1}
-                                    />
-                                </TabPanelPane>
-                                {!isFileViewOnly ?
-                                    <TabPanelPane key="rawdata">
+                                    <TabPanelPane key="processeddata">
                                         <CartSearchResultsControls
                                             currentTab={displayedTab}
                                             elements={selectedDatasets}
-                                            currentPage={pageNumbers.rawdata}
-                                            totalPageCount={totalPageCount.rawdata}
+                                            currentPage={pageNumbers.processeddata}
+                                            totalPageCount={totalPageCount.processeddata}
                                             updateCurrentPage={updateDisplayedPage}
+                                            fileViewOptions={{
+                                                filesToAddToFileView: filterForVisualizableFiles(selectedFiles),
+                                                fileViewName: DEFAULT_FILE_VIEW_NAME,
+                                                fileViewControlsEnabled: true,
+                                                isFileViewOnly,
+                                            }}
                                             cartType={cartType}
                                             loading={facetProgress !== -1}
                                         />
-                                        <CartFiles files={rawdataFiles} currentPage={pageNumbers.rawdata} cartType={cartType} loading={facetProgress !== -1} />
+                                        <CartFiles
+                                            files={selectedFiles}
+                                            isFileViewOnly={isFileViewOnly}
+                                            selectedFilesInFileView={selectedFilesInFileView}
+                                            currentPage={pageNumbers.processeddata}
+                                            defaultOnly={defaultOnly}
+                                            cartType={cartType}
+                                            loading={facetProgress !== -1}
+                                        />
                                     </TabPanelPane>
-                                : null}
-                            </TabPanel>
-                        </div>
-                    :
-                        <p className="cart__empty-message">Empty cart</p>
-                    }
-                </PanelBody>
-            </Panel>
-        </div>
+                                    {!isFileViewOnly ?
+                                        <TabPanelPane key="rawdata">
+                                            <CartSearchResultsControls
+                                                currentTab={displayedTab}
+                                                elements={selectedDatasets}
+                                                currentPage={pageNumbers.rawdata}
+                                                totalPageCount={totalPageCount.rawdata}
+                                                updateCurrentPage={updateDisplayedPage}
+                                                cartType={cartType}
+                                                loading={facetProgress !== -1}
+                                            />
+                                            <CartFiles files={rawdataFiles} currentPage={pageNumbers.rawdata} cartType={cartType} loading={facetProgress !== -1} />
+                                        </TabPanelPane>
+                                    : null}
+                                </TabPanel>
+                            </div>
+                        :
+                            <p className="cart__empty-message">Empty cart</p>
+                        }
+                    </PanelBody>
+                </Panel>
+                {seriesManager.isSeriesManagerOpen && (
+                    <ManageSeriesModal
+                        series={seriesManager.managedSeries}
+                        onCloseModalClick={() => seriesManager.setManagedSeries(null)}
+                    />
+                )}
+            </div>
+        </CartViewContext.Provider>
     );
 };
 

--- a/src/encoded/static/components/cart/constants.js
+++ b/src/encoded/static/components/cart/constants.js
@@ -1,0 +1,18 @@
+/**
+ * Pager controls for each tab.
+ */
+/** Number of dataset elements to display per page */
+export const PAGE_ELEMENT_COUNT = 25;
+/** Number of genome-browser tracks to display per page */
+export const PAGE_TRACK_COUNT = 20;
+/** Number of files to display per page */
+export const PAGE_FILE_COUNT = 25;
+/** Number of datasets to display at a time in series manager modal */
+export const SERIES_MANAGER_DATASET_COUNT = 6;
+
+
+/**
+ * Series types that don't allow their related datasets to be removed from the cart independently
+ * of the series.
+ */
+export const obligateSeriesTypes = ['SingleCellRnaSeries', 'FunctionalCharacterizationSeries'];

--- a/src/encoded/static/components/cart/context.js
+++ b/src/encoded/static/components/cart/context.js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+
+/**
+ * Context to pass data from main cart view component to grandchild components.
+ */
+const CartViewContext = React.createContext({});
+
+export default CartViewContext;

--- a/src/encoded/static/components/cart/facet.js
+++ b/src/encoded/static/components/cart/facet.js
@@ -2,9 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'underscore';
 import { Modal, ModalHeader, ModalBody } from '../../libs/ui/modal';
+import { keyCode } from '../../libs/constants';
 import { svgIcon } from '../../libs/svg-icons';
 import { tintColor, isLight } from '../datacolors';
-import { keyCode } from '../globals';
 import {
     isFileVisualizable,
     computeAssemblyAnnotationValue,

--- a/src/encoded/static/components/cart/facet.js
+++ b/src/encoded/static/components/cart/facet.js
@@ -1030,6 +1030,7 @@ export const CartFacets = ({
                     </ModalBody>
                 </Modal>
             : null}
+            {options.disabled ? <div className="cart__facet-disabled-overlay" /> : null}
         </div>
     );
 };
@@ -1069,6 +1070,8 @@ CartFacets.propTypes = {
         preferredOnly: PropTypes.bool,
         /** Called when the user changes the checkbox for viewing default files only */
         preferredOnlyChangeHandler: PropTypes.func,
+        /** True to disable the facets entirely */
+        disabled: PropTypes.bool,
     }).isRequired,
     /** Currently selected datasets */
     datasets: PropTypes.array.isRequired,

--- a/src/encoded/static/components/cart/remove_multiple.js
+++ b/src/encoded/static/components/cart/remove_multiple.js
@@ -30,9 +30,9 @@ const CartRemoveElementsModalComponent = ({ elements, closeClickHandler, removeM
             <ModalHeader labelId="label-remove-selected" title="Remove selected datasets from cart" closeModal={closeClickHandler} />
             <ModalBody>
                 <p id="description-remove-selected">
-                    Remove the {elements.length} currently selected datasets from the cart. Series
-                    datasets remain in the cart and can only be removed as a part of a series. This
-                    action is not reversible.
+                    Remove the {elements.length === 1 ? 'currently selected dataset' : `${elements.length} currently selected datasets`} from
+                    the cart. Series datasets remain in the cart and can only be removed as a part
+                    of a series. This action is not reversible.
                 </p>
             </ModalBody>
             <ModalFooter
@@ -135,9 +135,7 @@ const CartRemoveElementsComponent = ({
             <div className="remove-multiple-control__note">
                 Any datasets belonging to a series remain after removing the selected items from the cart.
             </div>
-            {isModalVisible
-                ? <CartRemoveElementsModal elements={nonSeriesDatasets} closeClickHandler={handleCloseClick} />
-                : null}
+            {isModalVisible && <CartRemoveElementsModal elements={nonSeriesDatasets} closeClickHandler={handleCloseClick} />}
         </div>
     );
 };

--- a/src/encoded/static/components/cart/remove_multiple.js
+++ b/src/encoded/static/components/cart/remove_multiple.js
@@ -29,7 +29,11 @@ const CartRemoveElementsModalComponent = ({ elements, closeClickHandler, removeM
         <Modal labelId="label-remove-selected" descriptionId="description-remove-selected" focusId="close-remove-items">
             <ModalHeader labelId="label-remove-selected" title="Remove selected datasets from cart" closeModal={closeClickHandler} />
             <ModalBody>
-                <p id="description-remove-selected">Remove the {elements.length} currently selected datasets from the cart. This action is not reversible.</p>
+                <p id="description-remove-selected">
+                    Remove the {elements.length} currently selected datasets from the cart. Series
+                    datasets remain in the cart and can only be removed as a part of a series. This
+                    action is not reversible.
+                </p>
             </ModalBody>
             <ModalFooter
                 closeModal={<button type="button" id="close-remove-items" onClick={closeClickHandler} className="btn btn-default">Cancel</button>}
@@ -101,6 +105,9 @@ const CartRemoveElementsComponent = ({
     /** True if the alert modal is visible */
     const [isModalVisible, setIsModalVisible] = React.useState(false);
 
+    // Filter the given elements so we only remove datasets not within a series.
+    const nonSeriesDatasets = elements.filter((element) => !element._relatedSeries);
+
     /**
      * Handle a click in the actuator button to open the alert modal.
      */
@@ -116,19 +123,22 @@ const CartRemoveElementsComponent = ({
     };
 
     return (
-        <>
+        <div className="remove-multiple-control">
             <button
                 type="button"
-                disabled={loading || inProgress || (savedCartObj && savedCartObj.locked)}
+                disabled={nonSeriesDatasets.length === 0 || loading || inProgress || (savedCartObj && savedCartObj.locked)}
                 className="btn btn-info btn-sm"
                 onClick={handleOpenClick}
             >
                 Remove selected items from cart
             </button>
+            <div className="remove-multiple-control__note">
+                Any datasets belonging to a series remain after removing the selected items from the cart.
+            </div>
             {isModalVisible
-                ? <CartRemoveElementsModal elements={elements} closeClickHandler={handleCloseClick} />
+                ? <CartRemoveElementsModal elements={nonSeriesDatasets} closeClickHandler={handleCloseClick} />
                 : null}
-        </>
+        </div>
     );
 };
 

--- a/src/encoded/static/components/cart/search_results.js
+++ b/src/encoded/static/components/cart/search_results.js
@@ -1,0 +1,103 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { hasType } from '../globals';
+import { Listing } from '../search';
+import * as constants from './constants';
+import CartViewContext from './context';
+import SeriesManagerActuator from './series';
+
+
+/**
+ * List of search results for the cart series and dataset views.
+ */
+export const CartResultTableList = ({ results, cartControls }) => {
+    const { allSeriesInCart } = React.useContext(CartViewContext);
+    return (
+        <ul className="result-table" id="result-table">
+            {results.length > 0 ?
+                results.map((result) => {
+                    // Determine if a dataset should have no cart controls even with `cartControls`
+                    // true.
+                    let seriesOfDataset;
+                    const isSeries = hasType(result, 'Series');
+                    const isSeriesDataset = result._relatedSeries;
+                    if (isSeries) {
+                        // Search result is a series object. Display its series manager actuator.
+                        seriesOfDataset = [result];
+                    } else if (isSeriesDataset) {
+                        // Search result it a related dataset to a series. Find each of the related
+                        // series that exist in the cart to display their series manager actuators.
+                        seriesOfDataset = result._relatedSeries.map((seriesPath) => (
+                            allSeriesInCart.find((seriesInCart) => seriesPath === seriesInCart['@id'])
+                        )).filter((series) => series);
+                    }
+
+                    return (
+                        <li key={result['@id']} className="result-item__wrapper">
+                            {Listing({ context: result, cartControls: !(isSeries || isSeriesDataset) && cartControls, mode: 'cart-view' })}
+                            {(isSeries || isSeriesDataset) && (
+                                <>
+                                    {seriesOfDataset.map((singleSeriesOfDataset) => (
+                                        <SeriesManagerActuator key={singleSeriesOfDataset['@id']} singleSeries={singleSeriesOfDataset} />
+                                    ))}
+                                </>
+                            )}
+                        </li>
+                    );
+                })
+            : null}
+        </ul>
+    );
+};
+
+CartResultTableList.propTypes = {
+    /** Array of search results to display */
+    results: PropTypes.array.isRequired,
+    /** True if items should display with cart controls */
+    cartControls: PropTypes.bool,
+};
+
+CartResultTableList.defaultProps = {
+    cartControls: false,
+};
+
+
+/**
+ * Display a page of cart contents within the cart display.
+ */
+export const CartSearchResults = ({ elements, currentPage, cartControls, loading }) => {
+    if (elements.length > 0) {
+        const pageStartIndex = currentPage * constants.PAGE_ELEMENT_COUNT;
+        const currentPageElements = elements.slice(pageStartIndex, pageStartIndex + constants.PAGE_ELEMENT_COUNT);
+        return (
+            <div className="cart-search-results">
+                <CartResultTableList results={currentPageElements} cartControls={cartControls} />
+            </div>
+        );
+    }
+
+    // No elements and the page isn't currently loading, so indicate no datasets to view.
+    if (!loading) {
+        return <div className="nav result-table cart__empty-message">No visible datasets on this page.</div>;
+    }
+
+    // Page is currently loading, so don't display anything for now.
+    return <div className="nav result-table cart__empty-message">Page currently loading&hellip;</div>;
+};
+
+CartSearchResults.propTypes = {
+    /** Array of cart items */
+    elements: PropTypes.array,
+    /** Page of results to display */
+    currentPage: PropTypes.number,
+    /** True if displaying an active cart */
+    cartControls: PropTypes.bool,
+    /** True if cart currently loading on page */
+    loading: PropTypes.bool.isRequired,
+};
+
+CartSearchResults.defaultProps = {
+    elements: [],
+    currentPage: 0,
+    cartControls: false,
+};

--- a/src/encoded/static/components/cart/series.js
+++ b/src/encoded/static/components/cart/series.js
@@ -44,8 +44,8 @@ const CartSeriesConfirmation = ({ requestRemoveConfirmation }) => {
                 </button>
             </div>
             <div className="cart-series-confirmation__help">
-                Removing a series object also removes its additional datasets from the cart. This
-                action is not reversible.
+                Removing a series object also removes its datasets from the cart. This action is
+                not reversible.
             </div>
         </div>
     );

--- a/src/encoded/static/components/cart/series.js
+++ b/src/encoded/static/components/cart/series.js
@@ -1,0 +1,277 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { Modal, ModalHeader, ModalBody, ModalFooter } from '../../libs/ui/modal';
+import * as Pager from '../../libs/ui/pager';
+import { useMount } from '../hooks';
+import { Listing } from '../search';
+import { cartManualSetOperationInProgress } from './actions';
+import * as constants from './constants';
+import CartViewContext from './context';
+import { calcTotalPageCount, getSeriesDatasets, isObligateSeries } from './util';
+
+
+/**
+ * Display a confirmation modal for removing a series object from the cart. This modal doesn't use
+ * the standard Modal mechanism because nested modals get awkward.
+ */
+const CartSeriesConfirmation = ({ requestRemoveConfirmation }) => {
+    const closeButton = React.useRef();
+
+    React.useEffect(() => {
+        // Focus the close button when the modal is opened.
+        closeButton.current.focus();
+    });
+
+    return (
+        <div className="cart-series-confirmation">
+            <div className="cart-series-confirmation__controls">
+                <button
+                    type="button"
+                    className="btn btn-sm btn-danger cart-series-confirmation__button cart-series-confirmation__button--confirm"
+                    onClick={() => requestRemoveConfirmation(true)}
+                >
+                    Remove series and datasets
+                </button>
+                <button
+                    id="care-series-confirmation-close"
+                    type="button"
+                    className="btn btn-sm cart-series-confirmation__button cart-series-confirmation__button--cancel"
+                    onClick={() => requestRemoveConfirmation(false)}
+                    ref={closeButton}
+                >
+                    Cancel
+                </button>
+            </div>
+            <div className="cart-series-confirmation__help">
+                Removing a series object also removes its additional datasets from the cart. This
+                action is not reversible.
+            </div>
+        </div>
+    );
+};
+
+CartSeriesConfirmation.propTypes = {
+    /** Called when the user confirms or cancels removing a series object */
+    requestRemoveConfirmation: PropTypes.func.isRequired,
+};
+
+
+/**
+ * Displays the modal unconditionally that lets you manage a series object in the cart.
+ */
+const ManageSeriesModalComponent = ({ series, onCloseModalClick, setCartInProgress }) => {
+    /** True if the user has requested removing a series object, but not yet confirmed */
+    const [isRemoveRequested, setIsRemoveRequested] = React.useState(false);
+    /** True if the user has confirmed removing the series object from the cart */
+    const [isRemoveConfirmed, setIsRemoveConfirmed] = React.useState(false);
+    /** Get all datasets currently in the cart to filter against `series` related_datasets */
+    const { allDatasetsInCart, setManagedSeries } = React.useContext(CartViewContext);
+    /** Current displayed page of related datasets */
+    const [currentPage, setCurrentPage] = React.useState(0);
+
+    // Get the datasets that are part of the series.
+    const seriesDatasets = getSeriesDatasets(series, allDatasetsInCart);
+    const totalPageCount = calcTotalPageCount(seriesDatasets.length, constants.SERIES_MANAGER_DATASET_COUNT);
+    const pageStartIndex = currentPage * constants.SERIES_MANAGER_DATASET_COUNT;
+    const currentPageElements = seriesDatasets.slice(pageStartIndex, pageStartIndex + constants.SERIES_MANAGER_DATASET_COUNT);
+
+    // Give a different hint on removing datasets depending on whether the series is obligatory.
+    const datasetRemovalNote = isObligateSeries(series)
+        ? 'Remove the series to remove these datasets from the cart.'
+        : 'Remove independently of the series, or remove all by removing the series';
+
+
+    /**
+     * Called when the user confirms closing the modal without taking action.
+     */
+    const onClose = () => {
+        setCartInProgress(false);
+        onCloseModalClick();
+    };
+
+    /**
+     * Called when the user clicks the "Remove series and datasets" button. Sets new properties to
+     * pass to `Listing` to trigger the removal of the series and its datasets.
+     * @param {boolean} isConfirmed True if the user confirms removing the series object
+     */
+    const requestRemoveConfirmation = (isConfirmed) => {
+        setIsRemoveRequested(false);
+        if (isConfirmed) {
+            setIsRemoveConfirmed(true);
+        }
+        setCartInProgress(false);
+    };
+
+    /**
+     * Called when the user clicks the cart icon in the series management modal to request to
+     * remove the series object from the cart.
+     */
+    const requestRemove = () => {
+        setCartInProgress(true);
+        setIsRemoveRequested(true);
+    };
+
+    /**
+     * Called when removing the series object from the cart has completed.
+     */
+    const onCompleteRemoveSeries = () => {
+        setManagedSeries(null);
+    };
+
+    useMount(() => (
+        // Clicking a link in the modal to the series or related dataset pages also sets the cart
+        // to not-in-progress.
+        () => {
+            setCartInProgress(false);
+        }
+    ));
+
+    React.useEffect(() => {
+        // Reset the current page when the user removes enough related datasets from the cart that
+        // the current page is beyond the new last page.
+        if (currentPage > totalPageCount - 1) {
+            setCurrentPage(totalPageCount - 1);
+        }
+    });
+
+    return (
+        <Modal focusId="manage-series-close" closeModal={onClose}>
+            <ModalHeader title="Manage series" closeModal={onClose} />
+            <ModalBody addCss="manage-series">
+                <div className="manage-series__header">
+                    <h2>Series</h2>
+                </div>
+                <ul className="result-table result-table--manage-series">
+                    <li className="result-item__wrapper">
+                        {Listing({
+                            context: series,
+                            cartControls: true,
+                            mode: 'cart-view',
+                            removeConfirmation: {
+                                requestRemove,
+                                requestRemoveConfirmation,
+                                isRemoveConfirmed,
+                                onCompleteRemoveSeries,
+                            },
+                        })}
+                        {isRemoveRequested && <div className="manage-series__cover" />}
+                    </li>
+                </ul>
+                {seriesDatasets.length > 0 && (
+                    <>
+                        <div className="manage-series__header">
+                            <div className="manage-series__header-title">
+                                <h2>Additional datasets</h2>
+                                <div className="manage-series__removal-note">{datasetRemovalNote}</div>
+                            </div>
+                            <div className="manage-series__header-pagination">
+                                {totalPageCount > 1 &&
+                                    <Pager.Simple total={totalPageCount} current={currentPage} updateCurrentPage={setCurrentPage} />
+                                }
+                            </div>
+                        </div>
+                        <ul className="result-table result-table">
+                            {currentPageElements.map((dataset) => (
+                                <li key={dataset['@id']} className="result-item__wrapper">
+                                    {Listing({
+                                        context: dataset,
+                                        cartControls: !isObligateSeries(series),
+                                        mode: 'cart-view',
+                                        removeConfirmation: {
+                                            requestRemove,
+                                            requestRemoveConfirmation,
+                                            isRemoveConfirmed,
+                                        },
+                                    })}
+                                    {isRemoveRequested && <div className="manage-series__cover" />}
+                                </li>
+                            ))}
+                        </ul>
+                    </>
+                )}
+                {isRemoveRequested && (
+                    <>
+                        <div className="manage-series__cover" />
+                        <CartSeriesConfirmation requestRemoveConfirmation={requestRemoveConfirmation} />
+                    </>
+                )}
+            </ModalBody>
+            <ModalFooter
+                closeModal={
+                    <button
+                        type="button"
+                        id="manage-series-close"
+                        onClick={onClose}
+                    >
+                        Close
+                    </button>
+                }
+            />
+        </Modal>
+    );
+};
+
+ManageSeriesModalComponent.propTypes = {
+    /** Series that contains the given datasets */
+    series: PropTypes.object.isRequired,
+    /** Called when the user closes the modal */
+    onCloseModalClick: PropTypes.func.isRequired,
+    /** Called to set the in-progress state of the cart when confirming removing the series */
+    setCartInProgress: PropTypes.func.isRequired,
+};
+
+ManageSeriesModalComponent.mapDispatchToProps = (dispatch) => ({
+    setCartInProgress: (isInProgress) => dispatch(cartManualSetOperationInProgress(isInProgress)),
+});
+
+export const ManageSeriesModal = connect(null, ManageSeriesModalComponent.mapDispatchToProps)(ManageSeriesModalComponent);
+
+
+export const useSeriesManager = () => {
+    // Series currently appearing in series manager modal.
+    const [singleSeries, setSingleSeries] = React.useState(null);
+
+    /**
+     * Sets the series and its datasets to manage within the modal that appears when these values get set.
+     */
+    const setManagedSeries = (series) => {
+        setSingleSeries(series);
+    };
+
+    /**
+     * True if a series and its related datasets have been set for managing.
+     */
+    const isSeriesManagerOpen = singleSeries;
+
+    return {
+        // States
+        isSeriesManagerOpen,
+        managedSeries: singleSeries,
+        // Actions
+        setManagedSeries,
+    };
+};
+
+
+/**
+ * Renders the button that triggers the display of the series management modal.
+ */
+const SeriesManagerActuator = ({ singleSeries }) => {
+    const { setManagedSeries } = React.useContext(CartViewContext);
+
+    return (
+        <div className="result-item__controls">
+            <button type="button" className="btn btn-info btn-xs" onClick={() => setManagedSeries(singleSeries)}>
+                {`Remove series datasets for ${singleSeries.accession}`}
+            </button>
+        </div>
+    );
+};
+
+SeriesManagerActuator.propTypes = {
+    /** Series that contains the given datasets */
+    singleSeries: PropTypes.object.isRequired,
+};
+
+export default SeriesManagerActuator;

--- a/src/encoded/static/components/cart/util.js
+++ b/src/encoded/static/components/cart/util.js
@@ -4,6 +4,7 @@
 
 import _ from 'underscore';
 import url from 'url';
+import { obligateSeriesTypes } from './constants';
 
 
 /**
@@ -27,6 +28,20 @@ export const allowedDatasetTypes = {
     annotations: { title: 'Annotations', type: 'Annotation' },
     'functional-characterization-experiments': { title: 'Functional characterizations', type: 'FunctionalCharacterizationExperiment' },
     'single-cell-units': { title: 'Single-cell units', type: 'SingleCellUnit' },
+    'aggregate-series': { title: 'Aggregate series', type: 'AggregateSeries' },
+    'differentiation-series': { title: 'Differentiation series', type: 'DifferentiationSeries' },
+    'disease-series': { title: 'Disease series', type: 'DiseaseSeries' },
+    'functional-characterization-series': { title: 'Functional characterization series', type: 'FunctionalCharacterizationSeries' },
+    'gene-silencing-series': { title: 'Gene silencing series', type: 'GeneSilencingSeries' },
+    'matched-set': { title: 'Matched set', type: 'MatchedSet' },
+    'multiomics-series': { title: 'Multiomics series', type: 'MultiomicsSeries' },
+    'organism-development-series': { title: 'Organism development series', type: 'OrganismDevelopmentSeries' },
+    'pulse-chase-time-series': { title: 'Pulse-chase time series', type: 'PulseChaseTimeSeries' },
+    'reference-epigenomes': { title: 'Reference epigenomes', type: 'ReferenceEpigenome' },
+    'replication-timing-series': { title: 'Replication timing series', type: 'ReplicationTimingSeries' },
+    'single-cell-rna-series': { title: 'Single-cell RNA series', type: 'SingleCellRnaSeries' },
+    'treatment-concentration-series': { title: 'Treatment concentration series', type: 'TreatmentConcentrationSeries' },
+    'treatment-time-series': { title: 'Treatment time series', type: 'TreatmentTimeSeries' },
 };
 
 /**
@@ -153,3 +168,38 @@ export const getObjectFieldValue = (object, field) => {
     }
     return value;
 };
+
+
+/**
+ * Test whether the given series object is an obligate series object or not. With obligate series,
+ * you can remove any of its related datasets independently of removing the related series.
+ * Alternatively, with grouping series (non-obligate), you cannot remove any related dataset
+ * without removing the related series object.
+ * @param {object} series Series object to test
+ * @returns {boolean} True if given series is an obligate series type
+ */
+export const isObligateSeries = (series) => (
+    obligateSeriesTypes.includes(series['@type'][0])
+);
+
+
+/**
+ * Get the related datasets from the series that currently exist in the cart.
+ * @param {object} series Series object from which to get related datasets in cart.
+ */
+export const getSeriesDatasets = (series, allDatasetsInCart) => (
+    series.related_datasets.map((relatedDataset) => (
+        allDatasetsInCart.find((cartDataset) => cartDataset['@id'] === relatedDataset['@id'])
+    )).filter((matchingCartDatasets) => !!matchingCartDatasets)
+);
+
+
+/**
+ * Calculate the total number of pages needed to display all items in any of the tab panes
+ * (datasets, files, etc.).
+ * @param {number} itemCount Total number of items being displayed on pages
+ * @param {number} maxCount Maximum number of items per page
+ *
+ * @return {number} Number of pages to contain all items
+ */
+export const calcTotalPageCount = (itemCount, maxCount) => Math.floor(itemCount / maxCount) + (itemCount % maxCount !== 0 ? 1 : 0);

--- a/src/encoded/static/components/dataset.js
+++ b/src/encoded/static/components/dataset.js
@@ -2520,7 +2520,7 @@ export const SeriesComponent = ({
                 <h1>Summary for {title.toLowerCase()} {context.accession}</h1>
                 <DoiRef context={context} />
                 <ReplacementAccessions context={context} />
-                <ItemAccessories item={context} audit={{ auditIndicators, auditId: 'series-audit' }} hasCartControls={seriesType === 'FunctionalCharacterizationSeries'} />
+                <ItemAccessories item={context} audit={{ auditIndicators, auditId: 'series-audit' }} hasCartControls />
             </header>
             {auditDetail(context.audit, 'series-audit', { session: reactContext.session, sessionProperties: reactContext.session_properties, except: context['@id'] })}
             <Panel>

--- a/src/encoded/static/components/donor.js
+++ b/src/encoded/static/components/donor.js
@@ -736,7 +736,7 @@ const DonorListingComponent = (props, reactContext) => {
     ].filter(Boolean);
 
     return (
-        <li className={resultItemClass(result)}>
+        <div className={resultItemClass(result)}>
             <div className="result-item">
                 <div className="result-item__data">
                     <a href={result['@id']} className="result-item__link">
@@ -762,7 +762,7 @@ const DonorListingComponent = (props, reactContext) => {
                 <PickerActions context={result} />
             </div>
             {props.auditDetail(result.audit, result['@id'], { session: reactContext.session, sessionProperties: reactContext.session_properties })}
-        </li>
+        </div>
     );
 };
 

--- a/src/encoded/static/components/experiment_series.js
+++ b/src/encoded/static/components/experiment_series.js
@@ -929,7 +929,7 @@ const ListingComponent = (props, reactContext) => {
     const totalDatasetCount = result.related_datasets.reduce((datasetCount, dataset) => (searchableDatasetStatuses.includes(dataset.status) ? datasetCount + 1 : datasetCount), 0);
 
     return (
-        <li className={resultItemClass(result)}>
+        <div className={resultItemClass(result)}>
             <div className="result-item">
                 <div className="result-item__data">
                     <a href={result['@id']} className="result-item__link">
@@ -966,7 +966,7 @@ const ListingComponent = (props, reactContext) => {
                 <PickerActions context={result} />
             </div>
             {props.auditDetail(result.audit, result['@id'], { session: reactContext.session, sessionProperties: reactContext.session_properties })}
-        </li>
+        </div>
     );
 };
 

--- a/src/encoded/static/components/file.js
+++ b/src/encoded/static/components/file.js
@@ -648,7 +648,7 @@ class ListingComponent extends React.Component {
         const result = this.props.context;
 
         return (
-            <li className={resultItemClass(result)}>
+            <div className={resultItemClass(result)}>
                 <div className="result-item">
                     <div className="result-item__data">
                         <a href={result['@id']} className="result-item__link">
@@ -668,7 +668,7 @@ class ListingComponent extends React.Component {
                     <PickerActions context={result} />
                 </div>
                 {this.props.auditDetail(result.audit, result['@id'], { session: this.context.session, sessionProperties: this.context.session_properties })}
-            </li>
+            </div>
         );
     }
 }

--- a/src/encoded/static/components/gene.js
+++ b/src/encoded/static/components/gene.js
@@ -181,7 +181,7 @@ globals.contentViews.register(Gene, 'Gene');
 const ListingComponent = (props, reactContext) => {
     const result = props.context;
     return (
-        <li className={resultItemClass(result)}>
+        <div className={resultItemClass(result)}>
             <div className="result-item">
                 <div className="result-item__data">
                     <a href={result['@id']} className="result-item__link">
@@ -202,7 +202,7 @@ const ListingComponent = (props, reactContext) => {
                 <PickerActions context={result} />
             </div>
             {props.auditDetail(result.audit, result['@id'], { session: reactContext.session, sessionProperties: reactContext.session_properties })}
-        </li>
+        </div>
     );
 };
 

--- a/src/encoded/static/components/genetic_modification.js
+++ b/src/encoded/static/components/genetic_modification.js
@@ -683,7 +683,7 @@ const ListingComponent = (props, reactContext) => {
     const result = props.context;
 
     return (
-        <li className={resultItemClass(result)}>
+        <div className={resultItemClass(result)}>
             <div className="result-item">
                 <div className="result-item__data">
                     <a href={result['@id']} className="result-item__link">{result.category} &mdash; {result.purpose}</a>
@@ -705,7 +705,7 @@ const ListingComponent = (props, reactContext) => {
                 <PickerActions context={result} />
             </div>
             {props.auditDetail(result.audit, result['@id'], { session: reactContext.session, sessionProperties: reactContext.session_properties })}
-        </li>
+        </div>
     );
 };
 

--- a/src/encoded/static/components/globals.js
+++ b/src/encoded/static/components/globals.js
@@ -44,21 +44,6 @@ documentViews.preview = new Registry();
 documentViews.file = new Registry();
 documentViews.detail = new Registry();
 
-// UNICODE entity codes, needed in JSX string templates. Each property named after the equivalent
-// HTML entity. Add new entries to this object as needed.
-export const uc = {
-    ldquo: '\u201c', // Left double quote
-    rdquo: '\u201d', // Right double quote
-};
-
-// Used to compare keyboard event key codes.
-export const keyCode = {
-    RETURN: 13,
-    ESC: 27,
-    SPACE: 32,
-};
-
-
 // Report-page cell components
 export const reportCell = new Registry();
 
@@ -404,3 +389,12 @@ export const isMediaQueryBreakpointActive = (min) => {
  * @returns Title in title case
  */
 export const titleize = (title) => title?.toLowerCase().replace(/(^|\s)\S/g, (firstLetter) => firstLetter.toUpperCase());
+
+
+/**
+ * Determine whether an object has the matching @type.
+ * @param {object} item Object to check the @type of
+ * @param {string} type Type to check for
+ * @returns {boolean} True if the object has the matching @type
+ */
+export const hasType = (item, type) => item['@type'].includes(type);

--- a/src/encoded/static/components/page.js
+++ b/src/encoded/static/components/page.js
@@ -41,7 +41,7 @@ globals.contentViews.register(Page, 'Page');
 
 
 const Listing = ({ context: result }) => (
-    <li className={resultItemClass(result)}>
+    <div className={resultItemClass(result)}>
         <div className="result-item">
             <div className="result-item__data">
                 <a href={result['@id']} className="result-item__link">{result.title}</a> <span className="page-listing-date">{dayjs.utc(result.date_created).format('MMMM D, YYYY')}</span>
@@ -51,7 +51,7 @@ const Listing = ({ context: result }) => (
             </div>
             <PickerActions context={result} />
         </div>
-    </li>
+    </div>
 );
 
 Listing.propTypes = {

--- a/src/encoded/static/components/pipeline.js
+++ b/src/encoded/static/components/pipeline.js
@@ -576,7 +576,7 @@ class ListingComponent extends React.Component {
         swTitle = _.uniq(swTitle);
 
         return (
-            <li className={resultItemClass(result)}>
+            <div className={resultItemClass(result)}>
                 <div className="result-item">
                     <div className="result-item__data">
                         <a href={result['@id']} className="result-item__link">{result.title}</a>
@@ -603,7 +603,7 @@ class ListingComponent extends React.Component {
                     <PickerActions context={result} />
                 </div>
                 {this.props.auditDetail(result.audit, result['@id'], { session: this.context.session, sessionProperties: this.context.session_properties, forcedEditLink: true })}
-            </li>
+            </div>
         );
     }
 }

--- a/src/encoded/static/components/publication.js
+++ b/src/encoded/static/components/publication.js
@@ -466,7 +466,7 @@ const ListingComponent = (props, context) => {
     const authors = authorList.length === 4 ? `${authorList.splice(0, 3).join(', ')}, et al` : result.authors;
 
     return (
-        <li className={resultItemClass(result)}>
+        <div className={resultItemClass(result)}>
             <div className="result-item">
                 <div className="result-item__data">
                     <a href={result['@id']} className="result-item__link">{result.title}</a>
@@ -493,7 +493,7 @@ const ListingComponent = (props, context) => {
                 <PickerActions context={result} />
             </div>
             {props.auditDetail(result.audit, result['@id'], { session: context.session, sessionProperties: context.session_properties, forcedEditLink: true })}
-        </li>
+        </div>
     );
 };
 

--- a/src/encoded/static/components/search.js
+++ b/src/encoded/static/components/search.js
@@ -207,7 +207,7 @@ const ItemComponent = ({ context: result, auditIndicators, auditDetail }, reactC
     const title = globals.listingTitles.lookup(result)({ context: result });
     const itemType = result['@type'][0];
     return (
-        <li className={resultItemClass(result)}>
+        <div className={resultItemClass(result)}>
             <div className="result-item">
                 <div className="result-item__data">
                     <a href={result['@id']} className="result-item__link">{title}</a>
@@ -224,7 +224,7 @@ const ItemComponent = ({ context: result, auditIndicators, auditDetail }, reactC
                 <PickerActions context={result} />
             </div>
             {auditDetail(result.audit, result['@id'], { session: reactContext.session, sessionProperties: reactContext.session_properties, except: result['@id'], forcedEditLink: true })}
-        </li>
+        </div>
     );
 };
 
@@ -292,7 +292,7 @@ class BiosampleComponent extends React.Component {
         }
 
         return (
-            <li className={resultItemClass(result)}>
+            <div className={resultItemClass(result)}>
                 <div className="result-item">
                     <div className="result-item__data">
                         <a href={result['@id']} className="result-item__link">
@@ -322,7 +322,7 @@ class BiosampleComponent extends React.Component {
                     <PickerActions context={result} />
                 </div>
                 {this.props.auditDetail(result.audit, result['@id'], { session: this.context.session, sessionProperties: this.context.session_properties })}
-            </li>
+            </div>
         );
     }
 }
@@ -483,7 +483,7 @@ const ExperimentComponent = (props, reactContext) => {
     }
 
     return (
-        <li className={resultItemClass(result)}>
+        <div className={resultItemClass(result)}>
             <div className="result-item">
                 <div className="result-item__data">
                     <a href={result['@id']} className="result-item__link">
@@ -624,7 +624,7 @@ const ExperimentComponent = (props, reactContext) => {
                 <PickerActions context={result} />
             </div>
             {props.auditDetail(result.audit, result['@id'], { session: reactContext.session, sessionProperties: reactContext.session_properties })}
-        </li>
+        </div>
     );
 };
 
@@ -656,7 +656,7 @@ globals.listingViews.register(Experiment, 'TransgenicEnhancerExperiment');
 
 
 const AnnotationComponent = ({ context: result, cartControls, mode, auditIndicators, auditDetail }, reactContext) => (
-    <li className={resultItemClass(result)}>
+    <div className={resultItemClass(result)}>
         <div className="result-item">
             <div className="result-item__data">
                 <a href={result['@id']} className="result-item__link">
@@ -687,7 +687,7 @@ const AnnotationComponent = ({ context: result, cartControls, mode, auditIndicat
             <PickerActions context={result} />
         </div>
         {auditDetail(result.audit, result['@id'], { session: reactContext.session, sessionProperties: reactContext.session_properties })}
-    </li>
+    </div>
 );
 
 AnnotationComponent.propTypes = {
@@ -723,7 +723,7 @@ const DatasetComponent = ({ context: result, auditIndicators, auditDetail }, rea
     const isReference = result['@type'][0] === 'Reference';
 
     return (
-        <li className={resultItemClass(result)}>
+        <div className={resultItemClass(result)}>
             <div className="result-item">
                 <div className="result-item__data">
                     <a href={result['@id']} className="result-item__link">
@@ -747,7 +747,7 @@ const DatasetComponent = ({ context: result, auditIndicators, auditDetail }, rea
                 <PickerActions context={result} />
             </div>
             {auditDetail(result.audit, result['@id'], { session: reactContext.session, sessionProperties: reactContext.session_properties })}
-        </li>
+        </div>
     );
 };
 
@@ -770,7 +770,7 @@ globals.listingViews.register(Dataset, 'Dataset');
 /**
  * Renders the search results of all Series dataset objects.
  */
-const SeriesComponent = ({ context: result, auditDetail, auditIndicators }, reactContext) => {
+const SeriesComponent = ({ context: result, cartControls, removeConfirmation, auditDetail, auditIndicators }, reactContext) => {
     let assays = [];
     let organism;
     let crisprReadout = [];
@@ -872,10 +872,10 @@ const SeriesComponent = ({ context: result, auditDetail, auditIndicators }, reac
                         if (lifeStage) {
                             lifeStages.push(lifeStage);
                         }
-                        if (biosample.treatments && (differentiationSeries || fccSeries)) {
+                        if (biosample.treatments?.length > 0 && (differentiationSeries || fccSeries)) {
                             treatmentTerm = [...treatmentTerm, ...biosample.treatments.filter((t) => t.treatment_term_name).map((t) => t.treatment_term_name)];
                         }
-                        if (biosample.treatments && treatmentConcentration) {
+                        if (biosample.treatments?.length > 0 && treatmentConcentration) {
                             treatmentTerm = [...treatmentTerm, ...biosample.treatments.filter((t) => t.treatment_term_name).map((t) => t.treatment_term_name)];
                             treatments = [...treatments, ...biosample.treatments.reduce((output, t) => {
                                 if (t.amount) {
@@ -885,7 +885,7 @@ const SeriesComponent = ({ context: result, auditDetail, auditIndicators }, reac
                             }, [])];
                             treatmentUnit = biosample.treatments[0].amount_units;
                         }
-                        if (biosample.treatments && treatmentTime) {
+                        if (biosample.treatments?.length > 0 && treatmentTime) {
                             treatmentTerm = [...treatmentTerm, ...biosample.treatments.filter((t) => t.treatment_term_name).map((t) => t.treatment_term_name)];
                             treatments = [...treatments, ...biosample.treatments.reduce((output, t) => {
                                 if (t.duration) {
@@ -951,7 +951,7 @@ const SeriesComponent = ({ context: result, auditDetail, auditIndicators }, reac
     }
 
     return (
-        <li className={resultItemClass(result)}>
+        <div className={resultItemClass(result)}>
             <div className="result-item">
                 <div className="result-item__data">
                     <a href={result['@id']} className="result-item__link">
@@ -1054,17 +1054,38 @@ const SeriesComponent = ({ context: result, auditDetail, auditIndicators }, reac
                     <Status item={result.status} badgeSize="small" css="result-table__status" />
                     {auditIndicators(result.audit, result['@id'], { session: reactContext.session, sessionProperties: reactContext.session_properties, search: true })}
                 </div>
+                {cartControls && !(reactContext.actions && reactContext.actions.length > 0) ?
+                    <div className="result-item__cart-control">
+                        <CartToggle element={result} removeConfirmation={removeConfirmation} />
+                    </div>
+                : null}
                 <PickerActions context={result} />
             </div>
             {auditDetail(result.audit, result['@id'], { session: reactContext.session, sessionProperties: reactContext.session_properties })}
-        </li>
+        </div>
     );
 };
 
 SeriesComponent.propTypes = {
     context: PropTypes.object.isRequired, // Dataset search results
+    /** True to display cart toggle button */
+    cartControls: PropTypes.bool,
+    /** Needed for series removals that require user confirmation */
+    removeConfirmation: PropTypes.shape({
+        /** Called by cart toggle when the user requests removing a series object from the cart */
+        requestRemove: PropTypes.func,
+        /** Called when the user confirms removing a series object from the cart */
+        requestRemoveConfirmation: PropTypes.func,
+        /** True if the user has confirmed they want to remove the series object from the cart */
+        isRemoveConfirmed: PropTypes.bool,
+    }),
     auditIndicators: PropTypes.func.isRequired, // Audit decorator function
     auditDetail: PropTypes.func.isRequired, // Audit decorator function
+};
+
+SeriesComponent.defaultProps = {
+    cartControls: false,
+    removeConfirmation: {},
 };
 
 SeriesComponent.contextTypes = {
@@ -1078,7 +1099,7 @@ globals.listingViews.register(Series, 'Series');
 
 
 const TargetComponent = ({ context: result, auditIndicators, auditDetail }, reactContext) => (
-    <li className={resultItemClass(result)}>
+    <div className={resultItemClass(result)}>
         <div className="result-item">
             <div className="result-item__data">
                 <a href={result['@id']} className="result-item__link">
@@ -1098,7 +1119,7 @@ const TargetComponent = ({ context: result, auditIndicators, auditDetail }, reac
             <PickerActions context={result} />
         </div>
         {auditDetail(result.audit, result['@id'], { session: reactContext.session, sessionProperties: reactContext.session_properties, except: result['@id'], forcedEditLink: true })}
-    </li>
+    </div>
 );
 
 TargetComponent.propTypes = {
@@ -1121,7 +1142,7 @@ const Image = (props) => {
     const result = props.context;
 
     return (
-        <li className={resultItemClass(result)}>
+        <div className={resultItemClass(result)}>
             <div className="result-item">
                 <div className="result-item__data">
                     <a href={result['@id']} className="result-item__link">{result['@id']}</a>
@@ -1138,7 +1159,7 @@ const Image = (props) => {
                 </div>
                 <PickerActions context={result} />
             </div>
-        </li>
+        </div>
     );
 };
 
@@ -1902,7 +1923,11 @@ ResultTable.contextTypes = {
 export const ResultTableList = ({ results, columns, cartControls, mode }) => (
     <ul className="result-table" id="result-table">
         {results.length > 0 ?
-            results.map((result) => Listing({ context: result, columns, key: result['@id'], cartControls, mode }))
+            results.map((result) => (
+                <li key={result['@id']} className="result-item__wrapper">
+                    {Listing({ context: result, columns, cartControls, mode })}
+                </li>
+            ))
         : null}
     </ul>
 );

--- a/src/encoded/static/components/software.js
+++ b/src/encoded/static/components/software.js
@@ -162,7 +162,7 @@ SoftwareVersionTable.defaultProps = {
 
 
 const ListingComponent = ({ context: result, auditIndicators, auditDetail }, reactContext) => (
-    <li className={resultItemClass(result)}>
+    <div className={resultItemClass(result)}>
         <div className="result-item">
             <div className="result-item__data">
                 <a href={result['@id']} className="result-item__link">{result.title}</a>
@@ -185,7 +185,7 @@ const ListingComponent = ({ context: result, auditIndicators, auditDetail }, rea
             <PickerActions context={result} />
         </div>
         {auditDetail(result.audit, result['@id'], { session: reactContext.session, sessionProperties: reactContext.session_properties, except: result['@id'], forcedEditLink: true })}
-    </li>
+    </div>
 );
 
 ListingComponent.propTypes = {

--- a/src/encoded/static/libs/constants.js
+++ b/src/encoded/static/libs/constants.js
@@ -1,0 +1,14 @@
+// UNICODE entity codes, needed in JSX string templates. Each property named after the equivalent
+// HTML entity. Add new entries to this object as needed.
+export const uc = {
+    ldquo: '\u201c', // Left double quote
+    rdquo: '\u201d', // Right double quote
+};
+
+// Used to compare keyboard event key codes.
+export const keyCode = {
+    TAB: 9,
+    RETURN: 13,
+    ESC: 27,
+    SPACE: 32,
+};

--- a/src/encoded/static/scss/encoded/modules/_cart.scss
+++ b/src/encoded/static/scss/encoded/modules/_cart.scss
@@ -1554,3 +1554,124 @@ $file-view-checkbox-size: 14px;
         }
     }
 }
+
+.cart-series-confirmation {
+    position: absolute;
+    top: 50px;
+    right: 10%;
+    left: 10%;
+    padding: 10px;
+    border: 1px solid #c0c0c0;
+    background-color: #fff;
+    box-shadow: 0 3px 9px rgba(0, 0, 0, 0.5);
+    z-index: 20;
+
+    @media screen and (min-width: $screen-sm-min) {
+        display: flex;
+        gap: 20px;
+    }
+
+    .cart-series-confirmation__controls {
+        @media screen and (min-width: $screen-sm-min) {
+            order: 2;
+        }
+
+        @media screen and (min-width: $screen-md-min) {
+            display: flex;
+            gap: 5px;
+        }
+    }
+
+    .cart-series-confirmation__help {
+        @media screen and (min-width: $screen-sm-min) {
+            order: 1;
+        }
+    }
+
+    .cart-series-confirmation__button {
+        width: 100%;
+        margin-bottom: 5px;
+        height: 40px;
+
+        @media screen and (min-width: $screen-md-min) {
+            width: auto;
+            height: 29px;
+            padding-top: 0;
+            padding-bottom: 0;
+            margin-bottom: 0;
+        }
+
+        &.cart-series-confirmation__button--confirm {
+            order: 2;
+        }
+
+        &.cart-series-confirmation__button--cancel {
+            order: 1;
+        }
+    }
+}
+
+.manage-series {
+    position: relative;
+
+    .manage-series__header {
+        display: flex;
+        gap: 10px;
+        justify-content: space-between;
+        align-items: center;
+        flex-wrap: wrap;
+        padding: 0 5px;
+        border-top: 1px solid #ccc;
+        border-right: 1px solid #ccc;
+        border-bottom: none;
+        border-left: 1px solid #ccc;
+        background-color: #f0f0f0;
+
+        h2 {
+            margin: 0;
+            font-size: 1rem;
+            border: none;
+        }
+    }
+
+    .manage-series__header-pagination {
+        flex: 0 1 auto;
+
+        .pager {
+            display: block;
+            margin-top: 5px;
+            margin-bottom: 5px;
+        }
+    }
+
+    .manage-series__removal-note {
+        font-size: 0.9rem;
+        font-weight: normal;
+        color: #404040;
+    }
+
+    .manage-series__result-table {
+        position: relative;
+    }
+
+    .manage-series__cover {
+        position: absolute;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
+        backdrop-filter: blur(1px);
+        z-index: 10;
+    }
+}
+
+.result-table.result-table--manage-series {
+    margin-bottom: 10px;
+}
+
+.remove-multiple-control {
+    .remove-multiple-control__note {
+        font-size: 0.9rem;
+        color: #606060;
+    }
+}

--- a/src/encoded/static/scss/encoded/modules/_search.scss
+++ b/src/encoded/static/scss/encoded/modules/_search.scss
@@ -167,6 +167,10 @@ $form-bg: #f3f3f3;
             margin: 0 0 0 25px;
         }
     }
+
+    @at-root #{&}__controls {
+        margin-bottom: 2px;
+    }
 }
 
 .search-list {
@@ -422,6 +426,10 @@ $form-bg: #f3f3f3;
 
     > li {
         border-bottom: 1px solid #e8e8e8;
+
+        &:last-child {
+            border-bottom: none;
+        }
     }
 
     &::before {


### PR DESCRIPTION
Preview demo: ~https://encd-6097-series-cart-pv2-fytanaka.demo.encodedcc.org/~

I moved the `<li>` above the level of `Listing()` so that I could insert the series manager actuators inside the `<li>` on the cart-view page without having to add this actuator to the Listing components. This does however mean I had to change the `<li>` to `<div>` on all existing Listing components.
