### PR TITLE
ENCD-6180-matrix-search

### DIFF
--- a/src/encoded/static/components/body_map.js
+++ b/src/encoded/static/components/body_map.js
@@ -1019,7 +1019,7 @@ export const BodyMapThumbnailAndModal = (props) => {
     };
 
     return (
-        <div className="facet body-map-thumbnail-and-modal">
+        <div className="body-map-thumbnail-and-modal">
             <ClickableThumbnail
                 toggleThumbnail={toggleThumbnail}
                 organism={props.organism}

--- a/src/encoded/static/components/matrix_chip_seq.js
+++ b/src/encoded/static/components/matrix_chip_seq.js
@@ -395,7 +395,7 @@ class ChIPSeqMatrixTextFilter extends TextFilter {
             'Enter any text string such as ac or H3 to filter ChIP target';
 
         return (
-            <div className="facet chip-seq-matrix-search">
+            <div className="chip-seq-matrix-search">
                 <input
                     type="search"
                     className="search-query"

--- a/src/encoded/static/components/search.js
+++ b/src/encoded/static/components/search.js
@@ -1235,16 +1235,14 @@ export class TextFilter extends React.Component {
     */
     render() {
         return (
-            <div className="facet">
-                <input
-                    type="search"
-                    className="search-query"
-                    placeholder="Enter search term(s)"
-                    defaultValue={this.getValue(this.props)}
-                    onKeyDown={this.onKeyDown}
-                    data-test="filter-search-box"
-                />
-            </div>
+            <input
+                type="search"
+                className="search-query"
+                placeholder="Enter search term(s)"
+                defaultValue={this.getValue(this.props)}
+                onKeyDown={this.onKeyDown}
+                data-test="filter-search-box"
+            />
         );
     }
 }

--- a/src/encoded/static/scss/encoded/modules/_matrix.scss
+++ b/src/encoded/static/scss/encoded/modules/_matrix.scss
@@ -1083,7 +1083,12 @@ table.matrix th.group-all-groups-cell {
             }
 
             &--clear {
+                flex: 1 0 auto;
                 min-width: 100px;
+
+                .clear-filters-control {
+                    margin-top: 0;
+                }
             }
         }
 


### PR DESCRIPTION
These search boxes have a `<div className="facet">` that seems to serve no purpose — no styles for the search box depend on being a child of `.facet`. For the grouped-facets change, .facet now has padding that offset these search boxes, so I removed the wrapper div from these search box input elements.

~https://encd-6180-matrix-search-pv1-fytanaka.demo.encodedcc.org/~