### PR TITLE
ENCD-6175-support-collection-series-and-transgenic-enhancer-experiments-in-cart

### DIFF
--- a/src/encoded/schemas/collection_series.json
+++ b/src/encoded/schemas/collection_series.json
@@ -140,6 +140,10 @@
             "title": "Target",
             "type": "string"
         },
+        "related_datasets.@id": {
+            "title": "Additional datasets",
+            "type": "string"
+        },
         "related_datasets.replicates.antibody.accession": {
             "title": "Linked antibody",
             "type": "string"

--- a/src/encoded/static/components/cart/cart.js
+++ b/src/encoded/static/components/cart/cart.js
@@ -110,6 +110,7 @@ const datasetTabTitles = {
     Annotation: 'annotations',
     FunctionalCharacterizationExperiment: 'FCEs',
     SingleCellUnit: 'single-cell units',
+    TransgenicEnhancerExperiment: 'TEEs',
 };
 
 
@@ -422,11 +423,12 @@ const CartTools = ({
     visualizable,
     isFileViewOnly,
 }) => {
-    // Make a list of all the dataset types currently in the cart.
-    const usedDatasetTypes = elements.reduce((types, element) => {
-        const type = atIdToType(element['@id']);
-        return types.includes(type) ? types : types.concat(type);
-    }, []);
+    // Make a list of all the allowed dataset types currently in the cart.
+    const usedDatasetTypes = new Set(
+        elements
+            .map((element) => atIdToType(element['@id']))
+            .filter((type) => allowedDatasetTypes[type])
+    );
 
     return (
         <div className="cart-tools">
@@ -447,7 +449,7 @@ const CartTools = ({
                 savedCartObj={savedCartObj}
                 sharedCartObj={sharedCart}
                 cartType={cartType}
-                usedDatasetTypes={usedDatasetTypes}
+                usedDatasetTypes={[...usedDatasetTypes]}
             />
         </div>
     );
@@ -1479,7 +1481,7 @@ const CartComponent = ({ context, savedCartObj, inProgress, fetch, session, loca
                                             series: <CounterTab title="Series" count={allSeries.length} icon="dataset" voice="series" />,
                                             datasets: (
                                                 <CounterTab
-                                                    title={`Selected ${selectedDatasetType ? datasetTabTitles[selectedDatasetType] : 'datasets'}`}
+                                                    title={`Selected ${selectedDatasetType && datasetTabTitles[selectedDatasetType] ? datasetTabTitles[selectedDatasetType] : 'datasets'}`}
                                                     count={selectedDatasets.length}
                                                     icon="dataset"
                                                     voice="selected datasets"

--- a/src/encoded/static/components/cart/index.js
+++ b/src/encoded/static/components/cart/index.js
@@ -261,9 +261,9 @@ const initializeCart = () => {
         /** @id of current cart */
         current: '',
         /** Cache of saved cart */
-        savedCartObj: {},
+        savedCartObj: { elements: [] },
         /** Indicates cart operations currently in progress */
-        inProgress: false,
+        inProgress: true,
         /** React component of alert to display */
         alert: null,
     };

--- a/src/encoded/static/components/cart/series.js
+++ b/src/encoded/static/components/cart/series.js
@@ -81,7 +81,6 @@ const ManageSeriesModalComponent = ({ series, onCloseModalClick, setCartInProgre
         ? 'Remove the series to remove these datasets from the cart.'
         : 'Remove independently of the series, or remove all by removing the series';
 
-
     /**
      * Called when the user confirms closing the modal without taking action.
      */

--- a/src/encoded/static/components/cart/toggle.js
+++ b/src/encoded/static/components/cart/toggle.js
@@ -16,8 +16,8 @@ import {
 } from './actions';
 import CartLoggedOutWarning, { useLoggedOutWarning } from './loggedout_warning';
 import CartMaxElementsWarning from './max_elements_warning';
-import { CART_MAX_ELEMENTS, DEFAULT_FILE_VIEW_NAME } from './util';
-import { hasType, truncateString } from '../globals';
+import { allowedDatasetTypes, CART_MAX_ELEMENTS, DEFAULT_FILE_VIEW_NAME } from './util';
+import { atIdToType, hasType, truncateString } from '../globals';
 
 
 /**
@@ -108,8 +108,10 @@ const CartToggleComponent = ({
                     showMaxElementsWarning();
                 } else {
                     if (hasType(targetElement, 'Series')) {
-                        // Extract all child datasets from the series and add them to the cart.
-                        const relatedDatasetPaths = targetElement.related_datasets.map((relatedDataset) => relatedDataset['@id']);
+                        // Extract allowed child datasets from the series and add them to the cart.
+                        const relatedDatasetPaths = targetElement.related_datasets
+                            .map((relatedDataset) => relatedDataset['@id'])
+                            .filter((path) => allowedDatasetTypes[atIdToType(path)]);
                         const seriesAndRelatedDatasetPaths = [targetElement['@id']].concat(relatedDatasetPaths);
                         addSeriesDatasets(seriesAndRelatedDatasetPaths);
                     }

--- a/src/encoded/static/components/cart/toggle.js
+++ b/src/encoded/static/components/cart/toggle.js
@@ -62,6 +62,18 @@ SeriesRemovalWarning.propTypes = {
 
 
 /**
+ * Initiates the immediate removal of a series object and its related datasets from the cart.
+ * @param {object} seriesElement Series object to remove from the cart
+ * @param {function} removeSeriesDatasets Function to remove the series and its datasets from the cart
+ * @returns {Promise} Promise that resolves when the series and its datasets are removed from the cart
+ */
+const removeSeries = async (seriesElement, removeSeriesDatasets) => {
+    const seriesAndRelatedDatasetPaths = [seriesElement].concat(seriesElement.related_datasets);
+    return removeSeriesDatasets(seriesAndRelatedDatasetPaths);
+};
+
+
+/**
  * Renders and controls the individual cart toggle icons.
  */
 const CartToggleComponent = ({
@@ -86,8 +98,7 @@ const CartToggleComponent = ({
         if (removeConfirmation.isRemoveConfirmed) {
             // Combine the series path with the paths of its related datasets and remove them all
             // from the cart.
-            const seriesAndRelatedDatasetPaths = [targetElement].concat(targetElement.related_datasets);
-            removeSeriesDatasets(seriesAndRelatedDatasetPaths).then(() => {
+            removeSeries(targetElement, removeSeriesDatasets).then(() => {
                 if (removeConfirmation.onCompleteRemoveSeries) {
                     removeConfirmation.onCompleteRemoveSeries();
                 }
@@ -120,7 +131,9 @@ const CartToggleComponent = ({
             } else if (hasType(targetElement, 'Series')) {
                 // Indicate that the user has requested removing a series object from the cart and
                 // therefore we need some user action.
-                if (removeConfirmation.requestRemove) {
+                if (removeConfirmation.immediate) {
+                    removeSeries(targetElement, removeSeriesDatasets);
+                } else if (removeConfirmation.requestRemove) {
                     removeConfirmation.requestRemove();
                 }
             } else {
@@ -188,6 +201,8 @@ CartToggleComponent.propTypes = {
         isRemoveConfirmed: PropTypes.bool,
         /** Called once removing a series object from the cart has completed */
         onCompleteRemoveSeries: PropTypes.func,
+        /** True to remove series and its related datasets without a confirmation modal */
+        immediate: PropTypes.bool,
     }),
     /** True if user is logged in */
     loggedIn: PropTypes.bool,

--- a/src/encoded/static/components/cart/util.js
+++ b/src/encoded/static/components/cart/util.js
@@ -42,6 +42,8 @@ export const allowedDatasetTypes = {
     'single-cell-rna-series': { title: 'Single-cell RNA series', type: 'SingleCellRnaSeries' },
     'treatment-concentration-series': { title: 'Treatment concentration series', type: 'TreatmentConcentrationSeries' },
     'treatment-time-series': { title: 'Treatment time series', type: 'TreatmentTimeSeries' },
+    'collection-series': { title: 'Collection series', type: 'CollectionSeries' },
+    'transgenic-enhancer-experiments': { title: 'Transgenic enhancer experiments', type: 'TransgenicEnhancerExperiment' },
 };
 
 /**

--- a/src/encoded/static/components/dataset.js
+++ b/src/encoded/static/components/dataset.js
@@ -2509,7 +2509,7 @@ export const SeriesComponent = ({
     return (
         <div className={itemClass}>
             <header>
-                <TopAccessories context={context} crumbs={displayedBreadCrumbs} />
+                <TopAccessories context={context} crumbs={displayedBreadCrumbs} removeConfirmation={{ immediate: true }} />
                 <h1>Summary for {title.toLowerCase()} {context.accession}</h1>
                 <DoiRef context={context} />
                 <ReplacementAccessions context={context} />

--- a/src/encoded/static/components/objectutils.js
+++ b/src/encoded/static/components/objectutils.js
@@ -815,7 +815,7 @@ ItemAccessories.contextTypes = {
 /**
  * Display the top section containing the breadcrumb links on summary pages.
  */
-export const TopAccessories = ({ context, crumbs }) => {
+export const TopAccessories = ({ context, crumbs, removeConfirmation }) => {
     const type = context['@type'][0];
     const isItemAllowedInCart = cartGetAllowedTypes().includes(type);
 
@@ -823,7 +823,11 @@ export const TopAccessories = ({ context, crumbs }) => {
         <div className="top-accessories">
             <Breadcrumbs root={`/search/?type=${type}${controlTypeParameter(type)}`} crumbs={crumbs} crumbsReleased={context.status === 'released'} />
             {isItemAllowedInCart ?
-                <CartToggle element={context} displayName />
+                <CartToggle
+                    element={context}
+                    removeConfirmation={removeConfirmation}
+                    displayName
+                />
             : null}
         </div>
     );
@@ -834,6 +838,20 @@ TopAccessories.propTypes = {
     context: PropTypes.object.isRequired,
     /** Object with breadcrumb contents */
     crumbs: PropTypes.arrayOf(PropTypes.object).isRequired,
+    /** For removing a series object on individual series pages */
+    removeConfirmation: PropTypes.shape({
+        /** Called by cart toggle when the user requests removing a series object from the cart */
+        requestRemove: PropTypes.func,
+        /** Called when the user confirms removing a series object from the cart */
+        requestRemoveConfirmation: PropTypes.func,
+        /** True if the user has confirmed they want to remove the series object from the cart */
+        isRemoveConfirmed: PropTypes.bool,
+        /** True to remove series and its related datasets without a confirmation modal */
+        immediate: PropTypes.bool,
+    }),
+};
+TopAccessories.defaultProps = {
+    removeConfirmation: {},
 };
 
 

--- a/src/encoded/static/components/search.js
+++ b/src/encoded/static/components/search.js
@@ -1049,7 +1049,10 @@ const SeriesComponent = ({ context: result, cartControls, removeConfirmation, au
                 </div>
                 {cartControls && !(reactContext.actions && reactContext.actions.length > 0) ?
                     <div className="result-item__cart-control">
-                        <CartToggle element={result} removeConfirmation={removeConfirmation} />
+                        <CartToggle
+                            element={result}
+                            removeConfirmation={Object.keys(removeConfirmation).length > 0 ? removeConfirmation : { immediate: true }}
+                        />
                     </div>
                 : null}
                 <PickerActions context={result} />
@@ -1071,6 +1074,8 @@ SeriesComponent.propTypes = {
         requestRemoveConfirmation: PropTypes.func,
         /** True if the user has confirmed they want to remove the series object from the cart */
         isRemoveConfirmed: PropTypes.bool,
+        /** True to remove series and its related datasets without a confirmation modal */
+        immediate: PropTypes.bool,
     }),
     auditIndicators: PropTypes.func.isRequired, // Audit decorator function
     auditDetail: PropTypes.func.isRequired, // Audit decorator function


### PR DESCRIPTION
* I found a very small but non-zero window in which the user can add datasets to the cart before the cart initialized on page load, causing a JS crash. The two modifications to `initializeCart` prevent this by setting the cart to the in-progress state on page load, and initializing the `elements` property on savedCartObj — a frequent dependency for cart code. Normal cart startup operation includes turning off the in-progress state once the user can truly interact with the cart.
* Many changes in this ticket guard against future dataset types being added to the cart before someone fully integrates them into the cart.

~https://encd-6175-collection-series-cart-qa1-fytanaka.demo.encodedcc.org/~