### PR TITLE
ENCD-6199-fixed-deep-biosample-crash

### DIFF
--- a/src/encoded/static/components/biosample.js
+++ b/src/encoded/static/components/biosample.js
@@ -25,7 +25,6 @@ const biosampleFieldsRetrieved = [
     'accession',
     'biosample_ontology.classification',
     'biosample_ontology.term_name',
-    'biosample_ontology.term_name',
     'organism.scientific_name',
     'parent_of',
     'status',


### PR DESCRIPTION
We’ve followed biosample chains through their `parent_of` links to other biosamples, but at a certain point `parent_of` stops being embedded, so we have to request them from the server. To avoid loading entire large biosamples, possibly with their own embedded `parent_of` chains, we only retrieve the specific fields we need from those biosamples.

At a certain point, `BiosampleTable` started using the organism.scientific_name property of these downstream biosamples, but we don’t get that property.

This branch now retrieves that property, and attempts to make it more obvious that the `collectChildren` function needs its retrieved fields updated by putting those fields into an array outside the function.

Preview demo: ~https://encd-6199-deep-biosample-crash-pv1-fytanaka.demo.encodedcc.org/~