### PR TITLE
ENCD-6242 For AWS_* env vars to work use None instead of 'default'

### DIFF
--- a/cloud-config/create-ami.py
+++ b/cloud-config/create-ami.py
@@ -161,7 +161,7 @@ def _parse_args():
     parser.add_argument('created_by', help='Your name')
     parser.add_argument('deployment_type', help='deployment type')
     parser.add_argument('instance_id', help='instance id')
-    parser.add_argument('--profile-name', default='default', help="AWS creds profile")
+    parser.add_argument('--profile-name', default=None, help="AWS creds profile")
     args = parser.parse_args()
     return args
 

--- a/src/encoded/commands/deploy.py
+++ b/src/encoded/commands/deploy.py
@@ -1153,6 +1153,9 @@ def _parse_args():
     # arm arch only available on demo
     if not args.role == 'demo' and args.arm_image_id:
         raise ValueError('Arm architecture is only available on demos')
+    # For AWS_* env vars to work use None instead of 'default'
+    if args.profile_name == 'default':
+        args.profile_name = None
     return args
 
 


### PR DESCRIPTION
Running deploy on codespaces currently errors with:
```
botocore.exceptions.ProfileNotFound: The config profile (default) could not be found
```

This happens because AWS credentials are configured as secrets on GitHub Codespaces rather than as a profile in ~/.aws/credentials.

It can be fixed by specifying profile_name=None instead of 'default' in deploy.py. The default profile is still used if environment variables are not present.

Tested by launching a demo from both codespaces with AWS_* environment variables and locally with my ~/.aws/credentials.