### PR TITLE
ENCD-6098 update visualize limit for matrix and search

### DIFF
--- a/src/encoded/static/components/matrix.js
+++ b/src/encoded/static/components/matrix.js
@@ -10,7 +10,7 @@ import { TextFilter } from './search';
  * Maximum number of selected items that can be visualized.
  * @constant
  */
-export const MATRIX_VISUALIZE_LIMIT = 500;
+export const MATRIX_VISUALIZE_LIMIT = 200;
 
 
 /**

--- a/src/encoded/static/components/search.js
+++ b/src/encoded/static/components/search.js
@@ -1996,7 +1996,7 @@ SearchControls.contextTypes = {
 
 
 // Maximum number of selected items that can be visualized.
-const VISUALIZE_LIMIT = 100;
+const VISUALIZE_LIMIT = 200;
 
 
 export class ResultTable extends React.Component {


### PR DESCRIPTION
There is an VISUALIZE_LIMIT for search and MATRIX_VISUALIZE_LIMIT for matrix. I changed both to 200.

Since there are limited data at local. I set limit to 10 to play with.
When number is bigger than 10 for search:
![image](https://user-images.githubusercontent.com/44071821/148980326-cd69fb5d-1f80-4f79-b96c-bc12091277c9.png)
When number is bigger than 10 for matrix:
![image](https://user-images.githubusercontent.com/44071821/148980693-ef92f79d-0969-4111-840b-d51375af7ed1.png)
When number is smaller than 10 for search:
![image](https://user-images.githubusercontent.com/44071821/148980853-c7239bea-4955-47ad-89c4-1d4c053266d4.png)
When number is smaller than 10 for matrix:
![image](https://user-images.githubusercontent.com/44071821/148980978-0fab097c-aa87-4e9f-bc39-23908715d811.png)

