### PR TITLE
ENCD-6271-fix-award-labels

### DIFF
--- a/src/encoded/static/components/award.js
+++ b/src/encoded/static/components/award.js
@@ -517,7 +517,7 @@ export class CategoryChart extends React.Component {
 
         return (
             <div className="award-charts__chart">
-                <div className="title">
+                <div className="award-charts__title">
                     {title}
                 </div>
                 {this.relevantData.length > 0 ?


### PR DESCRIPTION
We had been using a now-deleted CSS class, which wasn’t the correct one to use to begin with.