### PR TITLE
ENCD-6269 pin Valis summary page location

### DIFF
--- a/src/encoded/static/components/filegallery.js
+++ b/src/encoded/static/components/filegallery.js
@@ -3678,6 +3678,13 @@ class FileGalleryRendererComponent extends React.Component {
             meta = globals.graphDetail.lookup(this.state.infoNode)(this.state.infoNode, this.handleNodeClick, auditIndicators, auditDetail, this.context.session, this.context.sessionProperties);
         }
 
+        let defaultLocation = null;
+        if (context.examined_regions) {
+            defaultLocation = context.examined_regions[0];
+        } else if (context.examined_loci && context.examined_loci[0].gene && context.examined_loci[0].gene.locations) {
+            defaultLocation = context.examined_loci[0].gene.locations[0];
+        }
+
         // Prepare to display the file information modal.
         const modalTypeMap = {
             File: 'file',
@@ -3750,6 +3757,7 @@ class FileGalleryRendererComponent extends React.Component {
                                 assembly={this.state.selectedAssembly ? this.state.selectedAssembly.split(' ')[0] : ''}
                                 annotation={this.state.selectedAssembly ? this.state.selectedAssembly.split(' ')[1] : ''}
                                 displaySort
+                                defaultLocation={defaultLocation}
                             />
                         </TabPanelPane>
                         {!hideGraph

--- a/src/encoded/static/components/genome_browser.js
+++ b/src/encoded/static/components/genome_browser.js
@@ -97,7 +97,7 @@ const readGenomeBrowserLabelCoordinates = () => {
  * @param {boolean} [ignoreCache=false] True to not look into cache, false to use cache
  * @returns Default coordinates
  */
-const getDefaultCoordinates = (assembly, annotation, ignoreCache = false) => {
+const getDefaultCoordinates = (defaultLocation, assembly, annotation, ignoreCache = false) => {
     // Files to be displayed on all genome browser results
     let pinnedFiles = [];
     let contig = null;
@@ -296,6 +296,13 @@ const getDefaultCoordinates = (assembly, annotation, ignoreCache = false) => {
         x0 = 232475;
         x1 = 237997;
     }
+
+    if (defaultLocation) {
+        contig = defaultLocation.chromosome;
+        x0 = defaultLocation.start;
+        x1 = defaultLocation.end;
+    }
+
     window.sessionStorage.setItem(GV_COORDINATES_ASSEMBLY, assembly);
     window.sessionStorage.setItem(GV_COORDINATES_ANNOTATION, annotation);
 
@@ -756,7 +763,7 @@ class GenomeBrowser extends React.Component {
     }
 
     setBrowserDefaults(assembly, annotation, resolve) {
-        const { contig, x0, x1, pinnedFiles } = getDefaultCoordinates(assembly, annotation);
+        const { contig, x0, x1, pinnedFiles } = getDefaultCoordinates(this.props.defaultLocation, assembly, annotation);
 
         this.setState({ contig, x0, x1, pinnedFiles }, () => {
             if (resolve) {
@@ -1022,6 +1029,9 @@ class GenomeBrowser extends React.Component {
                 const opened = openedOutputTypes.includes(file.output_type);
                 trackObj.name = <TrackLabel file={file} label={label} long={opened} />;
                 trackObj.heightPx = opened ? 95 : trackObj.heightPx;
+            } else if (file.output_type && file.output_type === 'guide locations') {
+                trackObj.name = <TrackLabel file={file} label={label} long />;
+                trackObj.heightPx = 95;
             }
             return trackObj;
         });
@@ -1059,7 +1069,7 @@ class GenomeBrowser extends React.Component {
     }
 
     resetLocation() {
-        const { contig, x0, x1 } = getDefaultCoordinates(this.state.genome, this.state.annotation, true);
+        const { contig, x0, x1 } = getDefaultCoordinates(this.props.defaultLocation, this.state.genome, this.state.annotation, true);
         this.state.visualizer.setLocation({ contig, x0, x1 });
     }
 
@@ -1116,6 +1126,7 @@ GenomeBrowser.propTypes = {
     maxCharPerLine: PropTypes.number,
     /** File's dataset @id map to supplemental label for that dataset */
     supplementalShortLabels: PropTypes.object,
+    defaultLocation: PropTypes.object,
 };
 
 GenomeBrowser.defaultProps = {
@@ -1124,6 +1135,7 @@ GenomeBrowser.defaultProps = {
     displaySort: false, // Determines if sort buttons should be displayed
     maxCharPerLine: null,
     supplementalShortLabels: {},
+    defaultLocation: null,
 };
 
 GenomeBrowser.contextTypes = {


### PR DESCRIPTION
There are two main updates:
- in cases where `examined_loci` or `examined_regions` exist, those fields determine a default location for the browser
- files of output_type "guide locations" require additional track height