### PR TITLE
ENCD-6267-fcc-publication-filters-out-datapoint-experiments

### DIFF
--- a/src/encoded/schemas/functional_characterization_experiment.json
+++ b/src/encoded/schemas/functional_characterization_experiment.json
@@ -542,6 +542,9 @@
         "biosample_ontology.term_name": {
             "title": "Biosample term name"
         },
+        "datapoint": {
+            "title": "Datapoint"
+        },
         "description": {
             "title": "Description"
         },

--- a/src/encoded/schemas/functional_characterization_series.json
+++ b/src/encoded/schemas/functional_characterization_series.json
@@ -221,6 +221,10 @@
             "title": "Biosample summary",
             "type": "string"
         },
+        "datapoint": {
+            "title": "Datapoint",
+            "type": "boolean"
+        },
         "biosample_ontology.classification": {
             "title": "Biosample classification",
             "type": "string"

--- a/src/encoded/static/components/dataset.js
+++ b/src/encoded/static/components/dataset.js
@@ -2459,7 +2459,7 @@ const SeriesDatasetTableSection = ({ title, datasets, tableColumns, sortColumn, 
             <div className="experiment-table__subheader">
                 <>{title}s</>
                 <div className="experiment-table__subheader-controls">
-                    <CartAddAllElements elements={datasets.map((dataset) => dataset['@id'])} />
+                    <CartAddAllElements elements={datasets} />
                     {totalDatasetPageCount > 1
                         ? (
                             <Pager.Simple
@@ -3035,7 +3035,7 @@ const DiseaseExperimentTable = ({ datasetsByDisease, title, accession, isPrivile
                     <>
                         <div className="experiment-table__subheader">
                             {`${diseaseTerm.uppercaseFirstChar()} samples in series`}
-                            <CartAddAllElements elements={diseaseDatasets.map((experiment) => experiment['@id'])} />
+                            <CartAddAllElements elements={diseaseDatasets} />
                         </div>
                         <SortTable
                             list={diseaseDatasets}
@@ -3048,7 +3048,7 @@ const DiseaseExperimentTable = ({ datasetsByDisease, title, accession, isPrivile
                     <>
                         <div className="experiment-table__subheader">
                             Non-diseased experiments in series
-                            <CartAddAllElements elements={noDiseaseDatasets.map((experiment) => experiment['@id'])} />
+                            <CartAddAllElements elements={noDiseaseDatasets} />
                         </div>
                         <SortTable
                             list={noDiseaseDatasets}

--- a/src/encoded/static/components/experiment_series.js
+++ b/src/encoded/static/components/experiment_series.js
@@ -647,7 +647,7 @@ class ExperimentSeriesComponent extends React.Component {
         const { viewableDatasets } = this.state;
         if (Object.keys(viewableDatasets).length > 0) {
             // Add the "Add all to cart" button and internal tags from all related datasets.
-            const experimentIds = Object.values(viewableDatasets).map((experiment) => experiment['@id']);
+            const experiments = Object.values(viewableDatasets);
             const hubUrl = `http://genome.ucsc.edu/cgi-bin/hgTracks?hubClear=${window.location.origin}/batch_hub/type=Experiment%26accession=${
                 Object.values(viewableDatasets).map((experiment) => experiment.accession).join('%26accession=')
             }/hub.txt&db=hg38`;
@@ -655,7 +655,7 @@ class ExperimentSeriesComponent extends React.Component {
                 <div className="experiment-table__header">
                     <h4 className="experiment-table__title">{`Experiments in experiment series ${context.accession}`}</h4>
                     <div className="experiment-table__header-controls">
-                        <CartAddAllElements elements={experimentIds} />
+                        <CartAddAllElements elements={experiments} />
                         <a className="btn btn-info btn-sm" href={hubUrl} type="button" target="_blank" rel="noopener noreferrer">Visualize</a>
                     </div>
                 </div>

--- a/src/encoded/static/components/matrix_deeply_profiled_uniform_batch.js
+++ b/src/encoded/static/components/matrix_deeply_profiled_uniform_batch.js
@@ -393,8 +393,8 @@ const MatrixAddCart = ({ context, fetch, pageName }) => {
             }
             return [];
         }).then((data) => {
-            const experimentIds = data['@graph']?.map((experiment) => experiment['@id']);
-            setExperimentData(experimentIds || []);
+            const experiments = data['@graph'];
+            setExperimentData(experiments || []);
         });
     }, [context]);
 

--- a/src/encoded/static/components/publication.js
+++ b/src/encoded/static/components/publication.js
@@ -63,7 +63,7 @@ const datasetsColumns = {
         display: (dataset) => {
             const allowedTypes = cartGetAllowedTypes();
             if (allowedTypes.includes(dataset['@type'][0])) {
-                return <CartToggle element={dataset} />;
+                return <CartToggle element={dataset} removeConfirmation={{ immediate: true }} />;
             }
             return null;
         },

--- a/src/encoded/static/components/publication.js
+++ b/src/encoded/static/components/publication.js
@@ -172,7 +172,7 @@ const DatasetTable = ({ datasets }) => {
             const pageStartIndex = currentPage * PAGE_DATASET_COUNT;
             const visibleDatasetIds = totalDatasets.slice(pageStartIndex, pageStartIndex + PAGE_DATASET_COUNT);
             if (visibleDatasetIds.length > 0) {
-                requestObjects(visibleDatasetIds, '/search/?type=Dataset&limit=all&status!=deleted&status!=revoked&status!=replaced').then((requestedDatasets) => {
+                requestObjects(visibleDatasetIds.map((dataset) => dataset['@id']), '/search/?type=Dataset&limit=all&status!=deleted&status!=revoked&status!=replaced').then((requestedDatasets) => {
                     // Datasets referring to this publication have loaded. Only display those without a
                     // `datapoint` property and those where `datapoint` is false.
                     setVisibleDatasets(requestedDatasets);
@@ -186,10 +186,10 @@ const DatasetTable = ({ datasets }) => {
         // To filter out datasets that have a `datapoint` property value of true, we need to
         // retrieve all dataset objects in the publication, requesting just that property, and
         // filter to those that qualify for display.
-        requestObjects(datasets, '/search/?type=Dataset&limit=all&status!=deleted&status!=revoked&status!=replaced&field=datapoint').then((requestedDatasets) => {
+        requestObjects(datasets, '/search/?type=Dataset&limit=all&status!=deleted&status!=revoked&status!=replaced&field=datapoint&field=related_datasets.@type&field=related_datasets.@id').then((requestedDatasets) => {
             if (requestedDatasets) {
                 const filteredDatasets = requestedDatasets.filter((dataset) => !dataset.datapoint);
-                setTotalDatasets(filteredDatasets.map((dataset) => dataset['@id']));
+                setTotalDatasets(filteredDatasets);
             }
 
             // If the user logs in while viewing the page, clear the cache to avoid showing stale

--- a/src/encoded/static/components/publication.js
+++ b/src/encoded/static/components/publication.js
@@ -133,6 +133,8 @@ const DatasetTable = ({ datasets }) => {
     const [currentPage, setCurrentPage] = React.useState(0);
     // Dataset objects displayed on the currently displayed page.
     const [visibleDatasets, setVisibleDatasets] = React.useState([]);
+    // Paths of all datasets for the publication that qualify for display.
+    const [totalDatasets, setTotalDatasets] = React.useState([]);
     // Caches past-viewed pages of datasets.
     const pageCache = React.useRef(null);
 
@@ -155,7 +157,9 @@ const DatasetTable = ({ datasets }) => {
 
     // Calculate the total number of pages based on the total number of datasets and the number of
     // datasets per page.
-    const totalPageCount = React.useMemo(() => Math.floor(datasets.length / PAGE_DATASET_COUNT) + (datasets.length % PAGE_DATASET_COUNT !== 0 ? 1 : 0), [datasets]);
+    const totalPageCount = React.useMemo(() => (
+        Math.floor(totalDatasets.length / PAGE_DATASET_COUNT) + (totalDatasets.length % PAGE_DATASET_COUNT !== 0 ? 1 : 0)
+    ), [totalDatasets]);
 
     React.useEffect(() => {
         const cachedDatasets = getPageCache().read(currentPage);
@@ -166,25 +170,46 @@ const DatasetTable = ({ datasets }) => {
         } else {
             // Page not found in the cache. Request the datasets for the currently displayed page.
             const pageStartIndex = currentPage * PAGE_DATASET_COUNT;
-            const visibleDatasetIds = datasets.slice(pageStartIndex, pageStartIndex + PAGE_DATASET_COUNT);
-            requestObjects(visibleDatasetIds, '/search/?type=Dataset&limit=all&status!=deleted&status!=revoked&status!=replaced').then((requestedDatasets) => {
-                setVisibleDatasets(requestedDatasets);
-                getPageCache().write(currentPage, requestedDatasets);
-            });
+            const visibleDatasetIds = totalDatasets.slice(pageStartIndex, pageStartIndex + PAGE_DATASET_COUNT);
+            if (visibleDatasetIds.length > 0) {
+                requestObjects(visibleDatasetIds, '/search/?type=Dataset&limit=all&status!=deleted&status!=revoked&status!=replaced').then((requestedDatasets) => {
+                    // Datasets referring to this publication have loaded. Only display those without a
+                    // `datapoint` property and those where `datapoint` is false.
+                    setVisibleDatasets(requestedDatasets);
+                    getPageCache().write(currentPage, requestedDatasets);
+                });
+            }
         }
-    }, [datasets, currentPage]);
+    }, [totalDatasets, currentPage]);
+
+    React.useEffect(() => {
+        // To filter out datasets that have a `datapoint` property value of true, we need to
+        // retrieve all dataset objects in the publication, requesting just that property, and
+        // filter to those that qualify for display.
+        requestObjects(datasets, '/search/?type=Dataset&limit=all&status!=deleted&status!=revoked&status!=replaced&field=datapoint').then((requestedDatasets) => {
+            if (requestedDatasets) {
+                const filteredDatasets = requestedDatasets.filter((dataset) => !dataset.datapoint);
+                setTotalDatasets(filteredDatasets.map((dataset) => dataset['@id']));
+            }
+
+            // If the user logs in while viewing the page, clear the cache to avoid showing stale
+            // data and go back to viewing the first page.
+            getPageCache().clear();
+            setCurrentPage(0);
+        });
+    }, [datasets]);
 
     return (
         <>
-            {visibleDatasets.length > 0 ?
+            {totalDatasets.length > 0 &&
                 <SortTablePanel
-                    header={<DatasetTableHeader title="Datasets" elements={datasets} currentPage={currentPage} totalPageCount={totalPageCount} updateCurrentPage={updateCurrentPage} />}
-                    subheader={<div className="table-paged__count">{`${datasets.length} dataset${datasets.length === 1 ? '' : 's'}`}</div>}
+                    header={<DatasetTableHeader title="Datasets" elements={totalDatasets} currentPage={currentPage} totalPageCount={totalPageCount} updateCurrentPage={updateCurrentPage} />}
+                    subheader={<div className="table-paged__count">{`${totalDatasets.length} dataset${totalDatasets.length === 1 ? '' : 's'}`}</div>}
                     css="table-paged"
                 >
                     <SortTable list={visibleDatasets} columns={datasetsColumns} />
                 </SortTablePanel>
-            : null}
+            }
         </>
     );
 };

--- a/src/encoded/tests/data/inserts/functional_characterization_experiment.json
+++ b/src/encoded/tests/data/inserts/functional_characterization_experiment.json
@@ -12,6 +12,9 @@
         "date_released": "2016-01-01",
         "elements_mappings": ["ENCSR212POL", "ENCSR051STU"],
         "elements_references": ["ENCSR001REF"],
+        "references": [
+            "9c52b8c0-bdfd-11e4-bb52-0800200c9a66"
+        ],
         "submitted_by": "dignissim.euismod@amet.habitant",
         "uuid": "5a6d5a51-e62d-44b9-a1bd-5d1915247348",
         "examined_loci": [{
@@ -68,6 +71,9 @@
         "lab": "/labs/gregory-crawford/",
         "date_released": "2019-04-10",
         "accession": "ENCSR051STU",
+        "references": [
+            "9c52b8c0-bdfd-11e4-bb52-0800200c9a66"
+        ],
         "uuid": "b9e400e4-70ee-11e9-a923-1681be663d3e",
         "plasmids_library_type": "elements mapping"
     },
@@ -116,6 +122,9 @@
         "date_released": "2016-01-01",
         "elements_mappings": ["ENCSR212POL"],
         "elements_references": ["ENCSR848CFY"],
+        "references": [
+            "9c52b8c0-bdfd-11e4-bb52-0800200c9a66"
+        ],
         "submitted_by": "dignissim.euismod@amet.habitant",
         "uuid": "392ac214-317b-11ea-aec2-2e728ce88125",
         "examined_loci": [{

--- a/src/encoded/tests/data/inserts/functional_characterization_series.json
+++ b/src/encoded/tests/data/inserts/functional_characterization_series.json
@@ -1,12 +1,15 @@
 [
 	{
         "_test": "functional characterization series",
-				"accession": "ENCSR000FCS",
+        "accession": "ENCSR000FCS",
         "award": "ENCODE2",
         "description": "MPRA experiments series.",
         "lab": "thomas-gingeras",
         "status": "released",
         "submitted_by": "facilisi.tristique@potenti.vivamus",
+        "references": [
+            "9c52b8c0-bdfd-11e4-bb52-0800200c9a66"
+        ],
         "related_datasets": [
             "/experiments/ENCSR222MPR",
             "/experiments/ENCSR333MPR"

--- a/src/encoded/types/__init__.py
+++ b/src/encoded/types/__init__.py
@@ -250,9 +250,13 @@ class Publication(Item):
         },
     })
     def datasets(self, request, datasets):
-        allowed_dataset_types = ["/experiments/",
-                                 "/functional-characterization-experiments/",
-                                 "/annotations/", "/references/"]
+        allowed_dataset_types = [
+            "/experiments/",
+            "/functional-characterization-experiments/",
+            "/functional-characterization-series/",
+            "/annotations/",
+            "/references/"
+        ]
         filtered = set()
         for d in datasets:
             if d.startswith(tuple(allowed_dataset_types)):


### PR DESCRIPTION
The main complication with this ticket is that we now have to know which datasets within a publication qualify for display (based on their `datapoint` property) so that we know how many exist, but we don’t have those datasets to know whether they qualify until after the page has mounted.

To solve this, I do a request to the server for every dataset in the publication, but I only request the `datapoint` property for each, to reduce the size of the data we get from the server. We don’t use these objects for display — only to know which ones we _can_ display. We get the full objects for display as the user pages through the datasets.