### PR TITLE
ENCM-25 add human body map to single cell

### DIFF
--- a/src/encoded/static/components/app.js
+++ b/src/encoded/static/components/app.js
@@ -45,7 +45,7 @@ const portal = {
                 { id: 'chip', title: 'ChIP-seq matrix', url: '/chip-seq-matrix/?type=Experiment&replicates.library.biosample.donor.organism.scientific_name=Homo%20sapiens&assay_title=Histone%20ChIP-seq&assay_title=Mint-ChIP-seq&status=released', tag: 'collection' },
                 { id: 'bodymap', title: 'Human body map', url: '/summary/?type=Experiment&control_type!=*&replicates.library.biosample.donor.organism.scientific_name=Homo+sapiens', tag: 'collection' },
                 { id: 'series', title: 'Functional genomics series', url: '/series-search/?type=OrganismDevelopmentSeries', tag: 'collection' },
-                { id: 'single-cell', title: 'Single-cell experiments', url: '/single-cell/?type=Experiment&assay_slims=Single+cell&status!=replaced', tag: 'collection' },
+                { id: 'single-cell', title: 'Single-cell experiments', url: '/single-cell/?type=Experiment&assay_slims=Single+cell&status=released&replicates.library.biosample.donor.organism.scientific_name=Homo%20sapiens', tag: 'collection' },
                 { id: 'sep-mm-0' },
                 { id: 'functional-characterization', title: 'Functional Characterization data' },
                 { id: 'functional-char-assays', title: 'Experiment search', url: '/search/?type=FunctionalCharacterizationExperiment&type=FunctionalCharacterizationSeries&type=TransgenicEnhancerExperiment&config=FunctionalCharacterization&datapoint=false&control_type!=*', tag: 'collection' },

--- a/src/encoded/static/components/body_map.js
+++ b/src/encoded/static/components/body_map.js
@@ -794,12 +794,11 @@ class BodyMap extends React.Component {
                             </button>
                         </ul>
                     </div>
-                :
-                    <button type="button" className="clear-organs" onClick={this.clearOrgans}>
-                        <i className="icon icon-times-circle" />
-                        Clear body map selections
-                    </button>
-                }
+                : null}
+                <button type="button" className={`clear-organs ${this.props.displaySystems ? 'clear-organs-with-systems' : ''}`} onClick={this.clearOrgans}>
+                    <i className="icon icon-times-circle" />
+                    Clear body map selections
+                </button>
                 <div className="body-facet">
                     <div className="body-image-container">
                         {this.props.organism === 'Homo sapiens' ?
@@ -889,11 +888,11 @@ class BodyMap extends React.Component {
 BodyMap.propTypes = {
     context: PropTypes.object.isRequired,
     organism: PropTypes.string.isRequired,
-    displaySystems: PropTypes.bool,
+    displaySystems: PropTypes.bool, // Can be used to suppress list of systems slims
 };
 
 BodyMap.defaultProps = {
-    displaySystems: true,
+    displaySystems: true, // By default, systems slims are displayed
 };
 
 BodyMap.contextTypes = {
@@ -992,11 +991,11 @@ BodyMapModal.propTypes = {
     toggleThumbnail: PropTypes.func.isRequired,
     context: PropTypes.object.isRequired,
     organism: PropTypes.string.isRequired,
-    displaySystems: PropTypes.bool,
+    displaySystems: PropTypes.bool, // Can be used to suppress list of systems slims
 };
 
 BodyMapModal.defaultProps = {
-    displaySystems: true,
+    displaySystems: true, // By default, system slims are displayed
 };
 
 // Combining the body map thumbnail and the body map modal into one component
@@ -1061,11 +1060,11 @@ BodyMapThumbnailAndModal.propTypes = {
     context: PropTypes.object.isRequired,
     location: PropTypes.string.isRequired, // Should be context.location_href from parent
     organism: PropTypes.string.isRequired,
-    displaySystems: PropTypes.bool,
+    displaySystems: PropTypes.bool, // Can be used to suppress list of systems slims
 };
 
 BodyMapThumbnailAndModal.defaultProps = {
-    displaySystems: true,
+    displaySystems: true, // By default, system slims are displayed
 };
 
 export default BodyMap;

--- a/src/encoded/static/components/body_map.js
+++ b/src/encoded/static/components/body_map.js
@@ -768,31 +768,38 @@ class BodyMap extends React.Component {
     render() {
         return (
             <div className={`body-facet-container ${this.props.organism.toLowerCase().replace(/\s/g, '-')}`}>
-                <div className="body-list body-list-top">
-                    <ul className="body-list-inner">
-                        {Object.keys(this.SystemsList).map((b) => (
-                            <li key={b}>
-                                <span
-                                    id={b}
-                                    className={`body-list-element ${checkClass(this.state.selectedOrgan, b) ? 'active' : ''}`}
-                                    role="button"
-                                    tabIndex="0"
-                                    onClick={(e) => this.chooseOrgan(e)}
-                                    onKeyPress={(e) => this.chooseOrgan(e)}
-                                    onMouseEnter={(e) => highlightOrgan(e, this.BodyList, this.CellsList, this.SystemsList)}
-                                    onMouseLeave={unHighlightOrgan}
-                                    disabled={this.state.systemFacets.indexOf(b) === -1}
-                                >
-                                    {b}
-                                </span>
-                            </li>
-                        ))}
-                        <button type="button" className="clear-organs" onClick={this.clearOrgans}>
-                            <i className="icon icon-times-circle" />
-                            Clear body map selections
-                        </button>
-                    </ul>
-                </div>
+                {this.props.displaySystems ?
+                    <div className="body-list body-list-top">
+                        <ul className="body-list-inner">
+                            {Object.keys(this.SystemsList).map((b) => (
+                                <li key={b}>
+                                    <span
+                                        id={b}
+                                        className={`body-list-element ${checkClass(this.state.selectedOrgan, b) ? 'active' : ''}`}
+                                        role="button"
+                                        tabIndex="0"
+                                        onClick={(e) => this.chooseOrgan(e)}
+                                        onKeyPress={(e) => this.chooseOrgan(e)}
+                                        onMouseEnter={(e) => highlightOrgan(e, this.BodyList, this.CellsList, this.SystemsList)}
+                                        onMouseLeave={unHighlightOrgan}
+                                        disabled={this.state.systemFacets.indexOf(b) === -1}
+                                    >
+                                        {b}
+                                    </span>
+                                </li>
+                            ))}
+                            <button type="button" className="clear-organs clear-organs-with-systems" onClick={this.clearOrgans}>
+                                <i className="icon icon-times-circle" />
+                                Clear body map selections
+                            </button>
+                        </ul>
+                    </div>
+                :
+                    <button type="button" className="clear-organs" onClick={this.clearOrgans}>
+                        <i className="icon icon-times-circle" />
+                        Clear body map selections
+                    </button>
+                }
                 <div className="body-facet">
                     <div className="body-image-container">
                         {this.props.organism === 'Homo sapiens' ?
@@ -882,6 +889,11 @@ class BodyMap extends React.Component {
 BodyMap.propTypes = {
     context: PropTypes.object.isRequired,
     organism: PropTypes.string.isRequired,
+    displaySystems: PropTypes.bool,
+};
+
+BodyMap.defaultProps = {
+    displaySystems: true,
 };
 
 BodyMap.contextTypes = {
@@ -953,7 +965,7 @@ ClickableThumbnail.propTypes = {
 // Displayed when you click on <ClickableThumbnail>
 // Allows you to select organ / system filters
 export const BodyMapModal = (props) => {
-    const { context, isThumbnailExpanded, toggleThumbnail, organism } = props;
+    const { context, isThumbnailExpanded, toggleThumbnail, organism, displaySystems } = props;
     return (
         <div className="modal" style={{ display: 'block' }}>
             <div className={`body-map-container-pop-up ${isThumbnailExpanded ? 'expanded' : 'collapsed'}`}>
@@ -965,6 +977,7 @@ export const BodyMapModal = (props) => {
                     <BodyMap
                         context={context}
                         organism={organism}
+                        displaySystems={displaySystems}
                     />
                 </div>
                 <div className="spacer" />
@@ -979,6 +992,11 @@ BodyMapModal.propTypes = {
     toggleThumbnail: PropTypes.func.isRequired,
     context: PropTypes.object.isRequired,
     organism: PropTypes.string.isRequired,
+    displaySystems: PropTypes.bool,
+};
+
+BodyMapModal.defaultProps = {
+    displaySystems: true,
 };
 
 // Combining the body map thumbnail and the body map modal into one component
@@ -1032,6 +1050,7 @@ export const BodyMapThumbnailAndModal = (props) => {
                     toggleThumbnail={toggleThumbnail}
                     context={props.context}
                     organism={props.organism}
+                    displaySystems={props.displaySystems}
                 />
             : null}
         </div>
@@ -1042,6 +1061,11 @@ BodyMapThumbnailAndModal.propTypes = {
     context: PropTypes.object.isRequired,
     location: PropTypes.string.isRequired, // Should be context.location_href from parent
     organism: PropTypes.string.isRequired,
+    displaySystems: PropTypes.bool,
+};
+
+BodyMapThumbnailAndModal.defaultProps = {
+    displaySystems: true,
 };
 
 export default BodyMap;

--- a/src/encoded/static/components/facets/defaults.js
+++ b/src/encoded/static/components/facets/defaults.js
@@ -1368,7 +1368,7 @@ export const DefaultFacet = ({ facet, results, mode, relevantFilters, pathname, 
     };
 
     return (
-        <div className="facet">
+        <div className={`facet ${facet.title.toLowerCase()}__facet`}>
             <button
                 className="facet-expander"
                 type="button"

--- a/src/encoded/static/components/search.js
+++ b/src/encoded/static/components/search.js
@@ -1464,6 +1464,10 @@ export const FacetList = (props) => {
         isExpandable,
         hideDocType,
         options,
+        bodyMap,
+        organism,
+        bodyMapLocation,
+        displaySystems,
     } = props;
 
     const [expandedFacets, setExpandFacets] = React.useState(new Set());
@@ -1650,11 +1654,12 @@ export const FacetList = (props) => {
                         {facetGroups.length > 0
                             ? (
                                 <div className="facet-list-wrapper facet-list-wrapper--facet-group">
-                                    {props.bodyMap ?
+                                    {bodyMap ?
                                         <BodyMapThumbnailAndModal
                                             context={context}
-                                            location={context['@id']}
-                                            organism="Homo sapiens"
+                                            location={bodyMapLocation}
+                                            organism={organism || 'Homo sapiens'}
+                                            displaySystems={displaySystems}
                                         />
                                     : null}
                                     {props.additionalFacet ?
@@ -1760,6 +1765,9 @@ FacetList.propTypes = {
     /** True if the collapsible, false otherwise  */
     isExpandable: PropTypes.bool,
     bodyMap: PropTypes.bool,
+    organism: PropTypes.string,
+    bodyMapLocation: PropTypes.string,
+    displaySystems: PropTypes.bool,
     additionalFacet: PropTypes.object,
     /** Options to pass to facet components in FacetContext */
     options: PropTypes.object,
@@ -1776,6 +1784,9 @@ FacetList.defaultProps = {
     onFilter: null,
     isExpandable: true,
     bodyMap: false,
+    organism: 'Homo sapiens',
+    bodyMapLocation: '',
+    displaySystems: true,
     additionalFacet: null,
     options: {},
 };
@@ -2021,7 +2032,7 @@ export class ResultTable extends React.Component {
     }
 
     render() {
-        const { context, searchBase, actions, hideDocType, bodyMap } = this.props;
+        const { context, searchBase, actions, hideDocType, bodyMap, organism, bodyMapLocation, displaySystems } = this.props;
         const { facets, total, columns, filters } = context;
         const results = context['@graph'];
         const label = 'results';
@@ -2037,6 +2048,9 @@ export class ResultTable extends React.Component {
                     onFilter={this.onFilter}
                     hideDocType={hideDocType}
                     bodyMap={bodyMap}
+                    organism={organism}
+                    bodyMapLocation={bodyMapLocation}
+                    displaySystems={displaySystems}
                 />
                 {context.notification === 'Success' ?
                     <div className="search-results__result-list">
@@ -2063,6 +2077,9 @@ ResultTable.propTypes = {
     currentRegion: PropTypes.func,
     hideDocType: PropTypes.bool,
     bodyMap: PropTypes.bool,
+    organism: PropTypes.string,
+    bodyMapLocation: PropTypes.string,
+    displaySystems: PropTypes.bool,
 };
 
 ResultTable.defaultProps = {
@@ -2071,6 +2088,9 @@ ResultTable.defaultProps = {
     currentRegion: null,
     hideDocType: false,
     bodyMap: false,
+    organism: 'Homo sapiens',
+    bodyMapLocation: '',
+    displaySystems: true,
 };
 
 ResultTable.childContextTypes = {

--- a/src/encoded/static/components/single_cell.js
+++ b/src/encoded/static/components/single_cell.js
@@ -10,17 +10,17 @@ import * as globals from './globals';
 const singleCellList = {
     highThroughput: {
         title: 'High throughput',
-        search: '?type=Experiment&assay_slims=Single+cell&status!=replaced',
+        search: '?type=Experiment&assay_slims=Single+cell&status=released&replicates.library.biosample.donor.organism.scientific_name=Homo%20sapiens',
         description: 'Single cell experiments performed on hundreds to thousands of cells in parallel.',
     },
     perturbedHighThroughput: {
         title: 'Perturbed high throughput',
-        search: '?type=FunctionalCharacterizationExperiment&assay_slims=Single+cell',
+        search: '?type=FunctionalCharacterizationExperiment&assay_slims=Single+cell&status=released',
         description: 'Single cell experiments performed on pooled genetic perturbation screens.',
     },
     lowThroughput: {
         title: 'Low throughput',
-        search: '?type=SingleCellRnaSeries',
+        search: '?type=SingleCellRnaSeries&status=released',
         description: 'Single cell experiments where individual cells were isolated and investigated.',
     },
 };
@@ -33,19 +33,21 @@ const keepFacets = [
     'perturbation',
     'replicates.library.biosample.treatments.treatment_term_name',
     'biosample_ontology.term_name',
-    'replicates.library.biosample.organism.scientific_name',
-    'replicates.library.biosample.donor.organism.scientific_name',
     'biosample_ontology.classification',
     'biosample_ontology.term_name',
+    'biosample_ontology.system_slims',
+    'biosample_ontology.organ_slims',
     'organism.scientific_name',
     'lab.title',
-    'replicates.library.biosample.organism.scientific_name',
     'replicates.library.construction_platform.term_name',
     'replicates.library.construction_method',
     'replicates.library.biosample.subcellular_fraction_term_name',
+    'replicates.library.biosample.organism.scientific_name',
+    'replicates.library.biosample.donor.organism.scientific_name',
     'related_datasets.replicates.library.construction_platform.term_name',
     'related_datasets.replicates.library.construction_method',
     'related_datasets.replicates.library.biosample.subcellular_fraction_term_name',
+    'status',
 ];
 
 // Hide facets that we don't want to display
@@ -54,6 +56,15 @@ const filterFacet = (response) => {
     const filteredFacets = response.facets.filter((facet) => (keepFacets.indexOf(facet.field) > -1));
     newResponse.facets = filteredFacets;
     return newResponse;
+};
+
+const getOrganismTabs = (organisms, selectedOrganism) => {
+    const organismTabs = {};
+    const organismTerms = ['Homo sapiens', 'Mus musculus'];
+    organismTerms.forEach((organismName) => {
+        organismTabs[organismName] = <div className={`organism-button ${organismName.replace(' ', '-')} ${selectedOrganism === organismName ? 'active' : ''} ${!(organisms.includes(organismName)) ? 'disabled' : ''}`}><img src={`/static/img/bodyMap/organisms/${organismName.replace(' ', '-')}.svg`} alt={organismName} /><span>{organismName}</span></div>;
+    });
+    return organismTabs;
 };
 
 // The single cell page displays a table of results corresponding to groupings
@@ -65,8 +76,21 @@ const SingleCell = (props, context) => {
         const selectedType = query.getKeyValues('type')[0];
         selectedSeries = selectedType === 'Experiment' ? 'highThroughput' : selectedType === 'FunctionalCharacterizationExperiment' ? 'perturbedHighThroughput' : 'lowThroughput';
     }
-    const [descriptionData, setDescriptionData] = React.useState(null);
     const searchBase = url.parse(context.location_href).search || '';
+    const descriptionData = singleCellList[selectedSeries].description;
+
+    let bodyMapBool = false;
+    let organismTabs;
+    let selectedOrganism;
+    let organismField;
+    if (selectedSeries === 'highThroughput') {
+        bodyMapBool = true;
+        const organismFacet = props.context.facets.filter((f) => f.title === 'Organism')[0];
+        organismField = organismFacet ? organismFacet.field : null;
+        selectedOrganism = query.getKeyValues(organismField)[0];
+        const organisms = organismFacet && organismFacet.terms ? organismFacet.terms.map((term) => term.key).sort() : null;
+        organismTabs = organisms ? getOrganismTabs(organisms, selectedOrganism) : null;
+    }
 
     const newProps = {};
     newProps.context = filterFacet(props.context);
@@ -74,7 +98,6 @@ const SingleCell = (props, context) => {
     const handleTabClick = React.useCallback((series) => {
         const href = `/single-cell/${singleCellList[series].search}`;
         context.navigate(href);
-        setDescriptionData(singleCellList[series].description);
     }, [context]);
 
     const seriesTabs = {};
@@ -85,20 +108,17 @@ const SingleCell = (props, context) => {
             </div>;
     });
 
-    // Ensure that a tab is correctly initialized
-    React.useEffect(() => {
-        setDescriptionData(singleCellList[selectedSeries].description);
-        if (!(query.getKeyValues('type')[0])) {
-            const href = `/single-cell/${singleCellList[selectedSeries].search}`;
-            context.navigate(href);
-        }
-    }, []);
-
     // We want to retain some filters at all times
     const clearFilters = () => {
         const href = `/single-cell/${singleCellList[selectedSeries].search}`;
         context.navigate(href);
     };
+
+    const handleOrganismTabClick = React.useCallback((tab) => {
+        const q = new QueryString(props.context['@id']);
+        q.replaceKeyValue(organismField, tab);
+        context.navigate(`${q.format()}`);
+    }, [context]);
 
     return (
         <div className="layout">
@@ -115,21 +135,54 @@ const SingleCell = (props, context) => {
                         >
                             <div className="tab-body">
                                 <div className="tab-description">{descriptionData}</div>
-                                <div className="series-wrapper">
-                                    <Panel>
-                                        <PanelBody>
-                                            <button className="reset-encyclopedia" type="button" onClick={() => clearFilters()}>
-                                                Reset filters
-                                            </button>
-                                            <ResultTable
-                                                {...newProps}
-                                                searchBase={searchBase}
-                                                onChange={context.navigate}
-                                                hideDocType
-                                            />
-                                        </PanelBody>
-                                    </Panel>
-                                </div>
+                                {(selectedSeries === 'highThroughput') ?
+                                    <TabPanel
+                                        tabs={organismTabs}
+                                        selectedTab={selectedOrganism}
+                                        handleTabClick={handleOrganismTabClick}
+                                        tabPanelCss="matrix__data-wrapper epigenome-tabs"
+                                    >
+                                        <div className="matrix-facet-container">
+                                            <div className="series-wrapper">
+                                                <Panel>
+                                                    <PanelBody>
+                                                        <button className="reset-encyclopedia" type="button" onClick={() => clearFilters()}>
+                                                            Reset filters
+                                                        </button>
+                                                        <ResultTable
+                                                            {...newProps}
+                                                            searchBase={searchBase}
+                                                            onChange={context.navigate}
+                                                            hideDocType
+                                                            bodyMap={bodyMapBool}
+                                                            organism={selectedOrganism}
+                                                            bodyMapLocation={context.location_href}
+                                                            displaySystems={false}
+                                                        />
+                                                    </PanelBody>
+                                                </Panel>
+                                            </div>
+                                        </div>
+                                    </TabPanel>
+                                :
+                                    <div className="matrix-facet-container">
+                                        <div className="series-wrapper">
+                                            <Panel>
+                                                <PanelBody>
+                                                    <button className="reset-encyclopedia" type="button" onClick={() => clearFilters()}>
+                                                        Reset filters
+                                                    </button>
+                                                    <ResultTable
+                                                        {...newProps}
+                                                        searchBase={searchBase}
+                                                        onChange={context.navigate}
+                                                        hideDocType
+                                                    />
+                                                </PanelBody>
+                                            </Panel>
+                                        </div>
+                                    </div>
+                                }
                             </div>
                         </TabPanel>
                     </div>

--- a/src/encoded/static/components/single_cell.js
+++ b/src/encoded/static/components/single_cell.js
@@ -135,7 +135,7 @@ const SingleCell = (props, context) => {
                         >
                             <div className="tab-body">
                                 <div className="tab-description">{descriptionData}</div>
-                                {(selectedSeries === 'highThroughput') ?
+                                {(selectedSeries === 'highThroughput' && organismTabs) ?
                                     <TabPanel
                                         tabs={organismTabs}
                                         selectedTab={selectedOrganism}

--- a/src/encoded/static/libs/ui/panel.js
+++ b/src/encoded/static/libs/ui/panel.js
@@ -204,7 +204,7 @@ const TabPanel = ({
                 {tabFlange ? <div className="tab-flange" /> : null}
                 <div className="tab-border" />
             </div>
-            <div className="tab-content">
+            <div className={`tab-content tab-content-${getCurrentTab() ? getCurrentTab().replace(/\s/g, '').toLowerCase() : ''}`}>
                 {childrenCopy}
             </div>
         </div>

--- a/src/encoded/static/scss/encoded/modules/_body_map_facet.scss
+++ b/src/encoded/static/scss/encoded/modules/_body_map_facet.scss
@@ -173,15 +173,17 @@
 // Button to clear body map selections
 .clear-organs {
     font-family: Mada;
+    font-size: 0.8rem;
     border: 0;
     padding: 3px 10px;
-    font-size: 1rem;
     color: $Homo-sapiens;
     border-radius: 3px;
     background: #e0e0e0;
-    position: absolute;
-    bottom: -50px;
     right: 10px;
+    position: absolute;
+    top: 10px;
+    bottom: unset;
+    left: 10px;
 
     .icon {
         margin-right: 3px;
@@ -191,6 +193,18 @@
         cursor: pointer;
         background-color: lighten($Homo-sapiens, 45%);
     }
+
+    @media screen and (min-width: $screen-sm-min) {
+        font-size: 1rem;
+        left: unset;
+    }
+}
+
+.clear-organs-with-systems {
+    position: absolute;
+    bottom: -50px;
+    right: 10px;
+    top: unset;
 
     /* stylelint-disable-next-line media-feature-name-disallowed-list */
     @media screen and (max-width: $screen-md-min) {
@@ -268,6 +282,7 @@
 // Special styles for the pop-up modal version of the body map component
 .body-map-thumbnail-and-modal {
     max-width: min-content;
+    margin: 10px 15px 10px;
 
     .body-list {
         .body-list-element {
@@ -450,6 +465,8 @@
 }
 
 .body-facet-container {
+    position: relative;
+
     &.mus-musculus {
         .body-facet {
             padding: 0;

--- a/src/encoded/static/scss/encoded/modules/_search.scss
+++ b/src/encoded/static/scss/encoded/modules/_search.scss
@@ -501,6 +501,16 @@ $form-bg: #f3f3f3;
     .clear-filters-control {
         display: none;
     }
+
+    .organ__facet, .systems__facet {
+        display: none;
+    }
+
+    .tab-content-homosapiens, .tab-content-musmusculus {
+        .organism__facet {
+            display: none;
+        }
+    }
 }
 
 .region-search {

--- a/src/encoded/static/scss/encoded/modules/_tabs.scss
+++ b/src/encoded/static/scss/encoded/modules/_tabs.scss
@@ -42,6 +42,8 @@ $tab-color: #a8a8a8;
             margin: 0;
             padding: 5px 10px;
             color: #000;
+            height: 100%;
+            width: 100%;
 
             &:hover {
                 color: #000;

--- a/src/encoded/tests/features/single_cell.feature
+++ b/src/encoded/tests/features/single_cell.feature
@@ -11,6 +11,10 @@ Feature: Single cell
         Then I should see exactly one element with the css selector ".lowThroughput-tab"
         Then I should see exactly one element with the css selector ".series-wrapper"
 
+    Scenario: High throughput
+        When I click the link with text that contains "High throughput"
+        Then I should see "Single cell experiments performed on hundreds to thousands of cells in parallel."
+
     Scenario: Perturbed high throughput
         When I click the link with text that contains "Perturbed high throughput"
         Then I should see "Single cell experiments performed on pooled genetic perturbation screens."

--- a/src/encoded/tests/features/single_cell.feature
+++ b/src/encoded/tests/features/single_cell.feature
@@ -1,16 +1,9 @@
-@title
-Feature: Title
-
-    Scenario: Title updates
-        When I visit "/single-cell"
-        And I wait for the content to load
-        Then the title should contain the text "Single cell – ENCODE"
-
 @Summary
 Feature: Single cell
     Background:
-        When I visit "/single-cell/?type=Experiment&assay_slims=Single+cell&status!=replaced"
+        When I visit "/single-cell/?type=SingleCellRnaSeries&status=released"
         And I wait for the content to load
+        Then the title should contain the text "Single cell – ENCODE"
 
     Scenario: Single cell page
         Then I should see exactly one element with the css selector ".highThroughput-tab"
@@ -18,13 +11,7 @@ Feature: Single cell
         Then I should see exactly one element with the css selector ".lowThroughput-tab"
         Then I should see exactly one element with the css selector ".series-wrapper"
 
-    Scenario: Peturbed high throughput
+    Scenario: Perturbed high throughput
         When I click the link with text that contains "Perturbed high throughput"
         Then I should see "Single cell experiments performed on pooled genetic perturbation screens."
         Then I should see "No results found"
-
-    Scenario: Low throughput
-        When I click the link with text that contains "Low throughput"
-        And I wait for the content to load
-        Then I should see "Showing 2 of 2 results"
-        Then I should see exactly one element with the css selector ".tab-description"


### PR DESCRIPTION
- Body maps for human and mouse tabs are displayed for the “High throughput” tab
- Organism facet is displayed for “Low throughput” and “Perturbed high throughput” tabs
- Status facet is added for all single-cell tabs, and status=released is added to each query
- Minor style updates are implemented for the body map facet for margin consistency across facets
- System slims are not displayed for the body map on this page only
- Tests are updated (note: I ended up deleting the "low throughput" test because I couldn't get it to pass but maybe Forrest has insight into how to fix it so it will pass?)