### PR TITLE
ENCM-39 replace view all links

### DIFF
--- a/src/encoded/static/components/report.js
+++ b/src/encoded/static/components/report.js
@@ -6,6 +6,7 @@ import { Modal, ModalHeader, ModalBody, ModalFooter } from '../libs/ui/modal';
 import { encodedURIComponent } from '../libs/query_encoding';
 import * as Pager from '../libs/ui/pager';
 import QueryString from '../libs/query_string';
+import LimitSelector from '../libs/ui/limit-selector';
 import * as globals from './globals';
 import { TableItemCount } from './objectutils';
 import { FacetList } from './search';
@@ -708,64 +709,6 @@ const generateColumns = (context, schema) => {
 
 
 /**
- * Displays a control allowing the user to select the maximum number of items to display on one page.
- */
-const PageLimitSelector = ({ pageLimit, query, pageLimitOptions, displayText, ariaLabel }) => (
-    <div className="page-limit-selector">
-        {displayText ?
-            <div className="page-limit-selector__label">{displayText}:</div>
-        : null}
-        <div className="page-limit-selector__options">
-            {pageLimitOptions.map((limit) => {
-                // When changing the number of items per page, also go back to the first page by
-                // removing the "from=x" query-string parameter.
-                const limitQuery = query.clone();
-                limitQuery.deleteKeyValue('from');
-                if (limit === DEFAULT_PAGE_LIMIT) {
-                    limitQuery.deleteKeyValue('limit');
-                } else {
-                    limitQuery.replaceKeyValue('limit', limit);
-                }
-
-                return (
-                    <a
-                        key={limit}
-                        href={`?${limitQuery.format()}`}
-                        className={`page-limit-selector__option${limit === pageLimit ? ' page-limit-selector__option--selected' : ''}`}
-                        aria-label={`Show ${limit} ${ariaLabel}`}
-                    >
-                        {limit}
-                    </a>
-                );
-            })}
-        </div>
-    </div>
-);
-
-PageLimitSelector.defaultProps = {
-    /** Page limit options */
-    pageLimitOptions: [25, 50, 100, 200],
-    /** Display text */
-    displayText: 'Items per page',
-    /** Aria-label text */
-    ariaLabel: 'items per page',
-};
-
-PageLimitSelector.propTypes = {
-    /** New page limit to display */
-    pageLimit: PropTypes.number.isRequired,
-    /** Current page's QueryString query */
-    query: PropTypes.object.isRequired,
-    /** Page limit options */
-    pageLimitOptions: PropTypes.array,
-    /** Display text */
-    displayText: PropTypes.string,
-    /** Aria-label text */
-    ariaLabel: PropTypes.string,
-};
-
-
-/**
  * Renderer for the entire /report/ page.
  */
 const Report = ({ context }, reactContext) => {
@@ -913,7 +856,7 @@ const Report = ({ context }, reactContext) => {
                         </div>
                     </div>
                     <div className="results-table-control__pager">
-                        <PageLimitSelector pageLimit={pageLimit} query={query} />
+                        <LimitSelector pageLimit={pageLimit} query={query} />
                         {totalPages > 1 ?
                             <Pager.Multi currentPage={currentPage} total={totalPages} clickHandler={handlePagerClick} />
                         : null}
@@ -951,8 +894,6 @@ Report.propTypes = {
 Report.contextTypes = {
     navigate: PropTypes.func,
 };
-
-export default PageLimitSelector;
 
 globals.contentViews.register(Report, 'Report');
 globals.contentViews.register(Report, 'RNAExpressionReport');

--- a/src/encoded/static/components/report.js
+++ b/src/encoded/static/components/report.js
@@ -710,10 +710,11 @@ const generateColumns = (context, schema) => {
 /**
  * Displays a control allowing the user to select the maximum number of items to display on one page.
  */
-const pageLimitOptions = [25, 50, 100, 200];
-const PageLimitSelector = ({ pageLimit, query }) => (
+const PageLimitSelector = ({ pageLimit, query, pageLimitOptions, displayText, ariaLabel }) => (
     <div className="page-limit-selector">
-        <div className="page-limit-selector__label">Items per page:</div>
+        {displayText ?
+            <div className="page-limit-selector__label">{displayText}:</div>
+        : null}
         <div className="page-limit-selector__options">
             {pageLimitOptions.map((limit) => {
                 // When changing the number of items per page, also go back to the first page by
@@ -731,7 +732,7 @@ const PageLimitSelector = ({ pageLimit, query }) => (
                         key={limit}
                         href={`?${limitQuery.format()}`}
                         className={`page-limit-selector__option${limit === pageLimit ? ' page-limit-selector__option--selected' : ''}`}
-                        aria-label={`Show ${limit} items per page`}
+                        aria-label={`Show ${limit} ${ariaLabel}`}
                     >
                         {limit}
                     </a>
@@ -741,11 +742,26 @@ const PageLimitSelector = ({ pageLimit, query }) => (
     </div>
 );
 
+PageLimitSelector.defaultProps = {
+    /** Page limit options */
+    pageLimitOptions: [25, 50, 100, 200],
+    /** Display text */
+    displayText: 'Items per page',
+    /** Aria-label text */
+    ariaLabel: 'items per page',
+};
+
 PageLimitSelector.propTypes = {
     /** New page limit to display */
     pageLimit: PropTypes.number.isRequired,
     /** Current page's QueryString query */
     query: PropTypes.object.isRequired,
+    /** Page limit options */
+    pageLimitOptions: PropTypes.array,
+    /** Display text */
+    displayText: PropTypes.string,
+    /** Aria-label text */
+    ariaLabel: PropTypes.string,
 };
 
 
@@ -935,6 +951,8 @@ Report.propTypes = {
 Report.contextTypes = {
     navigate: PropTypes.func,
 };
+
+export default PageLimitSelector;
 
 globals.contentViews.register(Report, 'Report');
 globals.contentViews.register(Report, 'RNAExpressionReport');

--- a/src/encoded/static/components/search.js
+++ b/src/encoded/static/components/search.js
@@ -1909,7 +1909,7 @@ export const SearchControls = ({ context, visualizeDisabledTitle, showResultsTog
                 <a
                     rel="nofollow"
                     className="btn btn-info btn-sm"
-                    href={searchBase ? `${searchBase}&limit=all` : '?limit=all'}
+                    href={searchBase ? `/report/${searchBase}&limit=all` : '/report/?limit=all'}
                     onClick={onFilter}
                 >
                     View All

--- a/src/encoded/static/components/search.js
+++ b/src/encoded/static/components/search.js
@@ -6,7 +6,7 @@ import { Panel, PanelBody } from '../libs/ui/panel';
 import QueryString from '../libs/query_string';
 import { svgIcon } from '../libs/svg-icons';
 import { auditDecor } from './audit';
-import PageLimitSelector from './report';
+import LimitSelector from '../libs/ui/limit-selector';
 import { CartToggle, CartSearchControls, cartGetAllowedTypes } from './cart';
 import {
     FacetRegistry,
@@ -1902,19 +1902,17 @@ export const SearchControls = ({ context, visualizeDisabledTitle, showResultsTog
         );
 
     let resultsToggle = null;
-    const parsedUrl = React.useMemo(() => url.parse(context['@id']), [context]);
-    const query = React.useMemo(() => new QueryString(parsedUrl.query), [parsedUrl]);
+    const parsedUrl = url.parse(context['@id']);
+    const query = new QueryString(parsedUrl.query);
     // Get the current value of the "limit=x" query string parameter. No "limit=x" means the
     // default value applies. The back end allows exactly zero or one "limit=x" parameter.
-    const pageLimit = React.useMemo(() => {
-        const limitValues = query.getKeyValues('limit');
-        return limitValues.length === 1 ? Number(limitValues[0]) || DEFAULT_PAGE_LIMIT : DEFAULT_PAGE_LIMIT;
-    }, [query]);
+    const limitValues = query.getKeyValues('limit');
+    const pageLimit = limitValues.length === 1 ? Number(limitValues[0]) || DEFAULT_PAGE_LIMIT : DEFAULT_PAGE_LIMIT;
     const pageLimitOptions = [25, 50, 100, 200];
 
     if (showResultsToggle) {
         resultsToggle = (
-            <PageLimitSelector
+            <LimitSelector
                 pageLimit={pageLimit}
                 query={query}
                 pageLimitOptions={pageLimitOptions}

--- a/src/encoded/static/components/view_controls.js
+++ b/src/encoded/static/components/view_controls.js
@@ -43,6 +43,7 @@ const SearchViewButton = ({ viewType, query }) => {
     // the "field" query-string elements.
     const searchQuery = query.clone();
     searchQuery.deleteKeyValue('field');
+    searchQuery.deleteKeyValue('limit');
     return (
         <ViewControlButton viewType={viewType} queryString={searchQuery.format()}>
             {viewType.title}

--- a/src/encoded/static/components/view_controls.js
+++ b/src/encoded/static/components/view_controls.js
@@ -43,7 +43,6 @@ const SearchViewButton = ({ viewType, query }) => {
     // the "field" query-string elements.
     const searchQuery = query.clone();
     searchQuery.deleteKeyValue('field');
-    searchQuery.deleteKeyValue('limit');
     return (
         <ViewControlButton viewType={viewType} queryString={searchQuery.format()}>
             {viewType.title}

--- a/src/encoded/static/libs/ui/limit-selector.js
+++ b/src/encoded/static/libs/ui/limit-selector.js
@@ -1,0 +1,66 @@
+import PropTypes from 'prop-types';
+
+/**
+ * Default number of results when no "limit=x" specified in the query string. Determined by our
+ * back-end search code.
+ */
+const DEFAULT_PAGE_LIMIT = 25;
+
+/**
+ * Displays a control allowing the user to select the maximum number of items to display on one page.
+ */
+const LimitSelector = ({ pageLimit, query, pageLimitOptions, displayText, ariaLabel }) => (
+    <div className="page-limit-selector">
+        {displayText ?
+            <div className="page-limit-selector__label">{displayText}:</div>
+        : null}
+        <div className="page-limit-selector__options">
+            {pageLimitOptions.map((limit) => {
+                // When changing the number of items per page, also go back to the first page by
+                // removing the "from=x" query-string parameter.
+                const limitQuery = query.clone();
+                limitQuery.deleteKeyValue('from');
+                if (limit === DEFAULT_PAGE_LIMIT) {
+                    limitQuery.deleteKeyValue('limit');
+                } else {
+                    limitQuery.replaceKeyValue('limit', limit);
+                }
+
+                return (
+                    <a
+                        key={limit}
+                        href={`?${limitQuery.format()}`}
+                        className={`page-limit-selector__option${limit === pageLimit ? ' page-limit-selector__option--selected' : ''}`}
+                        aria-label={`Show ${limit} ${ariaLabel}`}
+                    >
+                        {limit}
+                    </a>
+                );
+            })}
+        </div>
+    </div>
+);
+
+LimitSelector.defaultProps = {
+    /** Page limit options */
+    pageLimitOptions: [25, 50, 100, 200],
+    /** Display text */
+    displayText: 'Items per page',
+    /** Aria-label text */
+    ariaLabel: 'items per page',
+};
+
+LimitSelector.propTypes = {
+    /** New page limit to display */
+    pageLimit: PropTypes.number.isRequired,
+    /** Current page's QueryString query */
+    query: PropTypes.object.isRequired,
+    /** Page limit options */
+    pageLimitOptions: PropTypes.array,
+    /** Display text */
+    displayText: PropTypes.string,
+    /** Aria-label text */
+    ariaLabel: PropTypes.string,
+};
+
+export default LimitSelector;

--- a/src/encoded/static/scss/encoded/modules/_search.scss
+++ b/src/encoded/static/scss/encoded/modules/_search.scss
@@ -535,3 +535,11 @@ $form-bg: #f3f3f3;
         }
     }
 }
+
+.search-page-limit-selector {
+    margin-bottom: 10px;
+
+    @media screen and (min-width: $screen-lg-min) {
+        margin-bottom: 20px;
+    }
+}


### PR DESCRIPTION
I think there was only one place where `limit=all` was on a button (on the search page); I think all the other cases were cases where data was being fetched.