### PR TITLE
ENCM-70 Remove extra body button.

### DIFF
--- a/src/encoded/static/components/body_map.js
+++ b/src/encoded/static/components/body_map.js
@@ -794,11 +794,12 @@ class BodyMap extends React.Component {
                             </button>
                         </ul>
                     </div>
-                : null}
-                <button type="button" className={`clear-organs ${this.props.displaySystems ? 'clear-organs-with-systems' : ''}`} onClick={this.clearOrgans}>
-                    <i className="icon icon-times-circle" />
-                    Clear body map selections
-                </button>
+                : (
+                    <button type="button" className={`clear-organs ${this.props.displaySystems ? 'clear-organs-with-systems' : ''}`} onClick={this.clearOrgans}>
+                        <i className="icon icon-times-circle" />
+                        Clear body map selections
+                    </button>
+                )}
                 <div className="body-facet">
                     <div className="body-image-container">
                         {this.props.organism === 'Homo sapiens' ?


### PR DESCRIPTION
Made the two clear-body-map buttons exclusive, instead of one or both.