### PR TITLE
ENCM-68 Fix reference epigenome body map margins

### DIFF
--- a/src/encoded/static/scss/encoded/modules/_matrix.scss
+++ b/src/encoded/static/scss/encoded/modules/_matrix.scss
@@ -35,6 +35,10 @@ $tab-color: #a8a8a8;
         .matrix__presentation {
             flex: 0 1 auto;
         }
+
+        > .body-map-thumbnail-and-modal {
+            margin: 0;
+        }
     }
 
     .test-project-selector {


### PR DESCRIPTION
Set body map thumbnail margin to 0 specifically on the reference epignome page.