### PR TITLE
ENCM-114 mixed genome annotation crashes

### DIFF
--- a/src/encoded/static/components/objectutils.js
+++ b/src/encoded/static/components/objectutils.js
@@ -925,12 +925,13 @@ export function computeAssemblyAnnotationValue(assembly, annotation) {
     // First level of sorting: most recent assemblies are ordered first (represented by numerical component of assembly)
     // Second level of sorting: assemblies without '-minimal' are sorted before assemblies with '-minimal' at the end (represented by tenths place value which is 5 if there is no '-minimal')
     // Third level of sorting: Annotations within an assembly are ordered with most recent first, with more recent annotations having a higher annotation number (with the exception of "ENSEMBL V65") (represented by the annotation number divided by 10,000, or, the three decimal places after the tenths place)
+    // If an annotation is mixed, it will be ordered between annotations with annotation numbers and '-minimal' annotations
     let assemblyNumber = /\d/.test(assembly) ? +assembly.match(/[0-9]+/g)[0] : 0;
     if (assembly?.indexOf('minimal') === -1) {
         // If there is no '-minimal', add 0.5 which will order this assembly ahead of any assembly with '-minimal' and the same numerical component
         assemblyNumber += 0.5;
     }
-    if (annotation) {
+    if (annotation && annotation !== 'mixed') {
         const annotationNumber = +annotation.match(/[0-9]+/g)[0];
         let annotationDecimal = 0;
         // All of the annotations are in order numerically except for "ENSEMBL V65" which should be ordered behind "M2"


### PR DESCRIPTION
Prevents crash on mixed annotations and sorts mixed annotations between numbered annotations and "-minimal" annotations