### PR TITLE
ENCM-138 Carts use default analysis to select analysis

### DIFF
--- a/src/encoded/static/components/cart/analysis.js
+++ b/src/encoded/static/components/cart/analysis.js
@@ -35,22 +35,35 @@ const labSortOrder = [
  */
 const compileAnalysesByTitle = (experiment, files = []) => {
     let compiledAnalyses = [];
+
     if (experiment.analyses && experiment.analyses.length > 0) {
         // Get all the analysis objects that qualify for inclusion in the Pipeline facet.
-        const qualifyingAnalyses = experiment.analyses.filter((analysis) => {
-            const rfas = _.uniq(analysis.pipeline_award_rfas);
+        let qualifyingAnalyses = [];
+        if (experiment.default_analysis) {
+            // Get the default analysis object if it exists.
+            const defaultAnalysis = experiment.analyses.find((analysis) => analysis['@id'] === experiment.default_analysis);
+            if (defaultAnalysis) {
+                qualifyingAnalyses = [defaultAnalysis];
+            }
+        }
 
-            // More than one lab OK, as long as none of them is `UNIFORM_PIPELINE_LAB` --
-            // `UNIFORM_PIPELINE_LAB` is only valid if alone.
-            return (
-                analysis.assembly
-                && analysis.assembly !== 'mixed'
-                && analysis.genome_annotation !== 'mixed'
-                && analysis.pipeline_award_rfas.length === 1
-                && analysis.pipeline_labs.length > 0
-                && !(analysis.pipeline_labs.length === 1 && analysis.pipeline_labs[0] === UNIFORM_PIPELINE_LAB && rfas.length > 1)
-            );
-        });
+        if (qualifyingAnalyses.length === 0) {
+            // No default analysis object, so get all the analysis objects that qualify for inclusion.
+            qualifyingAnalyses = experiment.analyses.filter((analysis) => {
+                const rfas = _.uniq(analysis.pipeline_award_rfas);
+
+                // More than one lab OK, as long as none of them is `UNIFORM_PIPELINE_LAB` --
+                // `UNIFORM_PIPELINE_LAB` is only valid if alone.
+                return (
+                    analysis.assembly
+                    && analysis.assembly !== 'mixed'
+                    && analysis.genome_annotation !== 'mixed'
+                    && analysis.pipeline_award_rfas.length === 1
+                    && analysis.pipeline_labs.length > 0
+                    && !(analysis.pipeline_labs.length === 1 && analysis.pipeline_labs[0] === UNIFORM_PIPELINE_LAB && rfas.length > 1)
+                );
+            });
+        }
 
         if (qualifyingAnalyses.length > 0) {
             // Group all the qualifying analyses' files by their title so we can consolidate their
@@ -204,5 +217,5 @@ export const compileDatasetAnalyses = (datasets) => {
             acc.concat(compiledAnalysis.analysisObjects)
         ), []);
     });
-    return compiledAnalyses;
+    return combinedAnalyses;
 };

--- a/src/encoded/static/components/cart/cart.js
+++ b/src/encoded/static/components/cart/cart.js
@@ -77,11 +77,22 @@ const datasetTarget = (dataset) => (hasType(dataset, 'Series') ? '' : dataset.ta
 
 
 /**
+ * Requested dataset properties not displayed in facets.
+ */
+const hiddenDatasetFacetFields = [
+    {
+        field: 'default_analysis',
+        title: 'Default analysis',
+    },
+];
+
+/**
  * Facet fields to request from server -- superset of those displayed in facets, minus calculated
  * props.
  */
 const requestedFacetFields = displayedFileFacetFields
     .concat(displayedDatasetFacetFields.map((facetField) => ({ ...facetField, dataset: true })))
+    .concat(hiddenDatasetFacetFields.map((facetField) => ({ ...facetField, dataset: true })))
     .filter((field) => !field.calculated).concat([
         { field: '@id' },
         { field: 'related_datasets', dataset: true },
@@ -90,6 +101,7 @@ const requestedFacetFields = displayedFileFacetFields
         { field: 'assembly' },
         { field: 'assay_term_name' },
         { field: 'annotation_subtype' },
+        { field: 'default_analysis' },
         { field: 'annotation_type' },
         { field: 'file_format_type' },
         { field: 'output_category' },

--- a/src/encoded/tests/features/cart.feature
+++ b/src/encoded/tests/features/cart.feature
@@ -34,8 +34,6 @@ Feature: Cart
         And I click the link to "/cart-view/"
         And I wait for the content to load
         Then I should see at least 11 elements with the css selector ".result-item"
-        When I press "cart-facet-term-hg19"
-        Then I should see "6 files selected"
         When I press "cart-facet-term-Experiment"
         Then I should see "3 files selected"
 


### PR DESCRIPTION
Carts selected an analysis from each dataset based on an algorithm we developed much earlier. Since then we’ve implemented a `default_analysis` calculated property on datasets that use its own algorithm to select an analysis. This branch now uses this `default_analysis` property — when available — to select analyses.