### PR TITLE
ENCM-144-rush-ad-cogdx

### DIFF
--- a/src/encoded/static/components/matrix_brain.js
+++ b/src/encoded/static/components/matrix_brain.js
@@ -40,6 +40,14 @@ const matrixAssaySortOrder = [
     'genotyping array',
 ];
 
+const cogdxMap = {
+    'No disease': 1,
+    'mild cognitive impairment': 2,
+    'Cognitive impairment': 3,
+    'Alzheimer\'s disease': 4,
+    'Alzheimer\'s disease and Cognitive impairment': 5,
+};
+
 /** Circle-sector of disease #1 */
 const DISEASE_SECTOR_COLOR_1 = '#27d266';
 
@@ -407,6 +415,7 @@ const convertContextToDataTable = (context, diseaseList, diseaseGroupIndex = 0) 
                         <div className="disease-text">
                             <div>
                                 <a href={url}>{globals.titleize(NO_DISEASE_LABEL === disease ? 'No cognitive impairment' : disease)}</a>
+                                {cogdxMap[disease] && <div className="disease-text__cogdx">Cogdx: {cogdxMap[disease]}</div>}
                             </div>
                         </div>
                     ),

--- a/src/encoded/static/scss/encoded/modules/_matrix.scss
+++ b/src/encoded/static/scss/encoded/modules/_matrix.scss
@@ -2259,7 +2259,11 @@ $rnaseq-term-name-colors:
 
     .disease-text {
         font-size: 1.2rem;
-        padding: 10px;
+        padding: 2px 10px;
+
+        .disease-text__cogdx {
+            font-size: 0.9rem;
+        }
     }
 
     .hide-item {


### PR DESCRIPTION
* Add Cogdx display below each disease column header.
* Adjust spacing of the Rush AD disease headers.
* Revert "ENCM-144-rush-ad-cogdx"
* Add new styles for Rush AD disease header.
* Remove a stray blank line.
* Revert auto-save formatting changes.
* Remove console.logs.