### PR TITLE
ENCM-180 Fix missing cart files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-    browser-tools: circleci/browser-tools@1.4.3
+    browser-tools: circleci/browser-tools@1.4.6
 
 executors:
   encoded-executor:

--- a/src/encoded/static/components/cart/cart.js
+++ b/src/encoded/static/components/cart/cart.js
@@ -817,7 +817,7 @@ const addToAccumulatingAnalyses = (analyses, currentResults) => {
         // One of the given analyses matches a new compiled analysis, so add the new ones' files to
         // the file list of the given analysis that matches. Then return the accumulating non-
         // matching analyses unchanged.
-        analyses[matchingAnalysisIndex].files.push(currentAnalysis.files);
+        analyses[matchingAnalysisIndex].files.push(...currentAnalysis.files);
         return accumulatedAnalyses;
     }, []);
     return analyses.concat(nonMatchingAnalyses);


### PR DESCRIPTION
In some cases with lots of files, it would add arrays of files as arrays to the file list, instead of adding the elements of an array of files to the file list. This fixes that.